### PR TITLE
fix: route MySQL JSON NULL cells to standard detail

### DIFF
--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::browse::query_execution::VisibleResultKind;
@@ -167,6 +168,15 @@ fn selected_cell_uses_json_detail_modal(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
+    let Some(row_idx) = state.result_interaction.selection().row() else {
+        return false;
+    };
+    let Some(result) = state.query.visible_result() else {
+        return false;
+    };
+    if matches!(result.value_at(row_idx, col_idx), Some(QueryValue::Null)) {
+        return false;
+    }
     let Some(column_data_type) = selected_column_data_type(state, col_idx) else {
         return false;
     };
@@ -447,6 +457,48 @@ mod tests {
                 if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonDetail)])
         ));
         assert!(!state.cell_detail.is_active());
+    }
+
+    #[test]
+    fn json_document_null_dispatches_to_existing_json_modal() {
+        let mut state = state_with_cell("jsonb", "null");
+
+        let result = reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert!(matches!(
+            result.expect("json null dispatch should be handled").as_slice(),
+            [Effect::DispatchActions(actions)]
+                if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonDetail)])
+        ));
+        assert!(!state.cell_detail.is_active());
+    }
+
+    #[test]
+    fn mysql_json_sql_null_opens_read_only_cell_detail() {
+        let mut state = state_with_cell("json", "");
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::from_string("mysql-test"),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state
+            .query
+            .set_current_result(Arc::new(QueryResult::success_with_values(
+                String::new(),
+                vec!["id".to_string(), "body".to_string()],
+                vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                1,
+                QuerySource::Preview,
+            )));
+
+        let result = reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert!(result.is_handled_and(Vec::is_empty));
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert!(state.cell_detail.is_active());
+        assert_eq!(state.cell_detail.content(), "NULL");
+        assert!(!state.json_detail.is_active());
     }
 
     #[test]

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, InputTarget, ModalKind};
@@ -14,6 +15,15 @@ fn cell_uses_json_detail_modal(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
+    let Some(row_idx) = state.result_interaction.selection().row() else {
+        return false;
+    };
+    let Some(result) = state.query.visible_result() else {
+        return false;
+    };
+    if matches!(result.value_at(row_idx, col_idx), Some(QueryValue::Null)) {
+        return false;
+    }
     let Some(table_detail) = state.session.table_detail() else {
         return false;
     };
@@ -545,6 +555,40 @@ mod tests {
                 &effects[0],
                 Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonDetail)])
             ));
+        }
+
+        #[test]
+        fn mysql_json_sql_null_uses_null_edit_reason() {
+            let mut state = state_with_json_column();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("mysql-test"),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://localhost/test",
+            );
+            let mut table = state.session.table_detail().expect("table detail").clone();
+            table.columns[1].data_type = "json".to_string();
+            state.session.set_table_detail_raw(Some(table));
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "name".to_string()],
+                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    1,
+                    QuerySource::Preview,
+                )));
+
+            let effects = reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert_eq!(
+                state.messages.last_error(),
+                Some("NULL cells are not editable inline yet")
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Problem
MySQL JSON columns containing SQL NULL route cell actions to the JSON modal, which consumes the action without opening a detail view or showing an edit reason.

## Background
The JSON modal supports JSON documents, but SQL NULL is not a JSON document and is not editable inline.

## Approach
Exclude typed SQL NULL values from JSON modal routing. Read actions use the ordinary Cell Detail view, while edit actions reuse the existing NULL-not-editable error. JSON documents, including JSON null, retain their existing modal behavior.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-468