### PR TITLE
test(mysql): align SAB-514 test coverage

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -35,226 +35,6 @@ pub enum AcknowledgeReason {
     AnalyzeExecution,
 }
 
-#[cfg(test)]
-mod mysql_tests {
-    use crate::domain::mysql_sql::mysql_statement_is_schema_modifying;
-
-    use super::*;
-    use rstest::rstest;
-
-    fn mysql(sql: &str) -> MultiStatementDecision {
-        evaluate_multi_statement_for_database_with_context(DatabaseType::MySQL, Some("app"), sql)
-    }
-
-    #[test]
-    fn max_risk_uses_destructive_confirmation() {
-        let decision = mysql(
-            r#"SELECT 'a; b', "quoted; identifier", `back;tick` /* block ; comment */;
-                UPDATE items SET value = 1"#,
-        );
-        match decision {
-            MultiStatementDecision::Allow { risk, statements } => {
-                assert_eq!(statements.len(), 2);
-                assert_eq!(risk.risk_level, RiskLevel::High);
-                assert_eq!(
-                    risk.confirmation,
-                    ConfirmationType::TableNameInput {
-                        target: "items".to_string()
-                    }
-                );
-                assert!(!risk.read_only_allowed);
-            }
-            MultiStatementDecision::Block { reason } => panic!("unexpected block: {reason}"),
-        }
-    }
-
-    #[test]
-    fn confirmation_target_preserves_input_case() {
-        let MultiStatementDecision::Allow { risk, .. } =
-            mysql("UPDATE CustomerOrders SET value = 1")
-        else {
-            panic!("unexpected block");
-        };
-        assert!(matches!(
-            risk.confirmation,
-            ConfirmationType::TableNameInput { ref target } if target == "CustomerOrders"
-        ));
-    }
-
-    #[test]
-    fn aligns_supported_mysql_ddl_risk_and_schema_classification() {
-        let cases = [
-            (
-                "RENAME TABLE items TO archived_items",
-                MySqlStatementKind::RenameTable,
-                RiskLevel::Medium,
-                "RENAME TABLE",
-            ),
-            (
-                "CREATE OR REPLACE VIEW item_view AS SELECT 1",
-                MySqlStatementKind::CreateView,
-                RiskLevel::Low,
-                "CREATE VIEW",
-            ),
-            (
-                "ALTER VIEW item_view AS SELECT 1",
-                MySqlStatementKind::AlterView,
-                RiskLevel::Medium,
-                "ALTER VIEW",
-            ),
-            (
-                "CREATE FULLTEXT INDEX item_text ON items (body)",
-                MySqlStatementKind::CreateIndex,
-                RiskLevel::Low,
-                "CREATE INDEX",
-            ),
-        ];
-
-        for (sql, expected_kind, expected_risk, expected_label) in cases {
-            let statement = classify_mysql_statement(sql).expect(sql);
-            assert_eq!(statement.kind(), &expected_kind, "{sql}");
-            assert_eq!(
-                mysql_statement_label(statement.kind()),
-                expected_label,
-                "{sql}"
-            );
-            assert!(
-                mysql_statement_is_schema_modifying(statement.kind()),
-                "{sql}"
-            );
-            assert_eq!(
-                mysql_statement_risk(&statement).risk_level,
-                expected_risk,
-                "{sql}"
-            );
-        }
-    }
-
-    #[rstest]
-    #[case::add_column("ALTER TABLE items ADD COLUMN value INT", "items")]
-    #[case::table_named_comment("ALTER TABLE comment ADD COLUMN value INT", "comment")]
-    #[case::table_named_repair("ALTER TABLE repair ADD COLUMN value INT", "repair")]
-    #[case::table_named_secondary_load(
-        "ALTER TABLE secondary_load ADD COLUMN value INT",
-        "secondary_load"
-    )]
-    #[case::table_named_secondary_unload(
-        "ALTER TABLE secondary_unload ADD COLUMN value INT",
-        "secondary_unload"
-    )]
-    #[case::table_option("ALTER TABLE items AVG_ROW_LENGTH=100", "items")]
-    #[case::no_op("ALTER TABLE items", "items")]
-    #[case::tablespace("ALTER TABLE items TABLESPACE ts", "items")]
-    #[case::check_partition("ALTER TABLE items CHECK PARTITION p0", "items")]
-    #[case::drop_column("ALTER TABLE items DROP COLUMN value", "items")]
-    #[case::drop_partition("ALTER TABLE items DROP PARTITION p0", "items")]
-    #[case::truncate_partition("ALTER TABLE items TRUNCATE PARTITION p0", "items")]
-    fn alter_table_requires_table_name_confirmation(#[case] sql: &str, #[case] target: &str) {
-        let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
-            panic!("expected Allow: {sql}");
-        };
-
-        assert_eq!(risk.risk_level, RiskLevel::High);
-        assert!(!risk.read_only_allowed);
-        assert_eq!(
-            risk.confirmation,
-            ConfirmationType::TableNameInput {
-                target: target.to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn replace_has_destructive_risk_mapping() {
-        let statement = classify_mysql_statement("REPLACE INTO items VALUES (1)").unwrap();
-        let risk = mysql_statement_risk(&statement);
-        assert_eq!(risk.risk_level, RiskLevel::High);
-        assert!(!risk.read_only_allowed);
-        assert!(matches!(
-            risk.confirmation,
-            ConfirmationType::TableNameInput { ref target } if target == "items"
-        ));
-    }
-
-    #[test]
-    fn read_only_allows_only_side_effect_free_mysql_reads() {
-        for sql in [
-            "SELECT 1",
-            "TABLE items",
-            "SHOW TABLES",
-            "DESCRIBE items",
-            "WITH rows AS (SELECT 1) SELECT * FROM rows",
-            "WITH RECURSIVE rows AS (SELECT 1) SELECT * FROM rows",
-            "SELECT LAST_INSERT_ID()",
-        ] {
-            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
-                panic!("{sql}");
-            };
-            assert!(risk.read_only_allowed, "{sql}");
-        }
-
-        for sql in [
-            "SELECT * FROM items FOR UPDATE",
-            "SELECT * FROM items FOR SHARE",
-            "SELECT * FROM items LOCK IN SHARE MODE",
-            "SELECT @value := value FROM items",
-            "SELECT GET_LOCK('sabiql', 0)",
-            "SELECT RELEASE_LOCK('sabiql')",
-            "SELECT RELEASE_ALL_LOCKS()",
-            "SELECT `GET_LOCK`('sabiql', 0)",
-            "SELECT `RELEASE_LOCK`('sabiql')",
-            "SELECT `RELEASE_ALL_LOCKS`()",
-            "SELECT LAST_INSERT_ID(42)",
-            "SELECT `LAST_INSERT_ID`(42)",
-            "/*!80000 SELECT 1 */",
-        ] {
-            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
-                panic!("{sql}");
-            };
-            assert!(!risk.read_only_allowed, "{sql}");
-        }
-    }
-
-    #[test]
-    fn explain_analyze_target_rejects_side_effects() {
-        for sql in [
-            "UPDATE items SET value = 1",
-            "SELECT * FROM items FOR UPDATE",
-            "SELECT * FROM items INTO OUTFILE '/tmp/items'",
-            "SELECT id INTO DUMPFILE '/tmp/items' FROM items",
-            "SELECT id INTO @value FROM items",
-            "TABLE items INTO OUTFILE '/tmp/items'",
-            "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/items' FROM rows",
-            "SHOW TABLES",
-            "DESCRIBE items",
-            "SELECT 1; SELECT 2",
-            "SELECT 1\nsystem echo unsafe",
-            "SELECT 1\n\\! echo unsafe",
-            "SELECT 'unfinished",
-            "SELECT 1 /* unfinished",
-            "MERGE INTO items USING source ON items.id = source.id",
-            "REPLACE INTO items VALUES (1)",
-        ] {
-            assert!(
-                evaluate_mysql_explain_analyze_target(sql).is_none(),
-                "{sql}"
-            );
-        }
-        for (sql, label) in [("SELECT 1", "SELECT"), ("TABLE items", "TABLE")] {
-            let risk = evaluate_mysql_explain_analyze_target(sql).expect(sql);
-            assert_eq!(risk.risk_level, RiskLevel::Low);
-            assert!(risk.read_only_allowed);
-            assert_eq!(
-                risk.confirmation,
-                ConfirmationType::Acknowledge {
-                    reason: AcknowledgeReason::AnalyzeExecution,
-                    label: label.to_string(),
-                }
-            );
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfirmationType {
     Immediate,
@@ -2329,5 +2109,225 @@ mod tests {
             )
             .is_none()
         );
+    }
+}
+
+#[cfg(test)]
+mod mysql_tests {
+    use crate::domain::mysql_sql::mysql_statement_is_schema_modifying;
+
+    use super::*;
+    use rstest::rstest;
+
+    fn mysql(sql: &str) -> MultiStatementDecision {
+        evaluate_multi_statement_for_database_with_context(DatabaseType::MySQL, Some("app"), sql)
+    }
+
+    #[test]
+    fn max_risk_uses_destructive_confirmation() {
+        let decision = mysql(
+            r#"SELECT 'a; b', "quoted; identifier", `back;tick` /* block ; comment */;
+                UPDATE items SET value = 1"#,
+        );
+        match decision {
+            MultiStatementDecision::Allow { risk, statements } => {
+                assert_eq!(statements.len(), 2);
+                assert_eq!(risk.risk_level, RiskLevel::High);
+                assert_eq!(
+                    risk.confirmation,
+                    ConfirmationType::TableNameInput {
+                        target: "items".to_string()
+                    }
+                );
+                assert!(!risk.read_only_allowed);
+            }
+            MultiStatementDecision::Block { reason } => panic!("unexpected block: {reason}"),
+        }
+    }
+
+    #[test]
+    fn confirmation_target_preserves_input_case() {
+        let MultiStatementDecision::Allow { risk, .. } =
+            mysql("UPDATE CustomerOrders SET value = 1")
+        else {
+            panic!("unexpected block");
+        };
+        assert!(matches!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput { ref target } if target == "CustomerOrders"
+        ));
+    }
+
+    #[test]
+    fn aligns_supported_mysql_ddl_risk_and_schema_classification() {
+        let cases = [
+            (
+                "RENAME TABLE items TO archived_items",
+                MySqlStatementKind::RenameTable,
+                RiskLevel::Medium,
+                "RENAME TABLE",
+            ),
+            (
+                "CREATE OR REPLACE VIEW item_view AS SELECT 1",
+                MySqlStatementKind::CreateView,
+                RiskLevel::Low,
+                "CREATE VIEW",
+            ),
+            (
+                "ALTER VIEW item_view AS SELECT 1",
+                MySqlStatementKind::AlterView,
+                RiskLevel::Medium,
+                "ALTER VIEW",
+            ),
+            (
+                "CREATE FULLTEXT INDEX item_text ON items (body)",
+                MySqlStatementKind::CreateIndex,
+                RiskLevel::Low,
+                "CREATE INDEX",
+            ),
+        ];
+
+        for (sql, expected_kind, expected_risk, expected_label) in cases {
+            let statement = classify_mysql_statement(sql).expect(sql);
+            assert_eq!(statement.kind(), &expected_kind, "{sql}");
+            assert_eq!(
+                mysql_statement_label(statement.kind()),
+                expected_label,
+                "{sql}"
+            );
+            assert!(
+                mysql_statement_is_schema_modifying(statement.kind()),
+                "{sql}"
+            );
+            assert_eq!(
+                mysql_statement_risk(&statement).risk_level,
+                expected_risk,
+                "{sql}"
+            );
+        }
+    }
+
+    #[rstest]
+    #[case::add_column("ALTER TABLE items ADD COLUMN value INT", "items")]
+    #[case::table_named_comment("ALTER TABLE comment ADD COLUMN value INT", "comment")]
+    #[case::table_named_repair("ALTER TABLE repair ADD COLUMN value INT", "repair")]
+    #[case::table_named_secondary_load(
+        "ALTER TABLE secondary_load ADD COLUMN value INT",
+        "secondary_load"
+    )]
+    #[case::table_named_secondary_unload(
+        "ALTER TABLE secondary_unload ADD COLUMN value INT",
+        "secondary_unload"
+    )]
+    #[case::table_option("ALTER TABLE items AVG_ROW_LENGTH=100", "items")]
+    #[case::no_op("ALTER TABLE items", "items")]
+    #[case::tablespace("ALTER TABLE items TABLESPACE ts", "items")]
+    #[case::check_partition("ALTER TABLE items CHECK PARTITION p0", "items")]
+    #[case::drop_column("ALTER TABLE items DROP COLUMN value", "items")]
+    #[case::drop_partition("ALTER TABLE items DROP PARTITION p0", "items")]
+    #[case::truncate_partition("ALTER TABLE items TRUNCATE PARTITION p0", "items")]
+    fn alter_table_requires_table_name_confirmation(#[case] sql: &str, #[case] target: &str) {
+        let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+            panic!("expected Allow: {sql}");
+        };
+
+        assert_eq!(risk.risk_level, RiskLevel::High);
+        assert!(!risk.read_only_allowed);
+        assert_eq!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput {
+                target: target.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn replace_has_destructive_risk_mapping() {
+        let statement = classify_mysql_statement("REPLACE INTO items VALUES (1)").unwrap();
+        let risk = mysql_statement_risk(&statement);
+        assert_eq!(risk.risk_level, RiskLevel::High);
+        assert!(!risk.read_only_allowed);
+        assert!(matches!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput { ref target } if target == "items"
+        ));
+    }
+
+    #[test]
+    fn read_only_allows_only_side_effect_free_mysql_reads() {
+        for sql in [
+            "SELECT 1",
+            "TABLE items",
+            "SHOW TABLES",
+            "DESCRIBE items",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+            "WITH RECURSIVE rows AS (SELECT 1) SELECT * FROM rows",
+            "SELECT LAST_INSERT_ID()",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(risk.read_only_allowed, "{sql}");
+        }
+
+        for sql in [
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items FOR SHARE",
+            "SELECT * FROM items LOCK IN SHARE MODE",
+            "SELECT @value := value FROM items",
+            "SELECT GET_LOCK('sabiql', 0)",
+            "SELECT RELEASE_LOCK('sabiql')",
+            "SELECT RELEASE_ALL_LOCKS()",
+            "SELECT `GET_LOCK`('sabiql', 0)",
+            "SELECT `RELEASE_LOCK`('sabiql')",
+            "SELECT `RELEASE_ALL_LOCKS`()",
+            "SELECT LAST_INSERT_ID(42)",
+            "SELECT `LAST_INSERT_ID`(42)",
+            "/*!80000 SELECT 1 */",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(!risk.read_only_allowed, "{sql}");
+        }
+    }
+
+    #[test]
+    fn explain_analyze_target_rejects_side_effects() {
+        for sql in [
+            "UPDATE items SET value = 1",
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items INTO OUTFILE '/tmp/items'",
+            "SELECT id INTO DUMPFILE '/tmp/items' FROM items",
+            "SELECT id INTO @value FROM items",
+            "TABLE items INTO OUTFILE '/tmp/items'",
+            "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/items' FROM rows",
+            "SHOW TABLES",
+            "DESCRIBE items",
+            "SELECT 1; SELECT 2",
+            "SELECT 1\nsystem echo unsafe",
+            "SELECT 1\n\\! echo unsafe",
+            "SELECT 'unfinished",
+            "SELECT 1 /* unfinished",
+            "MERGE INTO items USING source ON items.id = source.id",
+            "REPLACE INTO items VALUES (1)",
+        ] {
+            assert!(
+                evaluate_mysql_explain_analyze_target(sql).is_none(),
+                "{sql}"
+            );
+        }
+        for (sql, label) in [("SELECT 1", "SELECT"), ("TABLE items", "TABLE")] {
+            let risk = evaluate_mysql_explain_analyze_target(sql).expect(sql);
+            assert_eq!(risk.risk_level, RiskLevel::Low);
+            assert!(risk.read_only_allowed);
+            assert_eq!(
+                risk.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::AnalyzeExecution,
+                    label: label.to_string(),
+                }
+            );
+        }
     }
 }

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -890,9 +890,84 @@ done
             assert!(log.contains("SELECT 123"));
             assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
         }
