### PR TITLE
fix(mysql): cancel stale connection probes

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -25,6 +25,50 @@ use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, ConnectionsLoadedPayload,
 };
 
+#[derive(Default)]
+pub(crate) struct MySqlConnectionProbeTaskOwner {
+    active: std::sync::Mutex<Option<JoinHandle<()>>>,
+}
+
+impl MySqlConnectionProbeTaskOwner {
+    pub(crate) async fn spawn<F>(&self, task: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        self.cancel().await;
+        let task = tokio::spawn(task);
+        *self
+            .active
+            .lock()
+            .expect("MySQL connection probe task lock poisoned") = Some(task);
+    }
+
+    pub(crate) async fn cancel(&self) {
+        let task = self
+            .active
+            .lock()
+            .expect("MySQL connection probe task lock poisoned")
+            .take();
+        if let Some(task) = task {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for MySqlConnectionProbeTaskOwner {
+    fn drop(&mut self) {
+        if let Some(task) = self
+            .active
+            .get_mut()
+            .expect("MySQL connection probe task lock poisoned")
+            .take()
+        {
+            task.abort();
+        }
+    }
+}
+
 fn claim_and_save<T>(
     run_guard: &ConnectionSaveGuard,
     run_id: u64,
@@ -42,10 +86,11 @@ pub(crate) async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
     connection: &ConnectionDeps,
+    mysql_connection_probe_task: &MySqlConnectionProbeTaskOwner,
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     state: &AppState,
-) -> Result<Option<JoinHandle<()>>> {
+) -> Result<()> {
     match effect {
         Effect::SaveAndConnect {
             id,
@@ -68,7 +113,7 @@ pub(crate) async fn run(
                         })
                         .await
                         .ok();
-                    return Ok(None);
+                    return Ok(());
                 }
             };
             let store = Arc::clone(&connection.connection_store);
@@ -91,7 +136,7 @@ pub(crate) async fn run(
                             })
                             .await
                             .ok();
-                        return Ok(None);
+                        return Ok(());
                     }
                 };
                 let id = profile.id.clone();
@@ -125,7 +170,7 @@ pub(crate) async fn run(
                         None => {}
                     }
                 });
-                return Ok(None);
+                return Ok(());
             }
 
             let id = profile.id.clone();
@@ -145,47 +190,49 @@ pub(crate) async fn run(
                     database,
                 };
                 let probe = Arc::clone(&connection.mysql_connection_probe);
-                let task = tokio::spawn(async move {
-                    match probe.probe(&target.dsn).await {
-                        Ok(()) => {
-                            let save_result = tokio::task::spawn_blocking(move || {
-                                claim_and_save(&run_guard, run_id, || store.save(&profile))
-                            })
-                            .await
-                            .expect("connection store save task panicked");
-                            match save_result {
-                                Some(Ok(())) => {
-                                    tx.send(Action::ConnectionSaveCompleted { target, run_id })
+                mysql_connection_probe_task
+                    .spawn(async move {
+                        match probe.probe(&target.dsn).await {
+                            Ok(()) => {
+                                let save_result = tokio::task::spawn_blocking(move || {
+                                    claim_and_save(&run_guard, run_id, || store.save(&profile))
+                                })
+                                .await
+                                .expect("connection store save task panicked");
+                                match save_result {
+                                    Some(Ok(())) => {
+                                        tx.send(Action::ConnectionSaveCompleted { target, run_id })
+                                            .await
+                                            .ok();
+                                    }
+                                    Some(Err(e)) => {
+                                        tx.send(Action::ConnectionSaveFailed {
+                                            error: e.into(),
+                                            database_type,
+                                            run_id,
+                                        })
                                         .await
                                         .ok();
+                                    }
+                                    None => {}
                                 }
-                                Some(Err(e)) => {
-                                    tx.send(Action::ConnectionSaveFailed {
-                                        error: e.into(),
-                                        database_type,
-                                        run_id,
-                                    })
-                                    .await
-                                    .ok();
-                                }
-                                None => {}
+                            }
+                            Err(e) => {
+                                tx.send(Action::ConnectionSaveFailed {
+                                    error: ConnectionSaveError::Probe {
+                                        error: e,
+                                        dsn: target.dsn.clone(),
+                                    },
+                                    database_type,
+                                    run_id,
+                                })
+                                .await
+                                .ok();
                             }
                         }
-                        Err(e) => {
-                            tx.send(Action::ConnectionSaveFailed {
-                                error: ConnectionSaveError::Probe {
-                                    error: e,
-                                    dsn: target.dsn.clone(),
-                                },
-                                database_type,
-                                run_id,
-                            })
-                            .await
-                            .ok();
-                        }
-                    }
-                });
-                return Ok(Some(task));
+                    })
+                    .await;
+                return Ok(());
             }
 
             let provider = Arc::clone(metadata_provider);
@@ -238,29 +285,31 @@ pub(crate) async fn run(
                     }
                 }
             });
