### PR TITLE
[SAB-383] Show foreign key referential actions in Inspector

### DIFF
--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -85,6 +85,8 @@ pub struct InspectorForeignKeyRow {
     pub name: String,
     pub columns: String,
     pub references: String,
+    pub on_update: String,
+    pub on_delete: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -447,6 +449,8 @@ fn foreign_key_row(fk: &ForeignKey) -> InspectorForeignKeyRow {
         } else {
             format!("{references} (unresolved)")
         },
+        on_update: fk.on_update.to_string(),
+        on_delete: fk.on_delete.to_string(),
     }
 }
 
@@ -510,8 +514,8 @@ mod tests {
                 to_schema: "public".to_string(),
                 to_table: "orgs".to_string(),
                 to_columns: vec!["id".to_string()],
-                on_delete: FkAction::NoAction,
-                on_update: FkAction::NoAction,
+                on_delete: FkAction::Cascade,
+                on_update: FkAction::SetNull,
                 reference_resolved: true,
             }],
             indexes: vec![Index {
@@ -643,6 +647,31 @@ mod tests {
                 ]
             ),
             section => panic!("expected info section, got {section:?}"),
+        }
+    }
+
+    #[test]
+    fn foreign_key_rows_include_referential_actions() {
+        let model = build_loaded(
+            &EngineFeatureProfile::mysql_like(),
+            InspectorTab::ForeignKeys,
+            &table(),
+            DatabaseType::MySQL,
+            &TestDdlGenerator,
+        );
+
+        match model.section() {
+            Some(InspectorSection::ForeignKeys { rows }) => assert_eq!(
+                rows,
+                &[InspectorForeignKeyRow {
+                    name: "users_org_id_fkey".to_string(),
+                    columns: "org_id".to_string(),
+                    references: "public.orgs(id)".to_string(),
+                    on_update: "SET NULL".to_string(),
+                    on_delete: "CASCADE".to_string(),
+                }]
+            ),
+            section => panic!("expected foreign keys section, got {section:?}"),
         }
     }
 

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_marks_unresolved_reference.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_marks_unresolved_reference.snap
@@ -5,9 +5,9 @@ expression: output
 test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  public.posts                         ││Name                   Columns         References                                                                         │
-│  public.comments                      ││fk_users_department    department_id   public.departments(id)                                                             │
-│                                       ││fk_users_missing_org   org_id          public.missing_orgs(id) (unresolved)                                               │
+│  public.posts                         ││Name                   Columns         References                             On update   On delete                       │
+│  public.comments                      ││fk_users_department    department_id   public.departments(id)                 NO ACTION   CASCADE                         │
+│                                       ││fk_users_missing_org   org_id          public.missing_orgs(id) (unresolved)   NO ACTION   NO ACTION                       │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
@@ -5,8 +5,8 @@ expression: output
 test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  public.posts                         ││Name                  Columns         References                                                                          │
-│  public.comments                      ││fk_users_department   department_id   public.departments(id)                                                              │
+│  public.posts                         ││Name                  Columns         References               On update   On delete                                      │
+│  public.comments                      ││fk_users_department   department_id   public.departments(id)   NO ACTION   CASCADE                                        │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -519,7 +519,7 @@ impl Inspector {
         scroll_offset: usize,
         theme: &ThemePalette,
     ) {
-        let headers = ["Name", "Columns", "References"];
+        let headers = ["Name", "Columns", "References", "On update", "On delete"];
         // Width sampling sees only the first 50 rows, so row_fn rebuilds text
         // per visible row instead of indexing into the sample
         let data_rows: Vec<Vec<String>> = rows.iter().take(50).map(foreign_key_row_cells).collect();
@@ -790,6 +790,8 @@ fn foreign_key_row_cells(row: &InspectorForeignKeyRow) -> Vec<String> {
         row.name.clone(),
         row.columns.clone(),
         row.references.clone(),
+        row.on_update.clone(),
+        row.on_delete.clone(),
     ]
 }
 
@@ -852,5 +854,27 @@ mod tests {
 
         assert_eq!(index_row_cells(&row, false, true, false).len(), 3);
         assert_eq!(index_row_cells(&row, false, true, true).len(), 5);
+    }
+
+    #[test]
+    fn foreign_key_row_cells_include_referential_actions() {
+        let row = InspectorForeignKeyRow {
+            name: "fk_users_department".to_string(),
+            columns: "department_id".to_string(),
+            references: "public.departments(id)".to_string(),
+            on_update: "NO ACTION".to_string(),
+            on_delete: "CASCADE".to_string(),
+        };
+
+        assert_eq!(
+            foreign_key_row_cells(&row),
+            vec![
+                "fk_users_department",
+                "department_id",
+                "public.departments(id)",
+                "NO ACTION",
+                "CASCADE",
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Problem
Foreign-key metadata already contains ON UPDATE and ON DELETE actions, but the Inspector drops them before rendering.

## Background
This prevents users from determining how parent updates and deletes affect child rows.

## Approach
Carry the existing action labels through the Inspector view model and render them as columns in the existing Foreign Keys table, preserving the current identity, ordering, and unresolved-reference behavior.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-383