### PR TITLE
perf: reuse MySQL ER signature metadata

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -154,7 +154,7 @@ pub enum Effect {
         dsn: String,
         run_id: u64,
         new_metadata: Arc<DatabaseMetadata>,
-        signature_snapshot: TableSignatureSnapshot,
+        signature_snapshot: Arc<TableSignatureSnapshot>,
     },
 
     CopyToClipboard {

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
 use crate::domain::query_history::QueryHistoryScope;
-use crate::domain::{QueryValue, Table};
+use crate::domain::{DatabaseMetadata, QueryValue, Table, TableSignatureSnapshot};
 use crate::model::browse::session::ConnectionSaveGuard;
 use crate::ports::outbound::{AccessMode, AppSettings};
 use crate::update::action::{Action, ConnectionTarget};
@@ -149,6 +149,12 @@ pub enum Effect {
     SmartErRefresh {
         dsn: String,
         run_id: u64,
+    },
+    SmartErRefreshCacheAndDiff {
+        dsn: String,
+        run_id: u64,
+        new_metadata: Arc<DatabaseMetadata>,
+        signature_snapshot: TableSignatureSnapshot,
     },
 
     CopyToClipboard {

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -8,12 +8,13 @@ use tokio::sync::mpsc;
 use super::task::spawn_er_diagram_task;
 use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::effect::Effect;
-use crate::domain::ErTableInfo;
 use crate::domain::er::{er_output_filename, fk_neighbors_of_seeds, fk_reachable_tables_multi};
+use crate::domain::{DatabaseMetadata, ErTableInfo, TableSignatureSnapshot};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{ConfigWriter, ErDiagramExporter, ErLogWriter, MetadataProvider};
 use crate::update::action::{
-    Action, ErDiagramError, ErDiagramFailure, ErLogError, SmartErRefreshError, SmartErRefreshResult,
+    Action, ErDiagramError, ErDiagramFailure, ErLogError, SmartErRefreshError,
+    SmartErRefreshFetched, SmartErRefreshResult,
 };
 
 struct GenerateErDiagramRequest {
@@ -71,15 +72,25 @@ pub async fn run(
             .await
         }
         Effect::SmartErRefresh { dsn, run_id } => {
-            handle_smart_refresh(
+            handle_smart_refresh(action_tx, metadata_provider, dsn, run_id);
+            Ok(())
+        }
+        Effect::SmartErRefreshCacheAndDiff {
+            dsn,
+            run_id,
+            new_metadata,
+            signature_snapshot,
+        } => {
+            handle_smart_refresh_cache_and_diff(
                 action_tx,
-                metadata_provider,
                 state,
                 completion_engine,
                 dsn,
                 run_id,
-            );
-            Ok(())
+                new_metadata,
+                signature_snapshot,
+            )
+            .await
         }
 
         _ => unreachable!("er::run called with non-er effect"),
@@ -198,16 +209,11 @@ async fn handle_write_failure_log(
 fn handle_smart_refresh(
     action_tx: &mpsc::Sender<Action>,
     metadata_provider: &Arc<dyn MetadataProvider>,
-    state: &AppState,
-    completion_engine: &RefCell<CompletionEngine>,
     dsn: String,
     run_id: u64,
 ) {
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
-    let old_signatures = state.er_preparation.last_signatures().clone();
-    let cached_tables = collect_cached_table_names(completion_engine);
-    let request_dsn = dsn.clone();
 
     tokio::spawn(async move {
         let new_metadata = match provider.fetch_metadata(&dsn).await {
@@ -225,7 +231,7 @@ fn handle_smart_refresh(
             }
         };
 
-        let new_sigs_vec = match provider.fetch_table_signatures(&dsn).await {
+        let signature_snapshot = match provider.fetch_table_signatures(&dsn).await {
             Ok(s) => s,
             Err(e) => {
                 let new_metadata = Arc::new(new_metadata);
@@ -241,43 +247,82 @@ fn handle_smart_refresh(
             }
         };
 
-        let new_signatures: std::collections::HashMap<String, String> = new_sigs_vec
-            .iter()
-            .map(|s| (s.qualified_name(), s.signature.clone()))
-            .collect();
-
-        let old_names: HashSet<&str> = old_signatures.keys().map(String::as_str).collect();
-        let new_names: HashSet<&str> = new_signatures.keys().map(String::as_str).collect();
-
-        let added_tables: Vec<String> = new_names
-            .difference(&old_names)
-            .map(ToString::to_string)
-            .collect();
-        let removed_tables: Vec<String> = old_names
-            .difference(&new_names)
-            .map(ToString::to_string)
-            .collect();
-
-        let stale_tables: Vec<String> = new_signatures
-            .iter()
-            .filter(|(name, sig)| {
-                old_signatures
-                    .get(name.as_str())
-                    .is_some_and(|old_sig| old_sig != *sig)
-            })
-            .map(|(name, _)| name.clone())
-            .collect();
-
-        let missing_in_cache: Vec<String> = new_names
-            .iter()
-            .filter(|name| !cached_tables.contains(**name))
-            .map(ToString::to_string)
-            .collect();
-
-        tx.send(Action::SmartErRefreshCompleted(SmartErRefreshResult {
-            dsn: request_dsn,
+        tx.send(Action::SmartErRefreshFetched(SmartErRefreshFetched {
+            dsn,
             run_id,
             new_metadata: Arc::new(new_metadata),
+            signature_snapshot,
+        }))
+        .await
+        .ok();
+    });
+}
+
+async fn handle_smart_refresh_cache_and_diff(
+    action_tx: &mpsc::Sender<Action>,
+    state: &AppState,
+    completion_engine: &RefCell<CompletionEngine>,
+    dsn: String,
+    run_id: u64,
+    new_metadata: Arc<DatabaseMetadata>,
+    signature_snapshot: TableSignatureSnapshot,
+) -> Result<()> {
+    if !state.session.dsn_matches(&dsn) || !state.er_preparation.is_current_run(run_id) {
+        return Ok(());
+    }
+
+    let TableSignatureSnapshot {
+        signatures,
+        table_details,
+    } = signature_snapshot;
+    {
+        let mut engine = completion_engine.borrow_mut();
+        for detail in table_details {
+            engine.cache_table_detail(detail.qualified_name(), detail);
+        }
+    }
+
+    let old_signatures = state.er_preparation.last_signatures().clone();
+    let cached_tables = collect_cached_table_names(completion_engine);
+    let new_signatures: std::collections::HashMap<String, String> = signatures
+        .iter()
+        .map(|signature| (signature.qualified_name(), signature.signature.clone()))
+        .collect();
+
+    let old_names: HashSet<&str> = old_signatures.keys().map(String::as_str).collect();
+    let new_names: HashSet<&str> = new_signatures.keys().map(String::as_str).collect();
+
+    let added_tables: Vec<String> = new_names
+        .difference(&old_names)
+        .filter(|name| !cached_tables.contains(**name))
+        .map(ToString::to_string)
+        .collect();
+    let removed_tables: Vec<String> = old_names
+        .difference(&new_names)
+        .map(ToString::to_string)
+        .collect();
+
+    let stale_tables: Vec<String> = new_signatures
+        .iter()
+        .filter(|(name, sig)| {
+            old_signatures
+                .get(name.as_str())
+                .is_some_and(|old_sig| old_sig != *sig)
+        })
+        .map(|(name, _)| name.clone())
+        .collect();
+
+    let missing_in_cache: Vec<String> = new_names
+        .iter()
+        .filter(|name| !cached_tables.contains(**name))
+        .map(ToString::to_string)
+        .collect();
+
+    action_tx
+        .send(Action::SmartErRefreshCompleted(SmartErRefreshResult {
+            dsn,
+            run_id,
+            new_metadata,
             stale_tables,
             added_tables,
             removed_tables,
@@ -286,7 +331,7 @@ fn handle_smart_refresh(
         }))
         .await
         .ok();
-    });
+    Ok(())
 }
 
 fn collect_cached_er_tables(completion_engine: &RefCell<CompletionEngine>) -> Vec<ErTableInfo> {
@@ -320,4 +365,84 @@ fn collect_cached_table_names(completion_engine: &RefCell<CompletionEngine>) -> 
         .table_details_iter()
         .map(|(name, _)| name.clone())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        Column, ColumnAttributes, ConnectionId, DatabaseType, Table, TableKindInfo, TableSignature,
+    };
+
+    fn state_with_mysql_dsn(dsn: &str) -> AppState {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            dsn,
+        );
+        let _ = state.er_preparation.start_waiting_run();
+        state
+    }
+
+    fn light_table_detail() -> Table {
+        Table {
+            schema: "app".to_string(),
+            name: "items".to_string(),
+            owner: None,
+            columns: vec![Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                default: None,
+                attributes: ColumnAttributes::from_parts(false, true, false),
+                comment: None,
+                ordinal_position: 1,
+            }],
+            primary_key: Some(vec!["id".to_string()]),
+            foreign_keys: Vec::new(),
+            indexes: Vec::new(),
+            rls: None,
+            triggers: Vec::new(),
+            row_count_estimate: None,
+            comment: None,
+            source_ddl: None,
+            kind_info: TableKindInfo::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn signature_details_seed_empty_completion_cache_before_diff() {
+        let dsn = "mysql://user:password@localhost:3306/app";
+        let state = state_with_mysql_dsn(dsn);
+        let completion_engine = RefCell::new(CompletionEngine::new());
+        let (action_tx, mut action_rx) = mpsc::channel(1);
+        let table = light_table_detail();
+
+        handle_smart_refresh_cache_and_diff(
+            &action_tx,
+            &state,
+            &completion_engine,
+            dsn.to_string(),
+            1,
+            Arc::new(DatabaseMetadata::new("app".to_string())),
+            TableSignatureSnapshot {
+                signatures: vec![TableSignature {
+                    schema: "app".to_string(),
+                    name: "items".to_string(),
+                    signature: "signature".to_string(),
+                }],
+                table_details: vec![table],
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(completion_engine.borrow().has_cached_table("app.items"));
+        let Action::SmartErRefreshCompleted(result) = action_rx.recv().await.unwrap() else {
+            panic!("expected smart refresh completion");
+        };
+        assert!(result.added_tables.is_empty());
+        assert!(result.missing_in_cache.is_empty());
+    }
 }

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -251,7 +251,7 @@ fn handle_smart_refresh(
             dsn,
             run_id,
             new_metadata: Arc::new(new_metadata),
-            signature_snapshot,
+            signature_snapshot: Arc::new(signature_snapshot),
         }))
         .await
         .ok();
@@ -265,7 +265,7 @@ async fn handle_smart_refresh_cache_and_diff(
     dsn: String,
     run_id: u64,
     new_metadata: Arc<DatabaseMetadata>,
-    signature_snapshot: TableSignatureSnapshot,
+    signature_snapshot: Arc<TableSignatureSnapshot>,
 ) -> Result<()> {
     if !state.session.dsn_matches(&dsn) || !state.er_preparation.is_current_run(run_id) {
         return Ok(());
@@ -274,7 +274,7 @@ async fn handle_smart_refresh_cache_and_diff(
     let TableSignatureSnapshot {
         signatures,
         table_details,
-    } = signature_snapshot;
+    } = Arc::unwrap_or_clone(signature_snapshot);
     {
         let mut engine = completion_engine.borrow_mut();
         for detail in table_details {
@@ -426,14 +426,14 @@ mod tests {
             dsn.to_string(),
             1,
             Arc::new(DatabaseMetadata::new("app".to_string())),
-            TableSignatureSnapshot {
+            Arc::new(TableSignatureSnapshot {
                 signatures: vec![TableSignature {
                     schema: "app".to_string(),
                     name: "items".to_string(),
                     signature: "signature".to_string(),
                 }],
                 table_details: vec![table],
-            },
+            }),
         )
         .await
         .unwrap();

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -246,7 +246,8 @@ impl EffectRunner {
             e @ (Effect::GenerateErDiagramFromCache { .. }
             | Effect::ExtractFkNeighbors { .. }
             | Effect::WriteErFailureLog { .. }
-            | Effect::SmartErRefresh { .. }) => {
+            | Effect::SmartErRefresh { .. }
+            | Effect::SmartErRefreshCacheAndDiff { .. }) => {
                 cmd_er::run(
                     e,
                     &self.action_tx,
@@ -293,7 +294,7 @@ impl EffectRunner {
 mod tests {
     use super::*;
     use crate::cmd::test_fixtures;
-    use crate::domain::{DatabaseMetadata, TableSummary};
+    use crate::domain::{DatabaseMetadata, TableSignatureSnapshot, TableSummary};
     use crate::model::shared::render_output::{
         BrowseLayout, DetailLayout, ExplorerLayout, JsonDetailLayout,
     };
@@ -536,7 +537,7 @@ mod tests {
 
         use super::*;
         use crate::domain::connection::{ConnectionId, DatabaseType};
-        use crate::domain::{QueryResult, Table, TableSignature, WriteExecutionResult};
+        use crate::domain::{QueryResult, Table, WriteExecutionResult};
         use crate::model::connection::cache::ConnectionCache;
         use crate::ports::outbound::{AccessMode, DbOperationError};
         use crate::update::action::ConnectionTarget;
@@ -655,7 +656,7 @@ mod tests {
             async fn fetch_table_signatures(
                 &self,
                 _dsn: &str,
-            ) -> Result<Vec<TableSignature>, DbOperationError> {
+            ) -> Result<TableSignatureSnapshot, DbOperationError> {
                 unreachable!("test only starts table detail")
             }
         }

--- a/src/app/ports/outbound/metadata.rs
+++ b/src/app/ports/outbound/metadata.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::domain::{DatabaseMetadata, Table, TableSignature};
+use crate::domain::{DatabaseMetadata, Table, TableSignatureSnapshot};
 
 use super::DbOperationError;
 
@@ -30,5 +30,5 @@ pub trait MetadataProvider: Send + Sync {
     async fn fetch_table_signatures(
         &self,
         dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError>;
+    ) -> Result<TableSignatureSnapshot, DbOperationError>;
 }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -23,7 +23,9 @@ use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
 
 use crate::domain::SqliteDiagnosticsSnapshot;
-use crate::domain::{DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table};
+use crate::domain::{
+    DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table, TableSignatureSnapshot,
+};
 
 #[derive(Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
@@ -242,6 +244,14 @@ pub struct SmartErRefreshResult {
     pub removed_tables: Vec<String>,
     pub missing_in_cache: Vec<String>,
     pub new_signatures: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SmartErRefreshFetched {
+    pub dsn: String,
+    pub run_id: u64,
+    pub new_metadata: Arc<DatabaseMetadata>,
+    pub signature_snapshot: TableSignatureSnapshot,
 }
 
 #[derive(Debug, Clone)]
@@ -701,6 +711,7 @@ pub enum Action {
     ErConfirmSelection,
     ErOpenDiagram,
     ErGenerateFromCache,
+    SmartErRefreshFetched(SmartErRefreshFetched),
     SmartErRefreshCompleted(SmartErRefreshResult),
     SmartErRefreshFailed(SmartErRefreshError),
     ErDiagramOpened(ErDiagramInfo),
@@ -731,6 +742,7 @@ impl Action {
             | Self::ErConfirmSelection
             | Self::ErOpenDiagram
             | Self::ErGenerateFromCache
+            | Self::SmartErRefreshFetched(_)
             | Self::SmartErRefreshCompleted(_)
             | Self::SmartErRefreshFailed(_)
             | Self::ErDiagramOpened(_)

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -251,7 +251,7 @@ pub struct SmartErRefreshFetched {
     pub dsn: String,
     pub run_id: u64,
     pub new_metadata: Arc<DatabaseMetadata>,
-    pub signature_snapshot: TableSignatureSnapshot,
+    pub signature_snapshot: Arc<TableSignatureSnapshot>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -1,6 +1,7 @@
 mod diagram;
 mod smart_refresh_completed;
 mod smart_refresh_failed;
+mod smart_refresh_fetched;
 
 use std::time::Instant;
 
@@ -10,6 +11,7 @@ use crate::update::dispatch_result::DispatchResult;
 
 pub fn dispatch_er(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     diagram::reduce_diagram_lifecycle(state, action, now)
+        .or_else(|| smart_refresh_fetched::reduce_smart_refresh_fetched(state, action))
         .or_else(|| smart_refresh_completed::reduce_smart_refresh_completed(state, action, now))
         .or_else(|| smart_refresh_failed::reduce_smart_refresh_failed(state, action, now))
 }
@@ -21,11 +23,14 @@ mod tests {
 
     use super::*;
     use crate::cmd::effect::Effect;
-    use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, TableSummary};
+    use crate::domain::{
+        ConnectionId, DatabaseMetadata, DatabaseType, TableSignatureSnapshot, TableSummary,
+    };
     use crate::model::app_state::AppState;
     use crate::model::er_state::ErStatus;
     use crate::update::action::{
-        ErDiagramError, ErDiagramFailure, ErDiagramInfo, SmartErRefreshError, SmartErRefreshResult,
+        ErDiagramError, ErDiagramFailure, ErDiagramInfo, SmartErRefreshError,
+        SmartErRefreshFetched, SmartErRefreshResult,
     };
     use std::sync::Arc;
 
@@ -499,6 +504,71 @@ mod tests {
                 5
             );
             assert_eq!(state.er_preparation.last_signatures(), &new_sigs);
+        }
+    }
+
+    mod smart_er_refresh_fetched {
+        use super::*;
+
+        fn action(dsn: &str, run_id: u64) -> Action {
+            Action::SmartErRefreshFetched(SmartErRefreshFetched {
+                dsn: dsn.to_string(),
+                run_id,
+                new_metadata: make_metadata(1),
+                signature_snapshot: TableSignatureSnapshot {
+                    signatures: Vec::new(),
+                    table_details: Vec::new(),
+                },
+            })
+        }
+
+        #[test]
+        fn matching_connection_and_run_emits_cache_diff_effect() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            set_active_run_id(&mut state, 1);
+            state.er_preparation.mark_waiting_for_test();
+
+            let effects = reduce_er(
+                &mut state,
+                &action("postgres://localhost/test", 1),
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("reducer should handle action");
+
+            assert!(matches!(
+                &effects[0],
+                Effect::SmartErRefreshCacheAndDiff { run_id: 1, .. }
+            ));
+        }
+
+        #[test]
+        fn mismatched_connection_or_run_does_not_emit_cache_diff_effect() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            set_active_run_id(&mut state, 2);
+            state.er_preparation.mark_waiting_for_test();
+
+            assert!(
+                reduce_er(
+                    &mut state,
+                    &action("postgres://localhost/test", 1),
+                    Instant::now(),
+                )
+                .into_effects()
+                .expect("reducer should handle action")
+                .is_empty()
+            );
+
+            assert!(
+                reduce_er(
+                    &mut state,
+                    &action("postgres://localhost/other", 2),
+                    Instant::now(),
+                )
+                .into_effects()
+                .expect("reducer should handle action")
+                .is_empty()
+            );
         }
     }
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -515,10 +515,10 @@ mod tests {
                 dsn: dsn.to_string(),
                 run_id,
                 new_metadata: make_metadata(1),
-                signature_snapshot: TableSignatureSnapshot {
+                signature_snapshot: Arc::new(TableSignatureSnapshot {
                     signatures: Vec::new(),
                     table_details: Vec::new(),
-                },
+                }),
             })
         }
 

--- a/src/app/update/er/smart_refresh_fetched.rs
+++ b/src/app/update/er/smart_refresh_fetched.rs
@@ -1,0 +1,27 @@
+use crate::cmd::effect::Effect;
+use crate::model::app_state::AppState;
+use crate::update::action::{Action, SmartErRefreshFetched};
+use crate::update::dispatch_result::DispatchResult;
+
+pub(super) fn reduce_smart_refresh_fetched(state: &AppState, action: &Action) -> DispatchResult {
+    match action {
+        Action::SmartErRefreshFetched(SmartErRefreshFetched {
+            dsn,
+            run_id,
+            new_metadata,
+            signature_snapshot,
+        }) => {
+            if !state.session.dsn_matches(dsn) || !state.er_preparation.is_current_run(*run_id) {
+                return DispatchResult::handled();
+            }
+
+            DispatchResult::handled_with(vec![Effect::SmartErRefreshCacheAndDiff {
+                dsn: dsn.clone(),
+                run_id: *run_id,
+                new_metadata: new_metadata.clone(),
+                signature_snapshot: signature_snapshot.clone(),
+            }])
+        }
+        _ => DispatchResult::pass(),
+    }
+}

--- a/src/app/update/er/smart_refresh_fetched.rs
+++ b/src/app/update/er/smart_refresh_fetched.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::{Action, SmartErRefreshFetched};
@@ -19,7 +21,7 @@ pub(super) fn reduce_smart_refresh_fetched(state: &AppState, action: &Action) ->
                 dsn: dsn.clone(),
                 run_id: *run_id,
                 new_metadata: new_metadata.clone(),
-                signature_snapshot: signature_snapshot.clone(),
+                signature_snapshot: Arc::clone(signature_snapshot),
             }])
         }
         _ => DispatchResult::pass(),

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -33,7 +33,7 @@ pub use query_result::{ExplicitRowIdentity, QueryResult, QuerySource, QueryValue
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
 pub use sqlite_diagnostics::{DiagnosticField, SqliteDiagnosticsSnapshot};
-pub use table::{Table, TableSignature, TableSummary};
+pub use table::{Table, TableSignature, TableSignatureSnapshot, TableSummary};
 pub use table_kind::{TableKind, TableKindInfo};
 pub use trigger::{Trigger, TriggerEvent, TriggerTiming};
 pub use write_result::WriteExecutionResult;

--- a/src/domain/table.rs
+++ b/src/domain/table.rs
@@ -78,6 +78,12 @@ impl TableSignature {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TableSignatureSnapshot {
+    pub signatures: Vec<TableSignature>,
+    pub table_details: Vec<Table>,
+}
+
 impl TableSummary {
     pub fn new(
         schema: String,

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
-use crate::domain::{DatabaseMetadata, Schema, Table, TableSignature};
+use crate::domain::{DatabaseMetadata, Schema, Table, TableSignatureSnapshot};
 
 use super::adapter::MySqlAdapter;
 use super::cli::MySqlResultSet;
@@ -55,7 +55,7 @@ impl MetadataProvider for MySqlAdapter {
     async fn fetch_table_signatures(
         &self,
         dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
+    ) -> Result<TableSignatureSnapshot, DbOperationError> {
         signature::fetch_table_signatures(dsn).await
     }
 }

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -1,9 +1,13 @@
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
+use std::time::Duration;
 
 use crate::app::ports::outbound::DbOperationError;
-use crate::domain::{FkAction, Table, TableKind, TableKindInfo, TableSignature};
+use crate::domain::{
+    FkAction, Table, TableKind, TableKindInfo, TableSignature, TableSignatureSnapshot,
+};
 
-use super::super::cli::MySqlResultSet;
+use super::super::cli::{MYSQL_QUERY_TIMEOUT, MySqlResultSet};
 use super::super::sql::{
     FOREIGN_KEY_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS,
     SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
@@ -11,7 +15,7 @@ use super::super::sql::{
 };
 use super::catalog::{
     MySqlColumnMetadata, MySqlForeignKeyMetadata, MySqlTableMetadata, column_from_metadata,
-    execute_metadata_queries_in_session, expect_columns, foreign_keys_from_metadata,
+    execute_metadata_queries_in_session_with_program, expect_columns, foreign_keys_from_metadata,
     mark_single_column_unique, metadata_shape_error, metadata_snapshot_from_result,
     parse_column_metadata_row, parse_foreign_key_metadata, primary_key_names, required_text,
     selected_database,
@@ -26,9 +30,17 @@ struct MySqlSignatureColumnMetadata {
 
 pub(super) async fn fetch_table_signatures(
     dsn: &str,
-) -> Result<Vec<TableSignature>, DbOperationError> {
+) -> Result<TableSignatureSnapshot, DbOperationError> {
+    fetch_table_signatures_with_program(dsn, OsStr::new("mysql"), MYSQL_QUERY_TIMEOUT).await
+}
+
+async fn fetch_table_signatures_with_program(
+    dsn: &str,
+    program: &OsStr,
+    timeout: Duration,
+) -> Result<TableSignatureSnapshot, DbOperationError> {
     let database = selected_database(dsn)?;
-    let results = execute_metadata_queries_in_session(
+    let results = execute_metadata_queries_in_session_with_program(
         dsn,
         &[
             (TABLES_QUERY, TABLES_RESULT_COLUMNS),
@@ -39,6 +51,8 @@ pub(super) async fn fetch_table_signatures(
                 SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS,
             ),
         ],
+        program,
+        timeout,
     )
     .await?;
     let snapshot = metadata_snapshot_from_result(&database, None, &results[0])?;
@@ -77,7 +91,7 @@ fn table_signatures_from_metadata(
     columns: Vec<MySqlSignatureColumnMetadata>,
     foreign_keys: Vec<MySqlForeignKeyMetadata>,
     mut unique_columns_by_table: HashMap<String, HashSet<String>>,
-) -> Result<Vec<TableSignature>, DbOperationError> {
+) -> Result<TableSignatureSnapshot, DbOperationError> {
     let known_tables: HashSet<(String, String)> = tables
         .iter()
         .map(|table| (table.schema.clone(), table.name.clone()))
@@ -125,59 +139,63 @@ fn table_signatures_from_metadata(
         ));
     }
 
-    tables
-        .iter()
-        .map(|table| {
-            let key = (table.schema.clone(), table.name.clone());
-            let mut columns = columns_by_table.remove(&key).ok_or_else(|| {
-                DbOperationError::MetadataParseFailed(format!(
-                    "MySQL object has no column metadata: {}.{}",
-                    table.schema, table.name
-                ))
-            })?;
-            if columns.is_empty() {
-                return Err(DbOperationError::MetadataParseFailed(format!(
-                    "MySQL object has no column metadata: {}.{}",
-                    table.schema, table.name
-                )));
-            }
-            columns.sort_by_key(|column| column.ordinal_position);
-            let unique_columns = unique_columns_by_table
-                .remove(&table.name)
-                .unwrap_or_default();
-            mark_single_column_unique(&mut columns, &unique_columns);
-            let primary_key = primary_key_names(&columns);
-            let foreign_keys = foreign_keys_from_metadata(
-                foreign_keys_by_table.remove(&key).unwrap_or_default(),
-                database,
-            )?;
-            let detail = Table {
-                schema: table.schema.clone(),
-                name: table.name.clone(),
-                owner: None,
-                columns: columns.iter().map(column_from_metadata).collect(),
-                primary_key: (!primary_key.is_empty()).then_some(primary_key),
-                foreign_keys,
-                indexes: Vec::new(),
-                rls: None,
-                triggers: Vec::new(),
-                row_count_estimate: table.row_count_estimate,
-                comment: table.comment.clone(),
-                source_ddl: None,
-                kind_info: TableKindInfo {
-                    kind: table.kind,
-                    is_strict: false,
-                    without_rowid: false,
-                    virtual_module: None,
-                },
-            };
-            Ok(TableSignature {
-                schema: table.schema.clone(),
-                name: table.name.clone(),
-                signature: table_signature(&detail),
-            })
-        })
-        .collect()
+    let mut signatures = Vec::with_capacity(tables.len());
+    let mut table_details = Vec::with_capacity(tables.len());
+    for table in tables {
+        let key = (table.schema.clone(), table.name.clone());
+        let mut columns = columns_by_table.remove(&key).ok_or_else(|| {
+            DbOperationError::MetadataParseFailed(format!(
+                "MySQL object has no column metadata: {}.{}",
+                table.schema, table.name
+            ))
+        })?;
+        if columns.is_empty() {
+            return Err(DbOperationError::MetadataParseFailed(format!(
+                "MySQL object has no column metadata: {}.{}",
+                table.schema, table.name
+            )));
+        }
+        columns.sort_by_key(|column| column.ordinal_position);
+        let unique_columns = unique_columns_by_table
+            .remove(&table.name)
+            .unwrap_or_default();
+        mark_single_column_unique(&mut columns, &unique_columns);
+        let primary_key = primary_key_names(&columns);
+        let foreign_keys = foreign_keys_from_metadata(
+            foreign_keys_by_table.remove(&key).unwrap_or_default(),
+            database,
+        )?;
+        let detail = Table {
+            schema: table.schema.clone(),
+            name: table.name.clone(),
+            owner: None,
+            columns: columns.iter().map(column_from_metadata).collect(),
+            primary_key: (!primary_key.is_empty()).then_some(primary_key),
+            foreign_keys,
+            indexes: Vec::new(),
+            rls: None,
+            triggers: Vec::new(),
+            row_count_estimate: None,
+            comment: None,
+            source_ddl: None,
+            kind_info: TableKindInfo {
+                kind: table.kind,
+                is_strict: false,
+                without_rowid: false,
+                virtual_module: None,
+            },
+        };
+        signatures.push(TableSignature {
+            schema: table.schema.clone(),
+            name: table.name.clone(),
+            signature: table_signature(&detail),
+        });
+        table_details.push(detail);
+    }
+    Ok(TableSignatureSnapshot {
+        signatures,
+        table_details,
+    })
 }
 
 fn table_signature(table: &Table) -> String {
@@ -583,13 +601,26 @@ mod tests {
             table_signatures_from_metadata(&tables, "App", columns, foreign_keys, HashMap::new())
                 .unwrap();
 
-        assert_eq!(signatures.len(), 2);
-        assert_eq!(signatures[0].qualified_name(), "App.child");
-        assert!(signatures[0].signature.contains("id"));
-        assert!(signatures[0].signature.contains("fk_child_parent"));
+        assert_eq!(signatures.signatures.len(), 2);
+        assert_eq!(signatures.table_details.len(), 2);
+        assert_eq!(signatures.signatures[0].qualified_name(), "App.child");
+        assert!(signatures.signatures[0].signature.contains("id"));
+        assert!(
+            signatures.signatures[0]
+                .signature
+                .contains("fk_child_parent")
+        );
+        let child = &signatures.table_details[0];
+        assert_eq!(child.columns.len(), 2);
+        assert!(child.columns[1].is_unique());
+        assert_eq!(child.foreign_keys.len(), 1);
+        assert!(child.indexes.is_empty());
+        assert!(child.triggers.is_empty());
+        assert!(child.row_count_estimate.is_none());
+        assert!(child.comment.is_none());
         assert_ne!(
-            signatures[0].signature,
-            signatures_without_unique[0].signature
+            signatures.signatures[0].signature,
+            signatures_without_unique.signatures[0].signature
         );
     }
 
@@ -611,5 +642,122 @@ mod tests {
             DbOperationError::MetadataParseFailed(message)
                 if message.contains("no column metadata: app.users")
         ));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod session_tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn fake_signature_cli() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let program = directory.path().join("mysql-signature");
+        let transcript = directory.path().join("transcript.log");
+        std::fs::write(&transcript, "").unwrap();
+        let script = r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+transcript=$(dirname "$0")/transcript.log
+printf 'option=%s\nprocess=%s\n' "$option" "$$" >> "$transcript"
+trap 'printf "exit=%s\n" "$?" >> "$transcript"' EXIT
+eof=$(printf '\004')
+while IFS= read -r line; do
+  printf 'query=%s\n' "$line" >> "$transcript"
+  [ "$line" = "$eof" ] && exit 0
+  [ "$line" = ";" ] && continue
+    case "$line" in
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_probe.*/\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      ;;
+    *"SET SESSION TRANSACTION READ ONLY")
+      ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_session_marker.*/\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      ;;
+    *COLUMNS*)
+      printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">items</field><field name="COLUMN_NAME">id</field><field name="COLUMN_TYPE">int</field><field name="IS_NULLABLE">NO</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA"></field><field name="COLUMN_COMMENT" xsi:nil="true"/><field name="ORDINAL_POSITION">1</field><field name="PRIMARY_KEY_POSITION">1</field></row></resultset>'
+      ;;
+    *REFERENTIAL_CONSTRAINTS*)
+      printf '%s\n' '<resultset></resultset>'
+      ;;
+    *"GROUP BY s.TABLE_NAME"*)
+      printf '%s\n' '<resultset></resultset>'
+      ;;
+    *TABLES*)
+      printf '%s\n' '<resultset><row><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">items</field><field name="TABLE_TYPE">BASE TABLE</field><field name="TABLE_ROWS">1</field><field name="TABLE_COMMENT">table comment</field></row></resultset>'
+      ;;
+    *)
+      printf '%s\n' '<resultset></resultset>'
+      ;;
+  esac
+done
+"#;
+        std::fs::write(&program, script).unwrap();
+        let mut permissions = std::fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, transcript)
+    }
+
+    fn assert_process_stopped(transcript: &std::path::Path) {
+        for _ in 0..200 {
+            let pid = std::fs::read_to_string(transcript)
+                .unwrap()
+                .lines()
+                .find_map(|line| line.strip_prefix("process=")?.parse::<libc::pid_t>().ok());
+            if let Some(pid) = pid
+                && unsafe { libc::kill(pid, 0) } == -1
+            {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        panic!(
+            "fake mysql process is alive or did not start: {}",
+            std::fs::read_to_string(transcript).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn signature_metadata_uses_one_process_and_four_metadata_queries() {
+        let (_directory, program, transcript) = fake_signature_cli();
+        let snapshot = fetch_table_signatures_with_program(
+            "mysql://user:password@localhost:3306/app",
+            OsStr::new(&program),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "fake signature metadata CLI failed: {error:?}\n{}",
+                std::fs::read_to_string(&transcript).unwrap()
+            )
+        });
+
+        assert_eq!(snapshot.signatures.len(), 1);
+        assert_eq!(snapshot.table_details.len(), 1);
+        let transcript_text = std::fs::read_to_string(&transcript).unwrap();
+        assert_eq!(
+            transcript_text
+                .lines()
+                .filter(|line| line.starts_with("process="))
+                .count(),
+            1
+        );
+        assert_eq!(
+            transcript_text
+                .lines()
+                .filter(|line| {
+                    line.starts_with("query=") && line.contains("INFORMATION_SCHEMA")
+                })
+                .count(),
+            4
+        );
+        assert_process_stopped(&transcript);
     }
 }

--- a/src/infra/adapters/postgres/metadata.rs
+++ b/src/infra/adapters/postgres/metadata.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
-use crate::domain::{Column, DatabaseMetadata, Table, TableKindInfo, TableSignature};
+use crate::domain::{Column, DatabaseMetadata, Table, TableKindInfo, TableSignatureSnapshot};
 
 use super::PostgresAdapter;
 
@@ -46,11 +46,14 @@ impl MetadataProvider for PostgresAdapter {
     async fn fetch_table_signatures(
         &self,
         dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
+    ) -> Result<TableSignatureSnapshot, DbOperationError> {
         let json = self
             .execute_query(dsn, Self::table_signatures_query())
             .await?;
-        Self::parse_table_signatures(&json)
+        Ok(TableSignatureSnapshot {
+            signatures: Self::parse_table_signatures(&json)?,
+            table_details: Vec::new(),
+        })
     }
 
     async fn fetch_table_detail(

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -8,7 +8,7 @@ use crate::app::ports::outbound::{
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
 use crate::domain::{
     DatabaseMetadata, DiagnosticField, QueryResult, QueryValue, SqliteDiagnosticsSnapshot, Table,
-    TableSignature, WriteExecutionResult,
+    TableSignatureSnapshot, WriteExecutionResult,
 };
 use async_trait::async_trait;
 
@@ -132,7 +132,7 @@ impl MetadataProvider for DbAdapterRegistry {
     async fn fetch_table_signatures(
         &self,
         dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
+    ) -> Result<TableSignatureSnapshot, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_table_signatures(dsn).await,
             DatabaseType::SQLite => self.sqlite.fetch_table_signatures(dsn).await,
@@ -544,7 +544,7 @@ mod tests {
 
         let signatures = registry.fetch_table_signatures(&dsn).await.unwrap();
 
-        assert_eq!(signatures[0].qualified_name(), "main.users");
+        assert_eq!(signatures.signatures[0].qualified_name(), "main.users");
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/metadata/mod.rs
+++ b/src/infra/adapters/sqlite/metadata/mod.rs
@@ -8,7 +8,7 @@ mod trigger;
 use async_trait::async_trait;
 
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
-use crate::domain::{DatabaseMetadata, Table, TableSignature};
+use crate::domain::{DatabaseMetadata, Table, TableSignatureSnapshot};
 
 use super::sqlite3::metadata::RawNamedTableMetadata;
 use super::{SqliteAdapter, schema::MAIN_SCHEMA};
@@ -60,16 +60,21 @@ impl MetadataProvider for SqliteAdapter {
     async fn fetch_table_signatures(
         &self,
         dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
+    ) -> Result<TableSignatureSnapshot, DbOperationError> {
         let rows = self
             .fetch_table_signature_rows(Self::path_from_dsn(dsn)?)
             .await?;
-        rows.into_iter()
+        let signatures = rows
+            .into_iter()
             .map(|RawNamedTableMetadata { name, metadata }| {
                 let detail = table_from_metadata(&name, TableDetailMode::Signature, metadata)?;
                 Ok(signature::signature_for_table(&detail))
             })
-            .collect()
+            .collect::<Result<Vec<_>, DbOperationError>>()?;
+        Ok(TableSignatureSnapshot {
+            signatures,
+            table_details: Vec::new(),
+        })
     }
 }
 

--- a/src/infra/adapters/sqlite/metadata/signature_tests.rs
+++ b/src/infra/adapters/sqlite/metadata/signature_tests.rs
@@ -25,7 +25,7 @@ mod table_signatures {
 
         let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
 
-        assert_eq!(signatures.len(), 3);
+        assert_eq!(signatures.signatures.len(), 3);
         assert_eq!(process_counter.count(), 1);
     }
 
@@ -41,12 +41,17 @@ mod table_signatures {
 
         let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
         let names: Vec<_> = signatures
+            .signatures
             .iter()
             .map(|signature| signature.name.as_str())
             .collect();
 
         assert_eq!(names, ["notes_fts", "users"]);
-        assert!(signatures[0].signature.contains("CREATE VIRTUAL TABLE"));
+        assert!(
+            signatures.signatures[0]
+                .signature
+                .contains("CREATE VIRTUAL TABLE")
+        );
     }
 
     #[tokio::test]
@@ -57,10 +62,18 @@ mod table_signatures {
 
         let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
 
-        assert_eq!(signatures.len(), 1);
-        assert_eq!(signatures[0].qualified_name(), "main.users");
-        assert!(signatures[0].signature.contains("CREATE TABLE users"));
-        assert!(signatures[0].signature.contains("col=id:INTEGER"));
+        assert_eq!(signatures.signatures.len(), 1);
+        assert_eq!(signatures.signatures[0].qualified_name(), "main.users");
+        assert!(
+            signatures.signatures[0]
+                .signature
+                .contains("CREATE TABLE users")
+        );
+        assert!(
+            signatures.signatures[0]
+                .signature
+                .contains("col=id:INTEGER")
+        );
     }
 
     #[tokio::test]
@@ -79,6 +92,7 @@ mod table_signatures {
 
         let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
         let signature = signatures
+            .signatures
             .iter()
             .find(|signature| signature.name == "users")
             .unwrap();
@@ -104,6 +118,7 @@ mod table_signatures {
 
         let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
         let signature = signatures
+            .signatures
             .iter()
             .find(|signature| signature.name == "child")
             .expect("child table signature");
@@ -147,6 +162,7 @@ mod table_signatures {
             .fetch_table_signatures(&asc_dsn)
             .await
             .unwrap()
+            .signatures
             .into_iter()
             .find(|signature| signature.name == "users")
             .unwrap()
@@ -155,6 +171,7 @@ mod table_signatures {
             .fetch_table_signatures(&desc_dsn)
             .await
             .unwrap()
+            .signatures
             .into_iter()
             .find(|signature| signature.name == "users")
             .unwrap()
@@ -163,6 +180,7 @@ mod table_signatures {
             .fetch_table_signatures(&binary_dsn)
             .await
             .unwrap()
+            .signatures
             .into_iter()
             .find(|signature| signature.name == "users")
             .unwrap()
@@ -171,6 +189,7 @@ mod table_signatures {
             .fetch_table_signatures(&nocase_dsn)
             .await
             .unwrap()
+            .signatures
             .into_iter()
             .find(|signature| signature.name == "users")
             .unwrap()
@@ -206,6 +225,7 @@ mod table_signatures {
 
         let before = adapter.fetch_table_signatures(&dsn).await.unwrap();
         let before_signature = before
+            .signatures
             .iter()
             .find(|signature| signature.name == "users")
             .unwrap()
@@ -219,6 +239,7 @@ mod table_signatures {
 
         let after = adapter.fetch_table_signatures(&dsn).await.unwrap();
         let after_signature = &after
+            .signatures
             .iter()
             .find(|signature| signature.name == "users")
             .unwrap()

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -513,6 +513,7 @@ mod metadata_fetch {
                     .await
                     .map_err(|error| format!("{error:?}"))?;
                 let child_signature = signatures
+                    .signatures
                     .iter()
                     .find(|signature| signature.name == MYSQL_FK_CHILD)
                     .ok_or_else(|| "MySQL child signature was not returned".to_string())?;
@@ -634,7 +635,7 @@ mod metadata_fetch {
                     .fetch_table_signatures(db.dsn())
                     .await
                     .map_err(|error| format!("failed to fetch changed signatures: {error:?}"))?;
-                if before == after_add {
+                if before.signatures == after_add.signatures {
                     return Err("single unique index did not change the table signature".to_string());
                 }
 
@@ -651,7 +652,7 @@ mod metadata_fetch {
                     .fetch_table_signatures(db.dsn())
                     .await
                     .map_err(|error| format!("failed to fetch restored signatures: {error:?}"))?;
-                if before != after_drop {
+                if before.signatures != after_drop.signatures {
                     return Err("dropping the single unique index did not restore the signature".to_string());
                 }
                 Ok(())


### PR DESCRIPTION
## Problem

Smart ER's first generation refetched TABLES, COLUMNS, UNIQUE, and foreign-key metadata for every table even though the MySQL signature session had already fetched the reusable parts.

## Background

The signature fallback introduced for SAB-512 must remain available when signature acquisition fails.

## Approach

The signature metadata boundary now returns signatures with lightweight table details. MySQL derives both from the existing four result sets, and a DSN/run-gated ER effect seeds the existing completion cache before calculating the differential refresh. PostgreSQL and SQLite continue to return signatures without seeded details.

The focused fake-CLI measurement is one session and four metadata queries for both the per-table completion fetch and the batched signature fetch. For an initial N-table ER, this changes the full path from 5 + 4N queries and 2 + N sessions to 5 queries and 2 sessions.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-526/mysqlのer初回生成でsignature-metadataを再利用する
