### PR TITLE
fix(mysql): complete STRAIGHT_JOIN and partition aliases (SAB-532)

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -2180,6 +2180,72 @@ mod tests {
         }
 
         #[test]
+        fn mysql_straight_join_alias_completes_joined_table_columns() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "app.orders".to_string(),
+                create_table("app", "orders", &["order_id"]),
+            );
+            let mut metadata = metadata();
+            metadata.table_summaries.push(TableSummary::new(
+                "app".to_string(),
+                "orders".to_string(),
+                None,
+                false,
+            ));
+
+            let sql = "SELECT * FROM users u STRAIGHT_JOIN orders o WHERE o.ord";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "`order_id`" && candidate.kind == CompletionKind::Column
+            }));
+        }
+
+        #[test]
+        fn mysql_partition_alias_completes_table_columns() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "app.events".to_string(),
+                create_table("app", "events", &["event_id"]),
+            );
+            let mut metadata = metadata();
+            metadata.table_summaries.push(TableSummary::new(
+                "app".to_string(),
+                "events".to_string(),
+                None,
+                false,
+            ));
+
+            let sql = "SELECT * FROM events PARTITION (p0) AS e WHERE e.eve";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "`event_id`" && candidate.kind == CompletionKind::Column
+            }));
+        }
+
+        #[test]
         fn mysql_unique_case_insensitive_fallback_supports_non_ascii_names() {
             let mut e = engine();
             e.cache_table_detail(

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -2213,6 +2213,39 @@ mod tests {
         }
 
         #[test]
+        fn mysql_index_hint_for_join_preserves_straight_join_completion() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "app.orders".to_string(),
+                create_table("app", "orders", &["order_id"]),
+            );
+            let mut metadata = metadata();
+            metadata.table_summaries.push(TableSummary::new(
+                "app".to_string(),
+                "orders".to_string(),
+                None,
+                false,
+            ));
+
+            let sql = "SELECT * FROM users u USE INDEX FOR JOIN (idx_users) STRAIGHT_JOIN orders o WHERE o.ord";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "`order_id`" && candidate.kind == CompletionKind::Column
+            }));
+        }
+
+        #[test]
         fn mysql_partition_alias_completes_table_columns() {
             let mut e = engine();
             e.cache_table_detail(

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -2246,6 +2246,37 @@ mod tests {
         }
 
         #[test]
+        fn mysql_straight_join_after_condition_completes_final_alias_columns() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "app.items".to_string(),
+                create_table("app", "items", &["item_id"]),
+            );
+            let mut metadata = metadata();
+            metadata.table_summaries.extend([
+                TableSummary::new("app".to_string(), "orders".to_string(), None, false),
+                TableSummary::new("app".to_string(), "items".to_string(), None, false),
+            ]);
+
+            let sql = "SELECT * FROM users u STRAIGHT_JOIN orders o ON u.id = o.user_id STRAIGHT_JOIN items i ON i.order_id = o.id WHERE i.ite";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "`item_id`" && candidate.kind == CompletionKind::Column
+            }));
+        }
+
+        #[test]
         fn mysql_unique_case_insensitive_fallback_supports_non_ascii_names() {
             let mut e = engine();
             e.cache_table_detail(

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -736,12 +736,21 @@ impl SqlLexer {
         )
     }
 
-    fn is_mysql_index_hint_join(&self, tokens: &[Token], join_index: usize) -> bool {
+    fn is_mysql_index_hint_scope(&self, tokens: &[Token], scope_index: usize) -> bool {
         if !self.is_mysql() {
             return false;
         }
 
-        let Some(for_index) = tokens[..join_index]
+        let is_scope = matches!(
+            &tokens[scope_index].kind,
+            TokenKind::Keyword(word)
+                if matches!(word.as_str(), "JOIN" | "ORDER" | "GROUP")
+        );
+        if !is_scope {
+            return false;
+        }
+
+        let Some(for_index) = tokens[..scope_index]
             .iter()
             .rposition(|token| token.kind != TokenKind::Whitespace)
         else {
@@ -852,7 +861,7 @@ impl SqlLexer {
             if let TokenKind::Keyword(kw) = &token.kind {
                 match kw.as_str() {
                     "FROM" | "JOIN" | "STRAIGHT_JOIN" => {
-                        if kw == "JOIN" && self.is_mysql_index_hint_join(tokens, i) {
+                        if kw == "JOIN" && self.is_mysql_index_hint_scope(tokens, i) {
                             i += 1;
                             continue;
                         }
@@ -910,13 +919,17 @@ impl SqlLexer {
                         while next < tokens.len() && tokens[next].kind == TokenKind::Whitespace {
                             next += 1;
                         }
-                        if next >= tokens.len() || !self.is_mysql_index_hint_join(tokens, next) {
+                        if next >= tokens.len() || !self.is_mysql_index_hint_scope(tokens, next) {
                             in_for_clause = true;
                             can_start_straight_join = false;
                         }
                     }
                     // NO, KEY, SHARE are part of FOR locking clause
                     "NO" | "KEY" | "SHARE" if in_for_clause => {}
+                    "GROUP" | "ORDER" if self.is_mysql_index_hint_scope(tokens, i) => {
+                        i += 1;
+                        continue;
+                    }
                     "INSERT" | "REPLACE" => {
                         in_for_clause = false;
                         can_start_straight_join = false;
@@ -2111,6 +2124,24 @@ mod tests {
             assert_eq!(refs[0].alias, Some("u".to_string()));
             assert_eq!(refs[1].table, "orders");
             assert_eq!(refs[1].alias, Some("o".to_string()));
+        }
+
+        #[test]
+        fn mysql_index_hint_scopes_preserve_straight_join() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+
+            for scope in ["ORDER BY", "GROUP BY"] {
+                let sql = format!(
+                    "SELECT * FROM users u USE INDEX FOR {scope} (idx_users) STRAIGHT_JOIN orders o WHERE o.id = 1"
+                );
+                let tokens = l.tokenize(&sql, sql.len());
+
+                let refs = l.extract_table_references(&tokens);
+
+                assert_eq!(refs.len(), 2, "scope: {scope}");
+                assert_eq!(refs[0].alias, Some("u".to_string()), "scope: {scope}");
+                assert_eq!(refs[1].alias, Some("o".to_string()), "scope: {scope}");
+            }
         }
     }
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -930,9 +930,13 @@ impl SqlLexer {
                             continue;
                         }
                     }
-                    _ => {
+                    "SELECT" | "WHERE" | "GROUP" | "ORDER" | "HAVING" | "LIMIT" | "OFFSET"
+                    | "UNION" | "INTERSECT" | "EXCEPT" => {
                         in_for_clause = false;
                         can_start_straight_join = false;
+                    }
+                    _ => {
+                        in_for_clause = false;
                     }
                 }
             }
@@ -2018,6 +2022,20 @@ mod tests {
             assert_eq!(refs.len(), 1);
             assert_eq!(refs[0].table, "users");
             assert_eq!(refs[0].alias, Some("id".to_string()));
+        }
+
+        #[test]
+        fn mysql_straight_join_after_join_condition_returns_reference() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+            let sql = "SELECT * FROM users u STRAIGHT_JOIN orders o ON u.id = o.user_id STRAIGHT_JOIN items i ON i.order_id = o.id WHERE i.id = 1";
+            let tokens = l.tokenize(sql, sql.len());
+
+            let refs = l.extract_table_references(&tokens);
+
+            assert_eq!(refs.len(), 3);
+            assert_eq!(refs[0].alias, Some("u".to_string()));
+            assert_eq!(refs[1].alias, Some("o".to_string()));
+            assert_eq!(refs[2].alias, Some("i".to_string()));
         }
     }
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -927,11 +927,12 @@ impl SqlLexer {
                         }
                         if let Some(table_ref) = self.parse_table_reference(tokens, &mut i) {
                             refs.push(table_ref);
+                            can_start_straight_join = true;
                             continue;
                         }
                     }
                     "SELECT" | "WHERE" | "GROUP" | "ORDER" | "HAVING" | "LIMIT" | "OFFSET"
-                    | "UNION" | "INTERSECT" | "EXCEPT" => {
+                    | "SET" | "UNION" | "INTERSECT" | "EXCEPT" => {
                         in_for_clause = false;
                         can_start_straight_join = false;
                     }
@@ -2036,6 +2037,22 @@ mod tests {
             assert_eq!(refs[0].alias, Some("u".to_string()));
             assert_eq!(refs[1].alias, Some("o".to_string()));
             assert_eq!(refs[2].alias, Some("i".to_string()));
+        }
+
+        #[test]
+        fn mysql_update_straight_join_returns_joined_reference() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+            let sql =
+                "UPDATE users u STRAIGHT_JOIN orders o ON u.id = o.user_id SET o.status = 'done'";
+            let tokens = l.tokenize(sql, sql.len());
+
+            let refs = l.extract_table_references(&tokens);
+
+            assert_eq!(refs.len(), 2);
+            assert_eq!(refs[0].table, "users");
+            assert_eq!(refs[0].alias, Some("u".to_string()));
+            assert_eq!(refs[1].table, "orders");
+            assert_eq!(refs[1].alias, Some("o".to_string()));
         }
     }
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -163,6 +163,7 @@ const MYSQL_KEYWORDS: &[&str] = &[
     "FROM",
     "WHERE",
     "JOIN",
+    "STRAIGHT_JOIN",
     "LEFT",
     "RIGHT",
     "INNER",
@@ -815,7 +816,7 @@ impl SqlLexer {
 
             if let TokenKind::Keyword(kw) = &token.kind {
                 match kw.as_str() {
-                    "FROM" | "JOIN" => {
+                    "FROM" | "JOIN" | "STRAIGHT_JOIN" => {
                         in_for_clause = false;
                         i += 1;
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
@@ -977,6 +978,43 @@ impl SqlLexer {
             *i += 1;
         }
 
+        // Skip MySQL's table partition clause before reading the alias.
+        if self.is_mysql()
+            && *i < tokens.len()
+            && matches!(&tokens[*i].kind, TokenKind::Keyword(kw) if kw == "PARTITION")
+        {
+            let mut partition_start = *i + 1;
+            while partition_start < tokens.len()
+                && tokens[partition_start].kind == TokenKind::Whitespace
+            {
+                partition_start += 1;
+            }
+
+            if partition_start < tokens.len()
+                && tokens[partition_start].kind == TokenKind::Punctuation('(')
+            {
+                *i = partition_start;
+                let mut partition_depth = 0;
+                while *i < tokens.len() {
+                    match tokens[*i].kind {
+                        TokenKind::Punctuation('(') => partition_depth += 1,
+                        TokenKind::Punctuation(')') => {
+                            partition_depth -= 1;
+                        }
+                        _ => {}
+                    }
+                    *i += 1;
+                    if partition_depth == 0 {
+                        break;
+                    }
+                }
+
+                while *i < tokens.len() && tokens[*i].kind == TokenKind::Whitespace {
+                    *i += 1;
+                }
+            }
+        }
+
         // Check for alias (optional AS keyword)
         if *i < tokens.len()
             && let TokenKind::Keyword(kw) = &tokens[*i].kind
@@ -1019,6 +1057,7 @@ impl SqlLexer {
                 | "FROM"
                 | "WHERE"
                 | "JOIN"
+                | "STRAIGHT_JOIN"
                 | "ON"
                 | "AND"
                 | "OR"
@@ -1924,6 +1963,34 @@ mod tests {
             assert_eq!(refs[0].table, "users");
             assert_eq!(refs[1].table, "posts");
             assert_eq!(refs[2].table, "comments");
+        }
+
+        #[test]
+        fn mysql_straight_join_returns_joined_reference() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+            let sql = "SELECT * FROM users u STRAIGHT_JOIN orders o ON u.id = o.user_id";
+            let tokens = l.tokenize(sql, sql.len());
+
+            let refs = l.extract_table_references(&tokens);
+
+            assert_eq!(refs.len(), 2);
+            assert_eq!(refs[0].table, "users");
+            assert_eq!(refs[0].alias, Some("u".to_string()));
+            assert_eq!(refs[1].table, "orders");
+            assert_eq!(refs[1].alias, Some("o".to_string()));
+        }
+
+        #[test]
+        fn mysql_partition_clause_preserves_table_alias() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+            let sql = "SELECT * FROM events PARTITION (p0) AS e WHERE e.id = 1";
+            let tokens = l.tokenize(sql, sql.len());
+
+            let refs = l.extract_table_references(&tokens);
+
+            assert_eq!(refs.len(), 1);
+            assert_eq!(refs[0].table, "events");
+            assert_eq!(refs[0].alias, Some("e".to_string()));
         }
     }
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -736,6 +736,39 @@ impl SqlLexer {
         )
     }
 
+    fn is_mysql_index_hint_join(&self, tokens: &[Token], join_index: usize) -> bool {
+        if !self.is_mysql() {
+            return false;
+        }
+
+        let Some(for_index) = tokens[..join_index]
+            .iter()
+            .rposition(|token| token.kind != TokenKind::Whitespace)
+        else {
+            return false;
+        };
+        let is_for = matches!(
+            &tokens[for_index].kind,
+            TokenKind::Keyword(word) | TokenKind::Identifier(word)
+                if word.eq_ignore_ascii_case("FOR")
+        );
+        if !is_for {
+            return false;
+        }
+
+        let Some(index_hint_index) = tokens[..for_index]
+            .iter()
+            .rposition(|token| token.kind != TokenKind::Whitespace)
+        else {
+            return false;
+        };
+        matches!(
+            &tokens[index_hint_index].kind,
+            TokenKind::Keyword(word) | TokenKind::Identifier(word)
+                if word.eq_ignore_ascii_case("INDEX") || word.eq_ignore_ascii_case("KEY")
+        )
+    }
+
     fn is_punctuation(c: char) -> bool {
         matches!(c, '(' | ')' | ',' | ';' | '.' | '[' | ']')
     }
@@ -819,6 +852,10 @@ impl SqlLexer {
             if let TokenKind::Keyword(kw) = &token.kind {
                 match kw.as_str() {
                     "FROM" | "JOIN" | "STRAIGHT_JOIN" => {
+                        if kw == "JOIN" && self.is_mysql_index_hint_join(tokens, i) {
+                            i += 1;
+                            continue;
+                        }
                         if kw == "STRAIGHT_JOIN" && !can_start_straight_join {
                             i += 1;
                             continue;
@@ -869,8 +906,14 @@ impl SqlLexer {
                     }
                     // FOR starts a locking clause (FOR UPDATE, FOR NO KEY UPDATE, etc.)
                     "FOR" => {
-                        in_for_clause = true;
-                        can_start_straight_join = false;
+                        let mut next = i + 1;
+                        while next < tokens.len() && tokens[next].kind == TokenKind::Whitespace {
+                            next += 1;
+                        }
+                        if next >= tokens.len() || !self.is_mysql_index_hint_join(tokens, next) {
+                            in_for_clause = true;
+                            can_start_straight_join = false;
+                        }
                     }
                     // NO, KEY, SHARE are part of FOR locking clause
                     "NO" | "KEY" | "SHARE" if in_for_clause => {}
@@ -2044,6 +2087,21 @@ mod tests {
             let l = SqlLexer::new(DatabaseType::MySQL);
             let sql =
                 "UPDATE users u STRAIGHT_JOIN orders o ON u.id = o.user_id SET o.status = 'done'";
+            let tokens = l.tokenize(sql, sql.len());
+
+            let refs = l.extract_table_references(&tokens);
+
+            assert_eq!(refs.len(), 2);
+            assert_eq!(refs[0].table, "users");
+            assert_eq!(refs[0].alias, Some("u".to_string()));
+            assert_eq!(refs[1].table, "orders");
+            assert_eq!(refs[1].alias, Some("o".to_string()));
+        }
+
+        #[test]
+        fn mysql_index_hint_for_join_preserves_straight_join() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+            let sql = "SELECT * FROM users u USE INDEX FOR JOIN (idx_users) STRAIGHT_JOIN orders o WHERE o.id = 1";
             let tokens = l.tokenize(sql, sql.len());
 
             let refs = l.extract_table_references(&tokens);

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -803,6 +803,7 @@ impl SqlLexer {
         let mut i = 0;
         // Track FOR locking clause: FOR [NO KEY | KEY]? (UPDATE | SHARE)
         let mut in_for_clause = false;
+        let mut can_start_straight_join = false;
 
         while i < tokens.len() {
             let token = &tokens[i];
@@ -810,6 +811,7 @@ impl SqlLexer {
             // Reset state on statement terminator
             if token.kind == TokenKind::Punctuation(';') {
                 in_for_clause = false;
+                can_start_straight_join = false;
                 i += 1;
                 continue;
             }
@@ -817,7 +819,12 @@ impl SqlLexer {
             if let TokenKind::Keyword(kw) = &token.kind {
                 match kw.as_str() {
                     "FROM" | "JOIN" | "STRAIGHT_JOIN" => {
+                        if kw == "STRAIGHT_JOIN" && !can_start_straight_join {
+                            i += 1;
+                            continue;
+                        }
                         in_for_clause = false;
+                        can_start_straight_join = false;
                         i += 1;
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
                             i += 1;
@@ -833,12 +840,14 @@ impl SqlLexer {
                         }
                         if let Some(table_ref) = self.parse_table_reference(tokens, &mut i) {
                             refs.push(table_ref);
+                            can_start_straight_join = true;
                             continue;
                         }
                     }
                     // JOIN modifiers - skip to find JOIN, then parse table
                     "INNER" | "LEFT" | "RIGHT" | "FULL" | "CROSS" => {
                         in_for_clause = false;
+                        can_start_straight_join = false;
                         i += 1;
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
                             i += 1;
@@ -853,6 +862,7 @@ impl SqlLexer {
                             }
                             if let Some(table_ref) = self.parse_table_reference(tokens, &mut i) {
                                 refs.push(table_ref);
+                                can_start_straight_join = true;
                                 continue;
                             }
                         }
@@ -860,11 +870,13 @@ impl SqlLexer {
                     // FOR starts a locking clause (FOR UPDATE, FOR NO KEY UPDATE, etc.)
                     "FOR" => {
                         in_for_clause = true;
+                        can_start_straight_join = false;
                     }
                     // NO, KEY, SHARE are part of FOR locking clause
                     "NO" | "KEY" | "SHARE" if in_for_clause => {}
                     "INSERT" | "REPLACE" => {
                         in_for_clause = false;
+                        can_start_straight_join = false;
                         i += 1;
                         i = self.skip_mysql_modifiers(tokens, i, MYSQL_INSERT_MODIFIERS);
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
@@ -892,11 +904,13 @@ impl SqlLexer {
                         }
                     }
                     "UPDATE" if self.is_mysql_upsert_update(tokens, i) => {
+                        can_start_straight_join = false;
                         i += 1;
                         continue;
                     }
                     // UPDATE: skip if in FOR locking clause
                     "UPDATE" if !in_for_clause => {
+                        can_start_straight_join = false;
                         i += 1;
                         i = self.skip_mysql_modifiers(tokens, i, MYSQL_UPDATE_MODIFIERS);
                         while i < tokens.len() && tokens[i].kind == TokenKind::Whitespace {
@@ -918,6 +932,7 @@ impl SqlLexer {
                     }
                     _ => {
                         in_for_clause = false;
+                        can_start_straight_join = false;
                     }
                 }
             }
@@ -978,7 +993,6 @@ impl SqlLexer {
             *i += 1;
         }
 
-        // Skip MySQL's table partition clause before reading the alias.
         if self.is_mysql()
             && *i < tokens.len()
             && matches!(&tokens[*i].kind, TokenKind::Keyword(kw) if kw == "PARTITION")
@@ -1991,6 +2005,19 @@ mod tests {
             assert_eq!(refs.len(), 1);
             assert_eq!(refs[0].table, "events");
             assert_eq!(refs[0].alias, Some("e".to_string()));
+        }
+
+        #[test]
+        fn mysql_straight_join_select_modifier_does_not_create_reference() {
+            let l = SqlLexer::new(DatabaseType::MySQL);
+            let sql = "SELECT STRAIGHT_JOIN id FROM users id WHERE id.id = 1";
+            let tokens = l.tokenize(sql, sql.len());
+
+            let refs = l.extract_table_references(&tokens);
+
+            assert_eq!(refs.len(), 1);
+            assert_eq!(refs[0].table, "users");
+            assert_eq!(refs[0].alias, Some("id".to_string()));
         }
     }
 


### PR DESCRIPTION
## Problem
MySQL completion misses joined aliases with STRAIGHT_JOIN and aliases after PARTITION (...).

## Background
The lexer treats STRAIGHT_JOIN as an identifier and consumes PARTITION as the table alias, so qualified column completion cannot resolve the intended table.

## Approach
Recognize STRAIGHT_JOIN through the existing MySQL join-start path and skip only the balanced table-factor PARTITION (...) clause before normal alias extraction. Focused lexer and completion regressions cover both reproduction paths.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-532