### PR TITLE
fix(mysql): run EXPLAIN ANALYZE in read-only sessions

### DIFF
--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -110,7 +110,11 @@ pub(super) fn reduce_analyze(
                         query: explain_query,
                         source_query: content,
                         is_analyze: true,
-                        access_mode: AccessMode::from_read_only(state.session.is_read_only()),
+                        access_mode: if database_type == DatabaseType::MySQL {
+                            AccessMode::ReadOnly
+                        } else {
+                            AccessMode::from_read_only(state.session.is_read_only())
+                        },
                     }]);
                 }
             }
@@ -159,7 +163,11 @@ pub(super) fn reduce_analyze(
                     query: explain_query,
                     source_query: query,
                     is_analyze: true,
-                    access_mode: AccessMode::from_read_only(state.session.is_read_only()),
+                    access_mode: if database_type == DatabaseType::MySQL {
+                        AccessMode::ReadOnly
+                    } else {
+                        AccessMode::from_read_only(state.session.is_read_only())
+                    },
                 }]);
             }
             DispatchResult::handled()

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -590,7 +590,7 @@ mod tests {
                     query,
                     database_type: DatabaseType::MySQL,
                     is_analyze: true,
-                    access_mode: AccessMode::ReadWrite,
+                    access_mode: AccessMode::ReadOnly,
                     ..
                 } if query == "EXPLAIN ANALYZE FORMAT=TREE SELECT 1"
             ));


### PR DESCRIPTION
## Summary
- Run both MySQL EXPLAIN ANALYZE effect paths with AccessMode::ReadOnly.
- Preserve PostgreSQL, ordinary EXPLAIN, and existing static risk classification.

## Tests
- cargo test -p sabiql-app update::explain::tests --lib
- cargo clippy -p sabiql-app --lib -- -D warnings
- cargo fmt --all -- --check
- bash scripts/lint_all.sh
- Oracle MySQL 8.4 real-session verification