+
+        #[tokio::test]
+        async fn read_only_session_failure_never_writes_user_sql() {
+            let (_directory, program, log_file) = fake_mysql("read_only_failure");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadOnly,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            assert!(result.is_err());
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+            assert!(!log.contains("SELECT 123"), "{log}");
+        }
+
+        #[tokio::test]
+        async fn nonzero_cli_exit_discards_any_collected_stdout() {
+            let (_directory, program, log_file) = fake_mysql("failure");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+        }
+
+        #[tokio::test]
+        async fn classifies_cli_error_when_no_resultset_is_emitted() {
+            let (_directory, program, log_file) = fake_mysql("no_result_failure");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::ObjectMissing(details))
+                    if details.contains("missing_column")
+            ));
+        }
+
+        #[tokio::test]
+        async fn classifies_connection_refusal_from_the_shared_cli_error_path() {
+            let (_directory, program, log_file) = fake_mysql("connection_refused");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
+        }
     }
 
-    mod metadata_session {
+    mod adhoc {
         use super::*;
 
         #[tokio::test]
@@ -998,6 +1073,43 @@ done
         }
 
         #[tokio::test]
+        async fn generated_preview_and_metadata_queries_configure_read_only_session() {
+            for query in [
+                "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
+            ] {
+                let (_directory, program, option_file) = fake_mysql_multi();
+                let statements = split_mysql_statements(query)
+                    .unwrap()
+                    .into_iter()
+                    .map(|sql| classify_mysql_statement(&sql).unwrap())
+                    .collect::<Vec<_>>();
+
+                run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                    OsStr::new(&program),
+                    &option_file,
+                    &statements,
+                    AccessMode::ReadOnly,
+                    None,
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap();
+
+                let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+                let session_index = log
+                    .find(MYSQL_READ_ONLY_STATEMENT)
+                    .expect("read-only session statement");
+                let query_index = log.find(query).expect("generated query");
+                assert!(session_index < query_index, "{query}: {log}");
+            }
+        }
+    }
+
+    mod metadata_session {
+        use super::*;
+
+        #[tokio::test]
         async fn reuses_one_process_for_ordered_resultsets() {
             let (_directory, program, option_file) = fake_mysql_multi();
             let mut session =
@@ -1049,59 +1161,6 @@ done
             .map(|query| log.find(query).expect("query in transcript"))
             .collect::<Vec<_>>();
             assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
-        }
-
-        #[tokio::test]
-        async fn read_only_session_failure_never_writes_user_sql() {
-            let (_directory, program, log_file) = fake_mysql("read_only_failure");
-            let option_file = log_file.with_extension("cnf");
-            fs::write(&option_file, "[client]\n").unwrap();
-            let result = run_mysql_single_statement_with_program(
-                OsStr::new(&program),
-                &option_file,
-                "SELECT 123",
-                AccessMode::ReadOnly,
-                Duration::from_secs(5),
-            )
-            .await;
-
-            assert!(result.is_err());
-            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-            assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
-            assert!(!log.contains("SELECT 123"), "{log}");
-        }
-
-        #[tokio::test]
-        async fn generated_preview_and_metadata_queries_configure_read_only_session() {
-            for query in [
-                "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
-            ] {
-                let (_directory, program, option_file) = fake_mysql_multi();
-                let statements = split_mysql_statements(query)
-                    .unwrap()
-                    .into_iter()
-                    .map(|sql| classify_mysql_statement(&sql).unwrap())
-                    .collect::<Vec<_>>();
-
-                run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-                    OsStr::new(&program),
-                    &option_file,
-                    &statements,
-                    AccessMode::ReadOnly,
-                    None,
-                    Duration::from_secs(5),
-                )
-                .await
-                .unwrap();
-
-                let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-                let session_index = log
-                    .find(MYSQL_READ_ONLY_STATEMENT)
-                    .expect("read-only session statement");
-                let query_index = log.find(query).expect("generated query");
-                assert!(session_index < query_index, "{query}: {log}");
-            }
         }
 
         #[tokio::test]
