### PR TITLE
refactor: remove unused metadata state (SAB-518)

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -12,15 +12,10 @@ use crate::cmd::query_task::TableDetailTaskRegistry;
 use crate::cmd::sqlite_path_validate::validate_sqlite_database_path;
 use crate::domain::DatabaseMetadata;
 use crate::domain::sqlite_path_from_dsn;
-use crate::model::app_state::AppState;
 use crate::policy::sqlite_path::to_db_operation_error;
 use crate::ports::outbound::{DbOperationError, MetadataProvider, SqlitePathValidator};
 use crate::update::action::Action;
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "metadata effects use separate task registries for table details and connection context"
-)]
 pub async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
@@ -29,7 +24,6 @@ pub async fn run(
     sqlite_path_validator: &Arc<dyn SqlitePathValidator>,
     table_detail_tasks: &TableDetailTaskRegistry,
     metadata_tasks: &Arc<MetadataTaskRegistry>,
-    _state: &mut AppState,
     completion_engine: &RefCell<CompletionEngine>,
 ) -> Result<()> {
     match effect {

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -233,7 +233,6 @@ impl EffectRunner {
                     &self.connection.sqlite_path_validator,
                     &self.table_detail_tasks,
                     &self.metadata_tasks,
-                    state,
                     completion_engine,
                 )
                 .await?;


### PR DESCRIPTION
## Problem
The metadata effect handler accepts a mutable `AppState` reference that none of its effect branches use.

## Background
The unused argument makes `EffectRunner` pass mutable application state through a handler that depends only on metadata ports, task registries, the completion cache, and the metadata cache.

## Approach
Remove the unused `AppState` parameter and import from the metadata handler, then stop passing state from the metadata dispatch branch. Existing metadata effect dispatch and cancellation behavior remain unchanged.

## Screenshots
Not applicable.

## Linear Issue Link
- Fixes SAB-518: https://linear.app/sabiql/issue/SAB-518/metadata-effect-handlerから未使用のappstate引数を削除する
