### PR TITLE
refactor(mysql): centralize SSL mode conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,9 +1191,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,9 +1191,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -215,14 +215,7 @@ fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
         if key != "ssl-mode" {
             return None;
         }
-        Some(match value.as_ref() {
-            "DISABLED" => MySqlSslMode::Disabled,
-            "PREFERRED" => MySqlSslMode::Preferred,
-            "REQUIRED" => MySqlSslMode::Required,
-            "VERIFY_CA" => MySqlSslMode::VerifyCa,
-            "VERIFY_IDENTITY" => MySqlSslMode::VerifyIdentity,
-            _ => return None,
-        })
+        value.parse().ok()
     })
 }
 

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use url::Url;
 
 use super::ssl_mode::SslMode;
@@ -26,17 +27,36 @@ impl MySqlSslMode {
             Self::VerifyIdentity,
         ]
     }
-}
 
-impl std::fmt::Display for MySqlSslMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
             Self::Disabled => "DISABLED",
             Self::Preferred => "PREFERRED",
             Self::Required => "REQUIRED",
             Self::VerifyCa => "VERIFY_CA",
             Self::VerifyIdentity => "VERIFY_IDENTITY",
-        })
+        }
+    }
+}
+
+impl std::fmt::Display for MySqlSslMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for MySqlSslMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(Self::Disabled),
+            "PREFERRED" => Ok(Self::Preferred),
+            "REQUIRED" => Ok(Self::Required),
+            "VERIFY_CA" => Ok(Self::VerifyCa),
+            "VERIFY_IDENTITY" => Ok(Self::VerifyIdentity),
+            _ => Err(format!("Unknown MySQL SSL mode: {s}")),
+        }
     }
 }
 
@@ -256,14 +276,30 @@ mod tests {
 
     #[test]
     fn mysql_tls_modes_use_mysql_option_names() {
-        assert_eq!(
-            serde_json::to_string(&MySqlSslMode::VerifyCa).unwrap(),
-            "\"VERIFY_CA\""
-        );
-        assert_eq!(
-            serde_json::to_string(&MySqlSslMode::VerifyIdentity).unwrap(),
-            "\"VERIFY_IDENTITY\""
-        );
+        let expected = [
+            (MySqlSslMode::Disabled, "\"DISABLED\""),
+            (MySqlSslMode::Preferred, "\"PREFERRED\""),
+            (MySqlSslMode::Required, "\"REQUIRED\""),
+            (MySqlSslMode::VerifyCa, "\"VERIFY_CA\""),
+            (MySqlSslMode::VerifyIdentity, "\"VERIFY_IDENTITY\""),
+        ];
+
+        for (mode, serialized) in expected {
+            assert_eq!(serde_json::to_string(&mode).unwrap(), serialized);
+        }
+    }
+
+    #[test]
+    fn mysql_tls_modes_round_trip_through_canonical_names() {
+        for mode in MySqlSslMode::all_variants() {
+            assert_eq!(mode.as_str(), mode.to_string());
+            assert_eq!(mode.as_str().parse::<MySqlSslMode>().unwrap(), *mode);
+        }
+    }
+
+    #[test]
+    fn mysql_tls_modes_reject_unknown_names() {
+        assert!("unknown".parse::<MySqlSslMode>().is_err());
     }
 
     mod sqlite_deserialize {

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -192,16 +192,9 @@ fn normalize_mysql_host(host: &str) -> String {
 }
 
 fn parse_ssl_mode(value: &str) -> Result<MySqlSslMode, DbOperationError> {
-    match value {
-        "DISABLED" => Ok(MySqlSslMode::Disabled),
-        "PREFERRED" => Ok(MySqlSslMode::Preferred),
-        "REQUIRED" => Ok(MySqlSslMode::Required),
-        "VERIFY_CA" => Ok(MySqlSslMode::VerifyCa),
-        "VERIFY_IDENTITY" => Ok(MySqlSslMode::VerifyIdentity),
-        _ => Err(DbOperationError::ConnectionFailed(
-            "Invalid MySQL TLS mode".to_string(),
-        )),
-    }
+    value
+        .parse()
+        .map_err(|_| DbOperationError::ConnectionFailed("Invalid MySQL TLS mode".to_string()))
 }
 
 fn decode_url_component(value: &str) -> Result<String, DbOperationError> {
@@ -233,6 +226,18 @@ mod tests {
         assert_eq!(parsed.username, "user name");
         assert_eq!(parsed.password, "p@ss#word");
         assert_eq!(parsed.ssl_mode, MySqlSslMode::Required);
+    }
+
+    #[test]
+    fn rejects_unknown_ssl_mode_without_exposing_dsn_credentials() {
+        let error =
+            parse_mysql_dsn("mysql://user:secret@localhost:3306/app?ssl-mode=UNKNOWN").unwrap_err();
+
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "Invalid MySQL TLS mode" && !details.contains("secret")
+        ));
     }
 
     #[test]

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -161,7 +161,7 @@ impl ConnectionSetup {
                     field_area,
                     MySqlSslMode::all_variants()
                         .iter()
-                        .map(|mode| mysql_ssl_mode_label(*mode)),
+                        .map(MySqlSslMode::as_str),
                     form_state.ssl_dropdown().selected_index(),
                     theme,
                 );
@@ -442,16 +442,6 @@ fn ssl_mode_label_text(mode: SslMode) -> &'static str {
         SslMode::Require => "require",
         SslMode::VerifyCa => "verify-ca",
         SslMode::VerifyFull => "verify-full",
-    }
-}
-
-fn mysql_ssl_mode_label(mode: MySqlSslMode) -> &'static str {
-    match mode {
-        MySqlSslMode::Disabled => "DISABLED",
-        MySqlSslMode::Preferred => "PREFERRED",
-        MySqlSslMode::Required => "REQUIRED",
-        MySqlSslMode::VerifyCa => "VERIFY_CA",
-        MySqlSslMode::VerifyIdentity => "VERIFY_IDENTITY",
     }
 }
 


### PR DESCRIPTION
## Problem
MySQL SSL mode names are duplicated across domain formatting, DSN parsing, connection-error DSN re-reading, and the connection setup UI. These copies can drift when a mode is added or renamed.

## Background
The five supported MySQL TLS modes already share one canonical uppercase representation and must preserve their existing defaults, Serde names, and certificate-validation behavior.

## Approach
Make the domain enum the single source for canonical strings and parsing, while keeping infrastructure and application error translation at their boundaries. Reuse the same domain strings for MySQL connection setup labels and cover round-trips, unknown values, credential redaction, persistence, reconnect classification, and display behavior.