@@ -1388,61 +1447,6 @@ done
                 .status()
                 .expect("check script process");
             assert!(!status.success(), "script process {pid} is still running");
-        }
-
-        #[tokio::test]
-        async fn nonzero_cli_exit_discards_any_collected_stdout() {
-            let (_directory, program, log_file) = fake_mysql("failure");
-            let option_file = log_file.with_extension("cnf");
-            fs::write(&option_file, "[client]\n").unwrap();
-            let result = run_mysql_single_statement_with_program(
-                OsStr::new(&program),
-                &option_file,
-                "SELECT 123",
-                AccessMode::ReadWrite,
-                Duration::from_secs(5),
-            )
-            .await;
-
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
-        }
-
-        #[tokio::test]
-        async fn classifies_cli_error_when_no_resultset_is_emitted() {
-            let (_directory, program, log_file) = fake_mysql("no_result_failure");
-            let option_file = log_file.with_extension("cnf");
-            fs::write(&option_file, "[client]\n").unwrap();
-            let result = run_mysql_single_statement_with_program(
-                OsStr::new(&program),
-                &option_file,
-                "SELECT 123",
-                AccessMode::ReadWrite,
-                Duration::from_secs(5),
-            )
-            .await;
-
-            assert!(matches!(
-            result,
-            Err(DbOperationError::ObjectMissing(details))
-                if details.contains("missing_column")
-            ));
-        }
-
-        #[tokio::test]
-        async fn classifies_connection_refusal_from_the_shared_cli_error_path() {
-            let (_directory, program, log_file) = fake_mysql("connection_refused");
-            let option_file = log_file.with_extension("cnf");
-            fs::write(&option_file, "[client]\n").unwrap();
-            let result = run_mysql_single_statement_with_program(
-                OsStr::new(&program),
-                &option_file,
-                "SELECT 123",
-                AccessMode::ReadWrite,
-                Duration::from_secs(5),
-            )
-            .await;
-
-            assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
         }
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -539,24 +539,28 @@ mod tests {
     use crate::domain::mysql_sql::{classify_mysql_statement, split_mysql_statements};
     use crate::domain::{CommandTag, QueryValue, RefreshScope};
 
-    #[tokio::test]
-    async fn bounds_pty_drain_when_the_slave_stays_open() {
-        let (master, _slave) = create_mysql_pty().expect("create test PTY");
-        let mut pty = MySqlPty {
-            input: TokioFile::from_std(master.try_clone().expect("clone PTY master")),
-            output: TokioFile::from_std(master),
-            pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
-        };
+    mod cleanup {
+        use super::*;
 
-        assert!(
-            tokio::time::timeout(
-                MYSQL_PTY_DRAIN_TIMEOUT + Duration::from_secs(1),
-                drain_mysql_pty(&mut pty),
-            )
-            .await
-            .is_ok()
-        );
+        #[tokio::test]
+        async fn bounds_pty_drain_when_the_slave_stays_open() {
+            let (master, _slave) = create_mysql_pty().expect("create test PTY");
+            let mut pty = MySqlPty {
+                input: TokioFile::from_std(master.try_clone().expect("clone PTY master")),
+                output: TokioFile::from_std(master),
+                pending: Vec::new(),
+                frame_scanner: MySqlResultsetFrameScanner::default(),
+            };
+
+            assert!(
+                tokio::time::timeout(
+                    MYSQL_PTY_DRAIN_TIMEOUT + Duration::from_secs(1),
+                    drain_mysql_pty(&mut pty),
+                )
+                .await
+                .is_ok()
+            );
+        }
     }
 
     async fn export_mysql_csv_with_program(
@@ -861,219 +865,47 @@ done
         (directory, program, option_file)
     }
 
-    #[tokio::test]
-    async fn sends_user_sql_only_after_a_valid_mode_probe() {
-        let (_directory, program, log_file) = fake_mysql("success");
-        let option_file = log_file.with_extension("cnf");
-        fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_single_statement_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123",
-            AccessMode::ReadWrite,
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
+    mod single_statement {
+        use super::*;
 
-        assert_eq!(result.columns, vec!["value"]);
-        assert_eq!(result.values[0][0].as_str(), Some("ok"));
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert!(log.contains("__sabiql_probe"));
-        assert!(log.contains("SELECT 123"));
-        assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
-    }
-
-    #[tokio::test]
-    async fn configures_read_only_session_before_user_sql() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
-        let statements = split_mysql_statements("SELECT 2")
-            .unwrap()
-            .into_iter()
-            .map(|sql| classify_mysql_statement(&sql).unwrap())
-            .collect::<Vec<_>>();
-
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadOnly,
-            None,
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap_or_else(|error| {
-            let log = fs::read_to_string(&log_file).unwrap_or_default();
-            panic!("read-only execution failed: {error:?}; log: {log}");
-        });
-
-        assert_eq!(
-            result.result_set.unwrap().values[0][0].as_str(),
-            Some("two")
-        );
-        let log = fs::read_to_string(log_file).unwrap();
-        let session_index = log
-            .find(MYSQL_READ_ONLY_STATEMENT)
-            .expect("read-only session statement");
-        let user_index = log.find("SELECT 2").expect("user statement");
-        assert!(session_index < user_index, "{log}");
-        assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
-    }
-
-    #[tokio::test]
-    async fn known_empty_result_uses_expected_columns_without_replaying_query() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let query = "SELECT 1 AS first_alias WHERE FALSE";
-        let statements = split_mysql_statements(query)
-            .unwrap()
-            .into_iter()
-            .map(|sql| classify_mysql_statement(&sql).unwrap())
-            .collect::<Vec<_>>();
-
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadOnly,
-            Some(&["first_alias"]),
-            Duration::from_secs(5),
-        )
-        .await
-        .expect("known empty result");
-        let result_set = result.result_set.expect("result set");
-        assert_eq!(result_set.columns, ["first_alias"]);
-        assert!(result_set.values.is_empty());
-
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert_eq!(log.matches(query).count(), 1, "{log}");
-        assert!(!log.contains("__sabiql_metadata_inner"));
-    }
-
-    #[tokio::test]
-    async fn duplicate_empty_select_columns_are_rejected_without_replaying_user_sql() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let query = "SELECT 1 AS duplicate_alias, 2 AS duplicate_alias WHERE FALSE";
-        let statements = split_mysql_statements(query)
-            .unwrap()
-            .into_iter()
-            .map(|sql| classify_mysql_statement(&sql).unwrap())
-            .collect::<Vec<_>>();
-
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadWrite,
-            None,
-            Duration::from_secs(5),
-        )
-        .await;
-
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert!(
-            matches!(
-                result,
-                Err(DbOperationError::UnsupportedOperation(ref details))
-                    if details.contains("duplicate column names")
-            ),
-            "result={result:?}; log={log}"
-        );
-        assert_eq!(
-            log.lines().filter(|line| *line == query).count(),
-            1,
-            "{log}"
-        );
-    }
-
-    #[tokio::test]
-    async fn metadata_session_reuses_one_process_for_ordered_resultsets() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let mut session =
-            MySqlMetadataSession::spawn_with_program(OsStr::new(&program), &option_file)
-                .expect("spawn fake mysql");
-
-        session.probe().await.expect("mode probe");
-        session
-            .prepare_read_only()
+        #[tokio::test]
+        async fn sends_user_sql_only_after_a_valid_mode_probe() {
+            let (_directory, program, log_file) = fake_mysql("success");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
             .await
-            .expect("read-only session setup");
-        for query in [
-            "SELECT TABLES",
-            "SELECT COLUMNS",
-            "SELECT INDEXES",
-            "SELECT FOREIGN_KEYS",
-            "SELECT TRIGGERS",
-            "SHOW CREATE TABLE items",
-        ] {
-            session.execute(query).await.expect("metadata resultset");
+            .unwrap();
+
+            assert_eq!(result.columns, vec!["value"]);
+            assert_eq!(result.values[0][0].as_str(), Some("ok"));
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.contains("__sabiql_probe"));
+            assert!(log.contains("SELECT 123"));
+            assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
         }
