### PR TITLE
fix(app): scope MySQL INSERT completion contexts (SAB-531)

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -706,7 +706,7 @@ impl CompletionEngine {
             return CompletionContext::Column;
         }
 
-        let keywords_table = ["FROM", "JOIN", "INTO", "UPDATE"];
+        let keywords_table = ["FROM", "JOIN", "INTO", "UPDATE", "INSERT", "REPLACE"];
         let keywords_column = ["SELECT", "WHERE", "ON", "SET", "AND", "OR", "BY"];
 
         let mut last_table_pos = None;
@@ -759,7 +759,6 @@ impl CompletionEngine {
 
     fn insert_target_column_list_start(tokens: &[Token], cursor_pos: usize) -> Option<usize> {
         let mut insert_started = false;
-        let mut into_seen = false;
         let mut list_depth = 0;
         let mut list_start = None;
 
@@ -768,11 +767,9 @@ impl CompletionEngine {
                 break;
             }
 
-            if !into_seen {
+            if !insert_started {
                 if Self::token_is_word(token, "INSERT") || Self::token_is_word(token, "REPLACE") {
                     insert_started = true;
-                } else if insert_started && Self::token_is_word(token, "INTO") {
-                    into_seen = true;
                 }
                 continue;
             }
@@ -2561,6 +2558,8 @@ mod tests {
             for sql in [
                 "INSERT INTO users (na",
                 "REPLACE INTO users (na",
+                "INSERT users (na",
+                "REPLACE users (na",
                 "INSERT INTO app.users AS u (na",
             ] {
                 let candidates = e.get_candidates_for_database(
@@ -2587,7 +2586,7 @@ mod tests {
         fn mysql_insert_and_update_target_tables_remain_table_context() {
             let e = engine();
             let metadata = metadata();
-            for sql in ["INSERT INTO us", "UPDATE us"] {
+            for sql in ["INSERT INTO us", "UPDATE us", "INSERT us", "REPLACE us"] {
                 let candidates = e.get_candidates_for_database(
                     sql,
                     sql.chars().count(),

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -907,6 +907,7 @@ impl CompletionEngine {
 
         let mut assignment_start = update_index + 1;
         let mut depth: usize = 0;
+        let mut current_assignment_has_equals = false;
         for (index, token) in tokens.iter().enumerate().skip(update_index + 1) {
             if token.start >= cursor_pos {
                 break;
@@ -914,8 +915,13 @@ impl CompletionEngine {
             match &token.kind {
                 TokenKind::Punctuation('(') => depth += 1,
                 TokenKind::Punctuation(')') => depth = depth.saturating_sub(1),
-                TokenKind::Punctuation(',') if depth == 0 => assignment_start = index + 1,
-                TokenKind::Operator(operator) if operator == "=" && depth == 0 => {
+                TokenKind::Punctuation(',') if depth == 0 => {
+                    assignment_start = index + 1;
+                    current_assignment_has_equals = false;
+                }
+                TokenKind::Operator(operator)
+                    if operator == "=" && depth == 0 && !current_assignment_has_equals =>
+                {
                     if let Some(name) = tokens[assignment_start..index]
                         .iter()
                         .rev()
@@ -924,11 +930,15 @@ impl CompletionEngine {
                         written.insert(name.to_lowercase());
                     }
                     assignment_start = index + 1;
+                    current_assignment_has_equals = true;
                 }
                 _ => {}
             }
         }
 
+        if current_assignment_has_equals {
+            written.clear();
+        }
         written
     }
 
@@ -2704,6 +2714,42 @@ mod tests {
                     .iter()
                     .any(|candidate| candidate.kind == CompletionKind::Table)
             );
+        }
+
+        #[test]
+        fn mysql_upsert_rhs_keeps_assigned_columns_available() {
+            let e = engine();
+            let metadata = metadata();
+            let table = create_table("app", "users", &["id", "name", "email"]);
+
+            for (sql, expected) in [
+                (
+                    "INSERT INTO users (name) VALUES ('Ada') ON DUPLICATE KEY UPDATE name = na",
+                    "`name`",
+                ),
+                (
+                    "INSERT INTO users (name) VALUES ('Ada') ON DUPLICATE KEY UPDATE id = 1, name = id",
+                    "`id`",
+                ),
+            ] {
+                let candidates = e.get_candidates_for_database(
+                    sql,
+                    sql.chars().count(),
+                    Some(&metadata),
+                    Some(&table),
+                    &[],
+                    CompletionDatabaseScope {
+                        database_type: DatabaseType::MySQL,
+                        active_database: Some("app"),
+                    },
+                );
+
+                assert!(
+                    candidates
+                        .iter()
+                        .any(|candidate| candidate.text == expected)
+                );
+            }
         }
     }
 

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -760,6 +760,8 @@ impl CompletionEngine {
     fn insert_target_column_list_start(tokens: &[Token], cursor_pos: usize) -> Option<usize> {
         let mut insert_started = false;
         let mut list_depth = 0;
+        let mut partition_depth = 0;
+        let mut partition_pending = false;
         let mut list_start = None;
 
         for (index, token) in tokens.iter().enumerate() {
@@ -788,12 +790,38 @@ impl CompletionEngine {
                 continue;
             }
 
+            if partition_depth > 0 {
+                match &token.kind {
+                    TokenKind::Punctuation('(') => partition_depth += 1,
+                    TokenKind::Punctuation(')') => partition_depth -= 1,
+                    _ => {}
+                }
+                continue;
+            }
+
+            if partition_pending {
+                if token.kind == TokenKind::Whitespace {
+                    continue;
+                }
+                if token.kind == TokenKind::Punctuation('(') {
+                    partition_depth = 1;
+                    partition_pending = false;
+                    continue;
+                }
+                partition_pending = false;
+            }
+
             if Self::token_is_word(token, "VALUES")
                 || Self::token_is_word(token, "SELECT")
                 || Self::token_is_word(token, "SET")
                 || Self::token_is_word(token, "ON")
             {
                 return None;
+            }
+
+            if Self::token_is_word(token, "PARTITION") {
+                partition_pending = true;
+                continue;
             }
 
             if token.kind == TokenKind::Punctuation('(') {
@@ -1656,6 +1684,19 @@ mod tests {
 
             assert_eq!(token, "na");
             assert_eq!(ctx, CompletionContext::Column);
+        }
+
+        #[test]
+        fn insert_partition_name_does_not_return_column_context() {
+            let e = engine();
+            for sql in [
+                "INSERT INTO users PARTITION (p",
+                "REPLACE INTO users PARTITION (p",
+            ] {
+                let (_, ctx) = e.analyze(sql, sql.chars().count());
+
+                assert_ne!(ctx, CompletionContext::Column);
+            }
         }
     }
 
@@ -2560,6 +2601,8 @@ mod tests {
                 "REPLACE INTO users (na",
                 "INSERT users (na",
                 "REPLACE users (na",
+                "INSERT INTO users PARTITION (p0) (na",
+                "REPLACE INTO users PARTITION (p0) (na",
                 "INSERT INTO app.users AS u (na",
             ] {
                 let candidates = e.get_candidates_for_database(

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -415,6 +415,8 @@ impl CompletionEngine {
             }
             CompletionContext::Column => {
                 let keywords = self.primary_clause_keywords(&current_token);
+                let written_columns =
+                    Self::written_columns_for_completion(&prep.tokens, cursor_pos);
 
                 let before_token = prep
                     .before_cursor
@@ -480,6 +482,8 @@ impl CompletionEngine {
                     }
                     columns.extend(cached_columns);
                 }
+
+                columns.retain(|column| !written_columns.contains(&column.text.to_lowercase()));
 
                 let has_prefix = current_token.len() >= 2;
                 if has_prefix && !columns.is_empty() {
@@ -696,6 +700,12 @@ impl CompletionEngine {
     }
 
     fn detect_context_from_tokens(&self, tokens: &[Token], cursor_pos: usize) -> CompletionContext {
+        if Self::insert_target_column_list_start(tokens, cursor_pos).is_some()
+            || Self::upsert_update_index(tokens, cursor_pos).is_some()
+        {
+            return CompletionContext::Column;
+        }
+
         let keywords_table = ["FROM", "JOIN", "INTO", "UPDATE"];
         let keywords_column = ["SELECT", "WHERE", "ON", "SET", "AND", "OR", "BY"];
 
@@ -720,10 +730,181 @@ impl CompletionEngine {
 
         match (last_table_pos, last_column_pos) {
             (Some(t), Some(c)) if t > c => CompletionContext::Table,
-            (Some(t), None) if t > 0 => CompletionContext::Table,
+            (Some(_), None) => CompletionContext::Table,
             (_, Some(_)) => CompletionContext::Column,
             _ => CompletionContext::Keyword,
         }
+    }
+
+    fn token_is_word(token: &Token, word: &str) -> bool {
+        matches!(
+            &token.kind,
+            TokenKind::Keyword(value) | TokenKind::Identifier(value)
+                if value.eq_ignore_ascii_case(word)
+        )
+    }
+
+    fn column_name_from_token(token: &Token) -> Option<&str> {
+        match &token.kind {
+            TokenKind::Identifier(name) | TokenKind::BacktickIdentifier(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    fn previous_non_whitespace_index(tokens: &[Token], index: usize) -> Option<usize> {
+        tokens[..index]
+            .iter()
+            .rposition(|token| token.kind != TokenKind::Whitespace)
+    }
+
+    fn insert_target_column_list_start(tokens: &[Token], cursor_pos: usize) -> Option<usize> {
+        let mut insert_started = false;
+        let mut into_seen = false;
+        let mut list_depth = 0;
+        let mut list_start = None;
+
+        for (index, token) in tokens.iter().enumerate() {
+            if token.start >= cursor_pos {
+                break;
+            }
+
+            if !into_seen {
+                if Self::token_is_word(token, "INSERT") || Self::token_is_word(token, "REPLACE") {
+                    insert_started = true;
+                } else if insert_started && Self::token_is_word(token, "INTO") {
+                    into_seen = true;
+                }
+                continue;
+            }
+
+            if list_depth > 0 {
+                match &token.kind {
+                    TokenKind::Punctuation('(') => list_depth += 1,
+                    TokenKind::Punctuation(')') => {
+                        list_depth -= 1;
+                        if list_depth == 0 {
+                            return None;
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            if Self::token_is_word(token, "VALUES")
+                || Self::token_is_word(token, "SELECT")
+                || Self::token_is_word(token, "SET")
+                || Self::token_is_word(token, "ON")
+            {
+                return None;
+            }
+
+            if token.kind == TokenKind::Punctuation('(') {
+                list_depth = 1;
+                list_start = Some(index);
+            }
+        }
+
+        list_start
+    }
+
+    fn upsert_update_index(tokens: &[Token], cursor_pos: usize) -> Option<usize> {
+        let mut insert_started = false;
+
+        for (index, token) in tokens.iter().enumerate() {
+            if token.start >= cursor_pos {
+                break;
+            }
+            if Self::token_is_word(token, "INSERT") || Self::token_is_word(token, "REPLACE") {
+                insert_started = true;
+                continue;
+            }
+            if !insert_started || !Self::token_is_word(token, "UPDATE") {
+                continue;
+            }
+
+            let Some(key_index) = Self::previous_non_whitespace_index(tokens, index) else {
+                continue;
+            };
+            if !Self::token_is_word(&tokens[key_index], "KEY") {
+                continue;
+            }
+            let Some(duplicate_index) = Self::previous_non_whitespace_index(tokens, key_index)
+            else {
+                continue;
+            };
+            if !Self::token_is_word(&tokens[duplicate_index], "DUPLICATE") {
+                continue;
+            }
+            let Some(on_index) = Self::previous_non_whitespace_index(tokens, duplicate_index)
+            else {
+                continue;
+            };
+            if Self::token_is_word(&tokens[on_index], "ON") {
+                return Some(index);
+            }
+        }
+
+        None
+    }
+
+    fn written_columns_for_completion(tokens: &[Token], cursor_pos: usize) -> HashSet<String> {
+        let mut written = HashSet::new();
+
+        if let Some(open_index) = Self::insert_target_column_list_start(tokens, cursor_pos) {
+            let mut depth = 1;
+            for token in tokens.iter().skip(open_index + 1) {
+                if token.start >= cursor_pos {
+                    break;
+                }
+                match &token.kind {
+                    TokenKind::Punctuation('(') => depth += 1,
+                    TokenKind::Punctuation(')') => {
+                        if depth == 1 {
+                            break;
+                        }
+                        depth -= 1;
+                    }
+                    _ if depth == 1 => {
+                        if let Some(name) = Self::column_name_from_token(token) {
+                            written.insert(name.to_lowercase());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return written;
+        }
+
+        let Some(update_index) = Self::upsert_update_index(tokens, cursor_pos) else {
+            return written;
+        };
+
+        let mut assignment_start = update_index + 1;
+        let mut depth: usize = 0;
+        for (index, token) in tokens.iter().enumerate().skip(update_index + 1) {
+            if token.start >= cursor_pos {
+                break;
+            }
+            match &token.kind {
+                TokenKind::Punctuation('(') => depth += 1,
+                TokenKind::Punctuation(')') => depth = depth.saturating_sub(1),
+                TokenKind::Punctuation(',') if depth == 0 => assignment_start = index + 1,
+                TokenKind::Operator(operator) if operator == "=" && depth == 0 => {
+                    if let Some(name) = tokens[assignment_start..index]
+                        .iter()
+                        .rev()
+                        .find_map(Self::column_name_from_token)
+                    {
+                        written.insert(name.to_lowercase());
+                    }
+                    assignment_start = index + 1;
+                }
+                _ => {}
+            }
+        }
+
+        written
     }
 
     #[cfg(test)]
@@ -1450,6 +1631,34 @@ mod tests {
                 ctx,
                 CompletionContext::SchemaQualified("public".to_string())
             );
+        }
+
+        #[test]
+        fn insert_target_column_list_returns_column_context() {
+            let e = engine();
+            let (token, ctx) = e.analyze("INSERT INTO users (na", 21);
+
+            assert_eq!(token, "na");
+            assert_eq!(ctx, CompletionContext::Column);
+        }
+
+        #[test]
+        fn insert_target_table_returns_table_context() {
+            let e = engine();
+            let (token, ctx) = e.analyze("INSERT INTO us", 14);
+
+            assert_eq!(token, "us");
+            assert_eq!(ctx, CompletionContext::Table);
+        }
+
+        #[test]
+        fn upsert_assignment_returns_column_context() {
+            let e = engine();
+            let sql = "INSERT INTO users (id) VALUES (1) ON DUPLICATE KEY UPDATE na";
+            let (token, ctx) = e.analyze(sql, sql.chars().count());
+
+            assert_eq!(token, "na");
+            assert_eq!(ctx, CompletionContext::Column);
         }
     }
 
@@ -2336,6 +2545,122 @@ mod tests {
                 !candidates
                     .iter()
                     .any(|candidate| candidate.text == "`users`")
+            );
+        }
+
+        #[test]
+        fn mysql_insert_and_replace_target_columns_are_completed() {
+            let e = engine();
+            let metadata = metadata();
+            let table = create_table("app", "users", &["id", "name", "email"]);
+            let scope = CompletionDatabaseScope {
+                database_type: DatabaseType::MySQL,
+                active_database: Some("app"),
+            };
+
+            for sql in [
+                "INSERT INTO users (na",
+                "REPLACE INTO users (na",
+                "INSERT INTO app.users AS u (na",
+            ] {
+                let candidates = e.get_candidates_for_database(
+                    sql,
+                    sql.chars().count(),
+                    Some(&metadata),
+                    Some(&table),
+                    &[],
+                    scope,
+                );
+
+                assert!(candidates.iter().any(|candidate| {
+                    candidate.text == "`name`" && candidate.kind == CompletionKind::Column
+                }));
+                assert!(
+                    !candidates
+                        .iter()
+                        .any(|candidate| candidate.kind == CompletionKind::Table)
+                );
+            }
+        }
+
+        #[test]
+        fn mysql_insert_and_update_target_tables_remain_table_context() {
+            let e = engine();
+            let metadata = metadata();
+            for sql in ["INSERT INTO us", "UPDATE us"] {
+                let candidates = e.get_candidates_for_database(
+                    sql,
+                    sql.chars().count(),
+                    Some(&metadata),
+                    None,
+                    &[],
+                    CompletionDatabaseScope {
+                        database_type: DatabaseType::MySQL,
+                        active_database: Some("app"),
+                    },
+                );
+
+                assert!(candidates.iter().any(|candidate| {
+                    candidate.text == "`users`" && candidate.kind == CompletionKind::Table
+                }));
+            }
+        }
+
+        #[test]
+        fn mysql_insert_target_columns_exclude_previous_columns() {
+            let e = engine();
+            let metadata = metadata();
+            let table = create_table("app", "users", &["id", "name", "email"]);
+            let sql = "INSERT INTO users (id, na";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                Some(&table),
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                },
+            );
+
+            assert!(
+                candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "`name`")
+            );
+            assert!(!candidates.iter().any(|candidate| candidate.text == "`id`"));
+        }
+
+        #[test]
+        fn mysql_upsert_assignment_columns_are_completed_and_exclude_assignments() {
+            let e = engine();
+            let metadata = metadata();
+            let table = create_table("app", "users", &["id", "name", "email"]);
+            let sql =
+                "INSERT INTO users (id, name) VALUES (1, 'Ada') ON DUPLICATE KEY UPDATE id = 1, na";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                Some(&table),
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                },
+            );
+
+            assert!(
+                candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "`name`")
+            );
+            assert!(!candidates.iter().any(|candidate| candidate.text == "`id`"));
+            assert!(
+                !candidates
+                    .iter()
+                    .any(|candidate| candidate.kind == CompletionKind::Table)
             );
         }
     }

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -800,7 +800,6 @@ impl SqlLexer {
     pub fn extract_table_references(&self, tokens: &[Token]) -> Vec<TableReference> {
         let mut refs = Vec::new();
         let mut i = 0;
-        let mut prev_keyword: Option<&str> = None;
         // Track FOR locking clause: FOR [NO KEY | KEY]? (UPDATE | SHARE)
         let mut in_for_clause = false;
 
@@ -810,7 +809,6 @@ impl SqlLexer {
             // Reset state on statement terminator
             if token.kind == TokenKind::Punctuation(';') {
                 in_for_clause = false;
-                prev_keyword = None;
                 i += 1;
                 continue;
             }
@@ -819,7 +817,6 @@ impl SqlLexer {
                 match kw.as_str() {
                     "FROM" | "JOIN" => {
                         in_for_clause = false;
-                        prev_keyword = Some(kw.as_str());
                         i += 1;
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
                             i += 1;
@@ -841,7 +838,6 @@ impl SqlLexer {
                     // JOIN modifiers - skip to find JOIN, then parse table
                     "INNER" | "LEFT" | "RIGHT" | "FULL" | "CROSS" => {
                         in_for_clause = false;
-                        prev_keyword = Some(kw.as_str());
                         i += 1;
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
                             i += 1;
@@ -863,20 +859,43 @@ impl SqlLexer {
                     // FOR starts a locking clause (FOR UPDATE, FOR NO KEY UPDATE, etc.)
                     "FOR" => {
                         in_for_clause = true;
-                        prev_keyword = Some("FOR");
                     }
                     // NO, KEY, SHARE are part of FOR locking clause
-                    "NO" | "KEY" | "SHARE" if in_for_clause => {
-                        prev_keyword = Some(kw.as_str());
+                    "NO" | "KEY" | "SHARE" if in_for_clause => {}
+                    "INSERT" | "REPLACE" => {
+                        in_for_clause = false;
+                        i += 1;
+                        i = self.skip_mysql_modifiers(tokens, i, MYSQL_INSERT_MODIFIERS);
+                        while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
+                            i += 1;
+                        }
+                        if i < tokens.len()
+                            && matches!(&tokens[i].kind, TokenKind::Keyword(k) if k == "INTO")
+                        {
+                            i += 1;
+                            while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
+                                i += 1;
+                            }
+                        }
+                        if i < tokens.len()
+                            && matches!(&tokens[i].kind, TokenKind::Keyword(k) if k == "ONLY")
+                        {
+                            i += 1;
+                            while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
+                                i += 1;
+                            }
+                        }
+                        if let Some(table_ref) = self.parse_table_reference(tokens, &mut i) {
+                            refs.push(table_ref);
+                            continue;
+                        }
                     }
                     "UPDATE" if self.is_mysql_upsert_update(tokens, i) => {
-                        prev_keyword = Some("UPDATE");
                         i += 1;
                         continue;
                     }
                     // UPDATE: skip if in FOR locking clause
                     "UPDATE" if !in_for_clause => {
-                        prev_keyword = Some("UPDATE");
                         i += 1;
                         i = self.skip_mysql_modifiers(tokens, i, MYSQL_UPDATE_MODIFIERS);
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
@@ -896,29 +915,8 @@ impl SqlLexer {
                             continue;
                         }
                     }
-                    // INSERT INTO table_name ... (only after INSERT, not SELECT INTO)
-                    "INTO" if matches!(prev_keyword, Some("INSERT" | "REPLACE")) => {
-                        i += 1;
-                        while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
-                            i += 1;
-                        }
-                        // Skip ONLY keyword (PostgreSQL inheritance)
-                        if i < tokens.len()
-                            && matches!(&tokens[i].kind, TokenKind::Keyword(k) if k == "ONLY")
-                        {
-                            i += 1;
-                            while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
-                                i += 1;
-                            }
-                        }
-                        if let Some(table_ref) = self.parse_table_reference(tokens, &mut i) {
-                            refs.push(table_ref);
-                            continue;
-                        }
-                    }
-                    other => {
+                    _ => {
                         in_for_clause = false;
-                        prev_keyword = Some(other);
                     }
                 }
             }
@@ -2112,21 +2110,26 @@ mod tests {
             #[test]
             fn mysql_replace_target_is_extracted() {
                 let l = SqlLexer::new(DatabaseType::MySQL);
-                let sql = "REPLACE INTO users (name) VALUES ('Ada')";
-                let tokens = l.tokenize(sql, sql.len());
+                for sql in [
+                    "REPLACE INTO users (name) VALUES ('Ada')",
+                    "REPLACE users (name) VALUES ('Ada')",
+                    "INSERT users (name) VALUES ('Ada')",
+                ] {
+                    let tokens = l.tokenize(sql, sql.len());
 
-                assert_eq!(
-                    l.extract_target_table(&tokens, sql.len())
-                        .as_ref()
-                        .map(|table| table.table.as_str()),
-                    Some("users")
-                );
-                assert_eq!(
-                    l.extract_table_references(&tokens)
-                        .first()
-                        .map(|table| table.table.as_str()),
-                    Some("users")
-                );
+                    assert_eq!(
+                        l.extract_target_table(&tokens, sql.len())
+                            .as_ref()
+                            .map(|table| table.table.as_str()),
+                        Some("users")
+                    );
+                    assert_eq!(
+                        l.extract_table_references(&tokens)
+                            .first()
+                            .map(|table| table.table.as_str()),
+                        Some("users")
+                    );
+                }
             }
 
             #[test]

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -769,6 +769,34 @@ impl SqlLexer {
         }
     }
 
+    fn is_mysql_upsert_update(&self, tokens: &[Token], update_index: usize) -> bool {
+        if !self.is_mysql() {
+            return false;
+        }
+
+        let mut index = update_index;
+        for expected in ["KEY", "DUPLICATE", "ON"] {
+            let Some(previous_index) = tokens[..index]
+                .iter()
+                .rposition(|token| token.kind != TokenKind::Whitespace)
+            else {
+                return false;
+            };
+            index = previous_index;
+            let token = &tokens[index];
+            let is_expected = matches!(
+                &token.kind,
+                TokenKind::Keyword(word) | TokenKind::Identifier(word)
+                    if word.eq_ignore_ascii_case(expected)
+            );
+            if !is_expected {
+                return false;
+            }
+        }
+
+        true
+    }
+
     pub fn extract_table_references(&self, tokens: &[Token]) -> Vec<TableReference> {
         let mut refs = Vec::new();
         let mut i = 0;
@@ -841,6 +869,11 @@ impl SqlLexer {
                     "NO" | "KEY" | "SHARE" if in_for_clause => {
                         prev_keyword = Some(kw.as_str());
                     }
+                    "UPDATE" if self.is_mysql_upsert_update(tokens, i) => {
+                        prev_keyword = Some("UPDATE");
+                        i += 1;
+                        continue;
+                    }
                     // UPDATE: skip if in FOR locking clause
                     "UPDATE" if !in_for_clause => {
                         prev_keyword = Some("UPDATE");
@@ -864,7 +897,7 @@ impl SqlLexer {
                         }
                     }
                     // INSERT INTO table_name ... (only after INSERT, not SELECT INTO)
-                    "INTO" if prev_keyword == Some("INSERT") => {
+                    "INTO" if matches!(prev_keyword, Some("INSERT" | "REPLACE")) => {
                         i += 1;
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
                             i += 1;
@@ -1259,7 +1292,7 @@ impl SqlLexer {
                             }
                             return self.parse_table_reference(tokens, &mut i);
                         }
-                        "INSERT" => {
+                        "INSERT" | "REPLACE" => {
                             i += 1;
                             i = self.skip_mysql_modifiers(tokens, i, MYSQL_INSERT_MODIFIERS);
                             while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
@@ -2074,6 +2107,43 @@ mod tests {
                         "table reference for {sql}"
                     );
                 }
+            }
+
+            #[test]
+            fn mysql_replace_target_is_extracted() {
+                let l = SqlLexer::new(DatabaseType::MySQL);
+                let sql = "REPLACE INTO users (name) VALUES ('Ada')";
+                let tokens = l.tokenize(sql, sql.len());
+
+                assert_eq!(
+                    l.extract_target_table(&tokens, sql.len())
+                        .as_ref()
+                        .map(|table| table.table.as_str()),
+                    Some("users")
+                );
+                assert_eq!(
+                    l.extract_table_references(&tokens)
+                        .first()
+                        .map(|table| table.table.as_str()),
+                    Some("users")
+                );
+            }
+
+            #[test]
+            fn mysql_upsert_update_is_not_a_table_reference() {
+                let l = SqlLexer::new(DatabaseType::MySQL);
+                let sql = "INSERT INTO users (id) VALUES (1) ON DUPLICATE KEY UPDATE name = 'Ada'";
+                let tokens = l.tokenize(sql, sql.len());
+
+                let references = l.extract_table_references(&tokens);
+
+                assert_eq!(
+                    references
+                        .iter()
+                        .map(|table| table.table.as_str())
+                        .collect::<Vec<_>>(),
+                    vec!["users"]
+                );
             }
         }
 


### PR DESCRIPTION
## Problem
MySQL completion treats INSERT target column lists and ON DUPLICATE KEY UPDATE assignments as table contexts, so column candidates are missing and already written columns remain selectable.

## Background
The upsert UPDATE keyword was also being interpreted as a second table reference, which polluted completion metadata.

## Approach
Limit column completion to explicit INSERT/REPLACE target lists and MySQL upsert assignment clauses, filter columns already written in the active clause, and preserve target table extraction for normal INSERT and UPDATE statements.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-531