-            Ok(None)
+            Ok(())
         }
 
         Effect::ProbeMySqlConnection { target, run_id } => {
             let probe = Arc::clone(&connection.mysql_connection_probe);
             let tx = action_tx.clone();
-            let task = tokio::spawn(async move {
-                match probe.probe(&target.dsn).await {
-                    Ok(()) => tx
-                        .send(Action::MySqlConnectionProbeCompleted { target, run_id })
-                        .await
-                        .ok(),
-                    Err(error) => tx
-                        .send(Action::MySqlConnectionProbeFailed {
-                            target,
-                            run_id,
-                            error,
-                        })
-                        .await
-                        .ok(),
-                };
-            });
-            Ok(Some(task))
+            mysql_connection_probe_task
+                .spawn(async move {
+                    match probe.probe(&target.dsn).await {
+                        Ok(()) => tx
+                            .send(Action::MySqlConnectionProbeCompleted { target, run_id })
+                            .await
+                            .ok(),
+                        Err(error) => tx
+                            .send(Action::MySqlConnectionProbeFailed {
+                                target,
+                                run_id,
+                                error,
+                            })
+                            .await
+                            .ok(),
+                    };
+                })
+                .await;
+            Ok(())
         }
 
         Effect::LoadConnectionForEdit { id } => {
@@ -282,7 +331,7 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionEditLoadFailed(e)).ok();
                 }
             });
-            Ok(None)
+            Ok(())
         }
 
         Effect::LoadConnections => {
@@ -311,7 +360,7 @@ pub(crate) async fn run(
                 }))
                 .ok();
             });
-            Ok(None)
+            Ok(())
         }
 
         Effect::DeleteConnection { id } => {
@@ -326,7 +375,7 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionDeleteFailed(e)).ok();
                 }
             });
-            Ok(None)
+            Ok(())
         }
 
         Effect::SwitchConnection { connection_index } => {
@@ -348,7 +397,7 @@ pub(crate) async fn run(
                     .await
                     .ok();
             }
-            Ok(None)
+            Ok(())
         }
 
         Effect::SwitchToService { service_index } => {
@@ -367,7 +416,7 @@ pub(crate) async fn run(
                     .await
                     .ok();
             }
-            Ok(None)
+            Ok(())
         }
 
         _ => unreachable!("connection::run called with non-connection effect"),

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::cmd::cache::TtlCache;
 use crate::cmd::effect::Effect;
@@ -44,7 +45,7 @@ pub(crate) async fn run(
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     state: &AppState,
-) -> Result<()> {
+) -> Result<Option<JoinHandle<()>>> {
     match effect {
         Effect::SaveAndConnect {
             id,
@@ -67,7 +68,7 @@ pub(crate) async fn run(
                         })
                         .await
                         .ok();
-                    return Ok(());
+                    return Ok(None);
                 }
             };
             let store = Arc::clone(&connection.connection_store);
@@ -90,7 +91,7 @@ pub(crate) async fn run(
                             })
                             .await
                             .ok();
-                        return Ok(());
+                        return Ok(None);
                     }
                 };
                 let id = profile.id.clone();
@@ -124,7 +125,7 @@ pub(crate) async fn run(
                         None => {}
                     }
                 });
-                return Ok(());
+                return Ok(None);
             }
 
             let id = profile.id.clone();
@@ -144,7 +145,7 @@ pub(crate) async fn run(
                     database,
                 };
                 let probe = Arc::clone(&connection.mysql_connection_probe);
-                tokio::spawn(async move {
+                let task = tokio::spawn(async move {
                     match probe.probe(&target.dsn).await {
                         Ok(()) => {
                             let save_result = tokio::task::spawn_blocking(move || {
@@ -184,7 +185,7 @@ pub(crate) async fn run(
                         }
                     }
                 });
-                return Ok(());
+                return Ok(Some(task));
             }
 
             let provider = Arc::clone(metadata_provider);
@@ -237,13 +238,13 @@ pub(crate) async fn run(
                     }
                 }
             });
-            Ok(())
+            Ok(None)
         }
 
         Effect::ProbeMySqlConnection { target, run_id } => {
             let probe = Arc::clone(&connection.mysql_connection_probe);
             let tx = action_tx.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 match probe.probe(&target.dsn).await {
                     Ok(()) => tx
                         .send(Action::MySqlConnectionProbeCompleted { target, run_id })
@@ -259,7 +260,7 @@ pub(crate) async fn run(
                         .ok(),
                 };
             });