-        let empty_result = session
-            .execute_with_expected_columns("EMPTY_RESULT", &["known_column"])
-            .await
-            .expect("empty metadata resultset");
-        assert_eq!(empty_result.columns, ["known_column"]);
-        assert!(empty_result.values.is_empty());
-        session.finish().await.expect("finish fake mysql");
-
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert_eq!(
-            log.lines()
-                .filter(|line| line.starts_with("process="))
-                .count(),
-            1
-        );
-        let positions = [
-            "__sabiql_probe",
-            MYSQL_READ_ONLY_STATEMENT,
-            MYSQL_SESSION_MARKER_COLUMN,
-            "SELECT TABLES",
-            "SELECT COLUMNS",
-            "SELECT INDEXES",
-            "SELECT FOREIGN_KEYS",
-            "SELECT TRIGGERS",
-            "SHOW CREATE TABLE items",
-        ]
-        .into_iter()
-        .map(|query| log.find(query).expect("query in transcript"))
-        .collect::<Vec<_>>();
-        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
     }
 
-    #[tokio::test]
-    async fn read_only_session_failure_never_writes_user_sql() {
-        let (_directory, program, log_file) = fake_mysql("read_only_failure");
-        let option_file = log_file.with_extension("cnf");
-        fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_single_statement_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123",
-            AccessMode::ReadOnly,
-            Duration::from_secs(5),
-        )
-        .await;
+    mod metadata_session {
+        use super::*;
 
-        assert!(result.is_err());
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
-        assert!(!log.contains("SELECT 123"), "{log}");
-    }
-
-    #[tokio::test]
-    async fn generated_preview_and_metadata_queries_configure_read_only_session() {
-        for query in [
-            "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
-            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
-        ] {
+        #[tokio::test]
+        async fn configures_read_only_session_before_user_sql() {
             let (_directory, program, option_file) = fake_mysql_multi();
-            let statements = split_mysql_statements(query)
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+            let statements = split_mysql_statements("SELECT 2")
                 .unwrap()
                 .into_iter()
                 .map(|sql| classify_mysql_statement(&sql).unwrap())
                 .collect::<Vec<_>>();
 
-            run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
                 OsStr::new(&program),
                 &option_file,
                 &statements,
@@ -1082,187 +914,297 @@ done
                 Duration::from_secs(5),
             )
             .await
-            .unwrap();
+            .unwrap_or_else(|error| {
+                let log = fs::read_to_string(&log_file).unwrap_or_default();
+                panic!("read-only execution failed: {error:?}; log: {log}");
+            });
 
-            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert_eq!(
+                result.result_set.unwrap().values[0][0].as_str(),
+                Some("two")
+            );
+            let log = fs::read_to_string(log_file).unwrap();
             let session_index = log
                 .find(MYSQL_READ_ONLY_STATEMENT)
                 .expect("read-only session statement");
-            let query_index = log.find(query).expect("generated query");
-            assert!(session_index < query_index, "{query}: {log}");
+            let user_index = log.find("SELECT 2").expect("user statement");
+            assert!(session_index < user_index, "{log}");
+            assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
         }
-    }
 
-    #[tokio::test]
-    async fn external_metadata_fallback_configures_read_only_session_before_query() {
-        let (_directory, program, option_file) = fake_mysql_metadata_columns(false);
-        let columns = mysql_metadata_columns_external_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SHOW DATABASES",
-            AccessMode::ReadOnly,
-        )
-        .await
-        .unwrap_or_else(|error| {
-            let log =
-                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
-            panic!("external metadata fallback failed: {error:?}; log: {log}");
-        });
+        #[tokio::test]
+        async fn known_empty_result_uses_expected_columns_without_replaying_query() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let query = "SELECT 1 AS first_alias WHERE FALSE";
+            let statements = split_mysql_statements(query)
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
 
-        assert_eq!(columns, ["Database"]);
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        let positions = [
-            "__sabiql_probe",
-            MYSQL_READ_ONLY_STATEMENT,
-            MYSQL_SESSION_MARKER_COLUMN,
-            "SHOW DATABASES",
-        ]
-        .into_iter()
-        .map(|query| log.find(query).expect("query in transcript"))
-        .collect::<Vec<_>>();
-        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
-    }
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadOnly,
+                Some(&["first_alias"]),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("known empty result");
+            let result_set = result.result_set.expect("result set");
+            assert_eq!(result_set.columns, ["first_alias"]);
+            assert!(result_set.values.is_empty());
 
