### PR TITLE
[SAB-520] Inline same-feature synchronous transitions

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -12,7 +12,6 @@ use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
-use crate::policy::write::write_guardrails::WritePreview;
 use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
@@ -639,7 +638,6 @@ pub enum Action {
     ResultCancelCellEdit,
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
-    OpenWritePreviewConfirm(Box<WritePreview>),
     CopyFailed(ClipboardError),
     OpenFolderFailed(FolderOpenError),
     ToggleFocus,

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -7,6 +7,17 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::check_er_completion;
 
+pub(super) fn expand_prefetch_with_fk_neighbors(state: &AppState, run_id: u64) -> Vec<Effect> {
+    if !state.sql_modal.is_current_prefetch_run(run_id) {
+        return vec![];
+    }
+    let seed_tables = state.er_preparation.seed_tables().to_vec();
+    vec![Effect::ExtractFkNeighbors {
+        run_id,
+        seed_tables,
+    }]
+}
+
 pub(super) fn reduce_er_neighbors(
     state: &mut AppState,
     action: &Action,
@@ -14,14 +25,7 @@ pub(super) fn reduce_er_neighbors(
 ) -> DispatchResult {
     match action {
         Action::ExpandPrefetchWithFkNeighbors { run_id } => {
-            if !state.sql_modal.is_current_prefetch_run(*run_id) {
-                return DispatchResult::handled();
-            }
-            let seed_tables = state.er_preparation.seed_tables().to_vec();
-            DispatchResult::handled_with(vec![Effect::ExtractFkNeighbors {
-                run_id: *run_id,
-                seed_tables,
-            }])
+            DispatchResult::handled_with(expand_prefetch_with_fk_neighbors(state, *run_id))
         }
         Action::FkNeighborsDiscovered { run_id, tables } => {
             if !state.sql_modal.is_current_prefetch_run(*run_id) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -20,9 +20,7 @@ pub(super) fn check_er_completion(state: &mut AppState, now: Instant) -> Vec<Eff
         let Some(run_id) = state.sql_modal.active_prefetch_run_id() else {
             return vec![];
         };
-        return vec![Effect::DispatchActions(vec![
-            Action::ExpandPrefetchWithFkNeighbors { run_id },
-        ])];
+        return er_neighbors::expand_prefetch_with_fk_neighbors(state, run_id);
     }
 
     if !state.er_preparation.has_failures() {
@@ -963,6 +961,36 @@ mod tests {
 
             assert!(state.er_preparation.fk_expanded());
         }
+
+        #[test]
+        fn process_queue_starts_prefetch_effects_without_action_redispatch() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            state.session.set_metadata(Some(make_metadata(2)));
+            dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now());
+            let run_id = state
+                .sql_modal
+                .active_prefetch_run_id()
+                .expect("prefetch run");
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert_eq!(effects.len(), 2);
+            assert!(
+                effects
+                    .iter()
+                    .all(|effect| matches!(effect, Effect::PrefetchTableDetail { .. }))
+            );
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::DispatchActions(_)))
+            );
+        }
     }
 
     mod start_prefetch_scoped {
@@ -1195,12 +1223,8 @@ mod tests {
 
             assert!(effects.iter().any(|e| matches!(
                 e,
-                Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(
-                        a,
-                        Action::ExpandPrefetchWithFkNeighbors { run_id: action_run_id }
-                            if *action_run_id == run_id
-                    ))
+                Effect::ExtractFkNeighbors { run_id: action_run_id, .. }
+                    if *action_run_id == run_id
             )));
         }
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -399,6 +399,39 @@ mod tests {
         }
 
         #[test]
