### PR TITLE
fix(app): preserve pending MySQL probes during metadata reload (SAB-502)

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -542,7 +542,6 @@ impl BrowseSession {
 
     #[must_use]
     pub fn begin_reload(&mut self) -> u64 {
-        self.clear_mysql_connection_probe();
         self.is_reloading = true;
         self.begin_metadata_run()
     }
@@ -1273,6 +1272,32 @@ mod tests {
 
             session.finish_reload();
             assert!(!session.is_reloading());
+        }
+
+        #[test]
+        fn begin_reload_does_not_clear_pending_mysql_probe() {
+            let mut session = BrowseSession::default();
+            let id = ConnectionId::from_string("mysql-a");
+            let dsn = "mysql://user@localhost:3306/a";
+            session.activate_connection_with_target(
+                &id,
+                "mysql-a",
+                DatabaseType::MySQL,
+                dsn,
+                Some("a"),
+            );
+            session.set_connection_state(ConnectionState::Connected);
+            let probe_run_id = session.begin_mysql_connection_probe(&id, "mysql-a", dsn, Some("a"));
+
+            let reload_run_id = session.begin_reload();
+
+            assert_eq!(
+                session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(probe_run_id)
+            );
+            assert!(session.is_current_metadata_run(reload_run_id));
         }
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -355,6 +355,93 @@ mod tests {
                 effect,
                 Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
             )));
+
+            let reload_effects = reduce_app(
+                &mut state,
+                Action::ReloadMetadata,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(reload_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::Sequence(effects)
+                    if effects.iter().any(|effect| matches!(
+                        effect,
+                        Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
+                    ))
+            )));
+        }
+
+        #[test]
+        fn same_mysql_retry_blocks_reload_until_probe_success() {
+            let mut state = active_mysql_state();
+            let target = mysql_target("mysql-a", "a");
+            state.session.set_connection_state(ConnectionState::Failed);
+            state
+                .connection_error
+                .set_error(ConnectionErrorInfo::new("connection refused"));
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            let retry_run_id = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeMySqlConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("retry should start a MySQL probe");
+
+            let reload_effects = reduce_app(
+                &mut state,
+                Action::ReloadMetadata,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(reload_effects.is_empty());
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(retry_run_id)
+            );
+
+            let completion_effects = reduce_app(
+                &mut state,
+                Action::MySqlConnectionProbeCompleted {
+                    target: target.clone(),
+                    run_id: retry_run_id,
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert!(completion_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
+            )));
+
+            let reload_effects = reduce_app(
+                &mut state,
+                Action::ReloadMetadata,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(reload_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::Sequence(effects)
+                    if effects.iter().any(|effect| matches!(
+                        effect,
+                        Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
+                    ))
+            )));
         }
 
         #[test]
@@ -2051,7 +2138,7 @@ mod tests {
         }
 
         #[test]
-        fn postgres_reload_retry_does_not_use_old_mysql_probe_target() {
+        fn postgres_reload_does_not_clear_failed_mysql_probe() {
             let mut state = AppState::new("test".to_string());
             let postgres_id = ConnectionId::from_string("postgres-a");
             let postgres_dsn = "postgres://localhost/a".to_string();
@@ -2089,34 +2176,24 @@ mod tests {
                 },
             );
 
-            let reload_run_id = state.session.begin_reload();
-            assert!(state.session.pending_mysql_connection_probe().is_none());
-            reduce_app(
+            let reload_effects = reduce_app(
                 &mut state,
-                Action::MetadataFailed {
-                    dsn: postgres_dsn.clone(),
-                    run_id: reload_run_id,
-                    error: DbOperationError::ConnectionFailed("reload refused".to_string()),
-                },
+                Action::ReloadMetadata,
                 std::time::Instant::now(),
                 &AppServices::stub(),
             );
 
-            let retry_effects = reduce_connection_error(
-                &mut state,
-                &Action::RetryConnection,
-                std::time::Instant::now(),
-            )
-            .into_effects()
-            .unwrap();
-            assert!(retry_effects.iter().any(|effect| matches!(
-                effect,
-                Effect::FetchMetadata { dsn, .. } if dsn == &postgres_dsn
-            )));
-            assert!(
-                !retry_effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::ProbeMySqlConnection { .. }))
+            assert!(reload_effects.is_empty());
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(mysql_run_id)
+            );
+            assert_eq!(
+                state.messages.last_error(),
+                Some("Connection switch in progress")
             );
         }
 


### PR DESCRIPTION
## Problem
A retry against the same MySQL connection keeps the probe target equal to the active connection, so metadata reload can clear the pending probe before it reaches a terminal state.

## Background
The metadata gate must follow pending probe presence rather than whether the probe target differs from the active connection.

## Approach
Keep the existing pending-probe gate for metadata Load/Reload and preserve the pending probe through reload run creation. A focused lifecycle regression covers same-ID/DSN Retry, blocked reload, probe completion, and normal reload afterward.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-502