-    #[tokio::test]
-    async fn external_metadata_fallback_setup_failure_never_sends_query() {
-        let (_directory, program, option_file) = fake_mysql_metadata_columns(true);
-        let result = mysql_metadata_columns_external_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SHOW DATABASES",
-            AccessMode::ReadOnly,
-        )
-        .await;
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert_eq!(log.matches(query).count(), 1, "{log}");
+            assert!(!log.contains("__sabiql_metadata_inner"));
+        }
 
-        assert!(result.is_err());
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
-        assert!(!log.contains("SHOW DATABASES"), "{log}");
-    }
+        #[tokio::test]
+        async fn duplicate_empty_select_columns_are_rejected_without_replaying_user_sql() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let query = "SELECT 1 AS duplicate_alias, 2 AS duplicate_alias WHERE FALSE";
+            let statements = split_mysql_statements(query)
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
 
-    #[tokio::test]
-    async fn external_metadata_timeout_kills_and_reaps_the_process() {
-        let (_directory, program, option_file) =
-            fake_mysql_metadata_columns_with_hanging_query(false, true);
-        let result = run_mysql_metadata_query_with_read_only_session_with_timeout(
-            OsStr::new(&program),
-            &option_file,
-            "SHOW DATABASES",
-            Duration::from_secs(10),
-        )
-        .await;
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await;
 
-        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        let pid = log
-            .lines()
-            .find_map(|line| line.strip_prefix("process=")?.parse::<i32>().ok())
-            .expect("metadata process pid");
-        let status = std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stderr(std::process::Stdio::null())
-            .status()
-            .expect("check metadata process");
-        assert!(!status.success(), "metadata process {pid} is still running");
-    }
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(
+                matches!(
+                    result,
+                    Err(DbOperationError::UnsupportedOperation(ref details))
+                        if details.contains("duplicate column names")
+                ),
+                "result={result:?}; log={log}"
+            );
+            assert_eq!(
+                log.lines().filter(|line| *line == query).count(),
+                1,
+                "{log}"
+            );
+        }
 
-    #[tokio::test]
-    async fn exports_mysql_xml_rows_through_the_shared_csv_writer() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let path = option_file.with_file_name("export.csv");
+        #[tokio::test]
+        async fn reuses_one_process_for_ordered_resultsets() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let mut session =
+                MySqlMetadataSession::spawn_with_program(OsStr::new(&program), &option_file)
+                    .expect("spawn fake mysql");
 
-        export_mysql_csv_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 1",
-            path.clone(),
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
+            session.probe().await.expect("mode probe");
+            session
+                .prepare_read_only()
+                .await
+                .expect("read-only session setup");
+            for query in [
+                "SELECT TABLES",
+                "SELECT COLUMNS",
+                "SELECT INDEXES",
+                "SELECT FOREIGN_KEYS",
+                "SELECT TRIGGERS",
+                "SHOW CREATE TABLE items",
+            ] {
+                session.execute(query).await.expect("metadata resultset");
+            }
+            let empty_result = session
+                .execute_with_expected_columns("EMPTY_RESULT", &["known_column"])
+                .await
+                .expect("empty metadata resultset");
+            assert_eq!(empty_result.columns, ["known_column"]);
+            assert!(empty_result.values.is_empty());
+            session.finish().await.expect("finish fake mysql");
 
-        assert_eq!(fs::read_to_string(path).unwrap(), "value\none\n");
-    }
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert_eq!(
+                log.lines()
+                    .filter(|line| line.starts_with("process="))
+                    .count(),
+                1
+            );
+            let positions = [
+                "__sabiql_probe",
+                MYSQL_READ_ONLY_STATEMENT,
+                MYSQL_SESSION_MARKER_COLUMN,
+                "SELECT TABLES",
+                "SELECT COLUMNS",
+                "SELECT INDEXES",
+                "SELECT FOREIGN_KEYS",
+                "SELECT TRIGGERS",
+                "SHOW CREATE TABLE items",
+            ]
+            .into_iter()
+            .map(|query| log.find(query).expect("query in transcript"))
+            .collect::<Vec<_>>();
+            assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+        }
 
-    #[tokio::test]
-    async fn export_configures_read_only_session_before_user_sql() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
-        let path = option_file.with_file_name("export.csv");
-
-        export_mysql_csv_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 1",
-            path,
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
-
-        let log = fs::read_to_string(log_file).unwrap();
-        let session_index = log
-            .find(MYSQL_READ_ONLY_STATEMENT)
-            .expect("read-only session statement");
-        let user_index = log.find("SELECT 1").expect("user statement");
-        assert!(session_index < user_index, "{log}");
-        assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
-    }
-
-    #[tokio::test]
-    async fn export_ignores_cli_error_text_inside_resultset_fields() {
-        let (_directory, program, option_file) = fake_mysql("field_error");
-        let path = option_file.with_file_name("export.csv");
-
-        export_mysql_csv_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 1",
-            path.clone(),
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            fs::read_to_string(path).unwrap(),
-            "message\n\"line 1\nERROR 1146 (42S02): this is a cell value\"\n"
-        );
-    }
-
-    #[tokio::test]
-    async fn export_read_only_session_failure_never_writes_user_sql_or_partial_file() {
-        let (_directory, program, option_file) = fake_mysql("read_only_failure");
-        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
-        let output_directory = tempfile::tempdir().unwrap();
-        let final_path = output_directory.path().join("export.csv");
-
-        let result = export_to_path(final_path.clone(), |path| {
-            export_mysql_csv_with_program(
+        #[tokio::test]
+        async fn read_only_session_failure_never_writes_user_sql() {
+            let (_directory, program, log_file) = fake_mysql("read_only_failure");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
                 OsStr::new(&program),
                 &option_file,
                 "SELECT 123",
-                path,
+                AccessMode::ReadOnly,
                 Duration::from_secs(5),
             )
-        })
-        .await;
+            .await;
 
-        assert!(result.is_err());
-        let log = fs::read_to_string(log_file).unwrap();
-        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
-        assert!(!log.contains("SELECT 123"), "{log}");
-        assert!(!final_path.exists());
-        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+            assert!(result.is_err());
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+            assert!(!log.contains("SELECT 123"), "{log}");
+        }
+
+        #[tokio::test]
+        async fn generated_preview_and_metadata_queries_configure_read_only_session() {
+            for query in [
+                "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
+            ] {
+                let (_directory, program, option_file) = fake_mysql_multi();
+                let statements = split_mysql_statements(query)
+                    .unwrap()
+                    .into_iter()
+                    .map(|sql| classify_mysql_statement(&sql).unwrap())
+                    .collect::<Vec<_>>();
+
+                run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                    OsStr::new(&program),
+                    &option_file,
+                    &statements,
+                    AccessMode::ReadOnly,
+                    None,
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap();
+
+                let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+                let session_index = log
+                    .find(MYSQL_READ_ONLY_STATEMENT)
+                    .expect("read-only session statement");
+                let query_index = log.find(query).expect("generated query");
+                assert!(session_index < query_index, "{query}: {log}");
+            }
+        }
+
+        #[tokio::test]
+        async fn external_metadata_fallback_configures_read_only_session_before_query() {
+            let (_directory, program, option_file) = fake_mysql_metadata_columns(false);
+            let columns = mysql_metadata_columns_external_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SHOW DATABASES",
+                AccessMode::ReadOnly,
+            )
+            .await
+            .unwrap_or_else(|error| {
+                let log = fs::read_to_string(format!("{}.log", option_file.display()))
+                    .unwrap_or_default();
+                panic!("external metadata fallback failed: {error:?}; log: {log}");
+            });
+
+            assert_eq!(columns, ["Database"]);
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            let positions = [
+                "__sabiql_probe",
+                MYSQL_READ_ONLY_STATEMENT,
+                MYSQL_SESSION_MARKER_COLUMN,
+                "SHOW DATABASES",
+            ]
+            .into_iter()
+            .map(|query| log.find(query).expect("query in transcript"))
+            .collect::<Vec<_>>();
+            assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+        }
+
+        #[tokio::test]
+        async fn external_metadata_fallback_setup_failure_never_sends_query() {
+            let (_directory, program, option_file) = fake_mysql_metadata_columns(true);
+            let result = mysql_metadata_columns_external_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SHOW DATABASES",
+                AccessMode::ReadOnly,
+            )
+            .await;
+
+            assert!(result.is_err());
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+            assert!(!log.contains("SHOW DATABASES"), "{log}");
+        }
+
+        #[tokio::test]
+        async fn external_metadata_timeout_kills_and_reaps_the_process() {
+            let (_directory, program, option_file) =
+                fake_mysql_metadata_columns_with_hanging_query(false, true);
+            let result = run_mysql_metadata_query_with_read_only_session_with_timeout(
+                OsStr::new(&program),
+                &option_file,
+                "SHOW DATABASES",
+                Duration::from_secs(10),
+            )
+            .await;
+
+            assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            let pid = log
+                .lines()
+                .find_map(|line| line.strip_prefix("process=")?.parse::<i32>().ok())
+                .expect("metadata process pid");
+            let status = std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .stderr(std::process::Stdio::null())
+                .status()
+                .expect("check metadata process");
+            assert!(!status.success(), "metadata process {pid} is still running");
+        }
     }
 
