### PR TITLE
refactor: remove redundant MySQL inspector kind row

### DIFF
--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -631,6 +631,39 @@ mod tests {
     }
 
     #[test]
+    fn mysql_info_has_only_comment_rows_and_table_name() {
+        let model = build_loaded(
+            &EngineFeatureProfile::mysql_like(),
+            InspectorTab::Info,
+            &table(),
+            DatabaseType::MySQL,
+            &TestDdlGenerator,
+        );
+
+        assert_eq!(model.row_count(), 3);
+        match model.section() {
+            Some(InspectorSection::Info { rows }) => assert_eq!(
+                rows,
+                &[
+                    InspectorInfoRow::Field {
+                        field: InspectorInfoField::Comment,
+                        value: Some("Users".to_string()),
+                    },
+                    InspectorInfoRow::Field {
+                        field: InspectorInfoField::RowCount,
+                        value: Some("~3".to_string()),
+                    },
+                    InspectorInfoRow::Field {
+                        field: InspectorInfoField::TableName,
+                        value: Some("users".to_string()),
+                    },
+                ]
+            ),
+            section => panic!("expected info section, got {section:?}"),
+        }
+    }
+
+    #[test]
     fn mysql_info_omits_schema_and_indexes_hide_partial_column() {
         let mut table = table();
         table.indexes = vec![Index {

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -116,7 +116,6 @@ const MYSQL_INSPECTOR: InspectorProfile = InspectorProfile::new(
         InspectorInfoField::Comment,
         InspectorInfoField::RowCount,
         InspectorInfoField::TableName,
-        InspectorInfoField::TableKind,
     ],
 );
 
@@ -486,7 +485,6 @@ mod tests {
                 InspectorInfoField::Comment,
                 InspectorInfoField::RowCount,
                 InspectorInfoField::TableName,
-                InspectorInfoField::TableKind,
             ]
         );
         assert_eq!(

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_for_mysql_hides_schema_field.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_for_mysql_hides_schema_field.snap
@@ -8,7 +8,7 @@ test_project ▸ test_db ▸ -                                                  
 │  posts                                ││Comment: User accounts                                                                                                    │
 │  comments                             ││Rows:    ~100                                                                                                             │
 │                                       ││Table:   users                                                                                                            │
-│                                       ││Kind:    Table                                                                                                            │
+│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__mysql_header_and_explorer_show_table_names.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__mysql_header_and_explorer_show_table_names.snap
@@ -8,7 +8,7 @@ test_project ▸ app ▸ users                                                  
 │  audit_log                            ││Comment: (none)                                                                                                           │
 │                                       ││Rows:    (none)                                                                                                           │
 │                                       ││Table:   users                                                                                                            │
-│                                       ││Kind:    Table                                                                                                            │
+│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │


### PR DESCRIPTION
## Problem
The MySQL Inspector Info profile includes a TableKind row even though MySQL Explorer only exposes base tables, so the row provides no distinguishing information.

## Background
The shared TableKind field remains meaningful for SQLite table, view, and virtual-table distinctions.

## Approach
Remove only TableKind from the MySQL Inspector profile. Keep shared rendering and TableKind behavior unchanged, and lock the MySQL fields, row count, snapshot, and existing SQLite displays with focused tests.