### PR TITLE
feat(mysql): expose trigger execution metadata

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -71,6 +71,11 @@ BEFORE UPDATE ON mysql_cli_fixture
 FOR EACH ROW
 SET NEW.empty_text = NEW.empty_text;
 
+CREATE DEFINER='sabiql'@'%' TRIGGER a_mysql_cli_fixture_audit
+BEFORE UPDATE ON mysql_cli_fixture
+FOR EACH ROW FOLLOWS mysql_cli_fixture_audit
+SET NEW.empty_text = NEW.empty_text;
+
 CREATE TABLE mysql_preview_composite (
     first_key INT NOT NULL,
     second_key INT NOT NULL,

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -7,6 +7,8 @@ use crate::model::shared::inspector_tab::InspectorTab;
 use crate::policy::table_kind::{inspector_flags_label, inspector_kind_label};
 use crate::ports::outbound::DdlGenerator;
 
+pub const MYSQL_TRIGGER_DETAIL_LINES_PER_ROW: usize = 12;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InspectorViewModel {
     active_tab: InspectorTab,
@@ -14,6 +16,7 @@ pub struct InspectorViewModel {
     section: Option<InspectorSection>,
     empty_state: Option<InspectorEmptyState>,
     unavailable_reason: Option<InspectorUnavailableReason>,
+    mysql_trigger_details: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -156,6 +159,7 @@ impl InspectorViewModel {
                 section: None,
                 empty_state,
                 unavailable_reason: None,
+                mysql_trigger_details: false,
             };
         };
 
@@ -313,6 +317,8 @@ impl InspectorViewModel {
             section: Some(section),
             empty_state,
             unavailable_reason,
+            mysql_trigger_details: database_type == DatabaseType::MySQL
+                && active_tab == InspectorTab::Triggers,
         }
     }
 
@@ -337,10 +343,27 @@ impl InspectorViewModel {
     }
 
     pub fn row_count(&self) -> usize {
+        if self.mysql_trigger_details {
+            return self
+                .section
+                .as_ref()
+                .and_then(|section| match section {
+                    InspectorSection::Triggers { rows } => {
+                        Some(rows.len() * MYSQL_TRIGGER_DETAIL_LINES_PER_ROW)
+                    }
+                    _ => None,
+                })
+                .unwrap_or_default();
+        }
+
         self.section.as_ref().map_or(0, InspectorSection::row_count)
     }
 
     pub fn visible_rows(&self, pane_height: u16) -> usize {
+        if self.mysql_trigger_details {
+            return pane_height.saturating_sub(3) as usize;
+        }
+
         match self.section.as_ref() {
             Some(
                 InspectorSection::Info { .. }
@@ -756,6 +779,9 @@ mod tests {
             }
             section => panic!("expected trigger section, got {section:?}"),
         }
+        assert_eq!(model.row_count(), MYSQL_TRIGGER_DETAIL_LINES_PER_ROW);
+        assert_eq!(model.visible_rows(8), 5);
+        assert_eq!(model.max_scroll(8), 7);
     }
 
     #[test]

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -1,4 +1,6 @@
-use crate::domain::{DatabaseType, ForeignKey, Index, IndexType, RlsInfo, Table};
+use crate::domain::{
+    DatabaseType, ForeignKey, Index, IndexType, RlsInfo, Table, TriggerCreationContext,
+};
 use crate::model::browse::session::TableDetailState;
 use crate::model::shared::engine_feature_profile::{EngineFeatureProfile, InspectorInfoField};
 use crate::model::shared::inspector_tab::InspectorTab;
@@ -94,8 +96,10 @@ pub struct InspectorTriggerRow {
     pub name: String,
     pub timing: String,
     pub events: String,
+    pub action_order: Option<i32>,
     pub definition: String,
     pub security_context: Option<String>,
+    pub creation_context: Option<TriggerCreationContext>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -275,8 +279,10 @@ impl InspectorViewModel {
                             .map(ToString::to_string)
                             .collect::<Vec<_>>()
                             .join("/"),
+                        action_order: trigger.action_order,
                         definition: trigger.definition.clone(),
                         security_context: trigger.security_context.clone(),
+                        creation_context: trigger.creation_context.clone(),
                     })
                     .collect();
                 (
@@ -541,8 +547,10 @@ mod tests {
                 name: "users_updated".to_string(),
                 timing: TriggerTiming::Before,
                 events: vec![TriggerEvent::Update],
+                action_order: None,
                 definition: "set_updated_at".to_string(),
                 security_context: Some("INVOKER".to_string()),
+                creation_context: None,
             }],
             row_count_estimate: Some(3),
             comment: Some("Users".to_string()),
@@ -718,6 +726,35 @@ mod tests {
         match indexes.section() {
             Some(InspectorSection::Indexes { show_partial, .. }) => assert!(!show_partial),
             section => panic!("expected index section, got {section:?}"),
+        }
+    }
+
+    #[test]
+    fn mysql_trigger_rows_preserve_action_order_and_creation_context() {
+        let mut table = table();
+        table.triggers[0].action_order = Some(2);
+        table.triggers[0].creation_context = Some(TriggerCreationContext {
+            sql_mode: Some("STRICT_TRANS_TABLES".to_string()),
+            character_set_client: Some("utf8mb4".to_string()),
+            collation_connection: Some("utf8mb4_0900_ai_ci".to_string()),
+            database_collation: Some("utf8mb4_0900_ai_ci".to_string()),
+            created: Some("2026-08-21 10:20:30.00".to_string()),
+        });
+
+        let model = build_loaded(
+            &EngineFeatureProfile::mysql_like(),
+            InspectorTab::Triggers,
+            &table,
+            DatabaseType::MySQL,
+            &TestDdlGenerator,
+        );
+
+        match model.section() {
+            Some(InspectorSection::Triggers { rows }) => {
+                assert_eq!(rows[0].action_order, Some(2));
+                assert_eq!(rows[0].creation_context, table.triggers[0].creation_context);
+            }
+            section => panic!("expected trigger section, got {section:?}"),
         }
     }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -150,8 +150,10 @@ pub(super) mod tests {
                 name: "trg".to_string(),
                 timing: TriggerTiming::After,
                 events: vec![TriggerEvent::Update],
+                action_order: None,
                 definition: "f".to_string(),
                 security_context: None,
+                creation_context: None,
             }],
             ..test_support::table::minimal("", "")
         }

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -36,7 +36,7 @@ pub use schema::Schema;
 pub use sqlite_diagnostics::{DiagnosticField, SqliteDiagnosticsSnapshot};
 pub use table::{Table, TableSignature, TableSignatureSnapshot, TableSummary};
 pub use table_kind::{TableKind, TableKindInfo};