-    #[tokio::test]
-    async fn export_failure_removes_the_partial_file() {
-        let (_directory, program, option_file) = fake_mysql("failure");
-        let output_directory = tempfile::tempdir().unwrap();
-        let final_path = output_directory.path().join("export.csv");
+    mod export {
+        use super::*;
 
-        let result = export_to_path(final_path.clone(), |path| {
+        #[tokio::test]
+        async fn exports_mysql_xml_rows_through_the_shared_csv_writer() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let path = option_file.with_file_name("export.csv");
+
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path.clone(),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(fs::read_to_string(path).unwrap(), "value\none\n");
+        }
+
+        #[tokio::test]
+        async fn configures_read_only_session_before_user_sql() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+            let path = option_file.with_file_name("export.csv");
+
             export_mysql_csv_with_program(
                 OsStr::new(&program),
                 &option_file,
@@ -1270,40 +1212,187 @@ done
                 path,
                 Duration::from_secs(5),
             )
-        })
-        .await;
+            .await
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(!final_path.exists());
-        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
-    }
+            let log = fs::read_to_string(log_file).unwrap();
+            let session_index = log
+                .find(MYSQL_READ_ONLY_STATEMENT)
+                .expect("read-only session statement");
+            let user_index = log.find("SELECT 1").expect("user statement");
+            assert!(session_index < user_index, "{log}");
+            assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
+        }
 
-    #[tokio::test]
-    async fn export_timeout_kills_the_process_and_removes_the_partial_file() {
-        let (_directory, program, option_file) = fake_mysql("timeout");
-        let output_directory = tempfile::tempdir().unwrap();
-        let final_path = output_directory.path().join("export.csv");
+        #[tokio::test]
+        async fn ignores_cli_error_text_inside_resultset_fields() {
+            let (_directory, program, option_file) = fake_mysql("field_error");
+            let path = option_file.with_file_name("export.csv");
 
-        let result = export_to_path(final_path.clone(), |path| {
             export_mysql_csv_with_program(
                 OsStr::new(&program),
                 &option_file,
                 "SELECT 1",
-                path,
+                path.clone(),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                fs::read_to_string(path).unwrap(),
+                "message\n\"line 1\nERROR 1146 (42S02): this is a cell value\"\n"
+            );
+        }
+
+        #[tokio::test]
+        async fn read_only_session_failure_never_writes_user_sql_or_partial_file() {
+            let (_directory, program, option_file) = fake_mysql("read_only_failure");
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+            let output_directory = tempfile::tempdir().unwrap();
+            let final_path = output_directory.path().join("export.csv");
+
+            let result = export_to_path(final_path.clone(), |path| {
+                export_mysql_csv_with_program(
+                    OsStr::new(&program),
+                    &option_file,
+                    "SELECT 123",
+                    path,
+                    Duration::from_secs(5),
+                )
+            })
+            .await;
+
+            assert!(result.is_err());
+            let log = fs::read_to_string(log_file).unwrap();
+            assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+            assert!(!log.contains("SELECT 123"), "{log}");
+            assert!(!final_path.exists());
+            assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+        }
+
+        #[tokio::test]
+        async fn failure_removes_the_partial_file() {
+            let (_directory, program, option_file) = fake_mysql("failure");
+            let output_directory = tempfile::tempdir().unwrap();
+            let final_path = output_directory.path().join("export.csv");
+
+            let result = export_to_path(final_path.clone(), |path| {
+                export_mysql_csv_with_program(
+                    OsStr::new(&program),
+                    &option_file,
+                    "SELECT 1",
+                    path,
+                    Duration::from_secs(5),
+                )
+            })
+            .await;
+
+            assert!(result.is_err());
+            assert!(!final_path.exists());
+            assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+        }
+
+        #[tokio::test]
+        async fn timeout_kills_the_process_and_removes_the_partial_file() {
+            let (_directory, program, option_file) = fake_mysql("timeout");
+            let output_directory = tempfile::tempdir().unwrap();
+            let final_path = output_directory.path().join("export.csv");
+
+            let result = export_to_path(final_path.clone(), |path| {
+                export_mysql_csv_with_program(
+                    OsStr::new(&program),
+                    &option_file,
+                    "SELECT 1",
+                    path,
+                    Duration::from_millis(50),
+                )
+            })
+            .await;
+
+            assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+            assert!(!final_path.exists());
+            assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+        }
+    }
+
+    mod probe {
+        use super::*;
+
+        #[tokio::test]
+        async fn failure_never_writes_user_sql() {
+            for mode in ["unsupported", "invalid", "missing"] {
+                let (_directory, program, log_file) = fake_mysql(mode);
+                let option_file = log_file.with_extension("cnf");
+                fs::write(&option_file, "[client]\n").unwrap();
+                let result = run_mysql_single_statement_with_program(
+                    OsStr::new(&program),
+                    &option_file,
+                    "SELECT 123",
+                    AccessMode::ReadWrite,
+                    Duration::from_secs(5),
+                )
+                .await;
+                assert!(result.is_err(), "{mode}");
+                let log = fs::read_to_string(format!("{}.log", option_file.display()))
+                    .unwrap_or_default();
+                assert!(!log.contains("SELECT 123"), "{mode}: {log}");
+            }
+        }
+
+        #[tokio::test]
+        async fn timeout_kills_the_process_and_discards_output() {
+            let (_directory, program, log_file) = fake_mysql("timeout");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
                 Duration::from_millis(50),
             )
-        })
-        .await;
+            .await;
 
-        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
-        assert!(!final_path.exists());
-        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
-    }
+            assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+            let log =
+                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+            assert!(!log.contains("SELECT 123"));
+        }
 
