### PR TITLE
refactor(app): remove redundant feature availability

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -340,7 +340,7 @@ fn command_line_rows(feature_policy: &FeaturePolicy) -> Vec<HelpRow> {
     rows_from_binding_iter(
         COMMAND_LINE_KEYS
             .iter()
-            .filter(|binding| feature_policy.is_visible(binding.feature_requirement())),
+            .filter(|binding| feature_policy.is_enabled(binding.feature_requirement())),
     )
 }
 
@@ -357,10 +357,10 @@ fn reference_sections(
         &global::PANE_SWITCH,
         &global::INSPECTOR_TABS,
     ];
-    if feature_policy.is_visible(global::ER_DIAGRAM.feature_requirement()) {
+    if feature_policy.is_enabled(global::ER_DIAGRAM.feature_requirement()) {
         open_switch_rows.insert(2, &global::ER_DIAGRAM);
     }
-    if feature_policy.is_visible(sqlite_diagnostics(keymap_preset).feature_requirement()) {
+    if feature_policy.is_enabled(sqlite_diagnostics(keymap_preset).feature_requirement()) {
         open_switch_rows.insert(2, sqlite_diagnostics(keymap_preset));
     }
 
@@ -373,7 +373,7 @@ fn reference_sections(
         &result_active::UNSTAGE_DELETE,
         &inspector_ddl::YANK,
     ]);
-    if feature_policy.is_visible(json_detail::YANK.feature_requirement())
+    if feature_policy.is_enabled(json_detail::YANK.feature_requirement())
         && cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_json_detail_modal)
     {
         data_action_rows.extend(rows_from_mode_row_refs_if_visible(
@@ -386,10 +386,10 @@ fn reference_sections(
         &table_picker::TYPE_FILTER,
         &query_history_picker::TYPE_FILTER,
     ]);
-    if feature_policy.is_visible(er_picker::TYPE_FILTER.feature_requirement()) {
+    if feature_policy.is_enabled(er_picker::TYPE_FILTER.feature_requirement()) {
         search_filter_rows.insert(1, row_from_mode_row(&er_picker::TYPE_FILTER));
     }
-    if feature_policy.is_visible(json_search::TYPE_SEARCH.feature_requirement())
+    if feature_policy.is_enabled(json_search::TYPE_SEARCH.feature_requirement())
         && cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_json_detail_modal)
     {
         search_filter_rows.extend(rows_from_bindings_if_visible(
@@ -405,7 +405,7 @@ fn reference_sections(
         rows_from_bindings(CELL_EDIT_KEYS),
         rows_from_bindings_if_visible(SQL_MODAL_CONFIRMING_KEYS, feature_policy),
     ]);
-    if feature_policy.is_visible(FeatureRequirement::JsonDocumentEdit)
+    if feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit)
         && cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_json_detail_modal)
     {
         editing_rows.extend(rows_from_mode_rows_if_visible(
@@ -415,27 +415,27 @@ fn reference_sections(
     }
 
     let mut advanced_rows = Vec::new();
-    if feature_policy.is_visible(FeatureRequirement::Explain) {
+    if feature_policy.is_enabled(FeatureRequirement::Explain) {
         advanced_rows.extend(sql_current_rows(
             SqlHelpMode::Plan,
             keymap_preset,
             feature_policy,
         ));
     }
-    if feature_policy.is_visible(FeatureRequirement::PlanComparison) {
+    if feature_policy.is_enabled(FeatureRequirement::PlanComparison) {
         advanced_rows.extend(sql_current_rows(
             SqlHelpMode::Compare,
             keymap_preset,
             feature_policy,
         ));
     }
-    if feature_policy.is_visible(FeatureRequirement::ErDiagram) {
+    if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
         advanced_rows.extend(rows_from_mode_rows_if_visible(
             er_picker_rows(keymap_preset),
             feature_policy,
         ));
     }
-    if feature_policy.is_visible(FeatureRequirement::JsonDocumentDetail)
+    if feature_policy.is_enabled(FeatureRequirement::JsonDocumentDetail)
         && cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_json_detail_modal)
     {
         advanced_rows.extend(rows_from_mode_rows_if_visible(
@@ -531,7 +531,7 @@ fn sql_current_rows(
         },
         SqlHelpMode::Plan => {
             let mut bindings: Vec<&KeyBinding> = vec![sql_modal_plan_explain(keymap_preset)];
-            if feature_policy.is_visible(sql_modal_plan::ANALYZE.feature_requirement()) {
+            if feature_policy.is_enabled(sql_modal_plan::ANALYZE.feature_requirement()) {
                 bindings.push(&sql_modal_plan::ANALYZE);
             }
             bindings.extend([
@@ -545,7 +545,7 @@ fn sql_current_rows(
         }
         SqlHelpMode::Compare => {
             let mut bindings: Vec<&KeyBinding> = vec![sql_modal_compare_explain(keymap_preset)];
-            if feature_policy.is_visible(sql_modal_compare::ANALYZE.feature_requirement()) {
+            if feature_policy.is_enabled(sql_modal_compare::ANALYZE.feature_requirement()) {
                 bindings.push(&sql_modal_compare::ANALYZE);
             }
             bindings.extend([
@@ -622,7 +622,7 @@ fn rows_from_bindings_if_visible(
     rows_from_binding_iter(
         bindings
             .iter()
-            .filter(|binding| feature_policy.is_visible(binding.feature_requirement())),
+            .filter(|binding| feature_policy.is_enabled(binding.feature_requirement())),
     )
 }
 
@@ -638,7 +638,7 @@ fn rows_from_binding_refs_if_visible(
         bindings
             .iter()
             .copied()
-            .filter(|binding| feature_policy.is_visible(binding.feature_requirement())),
+            .filter(|binding| feature_policy.is_enabled(binding.feature_requirement())),
     )
 }
 
@@ -693,7 +693,7 @@ fn rows_from_mode_rows_if_visible(
     feature_policy: &FeaturePolicy,
 ) -> Vec<HelpRow> {
     rows.iter()
-        .filter(|row| feature_policy.is_visible(row.feature_requirement()))
+        .filter(|row| feature_policy.is_enabled(row.feature_requirement()))
         .map(row_from_mode_row)
         .collect()
 }
@@ -707,7 +707,7 @@ fn rows_from_mode_row_refs_if_visible(
     feature_policy: &FeaturePolicy,
 ) -> Vec<HelpRow> {
     rows.iter()
-        .filter(|row| feature_policy.is_visible(row.feature_requirement()))
+        .filter(|row| feature_policy.is_enabled(row.feature_requirement()))
         .map(|&row| row_from_mode_row(row))
         .collect()
 }

--- a/src/app/policy/feature_policy.rs
+++ b/src/app/policy/feature_policy.rs
@@ -12,12 +12,6 @@ pub enum FeatureRequirement {
     PlanComparison,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FeatureAvailability {
-    Hidden,
-    Enabled,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FeaturePolicy {
     profile: EngineFeatureProfile,
@@ -28,8 +22,8 @@ impl FeaturePolicy {
         Self { profile: *profile }
     }
 
-    pub fn availability(&self, requirement: FeatureRequirement) -> FeatureAvailability {
-        let supported = match requirement {
+    pub fn is_enabled(&self, requirement: FeatureRequirement) -> bool {
+        match requirement {
             FeatureRequirement::None => true,
             FeatureRequirement::ErDiagram => self.profile.supports_er_diagram(),
             FeatureRequirement::JsonDocumentDetail => self.profile.supports_json_document_detail(),
@@ -38,21 +32,7 @@ impl FeaturePolicy {
             FeatureRequirement::Explain => self.profile.supports_explain(),
             FeatureRequirement::ExplainAnalyze => self.profile.supports_explain_analyze(),
             FeatureRequirement::PlanComparison => self.profile.supports_plan_comparison(),
-        };
-
-        if supported {
-            FeatureAvailability::Enabled
-        } else {
-            FeatureAvailability::Hidden
         }
-    }
-
-    pub fn is_visible(&self, requirement: FeatureRequirement) -> bool {
-        !matches!(self.availability(requirement), FeatureAvailability::Hidden)
-    }
-
-    pub fn is_enabled(&self, requirement: FeatureRequirement) -> bool {
-        matches!(self.availability(requirement), FeatureAvailability::Enabled)
     }
 }
 
@@ -61,62 +41,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn postgres_profile_enables_postgres_features_and_hides_sqlite_diagnostics() {
-        let policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    fn feature_requirements_match_each_engine_profile() {
+        let requirements = [
+            FeatureRequirement::None,
+            FeatureRequirement::ErDiagram,
+            FeatureRequirement::JsonDocumentDetail,
+            FeatureRequirement::JsonDocumentEdit,
+            FeatureRequirement::SqliteDiagnostics,
+            FeatureRequirement::Explain,
+            FeatureRequirement::ExplainAnalyze,
+            FeatureRequirement::PlanComparison,
+        ];
+        let profiles = [
+            (
+                "postgresql",
+                EngineFeatureProfile::postgres_like(),
+                [true, true, true, true, false, true, true, true],
+            ),
+            (
+                "sqlite",
+                EngineFeatureProfile::sqlite_like(),
+                [true, false, false, false, true, true, false, false],
+            ),
+            (
+                "mysql",
+                EngineFeatureProfile::mysql_like(),
+                [true, true, true, true, false, true, true, true],
+            ),
+            (
+                "disconnected",
+                EngineFeatureProfile::disconnected(),
+                [true, false, false, false, false, false, false, false],
+            ),
+        ];
 
-        assert_eq!(
-            policy.availability(FeatureRequirement::ErDiagram),
-            FeatureAvailability::Enabled
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::JsonDocumentDetail),
-            FeatureAvailability::Enabled
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::JsonDocumentEdit),
-            FeatureAvailability::Enabled
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::ExplainAnalyze),
-            FeatureAvailability::Enabled
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::SqliteDiagnostics),
-            FeatureAvailability::Hidden
-        );
-    }
+        for (name, profile, expected) in profiles {
+            let policy = FeaturePolicy::new(&profile);
 
-    #[test]
-    fn sqlite_profile_enables_diagnostics_and_hides_postgres_features() {
-        let policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
-
-        assert_eq!(
-            policy.availability(FeatureRequirement::SqliteDiagnostics),
-            FeatureAvailability::Enabled
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::ErDiagram),
-            FeatureAvailability::Hidden
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::JsonDocumentDetail),
-            FeatureAvailability::Hidden
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::JsonDocumentEdit),
-            FeatureAvailability::Hidden
-        );
-        assert_eq!(
-            policy.availability(FeatureRequirement::PlanComparison),
-            FeatureAvailability::Hidden
-        );
-    }
-
-    #[test]
-    fn unrequired_operations_are_enabled() {
-        let policy = FeaturePolicy::new(&EngineFeatureProfile::disconnected());
-
-        assert!(policy.is_visible(FeatureRequirement::None));
-        assert!(policy.is_enabled(FeatureRequirement::None));
+            for (requirement, expected) in requirements.iter().zip(expected) {
+                assert_eq!(
+                    policy.is_enabled(*requirement),
+                    expected,
+                    "{name}: {requirement:?}"
+                );
+            }
+        }
     }
 }

--- a/src/app/policy/mod.rs
+++ b/src/app/policy/mod.rs
@@ -7,5 +7,5 @@ pub mod sqlite_path;
 pub mod table_kind;
 pub mod write;
 
-pub use feature_policy::{FeatureAvailability, FeaturePolicy, FeatureRequirement};
+pub use feature_policy::{FeaturePolicy, FeatureRequirement};
 pub use password_masking::mask_password;


### PR DESCRIPTION
## Problem
FeaturePolicy represented the same boolean capability through a two-value enum and separate visibility and enabled predicates.

## Approach
Make `is_enabled` the single capability predicate and use it for Help/catalog filtering while preserving the existing FeatureRequirement, EngineFeatureProfile, and reducer guard behavior.
