### PR TITLE
refactor: share row identity pairs in grid writes

### DIFF
--- a/src/app/policy/write/write_guardrails.rs
+++ b/src/app/policy/write/write_guardrails.rs
@@ -32,14 +32,6 @@ impl StableRowIdentity {
         }
     }
 
-    pub fn predicate_pairs_for_row(
-        &self,
-        result: &QueryResult,
-        row_idx: usize,
-    ) -> Option<Vec<(String, QueryValue)>> {
-        self.identity_pairs_for_row(result, row_idx)
-    }
-
     pub fn is_primary_key_column(&self, column_name: &str) -> bool {
         match self {
             Self::PrimaryKey(columns) | Self::Explicit(columns) => {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -425,6 +425,7 @@ fn open_write_preview_confirm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use crate::update::test_fixtures;
 
     use crate::domain::connection::ConnectionId;
@@ -1028,7 +1029,7 @@ mod tests {
             detail.columns[1].attributes = ColumnAttributes::PRIMARY_KEY;
             detail
                 .columns
-                .push(crate::test_support::column::test_nullable_column(
+                .push(test_support::column::test_nullable_column(
                     "name", "text", 3,
                 ));
             detail.primary_key = Some(vec!["first_id".to_string(), "second_id".to_string()]);

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -90,13 +90,12 @@ fn build_update_preview(
     if let Some(pairs) = identity_pairs.as_deref() {
         reject_sqlite_null_pk(state.session.active_database_type_or_default(), pairs)?;
     }
-    let predicate_pairs = identity.predicate_pairs_for_row(result, row_idx);
     let target = TargetSummary {
         schema: state.query.pagination.schema().to_string(),
         table: state.query.pagination.table().to_string(),
         key_values: identity_pairs.clone().unwrap_or_default(),
     };
-    let has_where = predicate_pairs
+    let has_where = identity_pairs
         .as_ref()
         .is_some_and(|pairs| !pairs.is_empty());
     let has_stable_row_identity = identity_pairs.is_some();
@@ -114,7 +113,7 @@ fn build_update_preview(
         &target.table,
         &column_name,
         &new_value,
-        &predicate_pairs.unwrap_or_default(),
+        &identity_pairs.unwrap_or_default(),
     );
     let preview = WritePreview {
         operation: WriteOperation::Update,
@@ -1002,6 +1001,63 @@ mod tests {
 
             let preview = submit_write_preview(&mut state);
             assert!(preview.diff[0].json_diff.is_some());
+            assert!(preview.sql.contains(r#"WHERE "id" = '1'"#));
+        }
+
+        #[test]
+        fn composite_primary_key_preserves_order_in_update_preview() {
+            let mut state = AppState::new("test_project".to_string());
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    "SELECT first_id, second_id, name FROM composite_users".to_string(),
+                    vec![
+                        "first_id".to_string(),
+                        "second_id".to_string(),
+                        "name".to_string(),
+                    ],
+                    vec![vec!["1".to_string(), "2".to_string(), "Alice".to_string()]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            let mut detail = users_table_detail();
+            detail.name = "composite_users".to_string();
+            detail.columns[0].name = "first_id".to_string();
+            detail.columns[1].name = "second_id".to_string();
+            detail.columns[1].attributes = ColumnAttributes::PRIMARY_KEY;
+            detail
+                .columns
+                .push(crate::test_support::column::test_nullable_column(
+                    "name", "text", 3,
+                ));
+            detail.primary_key = Some(vec!["first_id".to_string(), "second_id".to_string()]);
+            state.session.set_table_detail_raw(Some(detail));
+            state
+                .query
+                .pagination
+                .reset_for_table("public", "composite_users");
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 2, "Alice".to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft("Bob".to_string());
+
+            let preview = submit_write_preview(&mut state);
+
+            assert_eq!(
+                preview.target_summary.key_values,
+                vec![
+                    ("first_id".to_string(), QueryValue::text("1")),
+                    ("second_id".to_string(), QueryValue::text("2")),
+                ]
+            );
+            assert_eq!(
+                preview.sql,
+                "UPDATE \"public\".\"composite_users\" SET \"name\" = 'Bob' WHERE \"first_id\" = '1' AND \"second_id\" = '2'"
+            );
         }
 
         #[test]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -241,12 +241,9 @@ pub fn build_bulk_delete_preview(
             &identity_pairs,
         )?;
         if target_pairs.is_empty() {
-            target_pairs = identity_pairs;
+            target_pairs.clone_from(&identity_pairs);
         }
-        let predicate_pairs = identity
-            .predicate_pairs_for_row(result, row_idx)
-            .ok_or(EditGuardrailError::StableKeyColumnsMissing)?;
-        predicate_pairs_per_row.push(predicate_pairs);
+        predicate_pairs_per_row.push(identity_pairs);
     }
 
     let sql = services.sql_dialect.build_bulk_delete_sql(


### PR DESCRIPTION
## Problem
Grid writes derive the same stable row identity twice before building the update preview.

## Background
Target display, guardrail checks, and the SQL predicate should remain tied to one row identity extraction.

## Approach
Reuse one extracted identity pair set across the update preview and remove the trivial predicate alias. Bulk delete previews also reuse their existing extraction without changing predicate construction or safety checks.