### PR TITLE
fix(mysql): avoid labeling upsert rows as inserted (SAB-538)

### DIFF
--- a/src/domain/command_tag.rs
+++ b/src/domain/command_tag.rs
@@ -4,6 +4,7 @@ use super::query_result::RefreshScope;
 pub enum CommandTag {
     Select(u64),
     Insert(u64),
+    Affected(u64),
     Update(u64),
     Delete(u64),
     Create(String),
@@ -30,6 +31,7 @@ impl CommandTag {
         matches!(
             self,
             Self::Insert(_)
+                | Self::Affected(_)
                 | Self::Update(_)
                 | Self::Delete(_)
                 | Self::Create(_)
@@ -58,7 +60,11 @@ impl CommandTag {
 
     pub fn affected_rows(&self) -> Option<u64> {
         match self {
-            Self::Select(n) | Self::Insert(n) | Self::Update(n) | Self::Delete(n) => Some(*n),
+            Self::Select(n)
+            | Self::Insert(n)
+            | Self::Affected(n)
+            | Self::Update(n)
+            | Self::Delete(n) => Some(*n),
             _ => None,
         }
     }
@@ -67,6 +73,7 @@ impl CommandTag {
         match self {
             Self::Select(n) => row_count_label(*n, "selected"),
             Self::Insert(n) => row_count_label(*n, "inserted"),
+            Self::Affected(n) => row_count_label(*n, "affected"),
             Self::Update(n) => row_count_label(*n, "updated"),
             Self::Delete(n) => row_count_label(*n, "deleted"),
             Self::Create(obj) => format!("{} created", obj.to_lowercase()),
@@ -97,6 +104,7 @@ mod tests {
     fn affected_rows_returns_count_for_dml() {
         assert_eq!(CommandTag::Select(5).affected_rows(), Some(5));
         assert_eq!(CommandTag::Insert(3).affected_rows(), Some(3));
+        assert_eq!(CommandTag::Affected(2).affected_rows(), Some(2));
         assert_eq!(CommandTag::Update(1).affected_rows(), Some(1));
         assert_eq!(CommandTag::Delete(0).affected_rows(), Some(0));
     }
@@ -118,6 +126,7 @@ mod tests {
     #[test]
     fn display_message_singular_row() {
         assert_eq!(CommandTag::Insert(1).display_message(), "1 row inserted");
+        assert_eq!(CommandTag::Affected(1).display_message(), "1 row affected");
         assert_eq!(CommandTag::Delete(1).display_message(), "1 row deleted");
     }
 
@@ -130,6 +139,7 @@ mod tests {
     #[test]
     fn display_message_zero_rows() {
         assert_eq!(CommandTag::Delete(0).display_message(), "0 rows deleted");
+        assert_eq!(CommandTag::Affected(0).display_message(), "0 rows affected");
     }
 
     #[test]
@@ -175,6 +185,7 @@ mod tests {
     fn is_schema_modifying_false_for_non_ddl() {
         assert!(!CommandTag::Select(0).is_schema_modifying());
         assert!(!CommandTag::Insert(1).is_schema_modifying());
+        assert!(!CommandTag::Affected(1).is_schema_modifying());
         assert!(!CommandTag::Update(1).is_schema_modifying());
         assert!(!CommandTag::Delete(1).is_schema_modifying());
         assert!(!CommandTag::Truncate.is_schema_modifying());
@@ -193,6 +204,7 @@ mod tests {
     #[test]
     fn needs_refresh_true_for_dml_and_ddl() {
         assert!(CommandTag::Insert(1).needs_refresh());
+        assert!(CommandTag::Affected(1).needs_refresh());
         assert!(CommandTag::Update(1).needs_refresh());
         assert!(CommandTag::Delete(1).needs_refresh());
         assert!(CommandTag::Create("TABLE".to_string()).needs_refresh());

--- a/src/domain/mysql_sql/classifier.rs
+++ b/src/domain/mysql_sql/classifier.rs
@@ -27,6 +27,16 @@ pub(super) fn kind_and_target(tokens: &[Token]) -> Result<MySqlClassification, M
     }
 }
 
+pub(super) fn has_on_duplicate_key_update(tokens: &[Token]) -> bool {
+    tokens.windows(4).any(|window| {
+        window.iter().all(|token| token.depth == 0)
+            && matches!(&window[0].kind, TokenKind::Word(word) if word == "ON")
+            && matches!(&window[1].kind, TokenKind::Word(word) if word == "DUPLICATE")
+            && matches!(&window[2].kind, TokenKind::Word(word) if word == "KEY")
+            && matches!(&window[3].kind, TokenKind::Word(word) if word == "UPDATE")
+    })
+}
+
 fn classify_mysql_crud_statement(
     tokens: &[Token],
     start: usize,

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -44,6 +44,7 @@ pub enum MySqlStatementKind {
 pub struct MySqlStatement {
     sql: String,
     kind: MySqlStatementKind,
+    on_duplicate_key_update: bool,
     target: Option<String>,
     target_database: Option<String>,
 }
@@ -55,6 +56,10 @@ impl MySqlStatement {
 
     pub fn kind(&self) -> &MySqlStatementKind {
         &self.kind
+    }
+
+    pub fn has_on_duplicate_key_update(&self) -> bool {
+        self.on_duplicate_key_update
     }
 
     pub fn target(&self) -> Option<&str> {
@@ -97,6 +102,8 @@ pub fn classify_mysql_statement(sql: &str) -> Result<MySqlStatement, MySqlLexErr
     let (kind, target, target_database) = classifier::kind_and_target(&tokens)?;
     Ok(MySqlStatement {
         sql: sql.to_string(),
+        on_duplicate_key_update: matches!(kind, MySqlStatementKind::Insert)
+            && classifier::has_on_duplicate_key_update(&tokens),
         kind,
         target,
         target_database,
@@ -459,6 +466,19 @@ mod tests {
         assert_eq!(statement.target(), Some("users"));
         assert_eq!(statement.target_database(), None);
         assert!(validate_mysql_statements(&[statement], Some("app")).is_ok());
+    }
+
+    #[test]
+    fn classifies_insert_on_duplicate_key_update_shape() {
+        let upsert = classify_mysql_statement(
+            "INSERT INTO users (id, name) VALUES (1, 'Ada') ON DUPLICATE KEY UPDATE name = 'Grace'",
+        )
+        .unwrap();
+        let insert =
+            classify_mysql_statement("INSERT INTO users (id, name) VALUES (1, 'Ada')").unwrap();
+
+        assert!(upsert.has_on_duplicate_key_update());
+        assert!(!insert.has_on_duplicate_key_update());
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -233,17 +233,20 @@ pub(super) fn mysql_row_count_marker(
 }
 
 pub(super) fn mysql_command_tag(
-    kind: &MySqlStatementKind,
+    statement: &MySqlStatement,
     affected_rows: i64,
     user_result: Option<&MySqlResultSet>,
 ) -> CommandTag {
     let rows = || u64::try_from(affected_rows.max(0)).unwrap_or(0);
-    match kind {
+    match statement.kind() {
         MySqlStatementKind::Select
         | MySqlStatementKind::Table
         | MySqlStatementKind::Show
         | MySqlStatementKind::Describe => {
             CommandTag::Select(user_result.map_or(0, |result| result.values.len() as u64))
+        }
+        MySqlStatementKind::Insert if statement.has_on_duplicate_key_update() => {
+            CommandTag::Affected(rows())
         }
         MySqlStatementKind::Insert | MySqlStatementKind::Replace => CommandTag::Insert(rows()),
         MySqlStatementKind::Update { .. } => CommandTag::Update(rows()),
@@ -655,6 +658,40 @@ mod tests {
             mysql_refresh_scope(&MySqlStatementKind::CreateTable { temporary: false }),
             RefreshScope::Metadata
         );
+    }
+
+    #[test]
+    fn upsert_affected_rows_use_generic_command_tag() {
+        let statement = classify_mysql_multi_statement(
+            "INSERT INTO items (id, value) VALUES (1, 'new') ON DUPLICATE KEY UPDATE value = 'updated'",
+            Some("app"),
+        )
+        .unwrap()
+        .remove(0);
+
+        for affected_rows in [0, 1, 2] {
+            assert_eq!(
+                mysql_command_tag(&statement, affected_rows, None),
+                CommandTag::Affected(affected_rows as u64)
+            );
+        }
+        assert_eq!(mysql_refresh_scope(statement.kind()), RefreshScope::Data);
+    }
+
+    #[test]
+    fn regular_insert_command_tags_keep_insert_wording() {
+        for query in [
+            "INSERT INTO items (id, value) VALUES (1, 'new')",
+            "INSERT IGNORE INTO items (id, value) VALUES (1, 'new')",
+        ] {
+            let statement = classify_mysql_multi_statement(query, Some("app"))
+                .unwrap()
+                .remove(0);
+            assert_eq!(
+                mysql_command_tag(&statement, 1, None),
+                CommandTag::Insert(1)
+            );
+        }
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -189,7 +189,7 @@ async fn run_mysql_statement(
         Ok(rows) => rows,
         Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
     };
-    let tag = mysql_command_tag(statement.kind(), affected_rows, user_result.as_ref());
+    let tag = mysql_command_tag(statement, affected_rows, user_result.as_ref());
 
     Ok(MySqlStatementExecution {
         result_set: user_result,


### PR DESCRIPTION
## Problem
MySQL `ROW_COUNT()` values for `INSERT ... ON DUPLICATE KEY UPDATE` can describe affected rows rather than inserted rows, but the UI reports them as inserted.

## Background
An upsert can update an existing unique-key row, so the affected-row count has MySQL-specific semantics.

## Approach
Classify the existing upsert form and emit a generic affected-row command tag while preserving the count, refresh scope, and normal INSERT wording.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-538