### PR TITLE
fix: restore pagination from connection cache

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -193,6 +193,10 @@ impl QueryExecution {
         self.post_delete_row_selection = PostDeleteRowSelection::Keep;
     }
 
+    pub fn restore_pagination(&mut self, pagination: PaginationState) {
+        self.pagination = pagination;
+    }
+
     pub fn is_current_run(&self, run_id: u64) -> bool {
         self.run.is_current(run_id)
     }

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -6,7 +6,7 @@ use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{
     ConnectionId, DatabaseMetadata, DatabaseType, MetadataState, QueryResult, Table, TableSummary,
 };
-use crate::model::browse::query_execution::QueryExecution;
+use crate::model::browse::query_execution::{PaginationState, QueryExecution};
 use crate::model::browse::result_history::ResultHistory;
 use crate::model::connection::cache::ConnectionCache;
 use crate::model::connection::origin::ConnectionOrigin;
@@ -634,6 +634,7 @@ impl BrowseSession {
         inspector_tab: InspectorTab,
         query_result: Option<Arc<QueryResult>>,
         result_history: ResultHistory,
+        pagination: PaginationState,
     ) -> ConnectionCache {
         ConnectionCache {
             connection_dsn: self.dsn.clone(),
@@ -645,6 +646,7 @@ impl BrowseSession {
             selected_table_key: self.selected_table_key.clone(),
             query_result,
             result_history,
+            pagination,
             explorer_selected,
             inspector_tab,
         }
@@ -652,6 +654,7 @@ impl BrowseSession {
 
     fn restore_from_cache(&mut self, cache: &ConnectionCache, query: &mut QueryExecution) {
         query.reset_for_context_change();
+        query.restore_pagination(cache.pagination.clone());
         self.metadata.clone_from(&cache.metadata);
         self.effective_user.clone_from(&cache.effective_user);
         self.table_detail.clone_from(&cache.table_detail);
@@ -1285,8 +1288,18 @@ mod tests {
             let result = make_query_result();
             let mut history = ResultHistory::default();
             history.push(result.clone());
+            query
+                .pagination
+                .reset_for_table_with_estimate("public", "users", Some(1200));
+            query.pagination.set_page_result(2, false);
 
-            let cache = session.to_cache(5, InspectorTab::Indexes, Some(result), history);
+            let cache = session.to_cache(
+                5,
+                InspectorTab::Indexes,
+                Some(result),
+                history,
+                query.pagination.clone(),
+            );
 
             // Create a fresh session and restore
             let mut new_session = BrowseSession::default();
@@ -1302,6 +1315,11 @@ mod tests {
             assert_eq!(new_session.metadata_state(), &MetadataState::Loaded);
             assert!(query.current_result().is_some());
             assert_eq!(query.result_history().len(), 1);
+            assert_eq!(query.pagination.schema(), "public");
+            assert_eq!(query.pagination.table(), "users");
+            assert_eq!(query.pagination.current_page(), 2);
+            assert_eq!(query.pagination.total_rows_estimate(), Some(1200));
+            assert!(!query.pagination.reached_end());
             assert!(!query.is_running());
             assert!(!query.is_current_run(stale_run_id));
         }
@@ -1315,7 +1333,13 @@ mod tests {
             let _ = session.begin_reload();
             assert!(session.selection_generation() > 0);
 
-            let cache = session.to_cache(0, InspectorTab::Info, None, ResultHistory::default());
+            let cache = session.to_cache(
+                0,
+                InspectorTab::Info,
+                None,
+                ResultHistory::default(),
+                PaginationState::default(),
+            );
 
             let mut new_session = BrowseSession::default();
             new_session.set_selection_generation(42);
@@ -1334,7 +1358,13 @@ mod tests {
             let mut query = QueryExecution::default();
             let _ = session.select_table("public", "users", &mut query);
 
-            let cache = session.to_cache(0, InspectorTab::Info, None, ResultHistory::default());
+            let cache = session.to_cache(
+                0,
+                InspectorTab::Info,
+                None,
+                ResultHistory::default(),
+                PaginationState::default(),
+            );
 
             let mut restored = BrowseSession::default();
             let mut query = QueryExecution::default();
@@ -1361,6 +1391,7 @@ mod tests {
                 InspectorTab::Columns,
                 Some(make_query_result()),
                 ResultHistory::default(),
+                PaginationState::default(),
             );
 
             let mut restored = BrowseSession::default();
@@ -1472,7 +1503,13 @@ mod tests {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("cached_db"));
 
-            let cache = session.to_cache(0, InspectorTab::Info, None, ResultHistory::default());
+            let cache = session.to_cache(
+                0,
+                InspectorTab::Info,
+                None,
+                ResultHistory::default(),
+                PaginationState::default(),
+            );
 
             let mut new_session = BrowseSession::default();
             let mut query = QueryExecution::default();
@@ -1486,9 +1523,16 @@ mod tests {
             let cache = ConnectionCache::default();
             let mut session = BrowseSession::default();
             let mut query = QueryExecution::default();
+            query.pagination.reset_for_table("public", "old_table");
+            query.pagination.set_page_result(4, true);
             session.restore_from_cache(&cache, &mut query);
 
             assert!(session.database_name().is_none());
+            assert_eq!(query.pagination.current_page(), 0);
+            assert!(query.pagination.schema().is_empty());
+            assert!(query.pagination.table().is_empty());
+            assert!(query.pagination.total_rows_estimate().is_none());
+            assert!(!query.pagination.reached_end());
         }
     }
 

--- a/src/app/model/connection/cache.rs
+++ b/src/app/model/connection/cache.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, Table};
+use crate::model::browse::query_execution::PaginationState;
 use crate::model::browse::result_history::ResultHistory;
 use crate::model::shared::inspector_tab::InspectorTab;
 
@@ -16,6 +17,7 @@ pub struct ConnectionCache {
     pub selected_table_key: Option<String>,
     pub query_result: Option<Arc<QueryResult>>,
     pub result_history: ResultHistory,
+    pub pagination: PaginationState,
     pub explorer_selected: usize,
     pub inspector_tab: InspectorTab,
 }
@@ -73,6 +75,9 @@ mod tests {
         assert!(cache.table_detail.is_none());
         assert!(cache.selected_table_key.is_none());
         assert!(cache.query_result.is_none());
+        assert_eq!(cache.pagination.current_page(), 0);
+        assert!(cache.pagination.schema().is_empty());
+        assert!(cache.pagination.table().is_empty());
         assert_eq!(cache.explorer_selected, 0);
         assert_eq!(cache.inspector_tab, InspectorTab::default());
     }

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -94,6 +94,7 @@ pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
         state.ui.inspector_tab(),
         state.query.current_result().cloned(),
         state.query.result_history().clone(),
+        state.query.pagination.clone(),
     )
 }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -237,6 +237,7 @@ mod tests {
         ConnectionId, DatabaseMetadata, MetadataState, QueryResult, QuerySource, Table,
         TableKindInfo,
     };
+    use crate::model::browse::query_execution::PaginationState;
     use crate::model::browse::session::TableDetailState;
     use crate::model::connection::cache::ConnectionCache;
     use crate::model::connection::error::ConnectionErrorKind;
@@ -910,6 +911,9 @@ mod tests {
         use super::*;
 
         fn valid_mysql_cache(dsn: &str, database: &str) -> ConnectionCache {
+            let mut pagination = PaginationState::default();
+            pagination.reset_for_table_with_estimate("app", "users", Some(1200));
+            pagination.set_page_result(2, false);
             ConnectionCache {
                 connection_dsn: Some(dsn.to_string()),
                 database_type: Some(DatabaseType::MySQL),
@@ -924,6 +928,7 @@ mod tests {
                     1,
                     QuerySource::Preview,
                 ))),
+                pagination,
                 explorer_selected: 42,
                 inspector_tab: InspectorTab::ForeignKeys,
                 ..Default::default()
@@ -989,6 +994,10 @@ mod tests {
             assert_eq!(state.session.effective_user(), Some("user@localhost"));
             assert_eq!(state.session.selected_table_key(), Some("app.users"));
             assert!(state.query.current_result().is_some());
+            assert_eq!(state.query.pagination.schema(), "app");
+            assert_eq!(state.query.pagination.table(), "users");
+            assert_eq!(state.query.pagination.current_page(), 2);
+            assert_eq!(state.query.pagination.total_rows_estimate(), Some(1200));
             assert_eq!(state.ui.explorer_selected(), 42);
             assert_eq!(state.ui.inspector_tab(), InspectorTab::ForeignKeys);
         }
@@ -1072,12 +1081,16 @@ mod tests {
         fn sqlite_switch_restores_cache() {
             let mut state = AppState::new("test".to_string());
             let target_id = ConnectionId::new();
+            let mut pagination = PaginationState::default();
+            pagination.reset_for_table_with_estimate("main", "items", Some(900));
+            pagination.set_page_result(1, true);
             state.ui.set_explorer_selected_raw(7);
             state.connection_caches.save(
                 &target_id,
                 ConnectionCache {
                     explorer_selected: 42,
                     inspector_tab: InspectorTab::ForeignKeys,
+                    pagination,
                     ..Default::default()
                 },
             );
@@ -1098,11 +1111,128 @@ mod tests {
             );
             assert!(state.connection_caches.get(&target_id).is_some());
             assert_eq!(state.ui.explorer_selected(), 42);
+            assert_eq!(state.query.pagination.schema(), "main");
+            assert_eq!(state.query.pagination.table(), "items");
+            assert_eq!(state.query.pagination.current_page(), 1);
+            assert!(state.query.pagination.reached_end());
             assert_eq!(
                 state.session.active_database_type(),
                 Some(DatabaseType::SQLite)
             );
             assert_eq!(state.session.connection_state(), ConnectionState::Connected);
+        }
+
+        #[test]
+        fn cached_round_trip_restores_pagination_target_for_next_and_previous_pages() {
+            let mut state = AppState::new("test".to_string());
+            let connection_a = ConnectionId::from_string("connection-a");
+            let connection_b = ConnectionId::from_string("connection-b");
+            let dsn_a = "postgres://localhost/connection-a";
+            let dsn_b = "postgres://localhost/connection-b";
+
+            state.session.activate_connection_with_dsn(
+                &connection_a,
+                "connection-a",
+                DatabaseType::PostgreSQL,
+                dsn_a,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let _ = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            state
+                .query
+                .pagination
+                .reset_for_table_with_estimate("public", "users", Some(1500));
+            state.query.pagination.set_page_result(2, false);
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    "SELECT * FROM users".to_string(),
+                    vec!["id".to_string()],
+                    vec![vec!["1".to_string()]],
+                    1500,
+                    QuerySource::Preview,
+                )));
+
+            let mut pagination_b = PaginationState::default();
+            pagination_b.reset_for_table_with_estimate("main", "orders", Some(2600));
+            pagination_b.set_page_result(5, false);
+            state.connection_caches.save(
+                &connection_b,
+                ConnectionCache {
+                    selected_table_key: Some("main.orders".to_string()),
+                    query_result: Some(Arc::new(QueryResult::success(
+                        "SELECT * FROM orders".to_string(),
+                        vec!["id".to_string()],
+                        vec![vec!["2".to_string()]],
+                        2600,
+                        QuerySource::Preview,
+                    ))),
+                    pagination: pagination_b,
+                    ..Default::default()
+                },
+            );
+
+            reduce(
+                &mut state,
+                &create_postgres_switch_action(&connection_b, "connection-b"),
+            );
+
+            assert_eq!(state.session.dsn(), Some(dsn_b));
+            assert_eq!(state.session.selected_table_key(), Some("main.orders"));
+            assert_eq!(state.query.pagination.current_page(), 5);
+            assert_eq!(state.query.pagination.schema(), "main");
+            assert_eq!(state.query.pagination.table(), "orders");
+
+            let next_effects = reduce_app(
+                &mut state,
+                Action::ResultNextPage,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(next_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ExecutePreview {
+                    dsn,
+                    schema,
+                    table,
+                    offset: 3000,
+                    target_page: 6,
+                    ..
+                } if dsn == dsn_b && schema == "main" && table == "orders"
+            )));
+
+            state.query.mark_idle();
+            let previous_effects = reduce_app(
+                &mut state,
+                Action::ResultPrevPage,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(previous_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ExecutePreview {
+                    dsn,
+                    schema,
+                    table,
+                    offset: 2000,
+                    target_page: 4,
+                    ..
+                } if dsn == dsn_b && schema == "main" && table == "orders"
+            )));
+
+            reduce(
+                &mut state,
+                &create_postgres_switch_action(&connection_a, "connection-a"),
+            );
+            assert_eq!(state.session.dsn(), Some(dsn_a));
+            assert_eq!(state.session.selected_table_key(), Some("public.users"));
+            assert_eq!(state.query.pagination.current_page(), 2);
+            assert_eq!(state.query.pagination.schema(), "public");
+            assert_eq!(state.query.pagination.table(), "users");
         }
     }
 


### PR DESCRIPTION
## Problem
Switching to a cached connection restored its result and selected table but not its pagination target, so Next/Prev could query the previous connection's table and page.

## Approach
Store the existing pagination state in each connection cache and restore it with the selected table and current result. Add PostgreSQL, SQLite, MySQL, and A/B navigation lifecycle coverage.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-517/接続cache復yuan後のページ移動を復yuanしたtableへ向ける