### PR TITLE
fix: cancel stale metadata tasks

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::effect::Effect;
+use crate::cmd::metadata_task::MetadataTaskRegistry;
 use crate::cmd::query_task::TableDetailTaskRegistry;
 use crate::cmd::sqlite_path_validate::validate_sqlite_database_path;
 use crate::domain::DatabaseMetadata;
@@ -16,6 +17,10 @@ use crate::policy::sqlite_path::to_db_operation_error;
 use crate::ports::outbound::{DbOperationError, MetadataProvider, SqlitePathValidator};
 use crate::update::action::Action;
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "metadata effects use separate task registries for table details and connection context"
+)]
 pub async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
@@ -23,6 +28,7 @@ pub async fn run(
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     sqlite_path_validator: &Arc<dyn SqlitePathValidator>,
     table_detail_tasks: &TableDetailTaskRegistry,
+    metadata_tasks: &Arc<MetadataTaskRegistry>,
     _state: &mut AppState,
     completion_engine: &RefCell<CompletionEngine>,
 ) -> Result<()> {
@@ -33,13 +39,14 @@ pub async fn run(
                 metadata_provider,
                 metadata_cache,
                 sqlite_path_validator,
+                metadata_tasks,
                 dsn,
                 run_id,
             )
             .await
         }
         Effect::FetchEffectiveUser { dsn, run_id } => {
-            fetch_effective_user(action_tx, metadata_provider, dsn, run_id);
+            fetch_effective_user(action_tx, metadata_provider, metadata_tasks, dsn, run_id);
             Ok(())
         }
         Effect::FetchTableDetail {
@@ -71,6 +78,7 @@ pub async fn run(
                 action_tx,
                 metadata_provider,
                 completion_engine,
+                metadata_tasks,
                 dsn,
                 run_id,
                 schema,
@@ -87,7 +95,7 @@ pub async fn run(
         }
         Effect::DelayedProcessPrefetchQueue { run_id, delay_secs } => {
             let tx = action_tx.clone();
-            tokio::spawn(async move {
+            MetadataTaskRegistry::spawn(metadata_tasks, async move {
                 tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
                 tx.send(Action::ProcessPrefetchQueue { run_id }).await.ok();
             });
@@ -107,6 +115,7 @@ async fn fetch_metadata(
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     sqlite_path_validator: &Arc<dyn SqlitePathValidator>,
+    metadata_tasks: &Arc<MetadataTaskRegistry>,
     dsn: String,
     run_id: u64,
 ) -> Result<()> {
@@ -141,7 +150,7 @@ async fn fetch_metadata(
     let cache = metadata_cache.clone();
     let tx = action_tx.clone();
 
-    tokio::spawn(async move {
+    MetadataTaskRegistry::spawn(metadata_tasks, async move {
         match provider.fetch_metadata(&dsn).await {
             Ok(metadata) => {
                 let metadata = Arc::new(metadata);
@@ -172,13 +181,14 @@ async fn fetch_metadata(
 fn fetch_effective_user(
     action_tx: &mpsc::Sender<Action>,
     metadata_provider: &Arc<dyn MetadataProvider>,
+    metadata_tasks: &Arc<MetadataTaskRegistry>,
     dsn: String,
     run_id: u64,
 ) {
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
 
-    tokio::spawn(async move {
+    MetadataTaskRegistry::spawn(metadata_tasks, async move {
         let effective_user = provider.fetch_effective_user(&dsn).await.ok().flatten();
         tx.send(Action::EffectiveUserLoaded {
             dsn,
@@ -233,6 +243,7 @@ async fn prefetch_table_detail(
     action_tx: &mpsc::Sender<Action>,
     metadata_provider: &Arc<dyn MetadataProvider>,
     completion_engine: &RefCell<CompletionEngine>,
+    metadata_tasks: &Arc<MetadataTaskRegistry>,
     dsn: String,
     run_id: u64,
     schema: String,
@@ -257,7 +268,7 @@ async fn prefetch_table_detail(
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
 
-    tokio::spawn(async move {
+    MetadataTaskRegistry::spawn(metadata_tasks, async move {
         let result = tokio::time::timeout(
             tokio::time::Duration::from_secs(10),
             provider.fetch_table_columns_and_fks(&dsn, &schema, &table),

--- a/src/app/cmd/metadata_task.rs
+++ b/src/app/cmd/metadata_task.rs
@@ -1,0 +1,199 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+
+use tokio::task::JoinHandle;
+
+struct TaskEntry {
+    completed: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+#[derive(Default)]
+pub struct MetadataTaskRegistry {
+    active: Mutex<HashMap<u64, TaskEntry>>,
+    next_id: AtomicU64,
+}
+
+impl MetadataTaskRegistry {
+    pub fn spawn<F>(registry: &Arc<Self>, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let task_id = registry.next_id.fetch_add(1, Ordering::Relaxed);
+        let completed = Arc::new(AtomicBool::new(false));
+        registry
+            .active
+            .lock()
+            .expect("metadata task registry lock poisoned")
+            .insert(
+                task_id,
+                TaskEntry {
+                    completed: Arc::clone(&completed),
+                    handle: None,
+                },
+            );
+
+        let completion = TaskCompletion {
+            registry: Arc::downgrade(registry),
+            task_id,
+            completed: Arc::clone(&completed),
+        };
+        let handle = tokio::spawn(async move {
+            let _completion = completion;
+            task.await;
+        });
+
+        let mut handle = Some(handle);
+        let abort = {
+            let mut active = registry
+                .active
+                .lock()
+                .expect("metadata task registry lock poisoned");
+            match active.get_mut(&task_id) {
+                Some(entry) if !completed.load(Ordering::SeqCst) => {
+                    entry.handle = handle.take();
+                    false
+                }
+                Some(_) | None => {
+                    active.remove(&task_id);
+                    true
+                }
+            }
+        };
+
+        if abort {
+            handle
+                .take()
+                .expect("metadata task handle should be available")
+                .abort();
+        }
+    }
+
+    pub async fn cancel(&self) {
+        let handles = self
+            .active
+            .lock()
+            .expect("metadata task registry lock poisoned")
+            .drain()
+            .filter_map(|(_, entry)| entry.handle)
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
+    fn remove_completed(&self, task_id: u64, completed: &Arc<AtomicBool>) {
+        let mut active = self
+            .active
+            .lock()
+            .expect("metadata task registry lock poisoned");
+        let should_remove = active
+            .get(&task_id)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.completed, completed));
+        if should_remove {
+            active.remove(&task_id);
+        }
+    }
+}
+
+impl Drop for MetadataTaskRegistry {
+    fn drop(&mut self) {
+        let active = self
+            .active
+            .get_mut()
+            .expect("metadata task registry lock poisoned");
+        for entry in active.values_mut() {
+            if let Some(handle) = entry.handle.take() {
+                handle.abort();
+            }
+        }
+    }
+}
+
+struct TaskCompletion {
+    registry: Weak<MetadataTaskRegistry>,
+    task_id: u64,
+    completed: Arc<AtomicBool>,
+}
+
+impl Drop for TaskCompletion {
+    fn drop(&mut self) {
+        self.completed.store(true, Ordering::SeqCst);
+        if let Some(registry) = self.registry.upgrade() {
+            registry.remove_completed(self.task_id, &self.completed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::oneshot;
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+
+    struct DropSignal(Arc<AtomicUsize>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn tracks_four_concurrent_prefetch_tasks_and_cleans_them_up() {
+        let registry = Arc::new(MetadataTaskRegistry::default());
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let mut started = Vec::new();
+
+        for _ in 0..4 {
+            let (started_tx, started_rx) = oneshot::channel();
+            started.push(started_rx);
+            let guard = DropSignal(Arc::clone(&dropped));
+            MetadataTaskRegistry::spawn(&registry, async move {
+                let _guard = guard;
+                started_tx.send(()).ok();
+                pending::<()>().await;
+            });
+        }
+
+        for signal in started {
+            signal.await.expect("prefetch task should start");
+        }
+        assert_eq!(registry.active.lock().unwrap().len(), 4);
+
+        registry.cancel().await;
+
+        timeout(Duration::from_secs(1), async {
+            while dropped.load(Ordering::SeqCst) != 4 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("all prefetch tasks should be dropped");
+        assert!(registry.active.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn removes_completed_task_from_registry() {
+        let registry = Arc::new(MetadataTaskRegistry::default());
+        let (done_tx, done_rx) = oneshot::channel();
+        MetadataTaskRegistry::spawn(&registry, async move {
+            done_tx.send(()).ok();
+        });
+
+        done_rx.await.expect("task should complete");
+        timeout(Duration::from_secs(1), async {
+            while !registry.active.lock().unwrap().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("completed task should be removed");
+    }
+}

--- a/src/app/cmd/mod.rs
+++ b/src/app/cmd/mod.rs
@@ -5,6 +5,7 @@ pub mod completion_engine;
 pub mod connection;
 pub mod effect;
 pub mod er;
+mod metadata_task;
 mod query_task;
 pub mod render_schedule;
 pub mod runner;

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -14,6 +14,7 @@ use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::connection as cmd_connection;
 use crate::cmd::effect::Effect;
 use crate::cmd::er::handler as cmd_er;
+use crate::cmd::metadata_task::MetadataTaskRegistry;
 use crate::cmd::query_task::{QueryTaskRegistry, TableDetailTaskRegistry};
 use crate::cmd::settings as cmd_settings;
 use crate::cmd::sql_editor::completion as cmd_completion;
@@ -73,6 +74,7 @@ pub struct EffectRunner {
     action_tx: mpsc::Sender<Action>,
     query_tasks: QueryTaskRegistry,
     table_detail_tasks: TableDetailTaskRegistry,
+    metadata_tasks: Arc<MetadataTaskRegistry>,
 }
 
 impl EffectRunner {
@@ -97,6 +99,7 @@ impl EffectRunner {
             action_tx,
             query_tasks: QueryTaskRegistry::default(),
             table_detail_tasks: TableDetailTaskRegistry::default(),
+            metadata_tasks: Arc::new(MetadataTaskRegistry::default()),
         }
     }
 
@@ -104,9 +107,14 @@ impl EffectRunner {
         &self.action_tx
     }
 
-    fn cancel_active_tasks(&self) {
+    async fn cancel_metadata_tasks(&self) {
+        self.metadata_tasks.cancel().await;
+    }
+
+    async fn cancel_active_tasks(&self) {
         self.query_tasks.cancel();
         self.table_detail_tasks.cancel();
+        self.cancel_metadata_tasks().await;
     }
 
     pub async fn run<T: Renderer>(
@@ -183,6 +191,15 @@ impl EffectRunner {
             | Effect::DeleteConnection { .. }
             | Effect::SwitchConnection { .. }
             | Effect::SwitchToService { .. }) => {
+                if matches!(
+                    &e,
+                    Effect::SaveAndConnect { .. }
+                        | Effect::ProbeMySqlConnection { .. }
+                        | Effect::SwitchConnection { .. }
+                        | Effect::SwitchToService { .. }
+                ) {
+                    self.cancel_metadata_tasks().await;
+                }
                 if matches!(&e, Effect::ProbeMySqlConnection { .. }) {
                     self.table_detail_tasks.cancel();
                 }
@@ -205,6 +222,9 @@ impl EffectRunner {
             | Effect::ProcessPrefetchQueue { .. }
             | Effect::DelayedProcessPrefetchQueue { .. }
             | Effect::CacheInvalidate { .. }) => {
+                if matches!(&e, Effect::FetchMetadata { .. }) {
+                    self.cancel_metadata_tasks().await;
+                }
                 cmd_browse::metadata::run(
                     e,
                     &self.action_tx,
@@ -212,6 +232,7 @@ impl EffectRunner {
                     &self.metadata_cache,
                     &self.connection.sqlite_path_validator,
                     &self.table_detail_tasks,
+                    &self.metadata_tasks,
                     state,
                     completion_engine,
                 )
@@ -220,7 +241,7 @@ impl EffectRunner {
             }
 
             Effect::CancelActiveTasks => {
-                self.cancel_active_tasks();
+                self.cancel_active_tasks().await;
                 Ok(vec![])
             }
 
@@ -818,6 +839,253 @@ mod tests {
             })
             .await
             .expect("context cancellation should drop the pending table detail task");
+        }
+    }
+
+    mod metadata_context_termination {
+        use std::future::pending;
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use tokio::sync::oneshot;
+        use tokio::time::{Duration, timeout};
+
+        use super::*;
+        use crate::domain::Table;
+        use crate::domain::connection::{ConnectionId, DatabaseType};
+        use crate::ports::outbound::DbOperationError;
+        use crate::update::action::ConnectionTarget;
+        use crate::update::reducer::reduce;
+
+        struct DropSignal(Arc<AtomicUsize>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        struct PendingMetadataProvider {
+            metadata_started: Mutex<Option<oneshot::Sender<()>>>,
+            effective_user_started: Mutex<Option<oneshot::Sender<()>>>,
+            dropped: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl MetadataProvider for PendingMetadataProvider {
+            async fn fetch_metadata(
+                &self,
+                _dsn: &str,
+            ) -> Result<DatabaseMetadata, DbOperationError> {
+                let _guard = DropSignal(Arc::clone(&self.dropped));
+                self.metadata_started
+                    .lock()
+                    .expect("metadata started signal lock poisoned")
+                    .take()
+                    .expect("metadata should start once")
+                    .send(())
+                    .ok();
+                pending().await
+            }
+
+            async fn fetch_effective_user(
+                &self,
+                _dsn: &str,
+            ) -> Result<Option<String>, DbOperationError> {
+                let _guard = DropSignal(Arc::clone(&self.dropped));
+                self.effective_user_started
+                    .lock()
+                    .expect("effective user started signal lock poisoned")
+                    .take()
+                    .expect("effective user should start once")
+                    .send(())
+                    .ok();
+                pending().await
+            }
+
+            async fn fetch_table_detail(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                unreachable!("test only starts metadata tasks")
+            }
+
+            async fn fetch_table_columns_and_fks(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                unreachable!("test only starts metadata tasks")
+            }
+
+            async fn fetch_table_signatures(
+                &self,
+                _dsn: &str,
+            ) -> Result<TableSignatureSnapshot, DbOperationError> {
+                unreachable!("test only starts metadata tasks")
+            }
+        }
+
+        struct ProbeThatObservesDrop {
+            metadata_dropped: Arc<AtomicUsize>,
+            started: Mutex<Option<oneshot::Sender<bool>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl MySqlConnectionProbe for ProbeThatObservesDrop {
+            async fn probe(&self, _dsn: &str) -> Result<(), DbOperationError> {
+                self.started
+                    .lock()
+                    .expect("probe started signal lock poisoned")
+                    .take()
+                    .expect("probe should start once")
+                    .send(self.metadata_dropped.load(Ordering::SeqCst) > 0)
+                    .ok();
+                Ok(())
+            }
+        }
+
+        #[tokio::test]
+        async fn drops_old_metadata_before_new_mysql_probe_starts() {
+            let (metadata_started_tx, metadata_started_rx) = oneshot::channel();
+            let (probe_started_tx, probe_started_rx) = oneshot::channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let metadata_provider = PendingMetadataProvider {
+                metadata_started: Mutex::new(Some(metadata_started_tx)),
+                effective_user_started: Mutex::new(None),
+                dropped: Arc::clone(&dropped),
+            };
+            let probe = ProbeThatObservesDrop {
+                metadata_dropped: Arc::clone(&dropped),
+                started: Mutex::new(Some(probe_started_tx)),
+            };
+            let (action_tx, _action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn_and_probe(
+                Arc::new(metadata_provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+                Arc::new(test_fixtures::NoopDsnBuilder),
+                Arc::new(probe),
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::FetchMetadata {
+                        dsn: "postgres://localhost/old".to_string(),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            metadata_started_rx.await.expect("metadata should start");
+
+            runner
+                .run(
+                    vec![Effect::ProbeMySqlConnection {
+                        target: ConnectionTarget {
+                            id: ConnectionId::new(),
+                            dsn: "mysql://localhost/new".to_string(),
+                            name: "new".to_string(),
+                            database_type: DatabaseType::MySQL,
+                            database: Some("new".to_string()),
+                        },
+                        run_id: 2,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                probe_started_rx
+                    .await
+                    .expect("probe should start after cancellation")
+            );
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn quit_drops_effective_user_and_delayed_prefetch_tasks() {
+            let (effective_user_started_tx, effective_user_started_rx) = oneshot::channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let provider = PendingMetadataProvider {
+                metadata_started: Mutex::new(None),
+                effective_user_started: Mutex::new(Some(effective_user_started_tx)),
+                dropped: Arc::clone(&dropped),
+            };
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![
+                        Effect::FetchEffectiveUser {
+                            dsn: "postgres://localhost/current".to_string(),
+                            run_id: 1,
+                        },
+                        Effect::DelayedProcessPrefetchQueue {
+                            run_id: 1,
+                            delay_secs: 60,
+                        },
+                    ],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            effective_user_started_rx
+                .await
+                .expect("effective user should start");
+
+            let shutdown_effects = reduce(
+                &mut state,
+                Action::Quit,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            runner
+                .run(
+                    shutdown_effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert!(
+                timeout(Duration::from_millis(100), action_rx.recv())
+                    .await
+                    .is_err()
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Make `EffectRunner` own connection-scoped metadata futures for metadata loading, effective-user loading, table-detail prefetch, and delayed retry timers. Context cancellation now awaits provider future drops before new probes and cancels all metadata work on switch and exit, while preserving existing stale-action guards and table-detail cancellation.

Linear: [SAB-527](https://linear.app/sabiql/issue/SAB-527/接続切替時に古いmetadata-taskを停止する)

## Validation

- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/sabiql-sab527-target cargo test -p sabiql-app`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/sabiql-sab527-target cargo clippy -p sabiql-app --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/lint_all.sh`
