### PR TITLE
refactor(mysql): remove unused export row count payload

### DIFF
--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -222,7 +222,7 @@ pub fn reduce_pagination(
                     MySqlExportPlan::CountRows { statement } => {
                         (RerunnableCsvRowCount::QueryDatabase, Some(statement))
                     }
-                    MySqlExportPlan::UseResultRowCount { .. } => {
+                    MySqlExportPlan::UseResultRowCount => {
                         (RerunnableCsvRowCount::Known(row_count), None)
                     }
                 };

--- a/src/domain/mysql_sql/export.rs
+++ b/src/domain/mysql_sql/export.rs
@@ -3,7 +3,7 @@ use super::{MySqlStatementKind, classify_mysql_multi_statement, has_mysql_read_o
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MySqlExportPlan {
     CountRows { statement: String },
-    UseResultRowCount { statement: String },
+    UseResultRowCount,
 }
 
 pub fn mysql_export_plan(query: &str) -> Option<MySqlExportPlan> {
@@ -28,9 +28,7 @@ pub fn mysql_export_plan(query: &str) -> Option<MySqlExportPlan> {
             statement: statement.sql.clone(),
         }),
         MySqlStatementKind::Table | MySqlStatementKind::Show | MySqlStatementKind::Describe => {
-            Some(MySqlExportPlan::UseResultRowCount {
-                statement: statement.sql.clone(),
-            })
+            Some(MySqlExportPlan::UseResultRowCount)
         }
         _ => None,
     }
@@ -43,9 +41,9 @@ mod tests {
 
     #[rstest]
     #[case::select("SELECT id FROM users", MySqlExportPlan::CountRows { statement: "SELECT id FROM users".to_string() })]
-    #[case::table("TABLE users", MySqlExportPlan::UseResultRowCount { statement: "TABLE users".to_string() })]
-    #[case::show("SHOW TABLES", MySqlExportPlan::UseResultRowCount { statement: "SHOW TABLES".to_string() })]
-    #[case::describe("DESCRIBE users", MySqlExportPlan::UseResultRowCount { statement: "DESCRIBE users".to_string() })]
+    #[case::table("TABLE users", MySqlExportPlan::UseResultRowCount)]
+    #[case::show("SHOW TABLES", MySqlExportPlan::UseResultRowCount)]
+    #[case::describe("DESCRIBE users", MySqlExportPlan::UseResultRowCount)]
     fn plans_supported_mysql_export_queries(
         #[case] query: &str,
         #[case] expected: MySqlExportPlan,


### PR DESCRIPTION
## Problem

The MySQL CSV export plan stores a normalized SQL statement for TABLE, SHOW, and DESCRIBE exports even though the pagination consumer only uses the already fetched result row count.

## Background

Only SELECT exports need a statement for generating a count query. Keeping an unused statement payload creates an unnecessary SQL string clone and makes the other plan variant appear rerunnable.

## Approach

Represent TABLE, SHOW, and DESCRIBE exports with a unit variant while preserving SELECT count-query generation and the existing CSV export policy and lifecycle.

## Validation

- cargo fmt --all -- --check
- cargo test -p sabiql-domain mysql_sql::export::tests
- cargo test -p sabiql-app uses_count_only_for_mysql_select
- cargo test -p sabiql-app count_query_wraps_mysql_statement_with_newlines
- cargo clippy -p sabiql-app --all-targets -- -D warnings
- bash scripts/lint_all.sh