-pub use trigger::{Trigger, TriggerEvent, TriggerTiming};
+pub use trigger::{Trigger, TriggerCreationContext, TriggerEvent, TriggerTiming};
 pub use write_result::WriteExecutionResult;
 
 pub use connection::{

--- a/src/domain/trigger.rs
+++ b/src/domain/trigger.rs
@@ -80,13 +80,24 @@ impl FromStr for TriggerEvent {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerCreationContext {
+    pub sql_mode: Option<String>,
+    pub character_set_client: Option<String>,
+    pub collation_connection: Option<String>,
+    pub database_collation: Option<String>,
+    pub created: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct Trigger {
     pub name: String,
     pub timing: TriggerTiming,
     pub events: Vec<TriggerEvent>,
+    pub action_order: Option<i32>,
     pub definition: String,
     pub security_context: Option<String>,
+    pub creation_context: Option<TriggerCreationContext>,
 }
 
 #[cfg(test)]

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{
     ForeignKey, Index, IndexAttributes, IndexType, Table, TableKind, TableKindInfo, Trigger,
-    TriggerEvent, TriggerTiming,
+    TriggerCreationContext, TriggerEvent, TriggerTiming,
 };
 
 use super::super::sql::{
@@ -57,10 +57,12 @@ impl MySqlIndexVisibility {
 #[derive(Debug, Clone)]
 struct MySqlTriggerMetadata {
     name: String,
+    action_order: i32,
     timing: TriggerTiming,
     event: TriggerEvent,
     definition: String,
     security_context: Option<String>,
+    creation_context: TriggerCreationContext,
 }
 
 pub(super) async fn fetch_table_detail_in_session(
@@ -216,7 +218,7 @@ async fn fetch_table_detail_with_session(
         &session
             .execute_with_expected_columns(&triggers_query(schema, table), TRIGGER_RESULT_COLUMNS)
             .await?,
-    )?)?;
+    )?);
     let source_ddl = parse_source_ddl(
         &session
             .execute_with_expected_columns(
@@ -287,53 +289,49 @@ fn parse_trigger_metadata(
         .values
         .iter()
         .map(|row| {
-            if row.len() != 5 {
+            if row.len() != 11 {
                 return Err(metadata_shape_error("TRIGGERS row"));
             }
-            let timing = required_text(&row[1], "ACTION_TIMING")?
+            let timing = required_text(&row[2], "ACTION_TIMING")?
                 .parse::<TriggerTiming>()
                 .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
-            let event = required_text(&row[2], "EVENT_MANIPULATION")?
+            let event = required_text(&row[3], "EVENT_MANIPULATION")?
                 .parse::<TriggerEvent>()
                 .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
             Ok(MySqlTriggerMetadata {
                 name: required_text(&row[0], "TRIGGER_NAME")?.to_string(),
+                action_order: parse_positive_i32(&row[1], "ACTION_ORDER")?,
                 timing,
                 event,
-                definition: required_text(&row[3], "ACTION_STATEMENT")?.to_string(),
-                security_context: optional_text(&row[4], "DEFINER")?.map(str::to_string),
+                definition: required_text(&row[4], "ACTION_STATEMENT")?.to_string(),
+                security_context: optional_text(&row[5], "DEFINER")?.map(str::to_string),
+                creation_context: TriggerCreationContext {
+                    sql_mode: optional_text(&row[6], "SQL_MODE")?.map(str::to_string),
+                    character_set_client: optional_text(&row[7], "CHARACTER_SET_CLIENT")?
+                        .map(str::to_string),
+                    collation_connection: optional_text(&row[8], "COLLATION_CONNECTION")?
+                        .map(str::to_string),
+                    database_collation: optional_text(&row[9], "DATABASE_COLLATION")?
+                        .map(str::to_string),
+                    created: optional_text(&row[10], "CREATED")?.map(str::to_string),
+                },
             })
         })
         .collect()
 }
 
-fn triggers_from_metadata(
-    raw: Vec<MySqlTriggerMetadata>,
-) -> Result<Vec<Trigger>, DbOperationError> {
-    let mut triggers = Vec::new();
-    for metadata in raw {
-        if let Some(trigger) = triggers
-            .iter_mut()
-            .find(|trigger: &&mut Trigger| trigger.name == metadata.name)
-        {
-            if trigger.timing != metadata.timing
-                || trigger.definition != metadata.definition
-                || trigger.security_context != metadata.security_context
-            {
-                return Err(metadata_shape_error("TRIGGERS definition"));
-            }
-            trigger.events.push(metadata.event);
-        } else {
-            triggers.push(Trigger {
-                name: metadata.name,
-                timing: metadata.timing,
-                events: vec![metadata.event],
-                definition: metadata.definition,
-                security_context: metadata.security_context,
-            });
-        }
-    }
-    Ok(triggers)
+fn triggers_from_metadata(raw: Vec<MySqlTriggerMetadata>) -> Vec<Trigger> {
+    raw.into_iter()
+        .map(|metadata| Trigger {
+            name: metadata.name,
+            timing: metadata.timing,
+            events: vec![metadata.event],
+            action_order: Some(metadata.action_order),
+            definition: metadata.definition,
+            security_context: metadata.security_context,
+            creation_context: Some(metadata.creation_context),
+        })
+        .collect()
 }
 
 fn parse_source_ddl(result: &MySqlResultSet, kind: TableKind) -> Result<String, DbOperationError> {
@@ -896,42 +894,72 @@ mod tests {
     }
 
     #[test]
-    fn trigger_metadata_preserves_action_definer_and_event_order() {
+    fn trigger_metadata_preserves_action_order_context_and_definition() {
         let result = result(
             &[
                 "TRIGGER_NAME",
+                "ACTION_ORDER",
                 "ACTION_TIMING",
                 "EVENT_MANIPULATION",
                 "ACTION_STATEMENT",
                 "DEFINER",
+                "SQL_MODE",
+                "CHARACTER_SET_CLIENT",
+                "COLLATION_CONNECTION",
+                "DATABASE_COLLATION",
+                "CREATED",
             ],
             vec![
                 vec![
-                    QueryValue::Text("audit_changes".to_string()),
-                    QueryValue::Text("BEFORE".to_string()),
-                    QueryValue::Text("INSERT".to_string()),
-                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
-                    QueryValue::Text("sabiql@%".to_string()),
-                ],
-                vec![
-                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("z_add".to_string()),
+                    QueryValue::Text("1".to_string()),
                     QueryValue::Text("BEFORE".to_string()),
                     QueryValue::Text("UPDATE".to_string()),
-                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("SET @seen = 1".to_string()),
                     QueryValue::Text("sabiql@%".to_string()),
+                    QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
+                    QueryValue::Text("utf8mb4".to_string()),
+                    QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+                    QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+                    QueryValue::Text("2026-08-21 10:20:30.00".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("a_double".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("UPDATE".to_string()),
+                    QueryValue::Text("SET @seen = 2".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                    QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
+                    QueryValue::Text("utf8mb4".to_string()),
+                    QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+                    QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+                    QueryValue::Text("2026-08-21 10:20:31.00".to_string()),
                 ],
             ],
         );
 
-        let triggers = triggers_from_metadata(parse_trigger_metadata(&result).unwrap()).unwrap();
+        let triggers = triggers_from_metadata(parse_trigger_metadata(&result).unwrap());
 
-        assert_eq!(triggers.len(), 1);
-        assert_eq!(
-            triggers[0].events,
-            [TriggerEvent::Insert, TriggerEvent::Update]
-        );
-        assert_eq!(triggers[0].definition, "BEGIN\n  SET @seen = 1;\nEND");
+        assert_eq!(triggers.len(), 2);
+        assert_eq!(triggers[0].name, "z_add");
+        assert_eq!(triggers[0].action_order, Some(1));
+        assert_eq!(triggers[0].events, [TriggerEvent::Update]);
+        assert_eq!(triggers[0].definition, "SET @seen = 1");
         assert_eq!(triggers[0].security_context.as_deref(), Some("sabiql@%"));
+        assert_eq!(
+            triggers[0].creation_context,
+            Some(TriggerCreationContext {
+                sql_mode: Some("STRICT_TRANS_TABLES".to_string()),
+                character_set_client: Some("utf8mb4".to_string()),
+                collation_connection: Some("utf8mb4_0900_ai_ci".to_string()),
+                database_collation: Some("utf8mb4_0900_ai_ci".to_string()),
+                created: Some("2026-08-21 10:20:30.00".to_string()),
+            })
+        );
+        assert_eq!(triggers[1].name, "a_double");
+        assert_eq!(triggers[1].action_order, Some(2));
+        assert_eq!(triggers[1].events, [TriggerEvent::Update]);
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -587,7 +587,7 @@ while IFS= read -r line; do
       printf '%s\n' '<resultset><row><field name="CONSTRAINT_NAME">fk_items_self</field><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">items</field><field name="COLUMN_NAME">id</field><field name="REFERENCED_TABLE_SCHEMA">app</field><field name="REFERENCED_TABLE_NAME">items</field><field name="REFERENCED_COLUMN_NAME">id</field><field name="ORDINAL_POSITION">1</field><field name="UPDATE_RULE">CASCADE</field><field name="DELETE_RULE">CASCADE</field></row></resultset>'
       ;;
     *TRIGGERS*)
-      printf '%s\n' '<resultset><row><field name="TRIGGER_NAME">items_audit</field><field name="ACTION_TIMING">BEFORE</field><field name="EVENT_MANIPULATION">INSERT</field><field name="ACTION_STATEMENT">SET NEW.id = NEW.id</field><field name="DEFINER">app@localhost</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="TRIGGER_NAME">items_audit</field><field name="ACTION_ORDER">1</field><field name="ACTION_TIMING">BEFORE</field><field name="EVENT_MANIPULATION">INSERT</field><field name="ACTION_STATEMENT">SET NEW.id = NEW.id</field><field name="DEFINER">app@localhost</field><field name="SQL_MODE">STRICT_TRANS_TABLES</field><field name="CHARACTER_SET_CLIENT">utf8mb4</field><field name="COLLATION_CONNECTION">utf8mb4_0900_ai_ci</field><field name="DATABASE_COLLATION">utf8mb4_0900_ai_ci</field><field name="CREATED">2026-08-21 10:20:30.00</field></row></resultset>'
       ;;
     *SHOW\ CREATE\ VIEW*)
       if [ "$mode" = "view" ]; then

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -119,10 +119,16 @@ pub(in crate::adapters::mysql) const INDEX_RESULT_COLUMNS: &[&str] = &[
 ];
 pub(in crate::adapters::mysql) const TRIGGER_RESULT_COLUMNS: &[&str] = &[
     "TRIGGER_NAME",
+    "ACTION_ORDER",
     "ACTION_TIMING",
     "EVENT_MANIPULATION",
     "ACTION_STATEMENT",
     "DEFINER",
+    "SQL_MODE",
+    "CHARACTER_SET_CLIENT",
+    "COLLATION_CONNECTION",
+    "DATABASE_COLLATION",
+    "CREATED",
 ];
 const TABLE_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["Table", "Create Table"];
 const VIEW_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["View", "Create View"];
@@ -137,7 +143,7 @@ pub(in crate::adapters::mysql) fn indexes_query(schema: &str, table: &str) -> St
 
 pub(in crate::adapters::mysql) fn triggers_query(schema: &str, table: &str) -> String {
     format!(
-        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = {} AND EVENT_OBJECT_SCHEMA = {} AND EVENT_OBJECT_TABLE = {} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+        "SELECT TRIGGER_NAME, ACTION_ORDER, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER, SQL_MODE, CHARACTER_SET_CLIENT, COLLATION_CONNECTION, DATABASE_COLLATION, CREATED FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = {} AND EVENT_OBJECT_SCHEMA = {} AND EVENT_OBJECT_TABLE = {} ORDER BY EVENT_MANIPULATION, ACTION_TIMING, ACTION_ORDER",
         quote_string(schema),
         quote_string(schema),
         quote_string(table),
@@ -320,7 +326,7 @@ mod tests {
         assert_eq!(
             triggers_sql,
             format!(
-                "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = {quoted_schema} AND EVENT_OBJECT_SCHEMA = {quoted_schema} AND EVENT_OBJECT_TABLE = {quoted_table} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION"
+                "SELECT TRIGGER_NAME, ACTION_ORDER, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER, SQL_MODE, CHARACTER_SET_CLIENT, COLLATION_CONNECTION, DATABASE_COLLATION, CREATED FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = {quoted_schema} AND EVENT_OBJECT_SCHEMA = {quoted_schema} AND EVENT_OBJECT_TABLE = {quoted_table} ORDER BY EVENT_MANIPULATION, ACTION_TIMING, ACTION_ORDER"
             )
         );
 
@@ -432,10 +438,16 @@ mod tests {
             TRIGGER_RESULT_COLUMNS,
             &[
                 "TRIGGER_NAME",
+                "ACTION_ORDER",
                 "ACTION_TIMING",
                 "EVENT_MANIPULATION",
                 "ACTION_STATEMENT",
                 "DEFINER",
+                "SQL_MODE",
+                "CHARACTER_SET_CLIENT",
+                "COLLATION_CONNECTION",
+                "DATABASE_COLLATION",
+                "CREATED",
             ]
         );
     }

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -368,8 +368,10 @@ impl PostgresAdapter {
                     name: t.name,
                     timing,
                     events,
+                    action_order: None,
                     definition: t.definition,
                     security_context: t.security_context,
+                    creation_context: None,
                 })
             })
             .collect::<Result<Vec<_>, MetadataParseError>>()

--- a/src/infra/adapters/sqlite/metadata/trigger.rs
+++ b/src/infra/adapters/sqlite/metadata/trigger.rs
@@ -36,8 +36,10 @@ pub(super) fn parse_sqlite_trigger(
         name: trigger_name.to_string(),
         timing,
         events,
+        action_order: None,
         definition: sql.to_string(),
         security_context: None,
+        creation_context: None,
     })
 }
 

--- a/src/infra/adapters/sqlite/sql/ddl.rs
+++ b/src/infra/adapters/sqlite/sql/ddl.rs
@@ -172,9 +172,11 @@ mod tests {
                 name: "users_audit".to_string(),
                 timing: TriggerTiming::After,
                 events: vec![TriggerEvent::Insert],
+                action_order: None,
                 definition: "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END"
                     .to_string(),
                 security_context: None,
+                creation_context: None,
             });
 
             let ddl = adapter.generate_ddl(DatabaseType::SQLite, &table);

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -376,17 +376,35 @@ mod metadata_fetch {
                         detail.source_ddl()
                     ));
                 }
-                if detail.triggers.len() != 1 {
+                if detail.triggers.len() != 2 {
                     return Err(format!("unexpected MySQL triggers: {:?}", detail.triggers));
                 }
-                let trigger = &detail.triggers[0];
-                if trigger.name != "mysql_cli_fixture_audit"
-                    || trigger.timing != TriggerTiming::Before
-                    || trigger.events != [TriggerEvent::Update]
-                    || trigger.definition != "SET NEW.empty_text = NEW.empty_text"
-                    || trigger.security_context.as_deref() != Some("sabiql@%")
+                let first_trigger = &detail.triggers[0];
+                let second_trigger = &detail.triggers[1];
+                if first_trigger.name != "mysql_cli_fixture_audit"
+                    || first_trigger.action_order != Some(1)
+                    || first_trigger.timing != TriggerTiming::Before
+                    || first_trigger.events != [TriggerEvent::Update]
+                    || first_trigger.definition != "SET NEW.empty_text = NEW.empty_text"
+                    || first_trigger.security_context.as_deref() != Some("sabiql@%")
+                    || first_trigger
+                        .creation_context
+                        .as_ref()
+                        .is_none_or(|context| {
+                            context.sql_mode.is_none()
+                                || context.character_set_client.is_none()
+                                || context.collation_connection.is_none()
+                                || context.database_collation.is_none()
+                                || context.created.is_none()
+                        })
+                    || second_trigger.name != "a_mysql_cli_fixture_audit"
+                    || second_trigger.action_order != Some(2)
+                    || second_trigger.timing != TriggerTiming::Before
+                    || second_trigger.events != [TriggerEvent::Update]
+                    || second_trigger.definition != "SET NEW.empty_text = NEW.empty_text"
+                    || second_trigger.security_context.as_deref() != Some("sabiql@%")
                 {
-                    return Err(format!("unexpected MySQL trigger: {trigger:?}"));
+                    return Err(format!("unexpected MySQL triggers: {:?}", detail.triggers));
                 }
 
                 let view_detail = db

--- a/src/tests/harness/fixtures.rs
+++ b/src/tests/harness/fixtures.rs
@@ -106,8 +106,10 @@ pub fn sample_table_detail() -> Table {
         name: "audit_users".to_string(),
         timing: TriggerTiming::After,
         events: vec![TriggerEvent::Insert, TriggerEvent::Update],
+        action_order: None,
         definition: "audit_func".to_string(),
         security_context: Some("INVOKER".to_string()),
+        creation_context: None,
     }];
     table.row_count_estimate = Some(100);
     table.comment = Some("User accounts".to_string());

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -21,7 +21,7 @@ use crate::app::model::shared::viewport::{
     widths_fingerprint,
 };
 use crate::app::services::AppServices;
-use crate::domain::{DatabaseType, TriggerCreationContext};
+use crate::domain::DatabaseType;
 use crate::primitives::atoms::{apply_yank_flash, panel_block};
 use crate::primitives::utils::text_utils::{
     MIN_COL_WIDTH, PADDING, calculate_header_min_widths, truncate_to_width,
@@ -211,15 +211,15 @@ impl Inspector {
                 ViewportPlan::default()
             }
             Some(InspectorSection::Triggers { rows }) => {
-                Self::render_triggers(
+                return Self::render_triggers(
                     frame,
                     inner,
                     rows,
                     state.session.active_database_type_or_default(),
                     state.ui.inspector_scroll_offset(),
+                    state.ui.inspector_horizontal_offset(),
                     theme,
                 );
-                ViewportPlan::default()
             }
             Some(InspectorSection::Ddl { rows }) => {
                 Self::render_ddl(
@@ -634,29 +634,21 @@ impl Inspector {
         rows: &[InspectorTriggerRow],
         database_type: DatabaseType,
         scroll_offset: usize,
+        horizontal_offset: usize,
         theme: &ThemePalette,
-    ) {
+    ) -> ViewportPlan {
+        if database_type == DatabaseType::MySQL {
+            return Self::render_mysql_trigger_details(
+                frame,
+                area,
+                rows,
+                scroll_offset,
+                horizontal_offset,
+                theme,
+            );
+        }
+
         let (headers, widths): (&[&str], &[Constraint]) = match database_type {
-            DatabaseType::MySQL => (
-                &[
-                    "Order",
-                    "Name",
-                    "Timing",
-                    "Event",
-                    "Action",
-                    "Definer",
-                    "Creation Context",
-                ],
-                &[
-                    Constraint::Percentage(8),
-                    Constraint::Percentage(16),
-                    Constraint::Percentage(12),
-                    Constraint::Percentage(14),
-                    Constraint::Percentage(20),
-                    Constraint::Percentage(12),
-                    Constraint::Percentage(18),
-                ],
-            ),
             DatabaseType::PostgreSQL => (
                 &["Name", "Timing", "Event", "Function", "Security"],
                 &[
@@ -676,6 +668,7 @@ impl Inspector {
                     Constraint::Percentage(40),
                 ],
             ),
+            DatabaseType::MySQL => unreachable!("MySQL uses the detail renderer"),
         };
         let data_rows: Vec<Vec<String>> = rows
             .iter()
@@ -711,6 +704,71 @@ impl Inspector {
                     .collect()
             },
         );
+
+        ViewportPlan::default()
+    }
+
+    fn render_mysql_trigger_details(
+        frame: &mut Frame,
+        area: Rect,
+        rows: &[InspectorTriggerRow],
+        scroll_offset: usize,
+        horizontal_offset: usize,
+        theme: &ThemePalette,
+    ) -> ViewportPlan {
+        use crate::primitives::atoms::scroll_indicator::{
+            VerticalScrollParams, clamp_scroll_offset, render_vertical_scroll_indicator_bar,
+        };
+
+        let lines: Vec<Line> = rows
+            .iter()
+            .flat_map(mysql_trigger_detail_lines)
+            .map(|line| Line::from(line).style(Style::default().fg(theme.semantic.text.primary)))
+            .collect();
+        let total_lines = lines.len();
+        let has_vertical_scrollbar = total_lines > area.height as usize;
+        let content_area = Rect {
+            width: area.width.saturating_sub(u16::from(has_vertical_scrollbar)),
+            ..area
+        };
+        let visible_lines = content_area.height as usize;
+        let content_width = lines.iter().map(Line::width).max().unwrap_or_default();
+        let clamped_scroll_offset = clamp_scroll_offset(scroll_offset, visible_lines, total_lines);
+        let clamped_horizontal_offset = clamp_scroll_offset(
+            horizontal_offset,
+            content_area.width as usize,
+            content_width,
+        );
+
+        frame.render_widget(
+            Paragraph::new(lines).scroll((
+                clamped_scroll_offset.min(u16::MAX as usize) as u16,
+                clamped_horizontal_offset.min(u16::MAX as usize) as u16,
+            )),
+            content_area,
+        );
+
+        if has_vertical_scrollbar {
+            render_vertical_scroll_indicator_bar(
+                frame,
+                area,
+                VerticalScrollParams {
+                    position: clamped_scroll_offset,
+                    viewport_size: visible_lines,
+                    total_items: total_lines,
+                    has_horizontal_scrollbar: false,
+                },
+                theme,
+            );
+        }
+
+        ViewportPlan {
+            column_count: 1,
+            max_offset: content_width.saturating_sub(content_area.width as usize),
+            total_columns: 1,
+            available_width: content_area.width,
+            widths_fingerprint: 0,
+        }
     }
 
     fn render_ddl(
@@ -820,29 +878,61 @@ fn trigger_row_cells(row: &InspectorTriggerRow, database_type: DatabaseType) -> 
         row.events.clone(),
         row.definition.clone(),
     ]);
-    if database_type == DatabaseType::MySQL {
-        cells.push(row.security_context.clone().unwrap_or_default());
-        cells.push(
-            row.creation_context
-                .as_ref()
-                .map(trigger_creation_context)
-                .unwrap_or_default(),
-        );
-    } else if database_type != DatabaseType::SQLite {
+    if database_type != DatabaseType::SQLite {
         cells.push(row.security_context.clone().unwrap_or_default());
     }
     cells
 }
 
-fn trigger_creation_context(context: &TriggerCreationContext) -> String {
-    format!(
-        "SQL_MODE={}; CHARACTER_SET_CLIENT={}; COLLATION_CONNECTION={}; DATABASE_COLLATION={}; CREATED={}",
-        context.sql_mode.as_deref().unwrap_or_default(),
-        context.character_set_client.as_deref().unwrap_or_default(),
-        context.collation_connection.as_deref().unwrap_or_default(),
-        context.database_collation.as_deref().unwrap_or_default(),
-        context.created.as_deref().unwrap_or_default(),
-    )
+fn mysql_trigger_detail_lines(row: &InspectorTriggerRow) -> Vec<String> {
+    let context = row.creation_context.as_ref();
+    vec![
+        format!(
+            "Order: {}",
+            row.action_order
+                .map(|order| order.to_string())
+                .unwrap_or_default()
+        ),
+        format!("Name: {}", row.name),
+        format!("Timing: {}", row.timing),
+        format!("Event: {}", row.events),
+        format!("Action: {}", row.definition),
+        format!(
+            "Definer: {}",
+            row.security_context.as_deref().unwrap_or_default()
+        ),
+        format!(
+            "SQL_MODE: {}",
+            context
+                .and_then(|context| context.sql_mode.as_deref())
+                .unwrap_or_default()
+        ),
+        format!(
+            "CHARACTER_SET_CLIENT: {}",
+            context
+                .and_then(|context| context.character_set_client.as_deref())
+                .unwrap_or_default()
+        ),
+        format!(
+            "COLLATION_CONNECTION: {}",
+            context
+                .and_then(|context| context.collation_connection.as_deref())
+                .unwrap_or_default()
+        ),
+        format!(
+            "DATABASE_COLLATION: {}",
+            context
+                .and_then(|context| context.database_collation.as_deref())
+                .unwrap_or_default()
+        ),
+        format!(
+            "CREATED: {}",
+            context
+                .and_then(|context| context.created.as_deref())
+                .unwrap_or_default()
+        ),
+        String::new(),
+    ]
 }
 
 fn checkmark(value: bool) -> String {
@@ -877,6 +967,7 @@ fn calculate_column_widths(headers: &[&str], rows: &[Vec<String>]) -> Vec<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::TriggerCreationContext;
 
     #[test]
     fn index_row_cells_match_partial_header_visibility() {
@@ -916,13 +1007,17 @@ mod tests {
     }
 
     #[test]
-    fn mysql_trigger_row_cells_include_action_order_and_creation_context() {
+    fn mysql_trigger_details_render_all_creation_context_fields() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::layout::Rect;
+
         let row = InspectorTriggerRow {
             name: "audit_changes".to_string(),
             timing: "BEFORE".to_string(),
             events: "UPDATE".to_string(),
             action_order: Some(2),
-            definition: "SET NEW.value = NEW.value".to_string(),
+            definition: format!("SET NEW.value = {}", "x".repeat(100)),
             security_context: Some("sabiql@%".to_string()),
             creation_context: Some(TriggerCreationContext {
                 sql_mode: Some("STRICT_TRANS_TABLES".to_string()),
@@ -932,18 +1027,47 @@ mod tests {
                 created: Some("2026-08-21 10:20:30.00".to_string()),
             }),
         };
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        let theme =
+            crate::theme::palette_for(crate::app::model::shared::theme_id::ThemeId::Default);
+        let mut plan = ViewportPlan::default();
 
-        assert_eq!(
-            trigger_row_cells(&row, DatabaseType::MySQL),
-            vec![
-                "2",
-                "audit_changes",
-                "BEFORE",
-                "UPDATE",
-                "SET NEW.value = NEW.value",
-                "sabiql@%",
-                "SQL_MODE=STRICT_TRANS_TABLES; CHARACTER_SET_CLIENT=utf8mb4; COLLATION_CONNECTION=utf8mb4_0900_ai_ci; DATABASE_COLLATION=utf8mb4_0900_ai_ci; CREATED=2026-08-21 10:20:30.00",
-            ]
-        );
+        terminal
+            .draw(|frame| {
+                plan = Inspector::render_triggers(
+                    frame,
+                    Rect::new(0, 0, 80, 12),
+                    &[row],
+                    DatabaseType::MySQL,
+                    0,
+                    0,
+                    theme,
+                );
+            })
+            .unwrap();
+
+        assert!(plan.max_offset > 0);
+
+        let buffer = terminal.backend().buffer();
+        let rendered: String = (0..buffer.area.height)
+            .flat_map(|y| {
+                (0..buffer.area.width)
+                    .map(move |x| buffer.cell((x, y)).unwrap().symbol())
+                    .chain(std::iter::once("\n"))
+            })
+            .collect();
+
+        for expected in [
+            "SQL_MODE: STRICT_TRANS_TABLES",
+            "CHARACTER_SET_CLIENT: utf8mb4",
+            "COLLATION_CONNECTION: utf8mb4_0900_ai_ci",
+            "DATABASE_COLLATION: utf8mb4_0900_ai_ci",
+            "CREATED: 2026-08-21 10:20:30.00",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected:?} in {rendered:?}"
+            );
+        }
     }
 }

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -1006,6 +1006,8 @@ mod tests {
 
     #[test]
     fn mysql_trigger_details_render_all_creation_context_fields() {
+        use crate::app::model::shared::theme_id::ThemeId;
+        use crate::theme::palette_for;
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
         use ratatui::layout::Rect;
@@ -1026,8 +1028,7 @@ mod tests {
             }),
         };
         let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
-        let theme =
-            crate::theme::palette_for(crate::app::model::shared::theme_id::ThemeId::Default);
+        let theme = palette_for(ThemeId::Default);
         let mut plan = ViewportPlan::default();
 
         terminal

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -21,7 +21,7 @@ use crate::app::model::shared::viewport::{
     widths_fingerprint,
 };
 use crate::app::services::AppServices;
-use crate::domain::DatabaseType;
+use crate::domain::{DatabaseType, TriggerCreationContext};
 use crate::primitives::atoms::{apply_yank_flash, panel_block};
 use crate::primitives::utils::text_utils::{
     MIN_COL_WIDTH, PADDING, calculate_header_min_widths, truncate_to_width,
@@ -638,13 +638,23 @@ impl Inspector {
     ) {
         let (headers, widths): (&[&str], &[Constraint]) = match database_type {
             DatabaseType::MySQL => (
-                &["Name", "Timing", "Event", "Action", "Definer"],
                 &[
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(15),
+                    "Order",
+                    "Name",
+                    "Timing",
+                    "Event",
+                    "Action",
+                    "Definer",
+                    "Creation Context",
+                ],
+                &[
+                    Constraint::Percentage(8),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(12),
+                    Constraint::Percentage(14),
                     Constraint::Percentage(20),
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(15),
+                    Constraint::Percentage(12),
+                    Constraint::Percentage(18),
                 ],
             ),
             DatabaseType::PostgreSQL => (
@@ -796,16 +806,43 @@ fn foreign_key_row_cells(row: &InspectorForeignKeyRow) -> Vec<String> {
 }
 
 fn trigger_row_cells(row: &InspectorTriggerRow, database_type: DatabaseType) -> Vec<String> {
-    let mut cells = vec![
+    let mut cells = Vec::new();
+    if database_type == DatabaseType::MySQL {
+        cells.push(
+            row.action_order
+                .map(|order| order.to_string())
+                .unwrap_or_default(),
+        );
+    }
+    cells.extend([
         row.name.clone(),
         row.timing.clone(),
         row.events.clone(),
         row.definition.clone(),
-    ];
-    if !matches!(database_type, DatabaseType::SQLite) {
+    ]);
+    if database_type == DatabaseType::MySQL {
+        cells.push(row.security_context.clone().unwrap_or_default());
+        cells.push(
+            row.creation_context
+                .as_ref()
+                .map(trigger_creation_context)
+                .unwrap_or_default(),
+        );
+    } else if database_type != DatabaseType::SQLite {
         cells.push(row.security_context.clone().unwrap_or_default());
     }
     cells
+}
+
+fn trigger_creation_context(context: &TriggerCreationContext) -> String {
+    format!(
+        "SQL_MODE={}; CHARACTER_SET_CLIENT={}; COLLATION_CONNECTION={}; DATABASE_COLLATION={}; CREATED={}",
+        context.sql_mode.as_deref().unwrap_or_default(),
+        context.character_set_client.as_deref().unwrap_or_default(),
+        context.collation_connection.as_deref().unwrap_or_default(),
+        context.database_collation.as_deref().unwrap_or_default(),
+        context.created.as_deref().unwrap_or_default(),
+    )
 }
 
 fn checkmark(value: bool) -> String {
@@ -874,6 +911,38 @@ mod tests {
                 "public.departments(id)",
                 "NO ACTION",
                 "CASCADE",
+            ]
+        );
+    }
+
+    #[test]
+    fn mysql_trigger_row_cells_include_action_order_and_creation_context() {
+        let row = InspectorTriggerRow {
+            name: "audit_changes".to_string(),
+            timing: "BEFORE".to_string(),
+            events: "UPDATE".to_string(),
+            action_order: Some(2),
+            definition: "SET NEW.value = NEW.value".to_string(),
+            security_context: Some("sabiql@%".to_string()),
+            creation_context: Some(TriggerCreationContext {
+                sql_mode: Some("STRICT_TRANS_TABLES".to_string()),
+                character_set_client: Some("utf8mb4".to_string()),
+                collation_connection: Some("utf8mb4_0900_ai_ci".to_string()),
+                database_collation: Some("utf8mb4_0900_ai_ci".to_string()),
+                created: Some("2026-08-21 10:20:30.00".to_string()),
+            }),
+        };
+
+        assert_eq!(
+            trigger_row_cells(&row, DatabaseType::MySQL),
+            vec![
+                "2",
+                "audit_changes",
+                "BEFORE",
+                "UPDATE",
+                "SET NEW.value = NEW.value",
+                "sabiql@%",
+                "SQL_MODE=STRICT_TRANS_TABLES; CHARACTER_SET_CLIENT=utf8mb4; COLLATION_CONNECTION=utf8mb4_0900_ai_ci; DATABASE_COLLATION=utf8mb4_0900_ai_ci; CREATED=2026-08-21 10:20:30.00",
             ]
         );
     }

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -210,17 +210,15 @@ impl Inspector {
                 );
                 ViewportPlan::default()
             }
-            Some(InspectorSection::Triggers { rows }) => {
-                return Self::render_triggers(
-                    frame,
-                    inner,
-                    rows,
-                    state.session.active_database_type_or_default(),
-                    state.ui.inspector_scroll_offset(),
-                    state.ui.inspector_horizontal_offset(),
-                    theme,
-                );
-            }
+            Some(InspectorSection::Triggers { rows }) => Self::render_triggers(
+                frame,
+                inner,
+                rows,
+                state.session.active_database_type_or_default(),
+                state.ui.inspector_scroll_offset(),
+                state.ui.inspector_horizontal_offset(),
+                theme,
+            ),
             Some(InspectorSection::Ddl { rows }) => {
                 Self::render_ddl(
                     frame,


### PR DESCRIPTION
## Problem

The MySQL Triggers tab can display triggers in name order even when the server executes them in a different order, and it omits the creation-time context that affects trigger execution.

## Background

MySQL 8.4 supports multiple triggers in the same event/timing group with FOLLOWS or PRECEDES and exposes their action order and creation context through INFORMATION_SCHEMA.TRIGGERS.

## Approach

Carry the server action order and creation context through the existing metadata, domain, view-model, and Inspector paths while preserving the current trigger fields. Keep non-MySQL trigger behavior unchanged and remove only the MySQL-specific name merge that conflicts with MySQL trigger-name uniqueness.