### PR TITLE
fix(mysql): terminate statements independently

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -416,8 +416,7 @@ pub(super) async fn read_one_mysql_resultset(
 
 fn mysql_statement_input(query: &str) -> Vec<u8> {
     let query = query.trim_end();
-    let terminator = if query.ends_with(';') { "\n" } else { "\n;\n" };
-    [query.as_bytes(), terminator.as_bytes()].concat()
+    [query.as_bytes(), b"\n;\n"].concat()
 }
 
 #[cfg(test)]
@@ -425,11 +424,11 @@ mod statement_input_tests {
     use super::mysql_statement_input;
 
     #[test]
-    fn separates_semicolonless_statements_after_line_comments() {
+    fn separates_statements_after_line_comments_with_semicolons() {
         for query in [
             "SELECT 1",
-            "SELECT 1 -- trailing comment",
-            "SELECT 1 # trailing comment",
+            "SELECT 1 -- trailing comment;",
+            "SELECT 1 # trailing comment;",
         ] {
             assert_eq!(
                 mysql_statement_input(query),
@@ -439,8 +438,8 @@ mod statement_input_tests {
     }
 
     #[test]
-    fn keeps_existing_semicolon_terminator() {
-        assert_eq!(mysql_statement_input("SELECT 1;"), b"SELECT 1;\n");
+    fn adds_an_independent_separator_after_an_existing_semicolon() {
+        assert_eq!(mysql_statement_input("SELECT 1;"), b"SELECT 1;\n;\n");
     }
 }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1944,7 +1944,7 @@ mod query_execution {
                     .adapter()
                     .execute_adhoc(
                         db.dsn(),
-                        "SELECT 1 AS value WHERE FALSE -- trailing comment",
+                        "SELECT 1 AS value WHERE FALSE -- trailing comment;",
                         AccessMode::ReadWrite,
                     )
                     .await


### PR DESCRIPTION
## Problem

MySQL CLI statement framing treats a semicolon inside a trailing line comment as a statement terminator, so the following row-count marker can remain in the same incomplete statement.

## Background

The MySQL adapter sends each user statement and its marker through one interactive CLI session. A standalone separator is required when the query text ends in a comment containing `;`.

## Approach

Always append an independent `\n;\n` separator after trimmed statement text. Focused unit tests cover comment and existing-semicolon boundaries, and the Oracle MySQL 8.4 integration test exercises the marker boundary through the normal adapter path.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-497