### PR TITLE
fix(mysql): centralize port validation

### DIFF
--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -161,9 +161,6 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                 )?)?),
             ),
             DatabaseType::MySQL => {
-                if entry.port == Some(0) {
-                    return Err(ConnectionProfileError::InvalidMySqlPort);
-                }
                 let database = entry.database.clone().filter(|value| !value.is_empty());
                 Self::with_id_and_config(
                     id,


### PR DESCRIPTION
## Summary

Remove the duplicate MySQL port-zero precheck from configuration conversion so ConnectionProfile::with_id_and_config remains the single validation boundary.

Linear: https://linear.app/sabiql/issue/SAB-522/mysqlのport-0検証をドメイン境界へ一本化する

## Tests

- CARGO_TARGET_DIR=target-sab-522 RUSTC_WRAPPER= cargo test -p sabiql-infra connection_config
- CARGO_TARGET_DIR=target-sab-522 RUSTC_WRAPPER= cargo test -p sabiql-domain profile
- CARGO_TARGET_DIR=target-sab-522 RUSTC_WRAPPER= cargo clippy -p sabiql-infra --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- bash scripts/lint_all.sh