### PR TITLE
refactor(app): remove MySQL probe database type payload

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -87,7 +87,6 @@ pub enum TableDetailState {
 pub struct PendingMySqlConnectionProbe {
     pub id: ConnectionId,
     pub name: String,
-    pub database_type: DatabaseType,
     pub dsn: String,
     pub database: Option<String>,
     pub run_id: u64,
@@ -102,7 +101,6 @@ impl fmt::Debug for PendingMySqlConnectionProbe {
             .debug_struct("PendingMySqlConnectionProbe")
             .field("id", &self.id)
             .field("name", &self.name)
-            .field("database_type", &self.database_type)
             .field("dsn", &mask_password(&self.dsn))
             .field("database", &self.database)
             .field("run_id", &self.run_id)
@@ -332,7 +330,6 @@ impl BrowseSession {
         &mut self,
         id: &ConnectionId,
         name: &str,
-        database_type: DatabaseType,
         dsn: &str,
         database: Option<&str>,
     ) -> u64 {
@@ -345,7 +342,6 @@ impl BrowseSession {
         self.pending_mysql_connection_probe = Some(PendingMySqlConnectionProbe {
             id: id.clone(),
             name: name.to_string(),
-            database_type,
             dsn: dsn.to_string(),
             database: database.map(str::to_string),
             run_id,
@@ -385,7 +381,6 @@ impl BrowseSession {
         &self,
         id: &ConnectionId,
         name: &str,
-        database_type: DatabaseType,
         dsn: &str,
         database: Option<&str>,
         run_id: u64,
@@ -398,7 +393,6 @@ impl BrowseSession {
                     pending.run_id == run_id
                         && pending.id == *id
                         && pending.name == name
-                        && pending.database_type == database_type
                         && pending.dsn == dsn
                         && pending.database.as_deref() == database
                 })
@@ -1665,7 +1659,6 @@ mod tests {
             let _ = session.begin_mysql_connection_probe(
                 &id,
                 "mysql",
-                DatabaseType::MySQL,
                 "mysql://user:secret@localhost:3306/app",
                 Some("app"),
             );
@@ -1673,6 +1666,7 @@ mod tests {
             let debug = format!("{session:?}");
             assert!(!debug.contains("secret"));
             assert!(debug.contains("mysql://user:****@localhost:3306/app"));
+            assert!(!debug.contains("database_type"));
         }
 
         #[test]

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -285,7 +285,6 @@ mod tests {
             let probe_run_id = state.session.begin_mysql_connection_probe(
                 &target_id,
                 "mysql-b",
-                DatabaseType::MySQL,
                 "mysql://user@localhost:3306/b",
                 Some("b"),
             );

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -92,13 +92,12 @@ pub(super) fn reduce_connection_error(
                     id: pending.id,
                     dsn: pending.dsn,
                     name: pending.name,
-                    database_type: pending.database_type,
+                    database_type: DatabaseType::MySQL,
                     database: pending.database,
                 };
                 let run_id = state.session.begin_mysql_connection_probe(
                     &target.id,
                     &target.name,
-                    target.database_type,
                     &target.dsn,
                     target.database.as_deref(),
                 );
@@ -144,7 +143,6 @@ pub(super) fn reduce_connection_error(
                     let run_id = state.session.begin_mysql_connection_probe(
                         &target.id,
                         &target.name,
-                        target.database_type,
                         &target.dsn,
                         target.database.as_deref(),
                     );
@@ -311,7 +309,6 @@ mod tests {
         let _ = state.session.begin_mysql_connection_probe(
             &target_id,
             "mysql-b",
-            DatabaseType::MySQL,
             "mysql://user@localhost:3306/b?ssl-mode=PREFERRED",
             Some("b"),
         );
@@ -351,7 +348,6 @@ mod tests {
         let _ = state.session.begin_mysql_connection_probe(
             &target_id,
             "mysql-b",
-            DatabaseType::MySQL,
             "mysql://user@localhost:3306/b?ssl-mode=PREFERRED",
             Some("b"),
         );

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -45,13 +45,10 @@ pub fn reduce_connection_lifecycle(
             save_current_connection_cache(state);
 
             if *database_type == DatabaseType::MySQL {
-                let run_id = state.session.begin_mysql_connection_probe(
-                    id,
-                    name,
-                    *database_type,
-                    dsn,
-                    database.as_deref(),
-                );
+                let run_id =
+                    state
+                        .session
+                        .begin_mysql_connection_probe(id, name, dsn, database.as_deref());
                 state.query.reset_for_context_change();
                 return DispatchResult::handled_with(termination_effects(
                     &state.query,
@@ -104,7 +101,6 @@ pub fn reduce_connection_lifecycle(
                 || !state.session.is_current_mysql_connection_probe(
                     id,
                     name,
-                    *database_type,
                     dsn,
                     database.as_deref(),
                     *run_id,
@@ -137,7 +133,6 @@ pub fn reduce_connection_lifecycle(
                 || !state.session.is_current_mysql_connection_probe(
                     &target.id,
                     &target.name,
-                    target.database_type,
                     &target.dsn,
                     target.database.as_deref(),
                     *run_id,
@@ -209,7 +204,6 @@ pub(super) fn try_connect(state: &mut AppState, now: std::time::Instant) -> Vec<
                 let run_id = state.session.begin_mysql_connection_probe(
                     &target.id,
                     &target.name,
-                    target.database_type,
                     &target.dsn,
                     target.database.as_deref(),
                 );
@@ -2153,7 +2147,6 @@ mod tests {
             let run_id = state.session.begin_mysql_connection_probe(
                 &target.id,
                 &target.name,
-                target.database_type,
                 &target.dsn,
                 target.database.as_deref(),
             );

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -356,7 +356,6 @@ mod tests {
             let probe_run_id = state.session.begin_mysql_connection_probe(
                 &target.id,
                 &target.name,
-                target.database_type,
                 &target.dsn,
                 target.database.as_deref(),
             );
@@ -403,7 +402,6 @@ mod tests {
             let probe_run_id = state.session.begin_mysql_connection_probe(
                 &target.id,
                 &target.name,
-                target.database_type,
                 &target.dsn,
                 target.database.as_deref(),
             );

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -828,7 +828,6 @@ mod tests {
             let probe_run_id = state.session.begin_mysql_connection_probe(
                 &target.id,
                 &target.name,
-                target.database_type,
                 &target.dsn,
                 target.database.as_deref(),
             );


### PR DESCRIPTION
Remove the fixed database type payload from pending MySQL probe state and APIs; retries explicitly reconstruct MySQL targets while preserving stale guards. Tests: focused app probe tests, app all-target check, fmt, and lint_all.