+        fn process_queue_does_not_reprocess_requeued_backoff_table() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.sql_modal.begin_prefetch();
+            let qualified = "public.users".to_string();
+            state.sql_modal.fail_table_prefetch(
+                qualified.clone(),
+                FailedPrefetchEntry {
+                    failed_at: Instant::now(),
+                    error: "timeout".to_string(),
+                    retry_count: 1,
+                },
+            );
+            state.sql_modal.queue_table_prefetch(qualified.clone());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effects
+                    .iter()
+                    .filter(|effect| matches!(effect, Effect::DelayedProcessPrefetchQueue { .. }))
+                    .count(),
+                1
+            );
+            assert_eq!(state.sql_modal.take_next_prefetch(), Some(qualified));
+            assert!(!state.sql_modal.has_pending_prefetch());
+        }
+
+        #[test]
         fn no_dsn_requeues_without_marking_in_flight() {
             let mut state = AppState::new("test".to_string());
             let run_id = state.sql_modal.begin_prefetch();

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -170,11 +170,12 @@ pub(super) fn reduce_prefetch(
             let current_in_flight = state.sql_modal.prefetch_in_flight_count();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
 
+            let queued_tables: Vec<String> = (0..available_slots)
+                .filter_map(|_| state.sql_modal.take_next_prefetch())
+                .collect();
             let mut effects = Vec::new();
-            for _ in 0..available_slots {
-                if let Some(qualified_name) = state.sql_modal.take_next_prefetch()
-                    && let Some((schema, table)) = qualified_name.split_once('.')
-                {
+            for qualified_name in queued_tables {
+                if let Some((schema, table)) = qualified_name.split_once('.') {
                     effects.extend(prefetch_table_detail(state, *run_id, schema, table, now));
                 }
             }

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -24,6 +24,71 @@ fn completion_cache_capacity(table_count: usize) -> usize {
     table_count.clamp(MIN_COMPLETION_CACHE_CAPACITY, MAX_COMPLETION_CACHE_CAPACITY)
 }
 
+fn prefetch_table_detail(
+    state: &mut AppState,
+    run_id: u64,
+    schema: &str,
+    table: &str,
+    now: Instant,
+) -> Vec<Effect> {
+    if !state.sql_modal.is_current_prefetch_run(run_id) {
+        return vec![];
+    }
+    let qualified_name = format!("{schema}.{table}");
+
+    if state.sql_modal.is_table_prefetching(&qualified_name) {
+        return vec![];
+    }
+
+    if let Some(entry) = state.sql_modal.failed_prefetch(&qualified_name) {
+        if entry.retry_count >= MAX_PREFETCH_RETRIES {
+            let mut effects = if state.sql_modal.prefetch_tracks_er() {
+                state
+                    .er_preparation
+                    .on_table_failed(&qualified_name, entry.error.clone());
+                check_er_completion(state, now)
+            } else {
+                Vec::new()
+            };
+            if effects.is_empty()
+                && state.sql_modal.prefetch_tracks_er()
+                && state.er_preparation.is_waiting()
+            {
+                effects.push(Effect::ProcessPrefetchQueue { run_id });
+            }
+            return effects;
+        }
+
+        let backoff_secs = backoff_secs_for(entry.retry_count);
+        let elapsed = now.saturating_duration_since(entry.failed_at).as_secs();
+        if elapsed < backoff_secs {
+            let remaining = backoff_secs - elapsed;
+            state.sql_modal.queue_table_prefetch(qualified_name);
+            return vec![Effect::DelayedProcessPrefetchQueue {
+                run_id,
+                delay_secs: remaining,
+            }];
+        }
+    }
+
+    let Some(dsn) = state.session.dsn().map(String::from) else {
+        state.sql_modal.defer_table_prefetch(qualified_name);
+        return vec![];
+    };
+
+    state.sql_modal.start_table_prefetch(qualified_name.clone());
+    if state.sql_modal.prefetch_tracks_er() {
+        state.er_preparation.start_fetching(&qualified_name);
+    }
+
+    vec![Effect::PrefetchTableDetail {
+        dsn,
+        run_id,
+        schema: schema.to_string(),
+        table: table.to_string(),
+    }]
+}
+
 pub(super) fn reduce_prefetch(
     state: &mut AppState,
     action: &Action,
@@ -105,23 +170,19 @@ pub(super) fn reduce_prefetch(
             let current_in_flight = state.sql_modal.prefetch_in_flight_count();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
 
-            let mut actions = Vec::new();
+            let mut effects = Vec::new();
             for _ in 0..available_slots {
                 if let Some(qualified_name) = state.sql_modal.take_next_prefetch()
                     && let Some((schema, table)) = qualified_name.split_once('.')
                 {
-                    actions.push(Action::PrefetchTableDetail {
-                        run_id: *run_id,
-                        schema: schema.to_string(),
-                        table: table.to_string(),
-                    });
+                    effects.extend(prefetch_table_detail(state, *run_id, schema, table, now));
                 }
             }
 
-            if actions.is_empty() {
+            if effects.is_empty() {
                 DispatchResult::handled()
             } else {
-                DispatchResult::handled_with(vec![Effect::DispatchActions(actions)])
+                DispatchResult::handled_with(effects)
             }
         }
 
@@ -130,68 +191,7 @@ pub(super) fn reduce_prefetch(
             schema,
             table,
         } => {
-            if !state.sql_modal.is_current_prefetch_run(*run_id) {
-                return DispatchResult::handled();
-            }
-            let qualified_name = format!("{schema}.{table}");
-
-            if state.sql_modal.is_table_prefetching(&qualified_name) {
-                return DispatchResult::handled();
-            }
-
-            if let Some(entry) = state.sql_modal.failed_prefetch(&qualified_name) {
-                if entry.retry_count >= MAX_PREFETCH_RETRIES {
-                    // Exceeded retry limit — give up, don't re-queue
-                    let mut effects = if state.sql_modal.prefetch_tracks_er() {
-                        state
-                            .er_preparation
-                            .on_table_failed(&qualified_name, entry.error.clone());
-                        check_er_completion(state, now)
-                    } else {
-                        Vec::new()
-                    };
-                    // No fetch started → no completion event to re-drive the queue.
-                    if effects.is_empty()
-                        && state.sql_modal.prefetch_tracks_er()
-                        && state.er_preparation.is_waiting()
-                    {
-                        effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
-                    }
-                    return DispatchResult::handled_with(effects);
-                }
-
-                let backoff_secs = backoff_secs_for(entry.retry_count);
-                let elapsed = now.saturating_duration_since(entry.failed_at).as_secs();
-                if elapsed < backoff_secs {
-                    // Still in backoff — re-queue at tail and schedule a delayed retry
-                    // to avoid busy-looping while waiting for the backoff to expire.
-                    let remaining = backoff_secs - elapsed;
-                    state.sql_modal.queue_table_prefetch(qualified_name);
-                    return DispatchResult::handled_with(vec![
-                        Effect::DelayedProcessPrefetchQueue {
-                            run_id: *run_id,
-                            delay_secs: remaining,
-                        },
-                    ]);
-                }
-            }
-
-            let Some(dsn) = state.session.dsn().map(String::from) else {
-                state.sql_modal.defer_table_prefetch(qualified_name);
-                return DispatchResult::handled();
-            };
-
-            state.sql_modal.start_table_prefetch(qualified_name.clone());
-            if state.sql_modal.prefetch_tracks_er() {
-                state.er_preparation.start_fetching(&qualified_name);
-            }
-
-            DispatchResult::handled_with(vec![Effect::PrefetchTableDetail {
-                dsn,
-                run_id: *run_id,
-                schema: schema.clone(),
-                table: table.clone(),
-            }])
+            DispatchResult::handled_with(prefetch_table_detail(state, *run_id, schema, table, now))
         }
 
         Action::TableDetailCached {

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -15,11 +15,13 @@ use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::command::{command_to_action, parse_command};
 
+use super::write;
+
 pub fn reduce_execution(
     state: &mut AppState,
     action: &Action,
     now: Instant,
-    _services: &AppServices,
+    services: &AppServices,
 ) -> DispatchResult {
     match action {
         Action::QueryCompleted {
@@ -190,7 +192,9 @@ pub fn reduce_execution(
                     )])]
                 }
                 Action::SubmitCellEditWrite => {
-                    vec![Effect::DispatchActions(vec![Action::SubmitCellEditWrite])]
+                    write::reduce_write(state, &Action::SubmitCellEditWrite, now, services)
+                        .into_effects()
+                        .unwrap_or_default()
                 }
                 _ => vec![],
             })
@@ -361,6 +365,37 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::CellEdit);
             assert!(!state.should_quit);
+        }
+
+        #[test]
+        fn submit_write_enters_confirm_dialog_without_action_redispatch() {
+            let mut state = create_test_state();
+            state.query.set_current_result(editable_preview_result());
+            state
+                .session
+                .set_table_detail_raw(Some(users_table_detail()));
+            state.query.pagination.reset_for_table("public", "users");
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, "Alice".to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft("Bob".to_string());
+            state.modal.push_mode(InputMode::CommandLine);
+            state.command_line_input.set_content("write".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::CommandLineSubmit,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+            assert!(state.result_interaction.pending_write_preview().is_some());
         }
 
         #[test]

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -188,9 +188,7 @@ pub fn reduce_write(
                             result.target_row,
                             staged_count,
                         );
-                        return DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
-                            Action::OpenWritePreviewConfirm(Box::new(result.preview)),
-                        ])]);
+                        return open_write_preview_confirm(state, &result.preview, now);
                     }
                     Err(err) => {
                         state.messages.set_error_at(err.to_string(), now);
@@ -208,61 +206,12 @@ pub fn reduce_write(
             }
 
             match build_update_preview(state, services) {
-                Ok(preview) => DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
-                    Action::OpenWritePreviewConfirm(Box::new(preview)),
-                ])]),
+                Ok(preview) => open_write_preview_confirm(state, &preview, now),
                 Err(err) => {
                     state.messages.set_error_at(err.to_string(), now);
                     DispatchResult::handled()
                 }
             }
