### PR TITLE
fix(deps): update h2 to address RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,9 +1191,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Problem
Security Audit rejects the mysql branch lockfile because h2 0.4.15 is affected by RUSTSEC-2026-0258.

## Background
The advisory requires h2 0.4.16 or newer. This is an independent CI unblock and is unrelated to PR #746.

## Approach
Update only the h2 package entry and checksum in Cargo.lock to h2 0.4.16. No manifest, source, or unrelated dependency changes are included.