-    #[tokio::test]
-    async fn probe_failure_never_writes_user_sql() {
-        for mode in ["unsupported", "invalid", "missing"] {
-            let (_directory, program, log_file) = fake_mysql(mode);
+        #[cfg(feature = "test-support")]
+        #[tokio::test]
+        async fn initial_pty_output_timeout_kills_and_reaps_the_process() {
+            let (_directory, program, option_file) = fake_mysql_without_output();
+            let (pid, result) = run_mysql_cli_script_with_program_and_pid(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123;\n",
+                Duration::from_millis(50),
+            )
+            .await
+            .expect("spawn script process");
+
+            match result {
+                Err(DbOperationError::Timeout(details)) => {
+                    assert!(
+                        details.contains("initial MySQL PTY output wait"),
+                        "{details}"
+                    );
+                }
+                result => panic!("expected initial PTY output timeout, got {result:?}"),
+            }
+            let status = std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .stderr(std::process::Stdio::null())
+                .status()
+                .expect("check script process");
+            assert!(!status.success(), "script process {pid} is still running");
+        }
+
+        #[tokio::test]
+        async fn nonzero_cli_exit_discards_any_collected_stdout() {
+            let (_directory, program, log_file) = fake_mysql("failure");
             let option_file = log_file.with_extension("cnf");
             fs::write(&option_file, "[client]\n").unwrap();
             let result = run_mysql_single_statement_with_program(
@@ -1314,235 +1403,122 @@ done
                 Duration::from_secs(5),
             )
             .await;
-            assert!(result.is_err(), "{mode}");
-            let log =
-                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
-            assert!(!log.contains("SELECT 123"), "{mode}: {log}");
+
+            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
         }
-    }
 
-    #[tokio::test]
-    async fn probe_timeout_kills_the_process_and_discards_output() {
-        let (_directory, program, log_file) = fake_mysql("timeout");
-        let option_file = log_file.with_extension("cnf");
-        fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_single_statement_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123",
-            AccessMode::ReadWrite,
-            Duration::from_millis(50),
-        )
-        .await;
+        #[tokio::test]
+        async fn classifies_cli_error_when_no_resultset_is_emitted() {
+            let (_directory, program, log_file) = fake_mysql("no_result_failure");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
 
-        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
-        assert!(!log.contains("SELECT 123"));
-    }
-
-    #[cfg(feature = "test-support")]
-    #[tokio::test]
-    async fn initial_pty_output_timeout_kills_and_reaps_the_process() {
-        let (_directory, program, option_file) = fake_mysql_without_output();
-        let (pid, result) = run_mysql_cli_script_with_program_and_pid(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123;\n",
-            Duration::from_millis(50),
-        )
-        .await
-        .expect("spawn script process");
-
-        match result {
-            Err(DbOperationError::Timeout(details)) => {
-                assert!(
-                    details.contains("initial MySQL PTY output wait"),
-                    "{details}"
-                );
-            }
-            result => panic!("expected initial PTY output timeout, got {result:?}"),
-        }
-        let status = std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stderr(std::process::Stdio::null())
-            .status()
-            .expect("check script process");
-        assert!(!status.success(), "script process {pid} is still running");
-    }
-
-    #[tokio::test]
-    async fn nonzero_cli_exit_discards_any_collected_stdout() {
-        let (_directory, program, log_file) = fake_mysql("failure");
-        let option_file = log_file.with_extension("cnf");
-        fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_single_statement_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123",
-            AccessMode::ReadWrite,
-            Duration::from_secs(5),
-        )
-        .await;
-
-        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
-    }
-
-    #[tokio::test]
-    async fn classifies_cli_error_when_no_resultset_is_emitted() {
-        let (_directory, program, log_file) = fake_mysql("no_result_failure");
-        let option_file = log_file.with_extension("cnf");
-        fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_single_statement_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123",
-            AccessMode::ReadWrite,
-            Duration::from_secs(5),
-        )
-        .await;
-
-        assert!(matches!(
+            assert!(matches!(
             result,
             Err(DbOperationError::ObjectMissing(details))
                 if details.contains("missing_column")
-        ));
+            ));
+        }
+
+        #[tokio::test]
+        async fn classifies_connection_refusal_from_the_shared_cli_error_path() {
+            let (_directory, program, log_file) = fake_mysql("connection_refused");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
+        }
     }
 
-    #[tokio::test]
-    async fn classifies_connection_refusal_from_the_shared_cli_error_path() {
-        let (_directory, program, log_file) = fake_mysql("connection_refused");
-        let option_file = log_file.with_extension("cnf");
-        fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_single_statement_with_program(
-            OsStr::new(&program),
-            &option_file,
-            "SELECT 123",
-            AccessMode::ReadWrite,
-            Duration::from_secs(5),
-        )
-        .await;
+    mod multi_statement {
+        use super::*;
 
-        assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
-    }
+        #[tokio::test]
+        async fn executes_each_statement_and_returns_the_last_user_result() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+            let statements = split_mysql_statements("UPDATE items SET value = 1; SELECT 2")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
 
-    #[tokio::test]
-    async fn executes_each_statement_and_returns_the_last_user_result() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
-        let statements = split_mysql_statements("UPDATE items SET value = 1; SELECT 2")
-            .unwrap()
-            .into_iter()
-            .map(|sql| classify_mysql_statement(&sql).unwrap())
-            .collect::<Vec<_>>();
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("multi execution failed: {error:?}"));
 
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadWrite,
-            None,
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap_or_else(|error| panic!("multi execution failed: {error:?}"));
+            assert_eq!(
+                result.result_set,
+                Some(MySqlResultSet {
+                    columns: vec!["value".to_string()],
+                    values: vec![vec![QueryValue::Text("two".to_string())]],
+                })
+            );
+            assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
+            assert_eq!(result.refresh_scope, RefreshScope::Data);
+            let log = fs::read_to_string(log_file).unwrap();
+            assert!(log.contains("UPDATE items SET value = 1"));
+            assert!(log.matches("__sabiql_marker").count() >= 2);
+        }
 
-        assert_eq!(
-            result.result_set,
-            Some(MySqlResultSet {
-                columns: vec!["value".to_string()],
-                values: vec![vec![QueryValue::Text("two".to_string())]],
-            })
-        );
-        assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
-        assert_eq!(result.refresh_scope, RefreshScope::Data);
-        let log = fs::read_to_string(log_file).unwrap();
-        assert!(log.contains("UPDATE items SET value = 1"));
-        assert!(log.matches("__sabiql_marker").count() >= 2);
-    }
+        #[tokio::test]
+        async fn tail_error_is_classified_after_pty_drain() {
+            let (_directory, program, option_file) = fake_mysql_multi_with_tail_failure();
+            let query = "UPDATE items SET value = 1; CREATE TABLE created (id INT)";
+            let statements = split_mysql_statements(query)
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
 
-    #[tokio::test]
-    async fn tail_error_is_classified_after_pty_drain() {
-        let (_directory, program, option_file) = fake_mysql_multi_with_tail_failure();
-        let query = "UPDATE items SET value = 1; CREATE TABLE created (id INT)";
-        let statements = split_mysql_statements(query)
-            .unwrap()
-            .into_iter()
-            .map(|sql| classify_mysql_statement(&sql).unwrap())
-            .collect::<Vec<_>>();
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await;
 
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadWrite,
-            None,
-            Duration::from_secs(5),
-        )
-        .await;
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    source,
+                    refresh_scope: RefreshScope::Metadata,
+                    ..
+                }) if matches!(&*source, DbOperationError::ObjectMissing(_))
+            ));
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.lines().any(|line| line == "input_closed"), "{log}");
+        }
 
