### PR TITLE
fix: scope SQL completion to current statement (SAB-524)

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -298,7 +298,9 @@ impl CompletionEngine {
         let all_tokens = lexer.tokenize(content, content.len());
         let context = lexer.build_context(&all_tokens, cursor_pos);
         let candidate_context = lexer.build_context_before_cursor(&all_tokens, cursor_pos);
-        let tokens = lexer.tokens_for_statement(&all_tokens, cursor_pos).to_vec();
+        let tokens = lexer
+            .tokens_for_statement_before_cursor(&all_tokens, cursor_pos)
+            .to_vec();
         let in_string_or_comment =
             SqlLexer::is_in_string_or_comment_from_tokens(&all_tokens, cursor_pos);
         let before_cursor: String = content.chars().take(cursor_pos).collect();
@@ -3746,6 +3748,53 @@ mod tests {
 
     mod prepared_context {
         use super::*;
+
+        #[test]
+        fn candidate_tokens_exclude_tokens_crossing_cursor_for_each_database() {
+            let engine = engine();
+            let sql = "SELECT * FROM public.users";
+
+            for database_type in DatabaseType::all() {
+                let keyword_cursor = sql.find("FROM").unwrap() + 2;
+                let keyword_prep = engine.prepare_for_database(sql, keyword_cursor, *database_type);
+                assert!(
+                    keyword_prep
+                        .tokens
+                        .iter()
+                        .all(|token| token.end <= keyword_cursor)
+                );
+                assert!(
+                    !keyword_prep
+                        .candidate_context
+                        .tables
+                        .iter()
+                        .any(|table| { table.table == "users" })
+                );
+
+                let identifier_cursor = sql.find("users").unwrap() + 2;
+                let identifier_prep =
+                    engine.prepare_for_database(sql, identifier_cursor, *database_type);
+                assert!(
+                    identifier_prep
+                        .tokens
+                        .iter()
+                        .all(|token| token.end <= identifier_cursor)
+                );
+                assert!(
+                    !identifier_prep
+                        .tokens
+                        .iter()
+                        .any(|token| token.text == "users")
+                );
+                assert!(
+                    !identifier_prep
+                        .candidate_context
+                        .tables
+                        .iter()
+                        .any(|table| { table.table == "users" })
+                );
+            }
+        }
 
         #[test]
         fn is_in_string_or_comment_from_tokens_edges() {

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -132,6 +132,7 @@ pub(crate) enum CompletionContext {
 pub(crate) struct PreparedCompletion {
     pub(crate) tokens: Vec<Token>,
     pub(crate) context: SqlContext,
+    pub(crate) candidate_context: SqlContext,
     pub(crate) database_type: DatabaseType,
     pub(crate) before_cursor: String,
     pub(crate) current_token: String,
@@ -294,13 +295,15 @@ impl CompletionEngine {
         lexer: &SqlLexer,
         database_type: DatabaseType,
     ) -> PreparedCompletion {
-        let tokens = lexer.tokenize(content, content.len());
-        let context = lexer.build_context(&tokens, cursor_pos);
+        let all_tokens = lexer.tokenize(content, content.len());
+        let context = lexer.build_context(&all_tokens, cursor_pos);
+        let candidate_context = lexer.build_context_before_cursor(&all_tokens, cursor_pos);
+        let tokens = lexer.tokens_for_statement(&all_tokens, cursor_pos).to_vec();
         let in_string_or_comment =
-            SqlLexer::is_in_string_or_comment_from_tokens(&tokens, cursor_pos);
+            SqlLexer::is_in_string_or_comment_from_tokens(&all_tokens, cursor_pos);
         let before_cursor: String = content.chars().take(cursor_pos).collect();
         let current_token = self.extract_current_token(&before_cursor);
-        let cte_names: HashSet<String> = context
+        let cte_names: HashSet<String> = candidate_context
             .ctes
             .iter()
             .map(|cte| cte.name.to_lowercase())
@@ -308,6 +311,7 @@ impl CompletionEngine {
         PreparedCompletion {
             tokens,
             context,
+            candidate_context,
             database_type,
             before_cursor,
             current_token,
@@ -326,7 +330,7 @@ impl CompletionEngine {
         let mut missing = Vec::new();
         let mut seen = HashSet::new();
 
-        for table_ref in &prep.context.tables {
+        for table_ref in &prep.candidate_context.tables {
             if prep.cte_names.contains(&table_ref.table.to_lowercase()) {
                 continue;
             }
@@ -395,6 +399,7 @@ impl CompletionEngine {
             &prep.before_cursor,
             &prep.current_token,
             &prep.context,
+            &prep.candidate_context,
             &prep.tokens,
             cursor_pos,
         );
@@ -417,7 +422,7 @@ impl CompletionEngine {
                     .trim_end();
                 let after_comma = before_token.ends_with(',');
 
-                let target_qualified = prep.context.target_table.as_ref().and_then(|t| {
+                let target_qualified = prep.candidate_context.target_table.as_ref().and_then(|t| {
                     self.qualified_name_from_ref_for_database(t, metadata, scope.database_type)
                 });
 
@@ -434,7 +439,7 @@ impl CompletionEngine {
                 }
 
                 let referenced_tables: HashSet<String> = prep
-                    .context
+                    .candidate_context
                     .tables
                     .iter()
                     .filter(|t| !prep.cte_names.contains(&t.table.to_lowercase()))
@@ -443,7 +448,7 @@ impl CompletionEngine {
                     })
                     .collect();
                 let has_unresolved_reference = prep
-                    .context
+                    .candidate_context
                     .tables
                     .iter()
                     .filter(|t| !prep.cte_names.contains(&t.table.to_lowercase()))
@@ -519,7 +524,7 @@ impl CompletionEngine {
                 scope.database_type,
             ),
             CompletionContext::CteOrTable => self.cte_or_table_candidates_for_database(
-                &prep.context,
+                &prep.candidate_context,
                 metadata,
                 &current_token,
                 scope,
@@ -570,6 +575,7 @@ impl CompletionEngine {
             &before_cursor,
             &current_token,
             sql_context,
+            sql_context,
             tokens,
             cursor_pos,
         )
@@ -580,6 +586,7 @@ impl CompletionEngine {
         before_cursor: &str,
         current_token: &str,
         sql_context: &SqlContext,
+        candidate_context: &SqlContext,
         tokens: &[Token],
         cursor_pos: usize,
     ) -> (String, CompletionContext) {
@@ -603,7 +610,7 @@ impl CompletionEngine {
         let base_context = self.detect_context_from_tokens(tokens, cursor_pos);
 
         // If in FROM clause and CTEs are defined, suggest CTE names too
-        if base_context == CompletionContext::Table && !sql_context.ctes.is_empty() {
+        if base_context == CompletionContext::Table && !candidate_context.ctes.is_empty() {
             return (current_token.to_string(), CompletionContext::CteOrTable);
         }
 
@@ -2932,6 +2939,79 @@ mod tests {
         }
 
         #[test]
+        fn current_statement_prefetch_ignores_other_statements() {
+            let sql = "SELECT * FROM first_table; WITH current_cte AS (SELECT * FROM public.nested_table) SELECT * FROM public.current_table WHERE ; SELECT * FROM later_table";
+            let cursor_pos = sql.find("; SELECT * FROM later_table").unwrap();
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = [
+                "first_table",
+                "nested_table",
+                "current_table",
+                "later_table",
+            ]
+            .into_iter()
+            .map(|name| TableSummary::new("public".to_string(), name.to_string(), None, false))
+            .collect();
+
+            for database_type in DatabaseType::all() {
+                let prep = engine().prepare_for_database(sql, cursor_pos, *database_type);
+                let missing = engine().missing_tables_prepared(&prep, Some(&metadata));
+
+                assert_eq!(
+                    missing,
+                    vec![
+                        "public.nested_table".to_string(),
+                        "public.current_table".to_string(),
+                    ]
+                );
+            }
+        }
+
+        #[test]
+        fn cursor_boundaries_and_comments_keep_prefetch_in_scope() {
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = ["first_table", "current_table", "later_table"]
+                .into_iter()
+                .map(|name| TableSummary::new("public".to_string(), name.to_string(), None, false))
+                .collect();
+
+            let before_semicolon = "SELECT * FROM first_table; SELECT * FROM later_table";
+            let before_cursor = before_semicolon.find(';').unwrap();
+            let after_cursor = before_cursor + 1;
+
+            let before_prep = engine().prepare_for_database(
+                before_semicolon,
+                before_cursor,
+                DatabaseType::PostgreSQL,
+            );
+            assert_eq!(
+                engine().missing_tables_prepared(&before_prep, Some(&metadata)),
+                vec!["public.first_table".to_string()]
+            );
+
+            let after_prep = engine().prepare_for_database(
+                before_semicolon,
+                after_cursor,
+                DatabaseType::PostgreSQL,
+            );
+            assert!(
+                engine()
+                    .missing_tables_prepared(&after_prep, Some(&metadata))
+                    .is_empty()
+            );
+
+            let with_comment = "SELECT * FROM first_table; SELECT * FROM current_table -- FROM ignored_table\n; SELECT * FROM later_table";
+            let comment_cursor = with_comment.find("ignored_table").unwrap() + 3;
+            let comment_prep =
+                engine().prepare_for_database(with_comment, comment_cursor, DatabaseType::SQLite);
+
+            assert_eq!(
+                engine().missing_tables_prepared(&comment_prep, Some(&metadata)),
+                vec!["public.current_table".to_string()]
+            );
+        }
+
+        #[test]
         fn schema_qualified_table_returns_qualified_name() {
             let e = engine();
 
@@ -3624,6 +3704,43 @@ mod tests {
             assert!(!e.has_cached_table("public.t1")); // evicted
             assert!(e.has_cached_table("public.t2"));
             assert!(e.has_cached_table("public.t3"));
+        }
+    }
+
+    mod statement_scope {
+        use super::*;
+
+        #[test]
+        fn column_candidates_use_only_current_statement_context() {
+            let mut engine = engine();
+            for (name, column) in [
+                ("first_table", "first_only"),
+                ("current_table", "current_only"),
+                ("later_table", "later_only"),
+            ] {
+                engine.cache_table_detail(
+                    format!("public.{name}"),
+                    create_table("public", name, &[column]),
+                );
+            }
+
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = ["first_table", "current_table", "later_table"]
+                .into_iter()
+                .map(|name| TableSummary::new("public".to_string(), name.to_string(), None, false))
+                .collect();
+            let sql = "SELECT * FROM first_table; SELECT * FROM current_table WHERE ; SELECT * FROM later_table";
+            let cursor_pos = sql.find("; SELECT * FROM later_table").unwrap();
+            let candidates = engine.get_candidates(sql, cursor_pos, Some(&metadata), None, &[]);
+
+            assert!(
+                candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "current_only")
+            );
+            assert!(!candidates.iter().any(|candidate| {
+                matches!(candidate.text.as_str(), "first_only" | "later_only")
+            }));
         }
     }
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -1093,6 +1093,20 @@ impl SqlLexer {
     }
 
     pub fn build_context(&self, tokens: &[Token], cursor_pos: usize) -> SqlContext {
+        let tokens = self.tokens_for_statement(tokens, cursor_pos);
+        self.build_context_from_tokens(tokens, cursor_pos)
+    }
+
+    pub(crate) fn build_context_before_cursor(
+        &self,
+        tokens: &[Token],
+        cursor_pos: usize,
+    ) -> SqlContext {
+        let tokens = self.tokens_for_statement_before_cursor(tokens, cursor_pos);
+        self.build_context_from_tokens(tokens, cursor_pos)
+    }
+
+    fn build_context_from_tokens(&self, tokens: &[Token], cursor_pos: usize) -> SqlContext {
         let tables = self.extract_table_references(tokens);
         let ctes = self.extract_cte_definitions(tokens);
         let target_table = self.extract_target_table(tokens, cursor_pos);
@@ -1102,6 +1116,29 @@ impl SqlLexer {
             ctes,
             target_table,
         }
+    }
+
+    pub(crate) fn tokens_for_statement<'a>(
+        &self,
+        tokens: &'a [Token],
+        cursor_pos: usize,
+    ) -> &'a [Token] {
+        let (start_idx, end_idx) = self.find_statement_range(tokens, cursor_pos);
+        &tokens[start_idx..end_idx]
+    }
+
+    fn tokens_for_statement_before_cursor<'a>(
+        &self,
+        tokens: &'a [Token],
+        cursor_pos: usize,
+    ) -> &'a [Token] {
+        let statement_tokens = self.tokens_for_statement(tokens, cursor_pos);
+        let end_idx = statement_tokens
+            .iter()
+            .position(|token| token.start >= cursor_pos)
+            .unwrap_or(statement_tokens.len());
+
+        &statement_tokens[..end_idx]
     }
 
     fn find_semicolon_positions(&self, tokens: &[Token]) -> Vec<usize> {
@@ -1133,8 +1170,8 @@ impl SqlLexer {
                 break;
             }
             let semi_pos = tokens[semi_idx].end;
-            if cursor_pos <= semi_pos {
-                // Cursor is before or at this semicolon
+            if cursor_pos < semi_pos {
+                // Cursor is before this semicolon
                 return (start, semi_idx + 1);
             }
             start = semi_idx + 1;
@@ -1924,6 +1961,45 @@ mod tests {
             assert_eq!(ctx.ctes.len(), 1);
             assert_eq!(ctx.tables.len(), 2);
         }
+
+        #[test]
+        fn current_statement_context_excludes_other_statements() {
+            let sql = "SELECT * FROM first_table; WITH current_cte AS (SELECT * FROM public.nested_table) SELECT * FROM public.current_table current_alias WHERE current_alias.id IN (SELECT id FROM public.subquery_table); SELECT * FROM later_table";
+            let cursor_pos = sql.find("; SELECT * FROM later_table").unwrap();
+
+            for database_type in DatabaseType::all() {
+                let lexer = SqlLexer::new(*database_type);
+                let tokens = lexer.tokenize(sql, sql.len());
+                let context = lexer.build_context(&tokens, cursor_pos);
+
+                assert_eq!(
+                    context
+                        .ctes
+                        .iter()
+                        .map(|cte| cte.name.as_str())
+                        .collect::<Vec<_>>(),
+                    vec!["current_cte"]
+                );
+                assert_eq!(
+                    context
+                        .tables
+                        .iter()
+                        .map(|table| {
+                            (
+                                table.schema.as_deref(),
+                                table.table.as_str(),
+                                table.alias.as_deref(),
+                            )
+                        })
+                        .collect::<Vec<_>>(),
+                    vec![
+                        (Some("public"), "nested_table", None),
+                        (Some("public"), "current_table", Some("current_alias")),
+                        (Some("public"), "subquery_table", None),
+                    ]
+                );
+            }
+        }
     }
 
     mod target_table {
@@ -2228,6 +2304,19 @@ mod tests {
                 let sql = "UPDATE users SET x = 1; UPDATE orders SET y = 2";
                 // Cursor at position 35 (in "orders")
                 let cursor_pos = 35;
+                let tokens = l.tokenize(sql, sql.len());
+
+                let target = l.extract_target_table(&tokens, cursor_pos);
+
+                assert!(target.is_some());
+                assert_eq!(target.unwrap().table, "orders");
+            }
+
+            #[test]
+            fn cursor_immediately_after_semicolon_uses_next_statement() {
+                let l = lexer();
+                let sql = "UPDATE users SET x = 1; UPDATE orders SET y = 2";
+                let cursor_pos = sql.find(';').unwrap() + 1;
                 let tokens = l.tokenize(sql, sql.len());
 
                 let target = l.extract_target_table(&tokens, cursor_pos);

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -1127,7 +1127,7 @@ impl SqlLexer {
         &tokens[start_idx..end_idx]
     }
 
-    fn tokens_for_statement_before_cursor<'a>(
+    pub(crate) fn tokens_for_statement_before_cursor<'a>(
         &self,
         tokens: &'a [Token],
         cursor_pos: usize,
@@ -1135,7 +1135,7 @@ impl SqlLexer {
         let statement_tokens = self.tokens_for_statement(tokens, cursor_pos);
         let end_idx = statement_tokens
             .iter()
-            .position(|token| token.start >= cursor_pos)
+            .position(|token| token.end > cursor_pos)
             .unwrap_or(statement_tokens.len());
 
         &statement_tokens[..end_idx]


### PR DESCRIPTION
## Problem
SQL completion could use tables, aliases, and CTEs from statements outside the cursor's statement, including metadata prefetch targets.

## Background
The lexer already identified the statement range for mutation target extraction, but completion context construction and prefetching still consumed broader token input.

## Approach
Reuse the existing statement range for completion context and candidate tokens. Keep full current-statement references for existing alias completion while using the cursor-prefix context for candidate columns, CTE suggestions, and missing-table prefetch. Cover PostgreSQL, MySQL, and SQLite boundaries, comments, CTEs, subqueries, and qualified tables.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-524/sql補完の文脈をカーソル位置のstatement内に限定する