-            Ok(())
+            Ok(Some(task))
         }
 
         Effect::LoadConnectionForEdit { id } => {
@@ -281,7 +282,7 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionEditLoadFailed(e)).ok();
                 }
             });
-            Ok(())
+            Ok(None)
         }
 
         Effect::LoadConnections => {
@@ -310,7 +311,7 @@ pub(crate) async fn run(
                 }))
                 .ok();
             });
-            Ok(())
+            Ok(None)
         }
 
         Effect::DeleteConnection { id } => {
@@ -325,7 +326,7 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionDeleteFailed(e)).ok();
                 }
             });
-            Ok(())
+            Ok(None)
         }
 
         Effect::SwitchConnection { connection_index } => {
@@ -347,7 +348,7 @@ pub(crate) async fn run(
                     .await
                     .ok();
             }
-            Ok(())
+            Ok(None)
         }
 
         Effect::SwitchToService { service_index } => {
@@ -366,7 +367,7 @@ pub(crate) async fn run(
                     .await
                     .ok();
             }
-            Ok(())
+            Ok(None)
         }
 
         _ => unreachable!("connection::run called with non-connection effect"),

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -7,12 +7,12 @@ use std::time::Instant;
 
 use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 
 use crate::cmd::browse as cmd_browse;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::connection as cmd_connection;
+use crate::cmd::connection::MySqlConnectionProbeTaskOwner;
 use crate::cmd::effect::Effect;
 use crate::cmd::er::handler as cmd_er;
 use crate::cmd::metadata_task::MetadataTaskRegistry;
@@ -76,7 +76,7 @@ pub struct EffectRunner {
     query_tasks: QueryTaskRegistry,
     table_detail_tasks: TableDetailTaskRegistry,
     metadata_tasks: Arc<MetadataTaskRegistry>,
-    mysql_connection_probe_task: std::sync::Mutex<Option<JoinHandle<()>>>,
+    mysql_connection_probe_task: MySqlConnectionProbeTaskOwner,
 }
 
 impl EffectRunner {
@@ -102,7 +102,7 @@ impl EffectRunner {
             query_tasks: QueryTaskRegistry::default(),
             table_detail_tasks: TableDetailTaskRegistry::default(),
             metadata_tasks: Arc::new(MetadataTaskRegistry::default()),
-            mysql_connection_probe_task: std::sync::Mutex::new(None),
+            mysql_connection_probe_task: MySqlConnectionProbeTaskOwner::default(),
         }
     }
 
