### PR TITLE
fix(mysql): avoid duplicate statement validation (SAB-530)

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -43,7 +43,7 @@ pub(in crate::adapters::mysql) fn validate_mysql_multi_query(
 ) -> Result<Vec<MySqlStatement>, DbOperationError> {
     let statements = classify_mysql_multi_statement(query, selected_database)
         .map_err(DbOperationError::UnsupportedOperation)?;
-    validate_mysql_statements_for_execution(&statements, selected_database, access_mode)?;
+    validate_mysql_access_mode(&statements, access_mode)?;
     Ok(statements)
 }
 
@@ -54,6 +54,13 @@ pub(in crate::adapters::mysql) fn validate_mysql_statements_for_execution(
 ) -> Result<(), DbOperationError> {
     validate_mysql_statements(statements, selected_database)
         .map_err(DbOperationError::UnsupportedOperation)?;
+    validate_mysql_access_mode(statements, access_mode)
+}
+
+fn validate_mysql_access_mode(
+    statements: &[MySqlStatement],
+    access_mode: AccessMode,
+) -> Result<(), DbOperationError> {
     if access_mode.is_read_only() && !statements.iter().all(mysql_statement_is_read_only_allowed) {
         return Err(DbOperationError::PermissionDenied(
             "read-only mode blocks MySQL write statements".to_string(),


### PR DESCRIPTION
## Problem
Raw MySQL execution validates already classified statements twice, repeating lexing and validation.

## Background
The raw query path classifies and validates the submission before applying the execution access policy, while preclassified statements still require adapter-boundary revalidation.

## Approach
Apply only the access-mode policy to statements returned by classification, while retaining full statement revalidation for the classified execution boundary.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-530