### PR TITLE
refactor(app): derive engine feature profile

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -34,7 +34,7 @@ impl HelpDocument {
             filter.content(),
             filter.cursor(),
             state.settings.saved_keymap_preset(),
-            state.session.active_engine_feature_profile(),
+            &state.session.active_engine_feature_profile(),
             state.session.active_database_type().map(|database_type| {
                 let data_type = if database_type == DatabaseType::MySQL {
                     "json"

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -250,7 +250,7 @@ impl AppState {
 
     pub fn inspector_view_model(&self, ddl_generator: &dyn DdlGenerator) -> InspectorViewModel {
         InspectorViewModel::build_with_detail_state(
-            self.session.active_engine_feature_profile(),
+            &self.session.active_engine_feature_profile(),
             self.ui.inspector_tab(),
             self.session.table_detail_state(),
             self.session.active_database_type_or_default(),

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -156,7 +156,6 @@ pub struct BrowseSession {
     pending_mysql_connection_probe: Option<PendingMySqlConnectionProbe>,
     connection_generation: u64,
     database_generation: u64,
-    active_engine_feature_profile: EngineFeatureProfile,
     read_only: bool,
     is_reloading: bool,
 }
@@ -182,7 +181,6 @@ impl Default for BrowseSession {
             pending_mysql_connection_probe: None,
             connection_generation: 0,
             database_generation: 0,
-            active_engine_feature_profile: EngineFeatureProfile::disconnected(),
             read_only: false,
             is_reloading: false,
         }
@@ -451,7 +449,6 @@ impl BrowseSession {
             origin: ConnectionOrigin::Profile,
             database: database.map(str::to_string),
         });
-        self.active_engine_feature_profile = EngineFeatureProfile::for_database_type(database_type);
         self.dsn = Some(dsn.to_string());
         self.read_only = false;
         self.clear_mysql_connection_probe();
@@ -465,8 +462,6 @@ impl BrowseSession {
             origin: ConnectionOrigin::CliEphemeral,
             database: None,
         });
-        self.active_engine_feature_profile =
-            EngineFeatureProfile::for_database_type(DatabaseType::SQLite);
         self.dsn = Some(dsn.to_string());
         self.read_only = false;
         self.clear_mysql_connection_probe();
@@ -487,13 +482,6 @@ impl BrowseSession {
             origin: ConnectionOrigin::Profile,
             database: None,
         });
-        self.active_engine_feature_profile = EngineFeatureProfile::for_database_type(database_type);
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_active_engine_feature_profile_for_test(&mut self, database_type: DatabaseType) {
-        self.active_engine_feature_profile = EngineFeatureProfile::for_database_type(database_type);
     }
 
     pub fn clear_connection(&mut self) {
@@ -501,7 +489,6 @@ impl BrowseSession {
         self.active_connection = None;
         self.cancel_connection_save_and_disconnect();
         self.clear_mysql_connection_probe();
-        self.active_engine_feature_profile = EngineFeatureProfile::disconnected();
     }
 
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
@@ -806,8 +793,11 @@ impl BrowseSession {
         Some(QueryHistoryScope::new(connection_id, database))
     }
 
-    pub fn active_engine_feature_profile(&self) -> &EngineFeatureProfile {
-        &self.active_engine_feature_profile
+    pub fn active_engine_feature_profile(&self) -> EngineFeatureProfile {
+        match self.active_database_type() {
+            Some(database_type) => EngineFeatureProfile::for_database_type(database_type),
+            None => EngineFeatureProfile::disconnected(),
+        }
     }
 
     pub fn is_read_only(&self) -> bool {
@@ -1459,7 +1449,7 @@ mod tests {
             assert!(session.active_database_type().is_none());
             assert_eq!(
                 session.active_engine_feature_profile(),
-                &EngineFeatureProfile::disconnected()
+                EngineFeatureProfile::disconnected()
             );
             assert!(!session.is_read_only());
             assert!(!session.is_reloading());
@@ -1636,6 +1626,10 @@ mod tests {
 
             assert!(session.is_ephemeral_connection());
             assert!(!session.can_reenter_connection_setup());
+            assert_eq!(
+                session.active_engine_feature_profile(),
+                EngineFeatureProfile::sqlite_like()
+            );
         }
 
         #[test]
@@ -1678,6 +1672,28 @@ mod tests {
             assert!(session.selected_table_key().is_none());
             assert!(session.table_detail().is_none());
             assert_eq!(session.selection_generation(), 0);
+        }
+
+        #[test]
+        fn active_engine_feature_profile_uses_active_database_type() {
+            for (database_type, expected) in [
+                (
+                    DatabaseType::PostgreSQL,
+                    EngineFeatureProfile::postgres_like(),
+                ),
+                (DatabaseType::SQLite, EngineFeatureProfile::sqlite_like()),
+                (DatabaseType::MySQL, EngineFeatureProfile::mysql_like()),
+            ] {
+                let mut session = BrowseSession::default();
+                session.activate_connection_with_dsn(
+                    &ConnectionId::new(),
+                    "connection",
+                    database_type,
+                    "dsn",
+                );
+
+                assert_eq!(session.active_engine_feature_profile(), expected);
+            }
         }
 
         #[test]

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -211,7 +211,7 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
         } => {
             let max = palette_command_count(
                 state.settings.saved_keymap_preset(),
-                state.session.active_engine_feature_profile(),
+                &state.session.active_engine_feature_profile(),
             )
             .saturating_sub(1);
             let selected = state.ui.table_picker().selected();

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -135,9 +135,11 @@ mod tests {
         #[test]
         fn no_dsn_returns_error() {
             let mut state = AppState::new("test".to_string());
-            state
-                .session
-                .set_active_engine_feature_profile_for_test(DatabaseType::PostgreSQL);
+            state.session.set_active_connection_identity_for_test(
+                &ConnectionId::new(),
+                "postgres",
+                DatabaseType::PostgreSQL,
+            );
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -56,7 +56,7 @@ pub(super) fn mark_explain_unsupported_analyze(state: &mut AppState) {
 }
 
 fn apply_explain_unsupported_analyze_state(state: &mut AppState) {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if feature_policy.is_enabled(FeatureRequirement::Explain) {
         mark_explain_unsupported_analyze(state);
     } else {

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -49,7 +49,7 @@ pub(super) fn reduce_request(
                 .build_explain_sql(database_type, &content)
             {
                 Some(query) => query,
-                None if FeaturePolicy::new(state.session.active_engine_feature_profile())
+                None if FeaturePolicy::new(&state.session.active_engine_feature_profile())
                     .is_enabled(FeatureRequirement::Explain) =>
                 {
                     mark_explain_unsupported_query(state, &content);

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -21,7 +21,7 @@ pub(crate) fn require_er_diagram_enabled(
     state: &mut AppState,
     now: Instant,
 ) -> Option<DispatchResult> {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
         return None;
     }

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -28,7 +28,7 @@ pub fn handle_event(event: InputEvent, state: &AppState) -> Action {
 
 fn handle_paste_event(text: String, state: &AppState) -> Action {
     let action = Action::Paste(text);
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if !feature_policy.is_enabled(action.feature_requirement_for_state(state)) {
         return Action::None;
     }
@@ -49,7 +49,7 @@ fn handle_paste_event(text: String, state: &AppState) -> Action {
 }
 
 fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     let interaction = resolve_input_interaction(state);
     match interaction {
         InputInteraction::FormEditing(target) => {

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -13,7 +13,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
     let result_navigation = browse_ctx.is_result();
     let inspector_navigation = browse_ctx.is_inspector();
     let keymap_preset = state.settings.saved_keymap_preset();
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
 
     // Key sequence FSM: two-key sequences (zz, zt, zb)
     // Must be resolved before Ctrl/global actions so that the second key is

--- a/src/app/update/input/handlers/pickers.rs
+++ b/src/app/update/input/handlers/pickers.rs
@@ -83,7 +83,7 @@ pub fn handle_query_history_picker_keys(combo: KeyCombo) -> Action {
 }
 
 pub fn handle_er_table_picker_keys(combo: KeyCombo, state: &AppState) -> Action {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if let Some(action) = resolve_mode_with_policy(
         &combo,
         keybindings::er_picker_rows(state.settings.saved_keymap_preset()),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -28,7 +28,7 @@ pub fn reduce(
     now: Instant,
     services: &AppServices,
 ) -> Vec<Effect> {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if !feature_policy.is_enabled(action.feature_requirement_for_state(state)) {
         return vec![];
     }
@@ -130,7 +130,7 @@ fn reduce_inner(
                 let cmd_action = palette_action_for_index(
                     state.ui.table_picker().selected(),
                     state.settings.saved_keymap_preset(),
-                    state.session.active_engine_feature_profile(),
+                    &state.session.active_engine_feature_profile(),
                 );
                 state.modal.set_mode(InputMode::Normal);
                 return reduce(state, cmd_action, now, services);
@@ -3294,7 +3294,7 @@ mod tests {
         fn palette_index_of(state: &AppState, target: impl Fn(&Action) -> bool) -> usize {
             palette_commands(
                 state.settings.saved_keymap_preset(),
-                state.session.active_engine_feature_profile(),
+                &state.session.active_engine_feature_profile(),
             )
             .enumerate()
             .find(|(_, kb)| target(&kb.action))

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -15,9 +15,6 @@ fn initial_state_no_metadata() {
 fn explorer_shows_not_connected_when_no_active_connection() {
     let mut state = create_test_state();
     state.session.clear_connection();
-    state
-        .session
-        .set_active_engine_feature_profile_for_test(sabiql_domain::DatabaseType::PostgreSQL);
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/initial_state.rs
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                                       no dsn | -
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+┌ [1] Explorer ─────────────────────────┐[Info]                                                                                                                      
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +51,4 @@ test_project ▸ - ▸ -                                                        
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/ui/features/browse/json_detail.rs
+++ b/src/ui/features/browse/json_detail.rs
@@ -49,7 +49,7 @@ impl JsonDetail {
         let hints = if is_editing {
             vec![("Esc", "Normal")]
         } else {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
             let mut hints = vec![("y", "Copy")];
             hints.push(("/", "Search"));
             if feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit) {

--- a/src/ui/features/pickers/command_palette.rs
+++ b/src/ui/features/pickers/command_palette.rs
@@ -24,7 +24,7 @@ impl CommandPalette {
 
         let items: Vec<ListItem> = palette_commands(
             state.settings.saved_keymap_preset(),
-            state.session.active_engine_feature_profile(),
+            &state.session.active_engine_feature_profile(),
         )
         .enumerate()
         .map(|(i, kb)| {

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -26,7 +26,7 @@ pub fn render(
     now: Instant,
     theme: &ThemePalette,
 ) -> u16 {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if !feature_policy.is_enabled(FeatureRequirement::Explain) {
         let placeholder = Line::from(Span::styled(
             " EXPLAIN is unavailable for this database",

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -42,7 +42,7 @@ impl SqlModal {
             SqlModalStatus::ConfirmingHigh { .. } | SqlModalStatus::ConfirmingRisk { .. }
         );
         let engine_feature_profile = state.session.active_engine_feature_profile();
-        let feature_policy = FeaturePolicy::new(engine_feature_profile);
+        let feature_policy = FeaturePolicy::new(&engine_feature_profile);
         let active_tab =
             engine_feature_profile.normalize_sql_modal_tab(state.sql_modal.active_tab());
 
@@ -128,13 +128,13 @@ impl SqlModal {
                     Self::border_hint(
                         active_tab,
                         compare_can_yank,
-                        engine_feature_profile,
+                        &engine_feature_profile,
                         &feature_policy,
                         state.settings.saved_keymap_preset(),
                     )
                 }
             };
-            Self::render_modal_with_tabs(frame, active_tab, hint, engine_feature_profile, theme)
+            Self::render_modal_with_tabs(frame, active_tab, hint, &engine_feature_profile, theme)
         };
 
         // Add 1-char horizontal padding for breathing room inside the modal

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -155,7 +155,7 @@ impl Footer {
                 } else {
                     // Actions → Navigation → Help → Close/Cancel → Quit
                     let capabilities = state.session.active_engine_feature_profile();
-                    let feature_policy = FeaturePolicy::new(capabilities);
+                    let feature_policy = FeaturePolicy::new(&capabilities);
                     let active_inspector_tab =
                         capabilities.normalize_inspector_tab(state.ui.inspector_tab());
                     let mut list = vec![global::RELOAD.as_hint(), global::SQL.as_hint()];
@@ -316,7 +316,7 @@ impl Footer {
             }
             InputMode::SqliteDiagnostics => {
                 let feature_policy =
-                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                    FeaturePolicy::new(&state.session.active_engine_feature_profile());
                 let mut hints = Vec::new();
                 if feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
                     hints.push(sqlite_diagnostics::SCROLL.as_hint());
@@ -334,7 +334,7 @@ impl Footer {
             }
             InputMode::ErTablePicker => {
                 let feature_policy =
-                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                    FeaturePolicy::new(&state.session.active_engine_feature_profile());
                 let mut hints = Vec::new();
                 if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
                     hints.extend([
@@ -354,7 +354,7 @@ impl Footer {
             ],
             InputMode::JsonDetail => {
                 let feature_policy =
-                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                    FeaturePolicy::new(&state.session.active_engine_feature_profile());
                 if !feature_policy.is_enabled(FeatureRequirement::JsonDocumentDetail) {
                     vec![json_detail::CLOSE.as_hint()]
                 } else if matches!(state.json_detail.mode(), JsonDetailMode::Searching) {
@@ -379,7 +379,7 @@ impl Footer {
             }
             InputMode::JsonEdit => {
                 let feature_policy =
-                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                    FeaturePolicy::new(&state.session.active_engine_feature_profile());
                 if feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit) {
                     vec![
                         json_edit::ESC_NORMAL.as_hint(),


### PR DESCRIPTION
## Problem

BrowseSession stores an engine feature profile that is fully determined by the active connection database type, creating a second state source that can become stale.

## Background

The profile has no runtime payload beyond the existing static database-type mapping, so every connection lifecycle path reconstructs the same value.

## Approach

Derive the profile on demand from the active connection identity and return the disconnected profile when no connection is active. Existing feature policy and surface callers keep their behavior while borrowing the derived value where required.