-        assert!(matches!(
-            result,
-            Err(DbOperationError::QueryFailedAfterChange {
-                source,
-                refresh_scope: RefreshScope::Metadata,
-                ..
-            }) if matches!(&*source, DbOperationError::ObjectMissing(_))
-        ));
-        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-        assert!(log.lines().any(|line| line == "input_closed"), "{log}");
-    }
-
-    #[tokio::test]
-    async fn marker_failure_after_a_change_refreshes_the_current_scope() {
-        let (_directory, program, option_file) = fake_mysql_multi_with_marker_failure();
-        let statements = split_mysql_statements("UPDATE items SET value = 1")
-            .unwrap()
-            .into_iter()
-            .map(|sql| classify_mysql_statement(&sql).unwrap())
-            .collect::<Vec<_>>();
-
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadWrite,
-            None,
-            Duration::from_secs(5),
-        )
-        .await;
-
-        assert!(matches!(
-            result,
-            Err(DbOperationError::QueryFailedAfterChange {
-                source,
-                refresh_scope: RefreshScope::Data,
-                ..
-            }) if matches!(&*source, DbOperationError::QueryFailed(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn first_change_statement_failure_keeps_the_classified_error_unwrapped() {
-        for (details, summary) in [
-            (
-                "ERROR 1142 (42000): command denied to user",
-                "Permission denied",
-            ),
-            (
-                "ERROR 1062 (23000): Duplicate entry duplicate_value for key PRIMARY",
-                "Unique constraint violation",
-            ),
-            (
-                "ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails",
-                "Foreign key constraint violation",
-            ),
-            (
-                "ERROR 1205 (HY000): Lock wait timeout exceeded",
-                "Operation blocked by lock or timeout",
-            ),
-        ] {
-            let (_directory, program, option_file) =
-                fake_mysql_multi_with_statement_failure(details);
+        #[tokio::test]
+        async fn marker_failure_after_a_change_refreshes_the_current_scope() {
+            let (_directory, program, option_file) = fake_mysql_multi_with_marker_failure();
             let statements = split_mysql_statements("UPDATE items SET value = 1")
                 .unwrap()
                 .into_iter()
@@ -1558,72 +1534,122 @@ done
                 Duration::from_secs(5),
             )
             .await;
-            let Err(error) = result else {
-                panic!("expected the fake MySQL statement to fail");
-            };
 
-            assert_eq!(error.summary(), summary);
-            assert!(!matches!(
-                error,
-                DbOperationError::QueryFailedAfterChange { .. }
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    source,
+                    refresh_scope: RefreshScope::Data,
+                    ..
+                }) if matches!(&*source, DbOperationError::QueryFailed(_))
             ));
         }
-    }
 
-    #[tokio::test]
-    async fn marks_a_later_failure_after_a_confirmed_change_for_refresh() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let statements =
-            split_mysql_statements("UPDATE items SET value = 1; SELECT missing_column FROM items")
-                .unwrap()
-                .into_iter()
-                .map(|sql| classify_mysql_statement(&sql).unwrap())
-                .collect::<Vec<_>>();
+        #[tokio::test]
+        async fn first_change_statement_failure_keeps_the_classified_error_unwrapped() {
+            for (details, summary) in [
+                (
+                    "ERROR 1142 (42000): command denied to user",
+                    "Permission denied",
+                ),
+                (
+                    "ERROR 1062 (23000): Duplicate entry duplicate_value for key PRIMARY",
+                    "Unique constraint violation",
+                ),
+                (
+                    "ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails",
+                    "Foreign key constraint violation",
+                ),
+                (
+                    "ERROR 1205 (HY000): Lock wait timeout exceeded",
+                    "Operation blocked by lock or timeout",
+                ),
+            ] {
+                let (_directory, program, option_file) =
+                    fake_mysql_multi_with_statement_failure(details);
+                let statements = split_mysql_statements("UPDATE items SET value = 1")
+                    .unwrap()
+                    .into_iter()
+                    .map(|sql| classify_mysql_statement(&sql).unwrap())
+                    .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadWrite,
-            None,
-            Duration::from_secs(5),
-        )
-        .await;
+                let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                    OsStr::new(&program),
+                    &option_file,
+                    &statements,
+                    AccessMode::ReadWrite,
+                    None,
+                    Duration::from_secs(5),
+                )
+                .await;
+                let Err(error) = result else {
+                    panic!("expected the fake MySQL statement to fail");
+                };
 
-        assert!(matches!(
-            result,
-            Err(DbOperationError::QueryFailedAfterChange {
-                source,
-                refresh_scope: RefreshScope::Data,
-                ..
-            }) if matches!(&*source, DbOperationError::ObjectMissing(_))
-        ));
-    }
+                assert_eq!(error.summary(), summary);
+                assert!(!matches!(
+                    error,
+                    DbOperationError::QueryFailedAfterChange { .. }
+                ));
+            }
+        }
 
-    #[tokio::test]
-    async fn rejects_error_reported_after_row_count_marker() {
-        let (_directory, program, option_file) = fake_mysql_multi();
-        let statements = split_mysql_statements("SELECT missing_column FROM items")
+        #[tokio::test]
+        async fn marks_a_later_failure_after_a_confirmed_change_for_refresh() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements(
+                "UPDATE items SET value = 1; SELECT missing_column FROM items",
+            )
             .unwrap()
             .into_iter()
             .map(|sql| classify_mysql_statement(&sql).unwrap())
             .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
-            OsStr::new(&program),
-            &option_file,
-            &statements,
-            AccessMode::ReadWrite,
-            None,
-            Duration::from_secs(5),
-        )
-        .await;
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await;
 
-        assert!(matches!(
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    source,
+                    refresh_scope: RefreshScope::Data,
+                    ..
+                }) if matches!(&*source, DbOperationError::ObjectMissing(_))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_error_reported_after_row_count_marker() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements("SELECT missing_column FROM items")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            assert!(matches!(
             result,
             Err(DbOperationError::ObjectMissing(details))
                 if details.contains("missing_column")
-        ));
+            ));
+        }
     }
 }
 

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -748,7 +748,7 @@ done
     }
 
     #[test]
-    fn numeric_literal_validation_rejects_partial_values() {
+    fn accepts_valid_decimal_and_rejects_incomplete_numeric_literals() {
         assert!(is_sql_numeric_literal("1."));
         assert!(is_sql_numeric_literal(".5"));
         assert!(is_sql_numeric_literal("-1.2e-3"));

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2210,7 +2210,6 @@ mod query_execution {
         .await;
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
     async fn rejects_implicit_commit_transaction_and_matches_oracle_mysql_behavior() {

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -392,6 +392,31 @@ fn connection_error_collapsed() {
     insta::assert_snapshot!(output);
 }
 
+#[test]
+fn mysql_active_connection_retryable_error_shows_retry_action() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.session.activate_connection_with_target(
+        &sabiql_domain::ConnectionId::from_string("mysql-test"),
+        "mysql",
+        DatabaseType::MySQL,
+        "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
+        Some("app"),
+    );
+    state.modal.set_mode(InputMode::ConnectionError);
+    state
+        .connection_error
+        .set_error(ConnectionErrorInfo::with_kind(
+            ConnectionErrorKind::Timeout,
+            "ERROR 2003 (HY000): Can't connect to MySQL server on 'localhost' (110)",
+        ));
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
 fn render_service_error_without_service_file_hint(save_and_connect: bool) -> String {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__mysql_active_connection_retryable_error_shows_retry_action.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__mysql_active_connection_retryable_error_shows_retry_action.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/render_snapshots/table_explorer.rs
+source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
 test_project ▸ app ▸ -                                                                                                                             not loaded | mysql
@@ -23,15 +23,15 @@ test_project ▸ app ▸ -                                                      
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
-│                                       │└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-│                                       │┌ [3] Result ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│                                       ││(select a table to preview)                                                                                               │
-│                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
+│                        ╭ Connection Error ───────────────────────────────────────────────────────────────────────────────────────────────╮                        │
+│                        │✗ Connection timed out                                                                                           │                        │
+│                        │                                                                                                                 │                        │
+│                        │Hint: Check network connectivity                                                                                 │────────────────────────┘
+│                        │                                                                                                                 │────────────────────────┐
+│                        │▶ Details (press d to expand)                                                                                    │                        │
+│                        │                                                                                                                 │                        │
+│                        │Actions:  r  Retry   s  Switch   d  Details   y  Copy                                                            │                        │
+│                        ╰ Esc: Close ─────────────────────────────────────────────────────────────────────────────────────────────────────╯                        │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +51,4 @@ test_project ▸ app ▸ -                                                      
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Retry  s:Switch  d:Details  y:Copy  Esc:Close

--- a/src/tests/render_snapshots/table_explorer.rs
+++ b/src/tests/render_snapshots/table_explorer.rs
@@ -137,24 +137,6 @@ fn sqlite_explorer_shows_table_kind_suffixes() {
 }
 
 #[test]
-fn mysql_explorer_requests_metadata_load() {
-    let mut state = create_test_state();
-    state.session.activate_connection_with_target(
-        &ConnectionId::from_string("mysql-test"),
-        "mysql",
-        DatabaseType::MySQL,
-        "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
-        Some("app"),
-    );
-    state.session.mark_probe_connected();
-
-    let mut terminal = create_test_terminal();
-    let output = render_to_string(&mut terminal, &mut state);
-
-    insta::assert_snapshot!(output);
-}
-
-#[test]
 fn mysql_header_and_explorer_show_table_names() {
     let mut state = create_test_state();
     state.session.activate_connection_with_target(


### PR DESCRIPTION
## Problem
MySQL tests still included an unreachable explorer snapshot, an incomplete retry UI snapshot, and a flat CLI process test section.

## Background
SAB-514 completes the remaining test-only cleanup under the MySQL branch.

## Approach
Remove the unreachable snapshot, add representative retry coverage, make the Oracle MySQL integration test discoverable on all platforms, and group existing safeguards by behavior domain without changing production behavior or reducing assertions.

Fixes SAB-514: https://linear.app/sabiql/issue/SAB-514