-        }
-
-        Action::OpenWritePreviewConfirm(preview) => {
-            if state.session.is_read_only() {
-                state.messages.set_error_at(
-                    "Read-only mode: write operations are disabled".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
-            }
-            state
-                .result_interaction
-                .set_write_preview((**preview).clone());
-            let operation = preview.operation;
-            let title = match operation {
-                WriteOperation::Update => {
-                    state.query.clear_delete_refresh_target();
-                    format!("Confirm UPDATE: {}", preview.target_summary.table)
-                }
-                WriteOperation::Delete => {
-                    let n = state
-                        .query
-                        .pending_delete_refresh_target()
-                        .map_or(1, |target| target.expected_delete_count);
-                    format!(
-                        "Confirm DELETE: {} {} from {}",
-                        n,
-                        if n == 1 { "row" } else { "rows" },
-                        preview.target_summary.table
-                    )
-                }
-            };
-
-            state.confirm_dialog.open(
-                title,
-                build_write_preview_fallback_message(preview),
-                ConfirmIntent::ExecuteWrite {
-                    sql: preview.sql.clone(),
-                    blocked: preview.guardrail.blocked,
-                },
-            );
-            if matches!(operation, WriteOperation::Delete) {
-                state.modal.set_mode(InputMode::Normal);
-            }
-            state.modal.push_mode(InputMode::ConfirmDialog);
-
-            DispatchResult::handled()
         }
 
         Action::ExecuteWrite(query) => {
@@ -419,6 +368,55 @@ pub fn reduce_write(
     }
 }
 
+fn open_write_preview_confirm(
+    state: &mut AppState,
+    preview: &WritePreview,
+    now: Instant,
+) -> DispatchResult {
+    if state.session.is_read_only() {
+        state.messages.set_error_at(
+            "Read-only mode: write operations are disabled".to_string(),
+            now,
+        );
+        return DispatchResult::handled();
+    }
+    state.result_interaction.set_write_preview(preview.clone());
+    let operation = preview.operation;
+    let title = match operation {
+        WriteOperation::Update => {
+            state.query.clear_delete_refresh_target();
+            format!("Confirm UPDATE: {}", preview.target_summary.table)
+        }
+        WriteOperation::Delete => {
+            let n = state
+                .query
+                .pending_delete_refresh_target()
+                .map_or(1, |target| target.expected_delete_count);
+            format!(
+                "Confirm DELETE: {} {} from {}",
+                n,
+                if n == 1 { "row" } else { "rows" },
+                preview.target_summary.table
+            )
+        }
+    };
+
+    state.confirm_dialog.open(
+        title,
+        build_write_preview_fallback_message(preview),
+        ConfirmIntent::ExecuteWrite {
+            sql: preview.sql.clone(),
+            blocked: preview.guardrail.blocked,
+        },
+    );
+    if matches!(operation, WriteOperation::Delete) {
+        state.modal.set_mode(InputMode::Normal);
+    }
+    state.modal.push_mode(InputMode::ConfirmDialog);
+
+    DispatchResult::handled()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -475,6 +473,22 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft("Bob".to_string());
             state
+        }
+
+        fn submit_write_preview(state: &mut AppState) -> WritePreview {
+            let effects = dispatch_query(
+                state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+            assert!(effects.is_empty());
+            state
+                .result_interaction
+                .pending_write_preview()
+                .cloned()
+                .expect("write preview")
         }
 
         #[test]
@@ -651,25 +665,9 @@ mod tests {
         fn submit_write_opens_confirm_dialog() {
             let mut state = editable_state();
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-            assert_eq!(effects.len(), 1);
+            let preview = submit_write_preview(&mut state);
 
-            let dispatched = match &effects[0] {
-                Effect::DispatchActions(actions) => actions.first().expect("action"),
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            match dispatched {
-                Action::OpenWritePreviewConfirm(preview) => {
-                    assert!(preview.sql.contains("UPDATE"));
-                }
-                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-            }
+            assert!(preview.sql.contains("UPDATE"));
         }
 
         #[test]
@@ -686,27 +684,12 @@ mod tests {
             state.session.set_table_detail_raw(Some(detail));
             state.query.pagination.reset_for_table("main", "users");
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let preview = submit_write_preview(&mut state);
 
-            let dispatched = match &effects[0] {
-                Effect::DispatchActions(actions) => actions.first().expect("action"),
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            match dispatched {
-                Action::OpenWritePreviewConfirm(preview) => {
-                    assert_eq!(
-                        preview.sql,
-                        "UPDATE \"users\" SET \"name\" = 'Bob' WHERE \"id\" = '1'"
-                    );
-                }
-                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-            }
+            assert_eq!(
+                preview.sql,
+                "UPDATE \"users\" SET \"name\" = 'Bob' WHERE \"id\" = '1'"
+            );
         }
 
         #[test]
@@ -724,27 +707,12 @@ mod tests {
             state.session.set_table_detail_raw(Some(detail));
             state.query.pagination.reset_for_table("main", "users");
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let preview = submit_write_preview(&mut state);
 
-            let dispatched = match &effects[0] {
-                Effect::DispatchActions(actions) => actions.first().expect("action"),
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            match dispatched {
-                Action::OpenWritePreviewConfirm(preview) => {
-                    assert_eq!(
-                        preview.sql,
-                        "UPDATE \"users\" SET \"name\" = 'Bob' WHERE \"id\" = '1'"
-                    );
-                }
-                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-            }
+            assert_eq!(
+                preview.sql,
+                "UPDATE \"users\" SET \"name\" = 'Bob' WHERE \"id\" = '1'"
+            );
         }
 
         #[test]
@@ -781,25 +749,10 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft("7".to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let preview = submit_write_preview(&mut state);
 
-            let dispatched = match &effects[0] {
-                Effect::DispatchActions(actions) => actions.first().expect("action"),
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            match dispatched {
-                Action::OpenWritePreviewConfirm(preview) => {
-                    assert!(preview.sql.contains("SET \"score\" = 7"));
-                    assert!(!preview.sql.contains("SET \"score\" = '7'"));
-                }
-                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-            }
+            assert!(preview.sql.contains("SET \"score\" = 7"));
+            assert!(!preview.sql.contains("SET \"score\" = '7'"));
         }
 
         #[test]
@@ -833,25 +786,10 @@ mod tests {
                 .result_interaction
                 .begin_cell_edit(0, 1, "a\0b".to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let preview = submit_write_preview(&mut state);
 
-            let dispatched = match &effects[0] {
-                Effect::DispatchActions(actions) => actions.first().expect("action"),
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            match dispatched {
-                Action::OpenWritePreviewConfirm(preview) => {
-                    assert_eq!(preview.diff[0].before, "a\0b");
-                    assert_eq!(preview.diff[0].after, "a\0b");
-                }
-                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-            }
+            assert_eq!(preview.diff[0].before, "a\0b");
+            assert_eq!(preview.diff[0].after, "a\0b");
         }
 
         #[test]
@@ -888,24 +826,9 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft("42".to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let preview = submit_write_preview(&mut state);
 
-            let dispatched = match &effects[0] {
-                Effect::DispatchActions(actions) => actions.first().expect("action"),
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            match dispatched {
-                Action::OpenWritePreviewConfirm(preview) => {
-                    assert!(preview.sql.contains("SET \"score\" = 42.0"));
-                }
-                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-            }
+            assert!(preview.sql.contains("SET \"score\" = 42.0"));
         }
 
         #[test]
@@ -1034,21 +957,7 @@ mod tests {
         fn json_column_produces_structured_diff() {
             let mut state = editable_state_with_json();
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-
-            let preview = match &effects[0] {
-                Effect::DispatchActions(actions) => match actions.first().expect("action") {
-                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            let preview = submit_write_preview(&mut state);
             assert!(
                 preview.diff[0].json_diff.is_some(),
                 "jsonb column should have structured diff"
@@ -1085,20 +994,7 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft(r#"{"role":"user"}"#.to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-            let preview = match &effects[0] {
-                Effect::DispatchActions(actions) => match actions.first().expect("action") {
-                    Action::OpenWritePreviewConfirm(preview) => preview,
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            let preview = submit_write_preview(&mut state);
             assert!(preview.diff[0].json_diff.is_some());
         }
 
@@ -1125,21 +1021,7 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft(after.to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-
-            let preview = match &effects[0] {
-                Effect::DispatchActions(actions) => match actions.first().expect("action") {
-                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            let preview = submit_write_preview(&mut state);
             assert!(preview.diff[0].json_diff.is_none());
             assert_eq!(preview.diff[0].before, before);
             assert_eq!(preview.diff[0].after, after);
@@ -1156,21 +1038,7 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft(r#"{"key":"new"}"#.to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-
-            let preview = match &effects[0] {
-                Effect::DispatchActions(actions) => match actions.first().expect("action") {
-                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            let preview = submit_write_preview(&mut state);
             assert!(
                 preview.diff[0].json_diff.is_none(),
                 "text column should not have structured diff even if value looks like JSON"
@@ -1202,21 +1070,7 @@ mod tests {
                 .result_interaction
                 .replace_cell_edit_draft(after.to_string());
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-
-            let preview = match &effects[0] {
-                Effect::DispatchActions(actions) => match actions.first().expect("action") {
-                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            let preview = submit_write_preview(&mut state);
             assert!(preview.diff[0].json_diff.is_none());
             assert_eq!(preview.diff[0].before, before);
             assert_eq!(preview.diff[0].after, after);
@@ -1226,28 +1080,7 @@ mod tests {
         fn confirm_dialog_displays_and_executes_same_sql() {
             let mut state = editable_state();
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::SubmitCellEditWrite,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
-            let preview = match &effects[0] {
-                Effect::DispatchActions(actions) => match actions.first().expect("action") {
-                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-            let expected_sql = preview.sql.clone();
-
-            dispatch_query(
-                &mut state,
-                &Action::OpenWritePreviewConfirm(preview),
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            let expected_sql = submit_write_preview(&mut state).sql;
 
             assert_eq!(
                 state
@@ -1450,13 +1283,9 @@ mod tests {
             state.modal.set_mode(InputMode::Normal);
             let preview = delete_preview();
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::OpenWritePreviewConfirm(Box::new(preview)),
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects = open_write_preview_confirm(&mut state, &preview, Instant::now())
+                .into_effects()
+                .expect("write preview should be handled");
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
@@ -1474,13 +1303,9 @@ mod tests {
             state.query.set_delete_refresh_target(0, Some(2), 3);
             let preview = delete_preview();
 
-            let effects = dispatch_query(
-                &mut state,
-                &Action::OpenWritePreviewConfirm(Box::new(preview)),
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects = open_write_preview_confirm(&mut state, &preview, Instant::now())
+                .into_effects()
+                .expect("write preview should be handled");
 
             assert!(effects.is_empty());
             assert_eq!(

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -1425,20 +1425,7 @@ mod tests {
             );
 
             let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
-            let preview = match effects.first() {
-                Some(Effect::DispatchActions(actions)) => match actions.first() {
-                    Some(Action::OpenWritePreviewConfirm(preview)) => preview.clone(),
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
-
-            reduce_app(
-                &mut state,
-                Action::OpenWritePreviewConfirm(preview),
-                now,
-                &services,
-            );
+            assert!(effects.is_empty());
 
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
             assert!(state.result_interaction.pending_write_preview().is_some());
@@ -1474,13 +1461,11 @@ mod tests {
             );
 
             let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
-            let preview = match effects.first() {
-                Some(Effect::DispatchActions(actions)) => match actions.first() {
-                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            assert!(effects.is_empty());
+            let preview = state
+                .result_interaction
+                .pending_write_preview()
+                .expect("write preview");
 
             assert_eq!(
                 preview.sql,
@@ -1524,13 +1509,11 @@ mod tests {
             );
 
             let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
-            let preview = match effects.first() {
-                Some(Effect::DispatchActions(actions)) => match actions.first() {
-                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            assert!(effects.is_empty());
+            let preview = state
+                .result_interaction
+                .pending_write_preview()
+                .expect("write preview");
 
             assert!(preview.sql.contains("WHERE `id` = '1'"));
             assert!(preview.sql.contains("SET `settings` ="));
@@ -1668,13 +1651,11 @@ mod tests {
             );
 
             let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
-            let preview = match effects.first() {
-                Some(Effect::DispatchActions(actions)) => match actions.first() {
-                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
-                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
-                },
-                other => panic!("expected DispatchActions, got {other:?}"),
-            };
+            assert!(effects.is_empty());
+            let preview = state
+                .result_interaction
+                .pending_write_preview()
+                .expect("write preview");
 
             assert_eq!(
                 preview.sql,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -21,57 +21,7 @@ pub fn reduce_connection_lifecycle(
     _services: &AppServices,
 ) -> DispatchResult {
     match action {
-        Action::TryConnect => {
-            state.session.cancel_connection_save_and_disconnect();
-            if state.session.connection_state().is_not_connected()
-                && state.modal.active_mode() == InputMode::Normal
-            {
-                if let Some(dsn) = state.session.dsn().map(str::to_string) {
-                    if state.session.active_database_type() == Some(DatabaseType::MySQL) {
-                        if state.session.active_database().is_none() {
-                            state.messages.set_error_at(
-                                "MySQL connection field `database` is required".to_string(),
-                                now,
-                            );
-                            return DispatchResult::handled();
-                        }
-                        let target = ConnectionTarget {
-                            id: state
-                                .session
-                                .active_connection_id()
-                                .cloned()
-                                .expect("active MySQL connection"),
-                            dsn,
-                            name: state
-                                .session
-                                .active_connection_name()
-                                .unwrap_or_default()
-                                .to_string(),
-                            database_type: DatabaseType::MySQL,
-                            database: state.session.active_database().map(str::to_string),
-                        };
-                        let run_id = state.session.begin_mysql_connection_probe(
-                            &target.id,
-                            &target.name,
-                            target.database_type,
-                            &target.dsn,
-                            target.database.as_deref(),
-                        );
-                        state.session.mark_connecting();
-                        return DispatchResult::handled_with(vec![Effect::ProbeMySqlConnection {
-                            target,
-                            run_id,
-                        }]);
-                    }
-                    let run_id = state.session.begin_connecting(&dsn);
-                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
-                } else {
-                    DispatchResult::handled()
-                }
-            } else {
-                DispatchResult::handled()
-            }
-        }
+        Action::TryConnect => DispatchResult::handled_with(try_connect(state, now)),
 
         Action::SwitchConnection(target) => {
             state.session.cancel_connection_save_and_disconnect();
@@ -224,6 +174,55 @@ pub fn reduce_connection_lifecycle(
         }
 
         _ => DispatchResult::pass(),
+    }
+}
+
+pub(super) fn try_connect(state: &mut AppState, now: std::time::Instant) -> Vec<Effect> {
+    state.session.cancel_connection_save_and_disconnect();
+    if state.session.connection_state().is_not_connected()
+        && state.modal.active_mode() == InputMode::Normal
+    {
+        if let Some(dsn) = state.session.dsn().map(str::to_string) {
+            if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                if state.session.active_database().is_none() {
+                    state.messages.set_error_at(
+                        "MySQL connection field `database` is required".to_string(),
+                        now,
+                    );
+                    return vec![];
+                }
+                let target = ConnectionTarget {
+                    id: state
+                        .session
+                        .active_connection_id()
+                        .cloned()
+                        .expect("active MySQL connection"),
+                    dsn,
+                    name: state
+                        .session
+                        .active_connection_name()
+                        .unwrap_or_default()
+                        .to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database: state.session.active_database().map(str::to_string),
+                };
+                let run_id = state.session.begin_mysql_connection_probe(
+                    &target.id,
+                    &target.name,
+                    target.database_type,
+                    &target.dsn,
+                    target.database.as_deref(),
+                );
+                state.session.mark_connecting();
+                return vec![Effect::ProbeMySqlConnection { target, run_id }];
+            }
+            let run_id = state.session.begin_connecting(&dsn);
+            vec![Effect::FetchMetadata { dsn, run_id }]
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
     }
 }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -19,6 +19,7 @@ use crate::update::connection::helpers::{
     connection_save_fetch_effects, mysql_connection_completion_effects, reset_for_new_connection,
     save_current_connection_cache,
 };
+use crate::update::connection::lifecycle::try_connect;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{validate_all, validate_field};
 use crate::update::query_context::termination_effects;
@@ -236,9 +237,7 @@ pub fn reduce_connection_setup(
                 DispatchResult::handled()
             } else {
                 state.modal.set_mode(InputMode::Normal);
-                DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
-                    Action::TryConnect,
-                ])])
+                DispatchResult::handled_with(try_connect(state, now))
             }
         }
         Action::ConnectionSaveCompleted { target, run_id } => {
@@ -715,20 +714,12 @@ mod tests {
             fill_valid_form(&mut state);
 
             reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
-            reduce(&mut state, &Action::ConnectionSetupCancel, Instant::now());
+            let effects = reduce(&mut state, &Action::ConnectionSetupCancel, Instant::now())
+                .expect("cancel should retry previous connection");
 
-            assert!(state.session.connection_state().is_not_connected());
+            assert!(state.session.connection_state().is_connecting());
             assert_eq!(state.session.active_connection_id(), Some(&previous_id));
             assert_eq!(state.session.dsn(), Some("postgres://localhost/previous"));
-
-            let effects = reduce_connection_lifecycle(
-                &mut state,
-                &Action::TryConnect,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .into_effects()
-            .expect("retry handled");
             assert!(
                 effects
                     .iter()

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -318,11 +318,11 @@ mod tests {
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert!(effects.iter().any(|e| matches!(
-                e,
-                Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache))
-            )));
+            assert!(
+                effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::GenerateErDiagramFromCache { .. }))
+            );
         }
 
         #[test]

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -6,6 +6,8 @@ use crate::model::app_state::AppState;
 use crate::update::action::{Action, SmartErRefreshResult};
 use crate::update::dispatch_result::DispatchResult;
 
+use super::diagram::reduce_diagram_lifecycle;
+
 pub(super) fn reduce_smart_refresh_completed(
     state: &mut AppState,
     action: &Action,
@@ -53,7 +55,11 @@ pub(super) fn reduce_smart_refresh_completed(
                     "No schema changes detected, generating ER diagram...".to_string(),
                     now,
                 );
-                effects.push(Effect::DispatchActions(vec![Action::ErGenerateFromCache]));
+                effects.extend(
+                    reduce_diagram_lifecycle(state, &Action::ErGenerateFromCache, now)
+                        .into_effects()
+                        .unwrap_or_default(),
+                );
             } else {
                 if !stale_tables.is_empty() {
                     effects.push(Effect::EvictTablesFromCompletionCache {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2118,7 +2118,7 @@ mod tests {
         }
 
         #[test]
-        fn cancel_after_save_returns_to_normal_and_dispatches_try_connect() {
+        fn cancel_after_save_returns_to_normal_without_action_redispatch() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
             state.connection_setup.set_first_run(false);
@@ -2132,8 +2132,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::DispatchActions(_)));
+            assert!(effects.is_empty());
         }
     }
 


### PR DESCRIPTION
## Problem
Same-feature synchronous actions were re-entering the effect runner, adding action and recursion overhead to local state transitions.

## Background
The effect-runner convention keeps DispatchActions at cross-feature boundaries and uses direct helper calls for synchronous transitions within one feature.

## Approach
Route the connection retry, query write preview, metadata prefetch, metadata FK expansion, and ER cache-generation transitions through their leaf reducers/helpers. Remove OpenWritePreviewConfirm because its production callers disappear, while retaining cross-feature DispatchActions.

## Screenshots
N/A

## Linear issue link
- Fixes SAB-520: https://linear.app/sabiql/issue/SAB-520/同一feature内の同期action再投入を直接遷移へ置き換える