@@ -115,15 +115,7 @@ impl EffectRunner {
     }
 
     async fn cancel_mysql_connection_probe(&self) {
-        let task = self
-            .mysql_connection_probe_task
-            .lock()
-            .expect("MySQL connection probe task lock poisoned")
-            .take();
-        if let Some(task) = task {
-            task.abort();
-            let _ = task.await;
-        }
+        self.mysql_connection_probe_task.cancel().await;
     }
 
     async fn cancel_active_tasks(&self) {
@@ -209,12 +201,6 @@ impl EffectRunner {
             | Effect::SwitchToService { .. }) => {
                 if matches!(
                     &e,
-                    Effect::SaveAndConnect { .. } | Effect::ProbeMySqlConnection { .. }
-                ) {
-                    self.cancel_mysql_connection_probe().await;
-                }
-                if matches!(
-                    &e,
                     Effect::SaveAndConnect { .. }
                         | Effect::ProbeMySqlConnection { .. }
                         | Effect::SwitchConnection { .. }
@@ -225,21 +211,16 @@ impl EffectRunner {
                 if matches!(&e, Effect::ProbeMySqlConnection { .. }) {
                     self.table_detail_tasks.cancel();
                 }
-                let probe_task = cmd_connection::run(
+                cmd_connection::run(
                     e,
                     &self.action_tx,
                     &self.connection,
+                    &self.mysql_connection_probe_task,
                     &self.metadata_provider,
                     &self.metadata_cache,
                     state,
                 )
                 .await?;
-                if let Some(task) = probe_task {
-                    *self
-                        .mysql_connection_probe_task
-                        .lock()
-                        .expect("MySQL connection probe task lock poisoned") = Some(task);
-                }
                 Ok(vec![])
             }
 
@@ -336,19 +317,6 @@ impl EffectRunner {
                 cmd_completion::run(e, &self.action_tx, state, completion_engine).await?;
                 Ok(vec![])
             }
-        }
-    }
-}
-
-impl Drop for EffectRunner {
-    fn drop(&mut self) {
-        if let Some(task) = self
-            .mysql_connection_probe_task
-            .get_mut()
-            .expect("MySQL connection probe task lock poisoned")
-            .take()
-        {
-            task.abort();
         }
     }
 }
@@ -1137,7 +1105,10 @@ mod tests {
         use tokio::time::{Duration, timeout};
 
         use super::*;
-        use crate::domain::connection::{ConnectionId, DatabaseType};
+        use crate::domain::connection::{
+            ConnectionConfig, ConnectionId, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
+        };
+        use crate::model::browse::session::ConnectionSaveGuard;
         use crate::ports::outbound::DbOperationError;
         use crate::update::action::ConnectionTarget;
         use crate::update::reducer::reduce;
@@ -1174,6 +1145,23 @@ mod tests {
                 database_type: DatabaseType::MySQL,
                 database: Some("app".to_string()),
             }
+        }
+
+        fn mysql_config() -> ConnectionConfig {
+            ConnectionConfig::MySQL(MySqlConnectionConfig::new(
+                "localhost",
+                3306,
+                Some("app".to_string()),
+                "user",
+                "secret",
+                MySqlSslMode::Required,
+            ))
+        }
+
+        fn active_run_guard(run_id: u64) -> Arc<ConnectionSaveGuard> {
+            let guard = Arc::new(ConnectionSaveGuard::default());
+            guard.start(run_id);
+            guard
         }
 
         #[tokio::test]
@@ -1215,6 +1203,79 @@ mod tests {
                 started_rx.recv().await.as_deref(),
                 Some("mysql://localhost/old")
             );
+
+            runner
+                .run(
+                    vec![Effect::ProbeMySqlConnection {
+                        target: mysql_target("mysql://localhost/new"),
+                        run_id: 2,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("mysql://localhost/new")
+            );
+
+            runner
+                .run(
+                    vec![Effect::CancelActiveTasks],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(dropped.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn replacing_save_probe_aborts_previous_task_before_new_probe() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let probe = PendingMySqlConnectionProbe {
+                started: started_tx,
+                dropped: Arc::clone(&dropped),
+            };
+            let (action_tx, _action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn_and_probe(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+                Arc::new(test_fixtures::NoopDsnBuilder),
+                Arc::new(probe),
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::SaveAndConnect {
+                        id: None,
+                        name: "old".to_string(),
+                        config: mysql_config(),
+                        run_id: 1,
+                        run_guard: active_run_guard(1),
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(started_rx.recv().await.as_deref(), Some(""));
 
             runner
                 .run(

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::cmd::browse as cmd_browse;
 use crate::cmd::cache::TtlCache;
@@ -75,6 +76,7 @@ pub struct EffectRunner {
     query_tasks: QueryTaskRegistry,
     table_detail_tasks: TableDetailTaskRegistry,
     metadata_tasks: Arc<MetadataTaskRegistry>,
+    mysql_connection_probe_task: std::sync::Mutex<Option<JoinHandle<()>>>,
 }
 
 impl EffectRunner {
@@ -100,6 +102,7 @@ impl EffectRunner {
             query_tasks: QueryTaskRegistry::default(),
             table_detail_tasks: TableDetailTaskRegistry::default(),
             metadata_tasks: Arc::new(MetadataTaskRegistry::default()),
+            mysql_connection_probe_task: std::sync::Mutex::new(None),
         }
     }
 
@@ -111,10 +114,23 @@ impl EffectRunner {
         self.metadata_tasks.cancel().await;
     }
 
+    async fn cancel_mysql_connection_probe(&self) {
+        let task = self
+            .mysql_connection_probe_task
+            .lock()
+            .expect("MySQL connection probe task lock poisoned")
+            .take();
+        if let Some(task) = task {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+
     async fn cancel_active_tasks(&self) {
         self.query_tasks.cancel();
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
+        self.cancel_mysql_connection_probe().await;
     }
 
     pub async fn run<T: Renderer>(
@@ -193,6 +209,12 @@ impl EffectRunner {
             | Effect::SwitchToService { .. }) => {
                 if matches!(
                     &e,
+                    Effect::SaveAndConnect { .. } | Effect::ProbeMySqlConnection { .. }
+                ) {
+                    self.cancel_mysql_connection_probe().await;
+                }
+                if matches!(
+                    &e,
                     Effect::SaveAndConnect { .. }
                         | Effect::ProbeMySqlConnection { .. }
                         | Effect::SwitchConnection { .. }
@@ -203,7 +225,7 @@ impl EffectRunner {
                 if matches!(&e, Effect::ProbeMySqlConnection { .. }) {
                     self.table_detail_tasks.cancel();
                 }
-                cmd_connection::run(
+                let probe_task = cmd_connection::run(
                     e,
                     &self.action_tx,
                     &self.connection,
@@ -212,6 +234,12 @@ impl EffectRunner {
                     state,
                 )
                 .await?;
+                if let Some(task) = probe_task {
+                    *self
+                        .mysql_connection_probe_task
+                        .lock()
+                        .expect("MySQL connection probe task lock poisoned") = Some(task);
+                }
                 Ok(vec![])
             }
 
@@ -308,6 +336,19 @@ impl EffectRunner {
                 cmd_completion::run(e, &self.action_tx, state, completion_engine).await?;
                 Ok(vec![])
             }
+        }
+    }
+}
+
+impl Drop for EffectRunner {
+    fn drop(&mut self) {
+        if let Some(task) = self
+            .mysql_connection_probe_task
+            .get_mut()
+            .expect("MySQL connection probe task lock poisoned")
+            .take()
+        {
+            task.abort();
         }
     }
 }
@@ -1085,6 +1126,188 @@ mod tests {
                     .await
                     .is_err()
             );
+        }
+    }
+
+    mod mysql_connection_probe_lifecycle {
+        use std::future::pending;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use tokio::sync::mpsc::UnboundedSender;
+        use tokio::time::{Duration, timeout};
+
+        use super::*;
+        use crate::domain::connection::{ConnectionId, DatabaseType};
+        use crate::ports::outbound::DbOperationError;
+        use crate::update::action::ConnectionTarget;
+        use crate::update::reducer::reduce;
+
+        struct DropSignal(Arc<AtomicUsize>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        struct PendingMySqlConnectionProbe {
+            started: UnboundedSender<String>,
+            dropped: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl MySqlConnectionProbe for PendingMySqlConnectionProbe {
+            async fn probe(&self, dsn: &str) -> Result<(), DbOperationError> {
+                let _drop_signal = DropSignal(Arc::clone(&self.dropped));
+                self.started
+                    .send(dsn.to_string())
+                    .expect("probe receiver should stay alive");
+                pending().await
+            }
+        }
+
+        fn mysql_target(dsn: &str) -> ConnectionTarget {
+            ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: dsn.to_string(),
+                name: dsn.to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            }
+        }
+
+        #[tokio::test]
+        async fn replacing_probe_aborts_previous_task_before_starting_new_one() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let probe = PendingMySqlConnectionProbe {
+                started: started_tx,
+                dropped: Arc::clone(&dropped),
+            };
+            let (action_tx, _action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn_and_probe(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+                Arc::new(test_fixtures::NoopDsnBuilder),
+                Arc::new(probe),
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::ProbeMySqlConnection {
+                        target: mysql_target("mysql://localhost/old"),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("mysql://localhost/old")
+            );
+
+            runner
+                .run(
+                    vec![Effect::ProbeMySqlConnection {
+                        target: mysql_target("mysql://localhost/new"),
+                        run_id: 2,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("mysql://localhost/new")
+            );
+
+            runner
+                .run(
+                    vec![Effect::CancelActiveTasks],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(dropped.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn quitting_aborts_pending_mysql_probe_task() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let probe = PendingMySqlConnectionProbe {
+                started: started_tx,
+                dropped: Arc::clone(&dropped),
+            };
+            let (action_tx, _action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn_and_probe(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+                Arc::new(test_fixtures::NoopDsnBuilder),
+                Arc::new(probe),
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::ProbeMySqlConnection {
+                        target: mysql_target("mysql://localhost/pending"),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            timeout(Duration::from_secs(1), started_rx.recv())
+                .await
+                .expect("pending probe should start")
+                .expect("probe start signal should be sent");
+
+            let shutdown_effects = reduce(
+                &mut state,
+                Action::Quit,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.should_quit);
+            runner
+                .run(
+                    shutdown_effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
         }
     }
 }


### PR DESCRIPTION
## Problem
MySQL connection probes started during connection changes were detached, so stale CLI processes and sockets remained until their timeout.

## Background
Session-side run checks discard stale probe completions, but they do not stop the underlying probe task.

## Approach
The effect runner owns one MySQL connection-probe task, aborts and awaits it before replacement or active-task shutdown, and keeps the existing stale completion checks and `kill_on_drop` process boundary.

## Linear Issue Link (optional)
- Implements https://linear.app/sabiql/issue/SAB-468