### PR TITLE
fix: block queries during MySQL connection probes

### DIFF
--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -9,9 +9,8 @@ use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind};
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 use crate::update::query_context::termination_effects;
-
-const CONNECTION_SWITCH_IN_PROGRESS: &str = "Connection switch in progress";
 
 pub(super) fn reduce_loading(
     state: &mut AppState,
@@ -135,10 +134,7 @@ pub(super) fn reduce_loading(
             })
         }
         Action::LoadMetadata => {
-            if state.session.has_pending_connection_switch() {
-                state
-                    .messages
-                    .set_error_at(CONNECTION_SWITCH_IN_PROGRESS.to_string(), now);
+            if reject_pending_mysql_connection_probe(state, now) {
                 return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn().map(String::from) {
@@ -149,10 +145,7 @@ pub(super) fn reduce_loading(
             }
         }
         Action::ReloadMetadata => {
-            if state.session.has_pending_connection_switch() {
-                state
-                    .messages
-                    .set_error_at(CONNECTION_SWITCH_IN_PROGRESS.to_string(), now);
+            if reject_pending_mysql_connection_probe(state, now) {
                 return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn().map(String::from) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -309,6 +309,46 @@ mod tests {
             }
         }
 
+        #[test]
+        fn mysql_metadata_actions_during_same_connection_retry_preserve_probe() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql-a");
+            let dsn = "mysql://user@localhost:3306/a";
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql-a",
+                DatabaseType::MySQL,
+                dsn,
+                Some("a"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let probe_run_id =
+                state
+                    .session
+                    .begin_mysql_connection_probe(&id, "mysql-a", dsn, Some("a"));
+
+            for action in [Action::LoadMetadata, Action::ReloadMetadata] {
+                let effects = dispatch_metadata(&mut state, &action, Instant::now())
+                    .into_effects()
+                    .unwrap();
+
+                assert!(effects.is_empty());
+                assert_eq!(
+                    state
+                        .session
+                        .pending_mysql_connection_probe()
+                        .map(|pending| pending.run_id),
+                    Some(probe_run_id)
+                );
+                assert_eq!(
+                    state.messages.last_error(),
+                    Some("Connection switch in progress")
+                );
+            }
+        }
+
         fn contains_fetch_metadata(effect: &Effect) -> bool {
             match effect {
                 Effect::FetchMetadata { .. } => true,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -13,6 +13,7 @@ use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 use crate::update::input::command::{command_to_action, parse_command};
 
 use super::write;
@@ -215,6 +216,9 @@ pub fn reduce_execution(
             table,
             generation,
         }) => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if state.session.dsn().is_none() {
                 return DispatchResult::handled();
             }
@@ -247,6 +251,9 @@ pub fn reduce_execution(
         }
 
         Action::ExecuteAdhoc(query) => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
@@ -759,6 +766,42 @@ mod tests {
             assert!(!state.query.pagination.reached_end());
             assert_eq!(state.query.pagination.schema(), "public");
             assert_eq!(state.query.pagination.table(), "users");
+        }
+
+        #[test]
+        fn pending_probe_blocks_preview_and_adhoc_on_old_connection() {
+            let mut state = create_test_state();
+            let _ = state.session.begin_mysql_connection_probe(
+                &ConnectionId::new(),
+                "target",
+                "mysql://target",
+                Some("app"),
+            );
+
+            let preview_effects = dispatch_query(
+                &mut state,
+                &Action::ExecutePreview(TableTarget {
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation: 1,
+                }),
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .into_effects()
+            .expect("preview should be handled");
+            let adhoc_effects = dispatch_query(
+                &mut state,
+                &Action::ExecuteAdhoc("SELECT 1".to_string()),
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .into_effects()
+            .expect("adhoc should be handled");
+
+            assert!(preview_effects.is_empty());
+            assert!(adhoc_effects.is_empty());
+            assert!(!state.query.is_running());
         }
     }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -10,6 +10,7 @@ use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 pub fn dispatch_query(
     state: &mut AppState,
@@ -36,6 +37,9 @@ pub(super) fn preview_effect_for_current_table(
     target_page: usize,
     generation: u64,
 ) -> Option<Effect> {
+    if reject_pending_mysql_connection_probe(state, now) {
+        return None;
+    }
     let dsn = state.session.dsn().map(String::from)?;
     let run_id = state.query.begin_running(now);
     Some(Effect::ExecutePreview {

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -14,6 +14,7 @@ use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 const LARGE_EXPORT_THRESHOLD: usize = 100_000;
 
@@ -165,6 +166,9 @@ pub fn reduce_pagination(
 ) -> DispatchResult {
     match action {
         Action::RequestCsvExport => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if !state.can_request_csv_export() {
                 return DispatchResult::handled();
             }
@@ -257,6 +261,9 @@ pub fn reduce_pagination(
             export_query,
             file_name,
         } => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
@@ -278,6 +285,9 @@ pub fn reduce_pagination(
             file_name,
             row_count,
         } => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
@@ -332,6 +342,9 @@ pub fn reduce_pagination(
         }
 
         Action::ResultNextPage => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
                 return DispatchResult::handled();
             }
@@ -350,6 +363,9 @@ pub fn reduce_pagination(
         }
 
         Action::ResultPrevPage => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
                 return DispatchResult::handled();
             }

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -25,7 +25,7 @@ use crate::update::browse::query::{
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{
     EditGuardrailError, build_bulk_delete_preview, editable_preview_base, ensure_column_writable,
-    reject_sqlite_null_pk,
+    reject_pending_mysql_connection_probe, reject_sqlite_null_pk,
 };
 
 fn build_update_preview(
@@ -179,6 +179,9 @@ pub fn reduce_write(
 ) -> DispatchResult {
     match action {
         Action::SubmitCellEditWrite => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if !state.result_interaction.staged_delete_rows().is_empty() {
                 match build_bulk_delete_preview(state, services) {
                     Ok(result) => {
@@ -215,6 +218,9 @@ pub fn reduce_write(
         }
 
         Action::ExecuteWrite(query) => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: write operations are disabled".to_string(),

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -20,7 +20,7 @@ pub(super) fn reduce_connection_error(
             DispatchResult::handled()
         }
         Action::CloseConnectionError => {
-            if state.session.has_pending_connection_switch() {
+            if state.session.pending_mysql_connection_probe().is_some() {
                 state.session.clear_mysql_connection_probe();
                 state.connection_error.clear();
             } else {
@@ -327,6 +327,34 @@ mod tests {
             state.session.dsn(),
             Some("mysql://user@localhost:3306/a?ssl-mode=PREFERRED")
         );
+    }
+
+    #[test]
+    fn close_after_same_mysql_retry_clears_failed_probe_context() {
+        let mut state = AppState::new("test".to_string());
+        let id = ConnectionId::from_string("mysql-a");
+        let dsn = "mysql://user@localhost:3306/a?ssl-mode=PREFERRED";
+        state.session.activate_connection_with_target(
+            &id,
+            "mysql-a",
+            DatabaseType::MySQL,
+            dsn,
+            Some("a"),
+        );
+        let _ = state
+            .session
+            .begin_mysql_connection_probe(&id, "mysql-a", dsn, Some("a"));
+        state
+            .connection_error
+            .set_error(ConnectionErrorInfo::new("connection refused"));
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        assert!(!state.session.has_pending_connection_switch());
+        reduce_connection_error(&mut state, &Action::CloseConnectionError, Instant::now());
+
+        assert!(state.session.pending_mysql_connection_probe().is_none());
+        assert!(state.connection_error.error_info().is_none());
+        assert_eq!(state.input_mode(), InputMode::Normal);
     }
 
     #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -14,6 +14,11 @@ use super::helpers::{
     save_current_connection_cache,
 };
 
+fn clear_query_confirmation(state: &mut AppState) {
+    state.confirm_dialog.take_intent();
+    state.sql_modal.enter_normal();
+}
+
 pub fn reduce_connection_lifecycle(
     state: &mut AppState,
     action: &Action,
@@ -43,6 +48,7 @@ pub fn reduce_connection_lifecycle(
             }
 
             save_current_connection_cache(state);
+            clear_query_confirmation(state);
 
             if *database_type == DatabaseType::MySQL {
                 let run_id =
@@ -207,6 +213,8 @@ pub(super) fn try_connect(state: &mut AppState, now: std::time::Instant) -> Vec<
                     &target.dsn,
                     target.database.as_deref(),
                 );
+                clear_query_confirmation(state);
+                state.query.reset_for_context_change();
                 state.session.mark_connecting();
                 return vec![Effect::ProbeMySqlConnection { target, run_id }];
             }
@@ -236,9 +244,11 @@ mod tests {
     use crate::model::connection::error::ConnectionErrorKind;
     use crate::model::connection::state::ConnectionState;
     use crate::model::er_state::ErStatus;
+    use crate::model::shared::confirm_dialog::ConfirmIntent;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::model::shared::ui_state::ResultNavMode;
+    use crate::model::sql_editor::modal::SqlModalStatus;
     use crate::ports::outbound::DbOperationError;
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
@@ -409,6 +419,38 @@ mod tests {
                         && retry_target.dsn == target.dsn
                         && retry_target.database == target.database
             )));
+        }
+
+        #[test]
+        fn pending_probe_blocks_adhoc_on_old_connection_and_discards_confirmation() {
+            let mut state = active_mysql_state();
+            state.sql_modal.enter_editing();
+            state.confirm_dialog.open(
+                "Confirm UPDATE",
+                "",
+                ConfirmIntent::ExecuteWrite {
+                    sql: "UPDATE accounts SET name = 'wrong'".to_string(),
+                    blocked: false,
+                },
+            );
+            let target = mysql_target("mysql-b", "b");
+
+            reduce(&mut state, &Action::SwitchConnection(target));
+
+            assert_eq!(state.session.dsn(), Some("mysql://user@localhost:3306/a"));
+            assert!(state.session.pending_mysql_connection_probe().is_some());
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Normal));
+            assert!(state.confirm_dialog.intent().is_none());
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ExecuteAdhoc("DROP TABLE accounts".to_string()),
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
         }
     }
 

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -13,6 +13,7 @@ use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 use super::helpers::{
     begin_explain_running, finish_explain_unsupported_analyze, is_multi_statement,
@@ -27,6 +28,9 @@ pub(super) fn reduce_analyze(
 ) -> DispatchResult {
     match action {
         Action::ExplainAnalyzeRequest => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
                 return DispatchResult::handled();
@@ -115,6 +119,10 @@ pub(super) fn reduce_analyze(
         }
 
         Action::ExplainAnalyzeConfirm => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                state.sql_modal.cancel_confirmation();
+                return DispatchResult::handled();
+            }
             let query = match state.sql_modal.status() {
                 SqlModalStatus::ConfirmingAnalyzeHigh {
                     query,

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -10,6 +10,7 @@ use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 use super::helpers::{
     begin_explain_running, is_multi_statement, mark_explain_unavailable,
@@ -24,6 +25,9 @@ pub(super) fn reduce_request(
 ) -> DispatchResult {
     match action {
         Action::ExplainRequest => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
                 return DispatchResult::handled();

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -33,6 +33,17 @@ pub(crate) fn require_er_diagram_enabled(
     Some(DispatchResult::handled())
 }
 
+pub(crate) fn reject_pending_mysql_connection_probe(state: &mut AppState, now: Instant) -> bool {
+    if state.session.pending_mysql_connection_probe().is_none() {
+        return false;
+    }
+
+    state
+        .messages
+        .set_error_at("Connection switch in progress".to_string(), now);
+    true
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EditGuardrailError {
     #[error("No result to edit")]

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -7,6 +7,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::ports::outbound::AccessMode;
 use crate::update::action::{Action, ScrollAmount, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 pub(super) fn reduce_confirm_dialog(
     state: &mut AppState,
@@ -48,6 +49,11 @@ pub(super) fn reduce_confirm_dialog(
                     sql,
                     blocked: false,
                 }) => {
+                    if reject_pending_mysql_connection_probe(state, now) {
+                        state.result_interaction.clear_write_preview();
+                        state.query.clear_delete_refresh_target();
+                        return DispatchResult::handled();
+                    }
                     if let Some(dsn) = state.session.dsn().map(String::from) {
                         let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecuteWrite {
@@ -76,6 +82,9 @@ pub(super) fn reduce_confirm_dialog(
                     file_name,
                     row_count,
                 }) => {
+                    if reject_pending_mysql_connection_probe(state, now) {
+                        return DispatchResult::handled();
+                    }
                     if state.session.dsn() == Some(dsn.as_str())
                         && state.query.is_current_run(run_id)
                     {
@@ -97,6 +106,9 @@ pub(super) fn reduce_confirm_dialog(
                     row_count,
                     snapshot,
                 }) => {
+                    if reject_pending_mysql_connection_probe(state, now) {
+                        return DispatchResult::handled();
+                    }
                     if state.session.dsn() == Some(dsn.as_str())
                         && state.query.is_current_run(run_id)
                     {

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -1608,6 +1608,38 @@ mod tests {
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
             }
+
+            #[test]
+            fn confirm_during_pending_mysql_probe_does_not_open_sql_modal() {
+                let mut state = connected_state();
+                enter_query_history(&mut state, InputMode::Normal);
+                let test_conn = ConnectionId::from_string("test-conn");
+                state
+                    .query_history_picker
+                    .replace_entries(&[make_entry("SELECT * FROM users", &test_conn)]);
+                let target_id = ConnectionId::from_string("mysql-conn");
+                let _ = state.session.begin_mysql_connection_probe(
+                    &target_id,
+                    "mysql",
+                    "mysql://localhost/app",
+                    Some("app"),
+                );
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::QueryHistoryConfirmSelection,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::QueryHistoryPicker);
+                assert_eq!(state.query_history_picker.entries().len(), 1);
+                assert_eq!(
+                    state.messages.last_error.as_deref(),
+                    Some("Connection switch in progress")
+                );
+                assert!(effects.is_empty());
+            }
         }
     }
 }

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -6,6 +6,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::text_input::{TextInputEditing, TextInputState};
 use crate::update::action::{Action, InputTarget, ListMotion, ListTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 pub(super) fn reduce_query_history_picker(
     state: &mut AppState,
@@ -133,6 +134,9 @@ pub(super) fn reduce_query_history_picker(
             DispatchResult::handled()
         }
         Action::QueryHistoryConfirmSelection => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             let grouped = state.query_history_picker.grouped_filtered_entries();
             let selected = state.query_history_picker.clamped_selected();
             let query = grouped.get(selected).map(|g| g.entry.query.clone());

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -5,6 +5,7 @@ use crate::domain::mysql_sql::MySqlStatement;
 use crate::model::app_state::AppState;
 use crate::ports::outbound::AccessMode;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 pub(super) fn start_adhoc_if_connected(
     state: &mut AppState,
@@ -12,6 +13,10 @@ pub(super) fn start_adhoc_if_connected(
     now: Instant,
     classified_mysql_statements: Option<Vec<MySqlStatement>>,
 ) -> DispatchResult {
+    if reject_pending_mysql_connection_probe(state, now) {
+        return DispatchResult::handled();
+    }
+
     let Some(dsn) = state.session.dsn().map(String::from) else {
         state
             .sql_modal

--- a/src/app/update/sql_editor/high_risk.rs
+++ b/src/app/update/sql_editor/high_risk.rs
@@ -8,6 +8,7 @@ use crate::model::sql_editor::modal::{
 };
 use crate::update::action::{Action, InputTarget};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 use super::helpers::start_adhoc_if_connected;
 
@@ -106,6 +107,10 @@ pub(super) fn reduce_high_risk_confirmation(
         }
 
         Action::SqlModalConfirmExecute => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                state.sql_modal.cancel_confirmation();
+                return DispatchResult::handled();
+            }
             // `matches!` + flag instead of `if let` because the immutable borrow
             // from pattern matching must end before we can mutate `state.sql_modal.status`.
             let matched = matches!(

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -1133,6 +1133,48 @@ mod tests {
         }
     }
 
+    mod pending_probe {
+        use super::*;
+
+        #[test]
+        fn blocks_sql_modal_open_and_submit() {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_target(
+                &ConnectionId::new(),
+                "current",
+                DatabaseType::MySQL,
+                "mysql://current",
+                Some("app"),
+            );
+            let _ = state.session.begin_mysql_connection_probe(
+                &ConnectionId::new(),
+                "target",
+                "mysql://target",
+                Some("app"),
+            );
+
+            let effects = reduce_sql_modal(
+                &mut state,
+                &Action::OpenModal(ModalKind::SqlModal),
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("SQL modal open should be handled");
+
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::Normal);
+
+            state.modal.set_mode(InputMode::SqlModal);
+            state.sql_modal.editor.set_content("SELECT 1".to_string());
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("SQL modal submit should be handled");
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
+        }
+    }
+
     mod yank {
         use super::*;
         use crate::domain::explain_plan::ExplainPlan;

--- a/src/app/update/sql_editor/mode.rs
+++ b/src/app/update/sql_editor/mode.rs
@@ -6,11 +6,15 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::sql_modal_visible_rows;
 use crate::update::action::{Action, CursorMove, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
-pub(super) fn reduce_mode(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
+pub(super) fn reduce_mode(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         // Modal open/submit
         Action::OpenModal(ModalKind::SqlModal) => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.open_sql_tab();
             state.flash_timers.clear(FlashId::SqlModal);

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -12,12 +12,16 @@ use crate::policy::write::sql_risk::{
 use crate::policy::write::write_guardrails::AdhocRiskDecision;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 use super::helpers::start_adhoc_if_connected;
 
 pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::SqlModalSubmit => {
+            if reject_pending_mysql_connection_probe(state, now) {
+                return DispatchResult::handled();
+            }
             let query = state.sql_modal.editor.content().trim().to_string();
             if query.is_empty() {
                 return DispatchResult::handled();


### PR DESCRIPTION
## Summary
- Block SQL modal execution boundaries while a MySQL connection probe is pending.
- Discard stale SQL confirmation state when a MySQL probe starts and release the pending gate when the failure is closed, preserving retry behavior.
- Cover direct execution, preview, write, EXPLAIN, CSV export, history selection, and retry edge cases.

## Validation
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-a11-target cargo check -p sabiql-app`
- Focused `sabiql-app` tests for connection, SQL editor, query, EXPLAIN, and modal reducers
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-a11-target cargo clippy -p sabiql-app --all-targets -- -D warnings`
- `env -u CARGO_TARGET_DIR RUSTC_WRAPPER= bash scripts/lint_all.sh`

Base and merge target: `mysql`
Memo assignment: A11 (pending MySQL connection probe SQL execution gate)