### PR TITLE
fix: order table pane reveals

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -157,6 +157,20 @@ pub struct DeleteRefreshTarget {
     pub expected_delete_count: usize,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PendingPreview {
+    result: Arc<QueryResult>,
+    generation: u64,
+    target_page: Option<usize>,
+    highlight: bool,
+}
+
+impl PendingPreview {
+    pub(crate) fn into_parts(self) -> (Arc<QueryResult>, Option<usize>, bool) {
+        (self.result, self.target_page, self.highlight)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct QueryExecution {
     status: QueryStatus,
@@ -166,6 +180,7 @@ pub struct QueryExecution {
     result_generation: u64,
     result_highlight_until: Option<Instant>,
     pub pagination: PaginationState,
+    pending_preview: Option<PendingPreview>,
     pending_delete_refresh_target: Option<DeleteRefreshTarget>,
     post_delete_row_selection: PostDeleteRowSelection,
     run: AsyncRun,
@@ -189,6 +204,7 @@ impl QueryExecution {
 
     pub fn reset_for_context_change(&mut self) {
         self.mark_idle();
+        self.pending_preview = None;
         self.clear_delete_refresh_target();
         self.post_delete_row_selection = PostDeleteRowSelection::Keep;
     }
@@ -223,6 +239,35 @@ impl QueryExecution {
     pub fn clear_current_result(&mut self) {
         self.current_result = None;
         self.result_generation += 1;
+    }
+
+    pub(crate) fn defer_preview(
+        &mut self,
+        result: Arc<QueryResult>,
+        generation: u64,
+        target_page: Option<usize>,
+        highlight: bool,
+    ) {
+        self.pending_preview = Some(PendingPreview {
+            result,
+            generation,
+            target_page,
+            highlight,
+        });
+    }
+
+    pub(crate) fn has_pending_preview(&self, generation: u64) -> bool {
+        self.pending_preview
+            .as_ref()
+            .is_some_and(|pending| pending.generation == generation)
+    }
+
+    pub(crate) fn take_pending_preview(&mut self, generation: u64) -> Option<PendingPreview> {
+        if self.has_pending_preview(generation) {
+            self.pending_preview.take()
+        } else {
+            None
+        }
     }
 
     pub fn push_history(&mut self, result: Arc<QueryResult>) {
@@ -523,12 +568,14 @@ mod tests {
         let run_id = execution.begin_running(Instant::now());
         execution.set_delete_refresh_target(2, Some(3), 1);
         execution.set_post_delete_selection(PostDeleteRowSelection::Select(4));
+        execution.defer_preview(make_result(QuerySource::Preview), 1, Some(0), true);
 
         execution.reset_for_context_change();
 
         assert_eq!(execution.status(), QueryStatus::Idle);
         assert!(!execution.is_current_run(run_id));
         assert!(execution.pending_delete_refresh_target().is_none());
+        assert!(!execution.has_pending_preview(1));
         assert_eq!(
             execution.post_delete_row_selection(),
             PostDeleteRowSelection::Keep

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -193,6 +193,7 @@ impl QueryExecution {
     pub fn begin_running(&mut self, now: Instant) -> u64 {
         self.status = QueryStatus::Running;
         self.start_time = Some(now);
+        self.pending_preview = None;
         self.run.begin()
     }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -750,6 +750,14 @@ impl BrowseSession {
         &self.table_detail_state
     }
 
+    pub(crate) fn is_table_detail_terminal(&self, generation: u64) -> bool {
+        generation == self.selection_generation
+            && matches!(
+                self.table_detail_state,
+                TableDetailState::Loaded | TableDetailState::Error(_)
+            )
+    }
+
     pub fn selection_generation(&self) -> u64 {
         self.selection_generation
     }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -600,6 +600,9 @@ pub enum Action {
         generation: u64,
         source: QuerySource,
     },
+    RevealPendingPreview {
+        generation: u64,
+    },
     ExecuteWriteSucceeded {
         dsn: String,
         run_id: u64,

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -25,6 +25,7 @@ pub(super) fn reduce_table_detail(
 
             if state.session.set_table_detail(*detail.clone(), *generation) {
                 state.ui.set_inspector_scroll_offset(0);
+                return DispatchResult::handled_with(reveal_pending_preview(state, *generation));
             }
             DispatchResult::handled()
         }
@@ -46,6 +47,7 @@ pub(super) fn reduce_table_detail(
                 .mark_table_detail_failed(*generation, message.clone())
             {
                 state.messages.set_error_at(message, now);
+                return DispatchResult::handled_with(reveal_pending_preview(state, *generation));
             }
             DispatchResult::handled()
         }
@@ -82,5 +84,15 @@ pub(super) fn reduce_table_detail(
             }])
         }
         _ => DispatchResult::pass(),
+    }
+}
+
+fn reveal_pending_preview(state: &AppState, generation: u64) -> Vec<Effect> {
+    if state.query.has_pending_preview(generation) {
+        vec![Effect::DispatchActions(vec![
+            Action::RevealPendingPreview { generation },
+        ])]
+    } else {
+        vec![]
     }
 }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -372,6 +372,7 @@ mod tests {
     use super::*;
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
+    use crate::cmd::runner::EffectRunner;
     use crate::cmd::test_fixtures;
     use crate::domain::{ConnectionId, DatabaseType};
     use crate::ports::outbound::connection_store::MockConnectionStore;
@@ -417,6 +418,27 @@ mod tests {
         }
     }
 
+    async fn run_effects_and_clear_dirty<T: Renderer>(
+        runner: &EffectRunner,
+        effects: Vec<Effect>,
+        renderer: &mut T,
+        state: &mut AppState,
+        completion_engine: &std::cell::RefCell<CompletionEngine>,
+    ) -> Vec<Action> {
+        let pending = runner
+            .run(
+                effects,
+                renderer,
+                state,
+                completion_engine,
+                &AppServices::stub(),
+            )
+            .await
+            .unwrap();
+        state.clear_dirty();
+        pending
+    }
+
     async fn render_frames_after_inspector_terminal(inspector_failed: bool) -> Vec<RenderFrame> {
         let (mut state, generation, detail_run_id) =
             state_with_selected_table(DatabaseType::PostgreSQL);
@@ -440,17 +462,15 @@ mod tests {
         );
         append_runtime_render(&state, &mut query_effects);
         assert!(
-            runner
-                .run(
-                    query_effects,
-                    &mut renderer,
-                    &mut state,
-                    &completion_engine,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap()
-                .is_empty()
+            run_effects_and_clear_dirty(
+                &runner,
+                query_effects,
+                &mut renderer,
+                &mut state,
+                &completion_engine,
+            )
+            .await
+            .is_empty()
         );
         assert_eq!(
             renderer.frames,
@@ -483,16 +503,14 @@ mod tests {
             &AppServices::stub(),
         );
         append_runtime_render(&state, &mut effects);
-        let pending = runner
-            .run(
-                effects,
-                &mut renderer,
-                &mut state,
-                &completion_engine,
-                &AppServices::stub(),
-            )
-            .await
-            .unwrap();
+        let pending = run_effects_and_clear_dirty(
+            &runner,
+            effects,
+            &mut renderer,
+            &mut state,
+            &completion_engine,
+        )
+        .await;
         assert_eq!(
             renderer.frames,
             [RenderFrame {
@@ -512,17 +530,15 @@ mod tests {
         }
         append_runtime_render(&state, &mut next_effects);
         assert!(
-            runner
-                .run(
-                    next_effects,
-                    &mut renderer,
-                    &mut state,
-                    &completion_engine,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap()
-                .is_empty()
+            run_effects_and_clear_dirty(
+                &runner,
+                next_effects,
+                &mut renderer,
+                &mut state,
+                &completion_engine,
+            )
+            .await
+            .is_empty()
         );
 
         renderer.frames

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -420,14 +420,46 @@ mod tests {
     async fn render_frames_after_inspector_terminal(inspector_failed: bool) -> Vec<RenderFrame> {
         let (mut state, generation, detail_run_id) =
             state_with_selected_table(DatabaseType::PostgreSQL);
+        let (tx, _rx) = mpsc::channel(8);
+        let runner = test_fixtures::make_runner(
+            Arc::new(MockMetadataProvider::new()),
+            Arc::new(MockQueryExecutor::new()),
+            Arc::new(MockConnectionStore::new()),
+            TtlCache::new(300),
+            tx,
+        );
+        let completion_engine = std::cell::RefCell::new(CompletionEngine::new());
+        let mut renderer = RecordingRenderer { frames: vec![] };
         let query_action =
             query_completed_action(&mut state, preview_result(1), generation, Some(0));
-        reduce(
+        let mut query_effects = reduce(
             &mut state,
             query_action,
             Instant::now(),
             &AppServices::stub(),
         );
+        append_runtime_render(&state, &mut query_effects);
+        assert!(
+            runner
+                .run(
+                    query_effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            renderer.frames,
+            [RenderFrame {
+                inspector_terminal: false,
+                result_visible: false,
+            }]
+        );
+        renderer.frames.clear();
 
         let inspector_action = if inspector_failed {
             Action::TableDetailFailed {
@@ -451,17 +483,6 @@ mod tests {
             &AppServices::stub(),
         );
         append_runtime_render(&state, &mut effects);
-
-        let (tx, _rx) = mpsc::channel(8);
-        let runner = test_fixtures::make_runner(
-            Arc::new(MockMetadataProvider::new()),
-            Arc::new(MockQueryExecutor::new()),
-            Arc::new(MockConnectionStore::new()),
-            TtlCache::new(300),
-            tx,
-        );
-        let completion_engine = std::cell::RefCell::new(CompletionEngine::new());
-        let mut renderer = RecordingRenderer { frames: vec![] };
         let pending = runner
             .run(
                 effects,
@@ -472,6 +493,13 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            renderer.frames,
+            [RenderFrame {
+                inspector_terminal: true,
+                result_visible: false,
+            }]
+        );
 
         let mut next_effects = Vec::new();
         for action in pending {

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -370,11 +370,135 @@ fn apply_preview_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmd::cache::TtlCache;
+    use crate::cmd::completion_engine::CompletionEngine;
+    use crate::cmd::test_fixtures;
     use crate::domain::{ConnectionId, DatabaseType};
-    use crate::ports::outbound::DbOperationError;
+    use crate::ports::outbound::connection_store::MockConnectionStore;
+    use crate::ports::outbound::metadata::MockMetadataProvider;
+    use crate::ports::outbound::query_executor::MockQueryExecutor;
+    use crate::ports::outbound::{DbOperationError, RenderOutput, RenderResult, Renderer};
     use crate::update::browse::metadata::dispatch_metadata;
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
+    use crate::update::reducer::reduce;
+    use tokio::sync::mpsc;
+
+    #[derive(Debug, PartialEq)]
+    struct RenderFrame {
+        inspector_terminal: bool,
+        result_visible: bool,
+    }
+
+    struct RecordingRenderer {
+        frames: Vec<RenderFrame>,
+    }
+
+    impl Renderer for RecordingRenderer {
+        fn draw(
+            &mut self,
+            state: &AppState,
+            _services: &AppServices,
+            _now: Instant,
+        ) -> RenderResult<RenderOutput> {
+            self.frames.push(RenderFrame {
+                inspector_terminal: state
+                    .session
+                    .is_table_detail_terminal(state.session.selection_generation()),
+                result_visible: state.query.current_result().is_some(),
+            });
+            Ok(RenderOutput::default())
+        }
+    }
+
+    fn append_runtime_render(state: &AppState, effects: &mut Vec<Effect>) {
+        if state.render_dirty {
+            effects.push(Effect::Render);
+        }
+    }
+
+    async fn render_frames_after_inspector_terminal(inspector_failed: bool) -> Vec<RenderFrame> {
+        let (mut state, generation, detail_run_id) =
+            state_with_selected_table(DatabaseType::PostgreSQL);
+        let query_action =
+            query_completed_action(&mut state, preview_result(1), generation, Some(0));
+        reduce(
+            &mut state,
+            query_action,
+            Instant::now(),
+            &AppServices::stub(),
+        );
+
+        let inspector_action = if inspector_failed {
+            Action::TableDetailFailed {
+                dsn: "postgres://localhost/test".to_string(),
+                run_id: detail_run_id,
+                error: DbOperationError::QueryFailed("inspector failed".to_string()),
+                generation,
+            }
+        } else {
+            Action::TableDetailLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                run_id: detail_run_id,
+                detail: Box::new(users_table_detail()),
+                generation,
+            }
+        };
+        let mut effects = reduce(
+            &mut state,
+            inspector_action,
+            Instant::now(),
+            &AppServices::stub(),
+        );
+        append_runtime_render(&state, &mut effects);
+
+        let (tx, _rx) = mpsc::channel(8);
+        let runner = test_fixtures::make_runner(
+            Arc::new(MockMetadataProvider::new()),
+            Arc::new(MockQueryExecutor::new()),
+            Arc::new(MockConnectionStore::new()),
+            TtlCache::new(300),
+            tx,
+        );
+        let completion_engine = std::cell::RefCell::new(CompletionEngine::new());
+        let mut renderer = RecordingRenderer { frames: vec![] };
+        let pending = runner
+            .run(
+                effects,
+                &mut renderer,
+                &mut state,
+                &completion_engine,
+                &AppServices::stub(),
+            )
+            .await
+            .unwrap();
+
+        let mut next_effects = Vec::new();
+        for action in pending {
+            next_effects.extend(reduce(
+                &mut state,
+                action,
+                Instant::now(),
+                &AppServices::stub(),
+            ));
+        }
+        append_runtime_render(&state, &mut next_effects);
+        assert!(
+            runner
+                .run(
+                    next_effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        renderer.frames
+    }
 
     fn query_failed_action(
         state: &mut AppState,
@@ -672,56 +796,23 @@ mod tests {
             assert!(!state.query.has_pending_preview(generation));
         }
 
-        #[test]
-        fn preview_completion_waits_for_inspector_render_boundary() {
-            let (mut state, generation, detail_run_id) =
-                state_with_selected_table(DatabaseType::PostgreSQL);
-            let query_action =
-                query_completed_action(&mut state, preview_result(1), generation, Some(0));
-
-            dispatch_query(
-                &mut state,
-                &query_action,
-                Instant::now(),
-                &AppServices::stub(),
-            );
-
-            assert!(state.query.current_result().is_none());
-            assert!(state.query.has_pending_preview(generation));
-
-            let effects = dispatch_metadata(
-                &mut state,
-                &Action::TableDetailLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
-                    run_id: detail_run_id,
-                    detail: Box::new(users_table_detail()),
-                    generation,
-                },
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert!(state.session.is_table_detail_terminal(generation));
-            assert!(state.query.current_result().is_none());
-            assert!(matches!(
-                effects.as_slice(),
-                [Effect::DispatchActions(actions)]
-                    if matches!(
-                        actions.as_slice(),
-                        [Action::RevealPendingPreview { generation: action_generation }]
-                            if *action_generation == generation
-                    )
-            ));
-
-            dispatch_query(
-                &mut state,
-                &Action::RevealPendingPreview { generation },
-                Instant::now(),
-                &AppServices::stub(),
-            );
-
-            assert!(state.query.current_result().is_some());
-            assert!(!state.query.has_pending_preview(generation));
+        #[tokio::test]
+        async fn preview_reveal_follows_inspector_render_for_success_and_failure() {
+            for inspector_failed in [false, true] {
+                assert_eq!(
+                    render_frames_after_inspector_terminal(inspector_failed).await,
+                    [
+                        RenderFrame {
+                            inspector_terminal: true,
+                            result_visible: false,
+                        },
+                        RenderFrame {
+                            inspector_terminal: true,
+                            result_visible: true,
+                        },
+                    ]
+                );
+            }
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -725,6 +725,54 @@ mod tests {
         }
 
         #[test]
+        fn later_adhoc_run_drops_pending_preview_before_inspector_finishes() {
+            let (mut state, generation, detail_run_id) =
+                state_with_selected_table(DatabaseType::PostgreSQL);
+            let preview_action =
+                query_completed_action(&mut state, preview_result(1), generation, Some(0));
+
+            dispatch_query(
+                &mut state,
+                &preview_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.query.has_pending_preview(generation));
+
+            let adhoc_action = query_completed_action(&mut state, adhoc_result(), 0, None);
+            dispatch_query(
+                &mut state,
+                &adhoc_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(
+                state.query.current_result().map(|result| result.source),
+                Some(QuerySource::Adhoc)
+            );
+            assert!(!state.query.has_pending_preview(generation));
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: detail_run_id,
+                    detail: Box::new(users_table_detail()),
+                    generation,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.query.current_result().map(|result| result.source),
+                Some(QuerySource::Adhoc)
+            );
+        }
+
+        #[test]
         fn stale_selection_drops_old_pending_preview_before_new_one_is_released() {
             let (mut state, old_generation, old_detail_run_id) =
                 state_with_selected_table(DatabaseType::PostgreSQL);

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -38,6 +38,18 @@ pub fn reduce_execution(
                 return DispatchResult::handled();
             }
 
+            if *generation != 0
+                && result.source == QuerySource::Preview
+                && state.session.selected_table_key().is_some()
+                && !state.session.is_table_detail_terminal(*generation)
+            {
+                state.query.mark_idle();
+                state
+                    .query
+                    .defer_preview(Arc::clone(result), *generation, *target_page, true);
+                return DispatchResult::handled();
+            }
+
             state.query.mark_idle();
 
             match (result.source, result.is_error()) {
@@ -64,47 +76,7 @@ pub fn reduce_execution(
                 // Preview errors arrive as error results and are shown in the
                 // Result pane like any other preview.
                 (QuerySource::Preview, _) => {
-                    let preserved_result_col = state.result_interaction.selection().cell();
-                    let preserved_horizontal_offset = state.result_interaction.horizontal_offset();
-                    reset_view_for_new_result(state, now);
-
-                    if let Some(page) = target_page {
-                        state
-                            .query
-                            .pagination
-                            .set_page_result(*page, result.data_row_count() < PREVIEW_PAGE_SIZE);
-                    }
-                    state.query.set_current_result(Arc::clone(result));
-
-                    match state.query.post_delete_row_selection() {
-                        PostDeleteRowSelection::Keep => {}
-                        PostDeleteRowSelection::Clear => {
-                            state.result_interaction.reset_interaction();
-                        }
-                        PostDeleteRowSelection::Select(row) => {
-                            if result.data_row_count() > 0 && result.column_count() > 0 {
-                                let clamped = row.min(result.data_row_count() - 1);
-                                let max_col = result.column_count() - 1;
-                                let col = preserved_result_col
-                                    .unwrap_or(preserved_horizontal_offset)
-                                    .min(max_col);
-                                state.result_interaction.set_horizontal_offset(
-                                    preserved_horizontal_offset.min(max_col).min(col),
-                                );
-                                state.result_interaction.activate_cell(clamped, col);
-
-                                let visible = state.result_visible_rows();
-                                if visible > 0 && clamped >= visible {
-                                    state
-                                        .result_interaction
-                                        .set_scroll_offset(clamped - visible + 1);
-                                }
-                            }
-                        }
-                    }
-                    state
-                        .query
-                        .set_post_delete_selection(PostDeleteRowSelection::Keep);
+                    apply_preview_result(state, result, *target_page, now, true);
                 }
             }
 
@@ -118,6 +90,28 @@ pub fn reduce_execution(
             source,
         } => {
             if state.is_stale_query_run(dsn, *run_id) {
+                return DispatchResult::handled();
+            }
+
+            if *source == QuerySource::Preview
+                && *generation != 0
+                && *generation == state.session.selection_generation()
+                && state.session.selected_table_key().is_some()
+                && !state.session.is_table_detail_terminal(*generation)
+            {
+                let preview_query = state.query.pagination.qualified_name();
+                state.query.mark_idle();
+                state.query.defer_preview(
+                    Arc::new(QueryResult::error(
+                        preview_query,
+                        error.result_message(),
+                        0,
+                        QuerySource::Preview,
+                    )),
+                    *generation,
+                    None,
+                    false,
+                );
                 return DispatchResult::handled();
             }
 
@@ -152,6 +146,22 @@ pub fn reduce_execution(
                 vec![]
             };
             DispatchResult::handled_with(effects)
+        }
+
+        Action::RevealPendingPreview { generation } => {
+            if !state.session.is_table_detail_terminal(*generation) {
+                return DispatchResult::handled();
+            }
+
+            let Some(pending) = state.query.take_pending_preview(*generation) else {
+                return DispatchResult::handled();
+            };
+            let (result, target_page, highlight) = pending.into_parts();
+            if result.is_error() && !highlight {
+                state.query.clear_delete_refresh_target();
+            }
+            apply_preview_result(state, &result, target_page, now, highlight);
+            DispatchResult::handled()
         }
 
         Action::CommandLineSubmit => {
@@ -302,10 +312,67 @@ fn reset_view_for_new_result(state: &mut AppState, now: Instant) {
         .set_result_highlight(now + Duration::from_millis(500));
 }
 
+fn apply_preview_result(
+    state: &mut AppState,
+    result: &Arc<QueryResult>,
+    target_page: Option<usize>,
+    now: Instant,
+    highlight: bool,
+) {
+    let preserved_result_col = state.result_interaction.selection().cell();
+    let preserved_horizontal_offset = state.result_interaction.horizontal_offset();
+    state.result_interaction.reset_view();
+    if highlight {
+        state
+            .query
+            .set_result_highlight(now + Duration::from_millis(500));
+    }
+
+    if let Some(page) = target_page {
+        state
+            .query
+            .pagination
+            .set_page_result(page, result.data_row_count() < PREVIEW_PAGE_SIZE);
+    }
+    state.query.set_current_result(Arc::clone(result));
+
+    match state.query.post_delete_row_selection() {
+        PostDeleteRowSelection::Keep => {}
+        PostDeleteRowSelection::Clear => {
+            state.result_interaction.reset_interaction();
+        }
+        PostDeleteRowSelection::Select(row) => {
+            if result.data_row_count() > 0 && result.column_count() > 0 {
+                let clamped = row.min(result.data_row_count() - 1);
+                let max_col = result.column_count() - 1;
+                let col = preserved_result_col
+                    .unwrap_or(preserved_horizontal_offset)
+                    .min(max_col);
+                state
+                    .result_interaction
+                    .set_horizontal_offset(preserved_horizontal_offset.min(max_col).min(col));
+                state.result_interaction.activate_cell(clamped, col);
+
+                let visible = state.result_visible_rows();
+                if visible > 0 && clamped >= visible {
+                    state
+                        .result_interaction
+                        .set_scroll_offset(clamped - visible + 1);
+                }
+            }
+        }
+    }
+    state
+        .query
+        .set_post_delete_selection(PostDeleteRowSelection::Keep);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::ports::outbound::DbOperationError;
+    use crate::update::browse::metadata::dispatch_metadata;
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
 
@@ -317,12 +384,27 @@ mod tests {
     ) -> Action {
         let run_id = begin_query_run(state);
         Action::QueryFailed {
-            dsn: "postgres://localhost/test".to_string(),
+            dsn: state.session.dsn().unwrap_or_default().to_string(),
             run_id,
             error,
             generation,
             source,
         }
+    }
+
+    fn state_with_selected_table(database_type: DatabaseType) -> (AppState, u64, u64) {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "test",
+            database_type,
+            "postgres://localhost/test",
+        );
+        let generation = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        let detail_run_id = state.session.begin_table_detail_run();
+        (state, generation, detail_run_id)
     }
 
     mod command_line_submit {
@@ -556,6 +638,184 @@ mod tests {
             assert_eq!(state.query.pagination.current_page(), 3);
         }
 
+        #[rstest::rstest]
+        #[case(DatabaseType::PostgreSQL)]
+        #[case(DatabaseType::MySQL)]
+        #[case(DatabaseType::SQLite)]
+        fn inspector_terminal_state_precedes_preview_for_all_engines(
+            #[case] database_type: DatabaseType,
+        ) {
+            let (mut state, generation, detail_run_id) = state_with_selected_table(database_type);
+            let now = Instant::now();
+
+            let inspector_effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: detail_run_id,
+                    detail: Box::new(users_table_detail()),
+                    generation,
+                },
+                now,
+            )
+            .unwrap();
+
+            assert!(inspector_effects.is_empty());
+            assert!(state.session.is_table_detail_terminal(generation));
+            assert!(state.query.current_result().is_none());
+
+            let query_action =
+                query_completed_action(&mut state, preview_result(1), generation, Some(0));
+            dispatch_query(&mut state, &query_action, now, &AppServices::stub());
+
+            assert!(state.query.current_result().is_some());
+            assert!(!state.query.has_pending_preview(generation));
+        }
+
+        #[test]
+        fn preview_completion_waits_for_inspector_render_boundary() {
+            let (mut state, generation, detail_run_id) =
+                state_with_selected_table(DatabaseType::PostgreSQL);
+            let query_action =
+                query_completed_action(&mut state, preview_result(1), generation, Some(0));
+
+            dispatch_query(
+                &mut state,
+                &query_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(state.query.current_result().is_none());
+            assert!(state.query.has_pending_preview(generation));
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: detail_run_id,
+                    detail: Box::new(users_table_detail()),
+                    generation,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.is_table_detail_terminal(generation));
+            assert!(state.query.current_result().is_none());
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::DispatchActions(actions)]
+                    if matches!(
+                        actions.as_slice(),
+                        [Action::RevealPendingPreview { generation: action_generation }]
+                            if *action_generation == generation
+                    )
+            ));
+
+            dispatch_query(
+                &mut state,
+                &Action::RevealPendingPreview { generation },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(state.query.current_result().is_some());
+            assert!(!state.query.has_pending_preview(generation));
+        }
+
+        #[test]
+        fn stale_selection_drops_old_pending_preview_before_new_one_is_released() {
+            let (mut state, old_generation, old_detail_run_id) =
+                state_with_selected_table(DatabaseType::PostgreSQL);
+            let old_query_action =
+                query_completed_action(&mut state, preview_result(1), old_generation, Some(0));
+            dispatch_query(
+                &mut state,
+                &old_query_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.query.has_pending_preview(old_generation));
+
+            let new_generation = state
+                .session
+                .select_table("public", "orders", &mut state.query);
+            let new_detail_run_id = state.session.begin_table_detail_run();
+
+            assert_ne!(old_generation, new_generation);
+            assert!(!state.query.has_pending_preview(old_generation));
+            assert!(state.query.current_result().is_none());
+
+            dispatch_query(
+                &mut state,
+                &old_query_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.query.current_result().is_none());
+
+            let stale_inspector_effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: old_detail_run_id,
+                    detail: Box::new(users_table_detail()),
+                    generation: old_generation,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+            assert!(stale_inspector_effects.is_empty());
+            assert!(!state.session.is_table_detail_terminal(new_generation));
+
+            let new_query_action =
+                query_completed_action(&mut state, preview_result(1), new_generation, Some(0));
+            dispatch_query(
+                &mut state,
+                &new_query_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.query.current_result().is_none());
+            assert!(state.query.has_pending_preview(new_generation));
+
+            dispatch_query(
+                &mut state,
+                &Action::RevealPendingPreview {
+                    generation: old_generation,
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.query.current_result().is_none());
+            assert!(state.query.has_pending_preview(new_generation));
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: new_detail_run_id,
+                    detail: Box::new(users_table_detail()),
+                    generation: new_generation,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+            assert!(matches!(effects.as_slice(), [Effect::DispatchActions(_)]));
+
+            dispatch_query(
+                &mut state,
+                &Action::RevealPendingPreview {
+                    generation: new_generation,
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.query.current_result().is_some());
+            assert!(!state.query.has_pending_preview(new_generation));
+        }
+
         #[test]
         fn adhoc_success_writes_current_result_and_records_history() {
             let mut state = create_test_state();
@@ -756,6 +1016,66 @@ mod tests {
                     .is_some_and(|message| message.contains("Permission denied"))
             );
             assert!(state.messages.last_error.is_none());
+        }
+
+        #[test]
+        fn preview_failure_waits_for_inspector_then_releases_error_result() {
+            let (mut state, generation, detail_run_id) =
+                state_with_selected_table(DatabaseType::PostgreSQL);
+            state.query.set_delete_refresh_target(1, None, 1);
+            let query_action = query_failed_action(
+                &mut state,
+                DbOperationError::PermissionDenied("forbidden".to_string()),
+                generation,
+                QuerySource::Preview,
+            );
+
+            dispatch_query(
+                &mut state,
+                &query_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(state.query.current_result().is_none());
+            assert!(state.query.has_pending_preview(generation));
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: detail_run_id,
+                    error: DbOperationError::QueryFailed("inspector failed".to_string()),
+                    generation,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.is_table_detail_terminal(generation));
+            assert!(state.messages.last_error().is_some());
+            assert!(state.query.current_result().is_none());
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::DispatchActions(actions)]
+                    if matches!(
+                        actions.as_slice(),
+                        [Action::RevealPendingPreview { generation: action_generation }]
+                            if *action_generation == generation
+                    )
+            ));
+
+            dispatch_query(
+                &mut state,
+                &Action::RevealPendingPreview { generation },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let result = state.query.current_result().expect("released result");
+            assert!(result.is_error());
+            assert!(state.query.pending_delete_refresh_target().is_none());
+            assert!(!state.query.has_pending_preview(generation));
         }
 
         #[test]
@@ -1013,7 +1333,6 @@ mod tests {
         use super::*;
         use crate::domain::{CommandTag, DatabaseMetadata, TableSummary};
         use crate::model::sql_editor::modal::SqlModalStatus;
-        use crate::update::browse::metadata::dispatch_metadata;
 
         fn make_metadata(tables: Vec<(&str, &str)>) -> Arc<DatabaseMetadata> {
             Arc::new({

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -3109,6 +3109,7 @@ mod tests {
         use super::*;
         use crate::domain::{DatabaseMetadata, QueryResult, QuerySource};
         use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
+        use crate::test_support;
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
@@ -3161,6 +3162,20 @@ mod tests {
             for action in dispatch_actions {
                 reduce(&mut state, action, now, &AppServices::stub());
             }
+
+            let generation = state.session.selection_generation();
+            let detail_run_id = state.session.begin_table_detail_run();
+            reduce(
+                &mut state,
+                Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: detail_run_id,
+                    detail: Box::new(test_support::table::minimal("public", "users")),
+                    generation,
+                },
+                now,
+                &AppServices::stub(),
+            );
 
             // Simulate QueryCompleted with a full page of results
             let current_gen = state.session.selection_generation();


### PR DESCRIPTION
## Problem
Table selection can reveal the Result pane before the Inspector pane when asynchronous completions arrive in the opposite order.

## Background
The Inspector detail and preview query intentionally run in parallel, but their independent completion actions had no shared display-order contract.

## Approach
Keep both I/O operations parallel while holding a preview completion for the active table-selection generation until the Inspector reaches a terminal state. Release it through a follow-up action so the Inspector state is rendered first, including when Inspector loading fails, while stale generations remain isolated.