### PR TITLE
fix(mysql): preserve adhoc session state across statements (SAB-533)

### DIFF
--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -64,6 +64,10 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
                 if tokens.is_empty() && executable_statement && !contains_statement_separator {
                     tokens.extend(inner);
                     leading_executable_version_comment = true;
+                } else if is_safe_select_modifier_comment(&tokens, &inner)
+                    && !contains_statement_separator
+                {
+                    tokens.extend(inner);
                 } else if trailing_ddl_clause && !executable_statement {
                     // MySQL uses trailing executable comments for versioned DDL clauses such
                     // as DEFAULT CHARSET. Keep the clause out of statement classification.
@@ -311,6 +315,36 @@ fn is_safe_trailing_ddl_clause(tokens: &[Token], inner: &[Token]) -> bool {
         && !inner.iter().any(|token| {
             matches!(&token.kind, TokenKind::Word(word) if is_mysql_statement_keyword(word))
         })
+}
+
+fn is_safe_select_modifier_comment(tokens: &[Token], inner: &[Token]) -> bool {
+    let is_modifier = |token: &Token| {
+        matches!(
+            &token.kind,
+            TokenKind::Word(word)
+                if matches!(
+                    word.as_str(),
+                    "ALL"
+                        | "DISTINCT"
+                        | "DISTINCTROW"
+                        | "HIGH_PRIORITY"
+                        | "STRAIGHT_JOIN"
+                        | "SQL_SMALL_RESULT"
+                        | "SQL_BIG_RESULT"
+                        | "SQL_BUFFER_RESULT"
+                        | "SQL_NO_CACHE"
+                        | "SQL_CALC_FOUND_ROWS"
+                )
+        )
+    };
+    matches!(
+        tokens.first().and_then(|token| match &token.kind {
+            TokenKind::Word(word) => Some(word.as_str()),
+            _ => None,
+        }),
+        Some("SELECT")
+    ) && !inner.is_empty()
+        && tokens.iter().skip(1).chain(inner).all(is_modifier)
 }
 
 fn mysql_version_comment_content(body: &str) -> Result<Option<&str>, MySqlLexError> {

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -670,6 +670,16 @@ mod tests {
     }
 
     #[test]
+    fn accepts_sql_calc_found_rows_in_an_executable_select_modifier_comment() {
+        assert!(
+            classify_mysql_statement(
+                "SELECT /*!80000 SQL_CALC_FOUND_ROWS */ first_key FROM items WHERE FALSE"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
     fn rejects_multiple_drop_targets_and_ambiguous_ddl_quotes() {
         assert!(classify_mysql_statement("DROP TABLE app.keep, other.drop_me").is_err());
         assert!(classify_mysql_statement("DROP VIEW app.keep, other.drop_me").is_err());

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -118,6 +118,10 @@ pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLexError>
     side_effect::has_mysql_read_only_side_effect(sql)
 }
 
+pub fn mysql_statement_reads_session_diagnostics(sql: &str) -> Result<bool, MySqlLexError> {
+    side_effect::mysql_statement_reads_session_diagnostics(sql)
+}
+
 pub fn target_is_selected_database(
     statement: &MySqlStatement,
     selected_database: Option<&str>,

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -46,7 +46,7 @@ pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLe
 
 pub(super) fn mysql_statement_reads_session_diagnostics(sql: &str) -> Result<bool, MySqlLexError> {
     let tokens = lexer::lex_mysql_statement(sql)?;
-    Ok(tokens.windows(2).any(|window| {
+    if tokens.windows(2).any(|window| {
         let (TokenKind::Word(function) | TokenKind::Identifier(function)) = &window[0].kind else {
             return false;
         };
@@ -54,6 +54,29 @@ pub(super) fn mysql_statement_reads_session_diagnostics(sql: &str) -> Result<boo
             && ["FOUND_ROWS", "ROW_COUNT", "LAST_INSERT_ID"]
                 .iter()
                 .any(|name| function.eq_ignore_ascii_case(name))
+    }) {
+        return Ok(true);
+    }
+    Ok((0..tokens.len().saturating_sub(2)).any(|index| {
+        if !matches!(tokens[index].kind, TokenKind::Symbol('@'))
+            || !matches!(tokens[index + 1].kind, TokenKind::Symbol('@'))
+        {
+            return false;
+        }
+        let name_index = if matches!(
+            tokens.get(index + 3).map(|token| &token.kind),
+            Some(TokenKind::Symbol('.'))
+        ) {
+            index + 4
+        } else {
+            index + 2
+        };
+        tokens.get(name_index).is_some_and(|token| {
+            matches!(&token.kind, TokenKind::Word(name) | TokenKind::Identifier(name)
+                if ["WARNING_COUNT", "ERROR_COUNT"]
+                    .iter()
+                    .any(|diagnostic| name.eq_ignore_ascii_case(diagnostic)))
+        })
     }))
 }
 
@@ -279,6 +302,15 @@ mod tests {
         for function in ["FOUND_ROWS", "ROW_COUNT", "LAST_INSERT_ID"] {
             assert!(
                 mysql_statement_reads_session_diagnostics(&format!("SELECT {function}()")).unwrap()
+            );
+        }
+        for variable in ["warning_count", "error_count"] {
+            assert!(
+                mysql_statement_reads_session_diagnostics(&format!("SELECT @@{variable}")).unwrap()
+            );
+            assert!(
+                mysql_statement_reads_session_diagnostics(&format!("SELECT @@SESSION.{variable}"))
+                    .unwrap()
             );
         }
         assert!(!mysql_statement_reads_session_diagnostics("SELECT 'FOUND_ROWS()'").unwrap());

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -44,6 +44,19 @@ pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLe
     Ok(false)
 }
 
+pub(super) fn mysql_statement_reads_session_diagnostics(sql: &str) -> Result<bool, MySqlLexError> {
+    let tokens = lexer::lex_mysql_statement(sql)?;
+    Ok(tokens.windows(2).any(|window| {
+        let (TokenKind::Word(function) | TokenKind::Identifier(function)) = &window[0].kind else {
+            return false;
+        };
+        matches!(window[1].kind, TokenKind::Symbol('('))
+            && ["FOUND_ROWS", "ROW_COUNT", "LAST_INSERT_ID"]
+                .iter()
+                .any(|name| function.eq_ignore_ascii_case(name))
+    }))
+}
+
 fn has_mysql_read_only_side_effect_function(tokens: &[lexer::Token], index: usize) -> bool {
     let Some(word) = tokens.get(index).and_then(|token| match &token.kind {
         TokenKind::Word(word) | TokenKind::Identifier(word) => Some(word.as_str()),
@@ -259,5 +272,15 @@ mod tests {
     fn rejects_mixed_case_quoted_last_insert_id_with_an_argument() {
         assert!(has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`(42)").unwrap());
         assert!(!has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`()").unwrap());
+    }
+
+    #[test]
+    fn detects_mysql_session_diagnostic_reads() {
+        for function in ["FOUND_ROWS", "ROW_COUNT", "LAST_INSERT_ID"] {
+            assert!(
+                mysql_statement_reads_session_diagnostics(&format!("SELECT {function}()")).unwrap()
+            );
+        }
+        assert!(!mysql_statement_reads_session_diagnostics("SELECT 'FOUND_ROWS()'").unwrap());
     }
 }

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -132,7 +132,8 @@ pub(super) fn mysql_metadata_select_query(
             "MySQL empty SELECT cannot be used for metadata fallback".to_string(),
         ));
     }
-    if has_mysql_read_only_side_effect(query)
+    let query = strip_mysql_sql_calc_found_rows(query);
+    if has_mysql_read_only_side_effect(&query)
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
     {
         return Err(DbOperationError::UnsupportedOperation(
@@ -140,7 +141,6 @@ pub(super) fn mysql_metadata_select_query(
                 .to_string(),
         ));
     }
-    let query = strip_mysql_sql_calc_found_rows(query);
     Ok(sql::build_metadata_select_query(
         &query,
         source_alias,
@@ -173,6 +173,73 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
                 .iter()
                 .any(|modifier| &uppercase[start..end] == *modifier)
         })
+    }
+
+    fn executable_comment_modifier(
+        bytes: &[u8],
+        uppercase: &[u8],
+        start: usize,
+        end: usize,
+        outer_last_word: Option<(usize, usize)>,
+    ) -> Option<(usize, usize)> {
+        let mut index = start;
+        let mut last_word = outer_last_word;
+        let mut at_version_prefix = true;
+        let mut quote = None;
+        while index < end {
+            let byte = bytes[index];
+            if let Some(delimiter) = quote {
+                if byte == b'\\' {
+                    index = (index + 2).min(end);
+                    continue;
+                }
+                if byte == delimiter {
+                    if bytes.get(index + 1) == Some(&delimiter) {
+                        index += 2;
+                        continue;
+                    }
+                    quote = None;
+                }
+                index += 1;
+                continue;
+            }
+            if matches!(byte, b'\'' | b'"' | b'`') {
+                quote = Some(byte);
+                last_word = None;
+                at_version_prefix = false;
+                index += 1;
+                continue;
+            }
+            if byte.is_ascii_whitespace() {
+                index += 1;
+                continue;
+            }
+            if is_identifier_byte(byte) {
+                let word_start = index;
+                index += 1;
+                while index < end && is_identifier_byte(bytes[index]) {
+                    index += 1;
+                }
+                if index - word_start == MODIFIER.len()
+                    && &uppercase[word_start..index] == MODIFIER
+                    && is_select_modifier_prefix(uppercase, last_word)
+                    && bytes.get(index) != Some(&b'.')
+                {
+                    return Some((word_start, index));
+                }
+                let is_version =
+                    at_version_prefix && bytes[word_start..index].iter().all(u8::is_ascii_digit);
+                if !is_version {
+                    last_word = Some((word_start, index));
+                    at_version_prefix = false;
+                }
+                continue;
+            }
+            last_word = None;
+            at_version_prefix = false;
+            index += 1;
+        }
+        None
     }
 
     let bytes = query.as_bytes();
@@ -220,10 +287,37 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
             continue;
         }
         if bytes[index..].starts_with(b"/*") {
-            index = bytes[index + 2..]
+            let Some(comment_offset) = bytes[index + 2..]
                 .windows(2)
                 .position(|window| window == b"*/")
-                .map_or(bytes.len(), |offset| index + offset + 4);
+            else {
+                break;
+            };
+            let comment_end = index + 2 + comment_offset;
+            if bytes[index..].starts_with(b"/*!")
+                && let Some((start, end)) = executable_comment_modifier(
+                    bytes,
+                    &uppercase,
+                    index + 3,
+                    comment_end,
+                    last_word,
+                )
+            {
+                let only_versioned_modifier = bytes[index + 3..start]
+                    .iter()
+                    .chain(bytes[end..comment_end].iter())
+                    .all(|byte| byte.is_ascii_whitespace() || byte.is_ascii_digit());
+                let mut result = String::with_capacity(query.len() - MODIFIER.len());
+                if only_versioned_modifier {
+                    result.push_str(&query[..index]);
+                    result.push_str(&query[comment_end + 2..]);
+                } else {
+                    result.push_str(&query[..start]);
+                    result.push_str(&query[end..]);
+                }
+                return result;
+            }
+            index = comment_end + 2;
             continue;
         }
         if is_identifier_byte(byte) {
@@ -543,6 +637,18 @@ mod tests {
                 mysql_metadata_select_query(query, "__source", "__marker").unwrap();
             assert!(fallback_query.contains(query), "{query}");
         }
+    }
+
+    #[test]
+    fn metadata_fallback_removes_sql_calc_found_rows_from_executable_comments() {
+        let fallback_query = mysql_metadata_select_query(
+            "SELECT /*!80000 SQL_CALC_FOUND_ROWS */ first_key FROM items WHERE FALSE",
+            "__source",
+            "__marker",
+        )
+        .unwrap();
+
+        assert!(!fallback_query.contains("SQL_CALC_FOUND_ROWS"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -30,12 +30,6 @@ pub(in crate::adapters::mysql) struct MySqlExecutionResult {
     pub(in crate::adapters::mysql) refresh_scope: RefreshScope,
 }
 
-pub(super) struct MySqlCommandEvent {
-    pub(super) kind: MySqlStatementKind,
-    pub(super) target: Option<String>,
-    pub(super) tag: CommandTag,
-}
-
 pub(in crate::adapters::mysql) fn validate_mysql_multi_query(
     query: &str,
     selected_database: Option<&str>,
@@ -288,98 +282,6 @@ pub(super) fn mysql_refresh_scope(kind: &MySqlStatementKind) -> RefreshScope {
     } else {
         RefreshScope::None
     }
-}
-
-#[derive(Default)]
-struct MySqlPendingTransactionTags {
-    data: Vec<CommandTag>,
-    savepoints: Vec<(String, usize)>,
-}
-
-fn apply_pending_mysql_data(
-    pending: MySqlPendingTransactionTags,
-    committed_data: &mut Option<CommandTag>,
-) {
-    if let Some(tag) = pending.data.last() {
-        *committed_data = Some(tag.clone());
-    }
-}
-
-pub(super) fn aggregate_mysql_command_tag(events: &[MySqlCommandEvent]) -> Option<CommandTag> {
-    let mut committed_schema = None;
-    let mut committed_data = None;
-    let mut pending = None;
-    let mut last_tag = None;
-
-    for event in events {
-        last_tag = Some(event.tag.clone());
-        match &event.kind {
-            MySqlStatementKind::Begin | MySqlStatementKind::StartTransaction => {
-                pending = Some(MySqlPendingTransactionTags::default());
-            }
-            MySqlStatementKind::Commit => {
-                if let Some(transaction) = pending.take() {
-                    apply_pending_mysql_data(transaction, &mut committed_data);
-                }
-            }
-            MySqlStatementKind::Rollback => {
-                pending = None;
-            }
-            MySqlStatementKind::Savepoint => {
-                if let Some(transaction) = pending.as_mut()
-                    && let Some(name) = event.target.as_deref()
-                {
-                    transaction
-                        .savepoints
-                        .retain(|(current, _)| !current.eq_ignore_ascii_case(name));
-                    transaction
-                        .savepoints
-                        .push((name.to_string(), transaction.data.len()));
-                }
-            }
-            MySqlStatementKind::RollbackToSavepoint => {
-                if let Some(transaction) = pending.as_mut()
-                    && let Some(name) = event.target.as_deref()
-                    && let Some(index) = transaction
-                        .savepoints
-                        .iter()
-                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
-                {
-                    transaction.data.truncate(transaction.savepoints[index].1);
-                    transaction.savepoints.truncate(index + 1);
-                }
-            }
-            MySqlStatementKind::ReleaseSavepoint => {
-                if let Some(transaction) = pending.as_mut()
-                    && let Some(name) = event.target.as_deref()
-                    && let Some(index) = transaction
-                        .savepoints
-                        .iter()
-                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
-                {
-                    transaction.savepoints.remove(index);
-                }
-            }
-            MySqlStatementKind::CreateTable { temporary: true }
-            | MySqlStatementKind::DropTable { temporary: true } => {}
-            kind if mysql_statement_is_persistent_schema_change(kind) => {
-                if let Some(transaction) = pending.take() {
-                    apply_pending_mysql_data(transaction, &mut committed_data);
-                }
-                committed_schema = Some(event.tag.clone());
-            }
-            kind if mysql_statement_is_data_modifying(kind) => {
-                if let Some(transaction) = pending.as_mut() {
-                    transaction.data.push(event.tag.clone());
-                } else {
-                    committed_data = Some(event.tag.clone());
-                }
-            }
-            _ => {}
-        }
-    }
-
-    committed_schema.or(committed_data).or(last_tag)
 }
 
 #[cfg(test)]
@@ -692,67 +594,5 @@ mod tests {
                 CommandTag::Insert(1)
             );
         }
-    }
-
-    #[test]
-    fn transaction_rollback_removes_pending_data_tag() {
-        let events = vec![
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Begin,
-                target: None,
-                tag: CommandTag::Begin,
-            },
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Update { has_where: true },
-                target: Some("items".to_string()),
-                tag: CommandTag::Update(1),
-            },
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Rollback,
-                target: None,
-                tag: CommandTag::Rollback,
-            },
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Select,
-                target: None,
-                tag: CommandTag::Select(1),
-            },
-        ];
-
-        assert_eq!(
-            aggregate_mysql_command_tag(&events),
-            Some(CommandTag::Select(1))
-        );
-    }
-
-    #[test]
-    fn ddl_implicit_commit_keeps_prior_data_change() {
-        let events = vec![
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Begin,
-                target: None,
-                tag: CommandTag::Begin,
-            },
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Insert,
-                target: Some("items".to_string()),
-                tag: CommandTag::Insert(1),
-            },
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::CreateTable { temporary: false },
-                target: Some("created".to_string()),
-                tag: CommandTag::Create("TABLE".to_string()),
-            },
-            MySqlCommandEvent {
-                kind: MySqlStatementKind::Rollback,
-                target: None,
-                tag: CommandTag::Rollback,
-            },
-        ];
-
-        assert_eq!(
-            aggregate_mysql_command_tag(&events),
-            Some(CommandTag::Create("TABLE".to_string()))
-        );
     }
 }

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -150,14 +150,35 @@ pub(super) fn mysql_metadata_select_query(
 
 fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
     const MODIFIER: &[u8] = b"SQL_CALC_FOUND_ROWS";
+    const SELECT_MODIFIERS: &[&[u8]] = &[
+        b"SELECT",
+        b"ALL",
+        b"DISTINCT",
+        b"DISTINCTROW",
+        b"HIGH_PRIORITY",
+        b"STRAIGHT_JOIN",
+        b"SQL_SMALL_RESULT",
+        b"SQL_BIG_RESULT",
+        b"SQL_BUFFER_RESULT",
+        b"SQL_NO_CACHE",
+    ];
 
     fn is_identifier_byte(byte: u8) -> bool {
         byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$') || byte >= 0x80
     }
 
+    fn is_select_modifier_prefix(uppercase: &[u8], last_word: Option<(usize, usize)>) -> bool {
+        last_word.is_some_and(|(start, end)| {
+            SELECT_MODIFIERS
+                .iter()
+                .any(|modifier| &uppercase[start..end] == *modifier)
+        })
+    }
+
     let bytes = query.as_bytes();
     let uppercase = bytes.to_ascii_uppercase();
     let mut quote = None;
+    let mut last_word = None;
     let mut index = 0;
     while index < bytes.len() {
         let byte = bytes[index];
@@ -178,6 +199,7 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
         }
         if matches!(byte, b'\'' | b'"' | b'`') {
             quote = Some(byte);
+            last_word = None;
             index += 1;
             continue;
         }
@@ -204,16 +226,27 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
                 .map_or(bytes.len(), |offset| index + offset + 4);
             continue;
         }
-        if index + MODIFIER.len() <= bytes.len()
-            && &uppercase[index..index + MODIFIER.len()] == MODIFIER
-            && (index == 0 || !is_identifier_byte(bytes[index - 1]))
-            && (index + MODIFIER.len() == bytes.len()
-                || !is_identifier_byte(bytes[index + MODIFIER.len()]))
-        {
-            let mut result = String::with_capacity(query.len() - MODIFIER.len());
-            result.push_str(&query[..index]);
-            result.push_str(&query[index + MODIFIER.len()..]);
-            return result;
+        if is_identifier_byte(byte) {
+            let start = index;
+            index += 1;
+            while index < bytes.len() && is_identifier_byte(bytes[index]) {
+                index += 1;
+            }
+            if index - start == MODIFIER.len()
+                && &uppercase[start..index] == MODIFIER
+                && is_select_modifier_prefix(&uppercase, last_word)
+                && bytes.get(index) != Some(&b'.')
+            {
+                let mut result = String::with_capacity(query.len() - MODIFIER.len());
+                result.push_str(&query[..start]);
+                result.push_str(&query[index..]);
+                return result;
+            }
+            last_word = Some((start, index));
+            continue;
+        }
+        if !byte.is_ascii_whitespace() {
+            last_word = None;
         }
         index += 1;
     }
@@ -502,6 +535,7 @@ mod tests {
     fn metadata_fallback_keeps_sql_calc_found_rows_identifiers_and_comments() {
         for query in [
             "SELECT $SQL_CALC_FOUND_ROWS FROM items WHERE FALSE",
+            "SELECT t.SQL_CALC_FOUND_ROWS FROM items AS t WHERE FALSE",
             "SELECT /* SQL_CALC_FOUND_ROWS */ value FROM items WHERE FALSE",
             "SELECT 'SQL_CALC_FOUND_ROWS' AS value WHERE FALSE",
         ] {

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -152,7 +152,7 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
     const MODIFIER: &[u8] = b"SQL_CALC_FOUND_ROWS";
 
     fn is_identifier_byte(byte: u8) -> bool {
-        byte.is_ascii_alphanumeric() || byte == b'_'
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$') || byte >= 0x80
     }
 
     let bytes = query.as_bytes();
@@ -179,6 +179,29 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
         if matches!(byte, b'\'' | b'"' | b'`') {
             quote = Some(byte);
             index += 1;
+            continue;
+        }
+        if byte == b'#' {
+            index = bytes[index..]
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(bytes.len(), |offset| index + offset + 1);
+            continue;
+        }
+        if bytes[index..].starts_with(b"--")
+            && bytes.get(index + 2).is_none_or(u8::is_ascii_whitespace)
+        {
+            index = bytes[index..]
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(bytes.len(), |offset| index + offset + 1);
+            continue;
+        }
+        if bytes[index..].starts_with(b"/*") {
+            index = bytes[index + 2..]
+                .windows(2)
+                .position(|window| window == b"*/")
+                .map_or(bytes.len(), |offset| index + offset + 4);
             continue;
         }
         if index + MODIFIER.len() <= bytes.len()
@@ -473,6 +496,19 @@ mod tests {
 
         assert!(!fallback_query.contains("SQL_CALC_FOUND_ROWS"));
         assert!(fallback_query.contains("SELECT  first_key FROM items WHERE FALSE"));
+    }
+
+    #[test]
+    fn metadata_fallback_keeps_sql_calc_found_rows_identifiers_and_comments() {
+        for query in [
+            "SELECT $SQL_CALC_FOUND_ROWS FROM items WHERE FALSE",
+            "SELECT /* SQL_CALC_FOUND_ROWS */ value FROM items WHERE FALSE",
+            "SELECT 'SQL_CALC_FOUND_ROWS' AS value WHERE FALSE",
+        ] {
+            let fallback_query =
+                mysql_metadata_select_query(query, "__source", "__marker").unwrap();
+            assert!(fallback_query.contains(query), "{query}");
+        }
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -310,6 +310,7 @@ fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
                 let mut result = String::with_capacity(query.len() - MODIFIER.len());
                 if only_versioned_modifier {
                     result.push_str(&query[..index]);
+                    result.push(' ');
                     result.push_str(&query[comment_end + 2..]);
                 } else {
                     result.push_str(&query[..start]);
@@ -649,6 +650,14 @@ mod tests {
         .unwrap();
 
         assert!(!fallback_query.contains("SQL_CALC_FOUND_ROWS"));
+
+        let no_space_fallback_query = mysql_metadata_select_query(
+            "SELECT/*!80000 SQL_CALC_FOUND_ROWS */first_key FROM items WHERE FALSE",
+            "__source",
+            "__marker",
+        )
+        .unwrap();
+        assert!(no_space_fallback_query.contains("SELECT first_key FROM items WHERE FALSE"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -140,11 +140,61 @@ pub(super) fn mysql_metadata_select_query(
                 .to_string(),
         ));
     }
+    let query = strip_mysql_sql_calc_found_rows(query);
     Ok(sql::build_metadata_select_query(
-        query,
+        &query,
         source_alias,
         marker_alias,
     ))
+}
+
+fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
+    const MODIFIER: &[u8] = b"SQL_CALC_FOUND_ROWS";
+
+    fn is_identifier_byte(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric() || byte == b'_'
+    }
+
+    let bytes = query.as_bytes();
+    let uppercase = bytes.to_ascii_uppercase();
+    let mut quote = None;
+    let mut index = 0;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(delimiter) = quote {
+            if byte == b'\\' {
+                index = (index + 2).min(bytes.len());
+                continue;
+            }
+            if byte == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                    continue;
+                }
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+        if matches!(byte, b'\'' | b'"' | b'`') {
+            quote = Some(byte);
+            index += 1;
+            continue;
+        }
+        if index + MODIFIER.len() <= bytes.len()
+            && &uppercase[index..index + MODIFIER.len()] == MODIFIER
+            && (index == 0 || !is_identifier_byte(bytes[index - 1]))
+            && (index + MODIFIER.len() == bytes.len()
+                || !is_identifier_byte(bytes[index + MODIFIER.len()]))
+        {
+            let mut result = String::with_capacity(query.len() - MODIFIER.len());
+            result.push_str(&query[..index]);
+            result.push_str(&query[index + MODIFIER.len()..]);
+            return result;
+        }
+        index += 1;
+    }
+    query.to_string()
 }
 
 pub(super) fn validate_mysql_session_marker(
@@ -410,6 +460,19 @@ mod tests {
             )
         );
         assert_eq!(fallback_query.matches("SELECT SLEEP(10)").count(), 1);
+    }
+
+    #[test]
+    fn metadata_fallback_removes_sql_calc_found_rows_from_the_source_query() {
+        let fallback_query = mysql_metadata_select_query(
+            "SELECT SQL_CALC_FOUND_ROWS first_key FROM items WHERE FALSE",
+            "__source",
+            "__marker",
+        )
+        .unwrap();
+
+        assert!(!fallback_query.contains("SQL_CALC_FOUND_ROWS"));
+        assert!(fallback_query.contains("SELECT  first_key FROM items WHERE FALSE"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -684,13 +684,8 @@ exit 0
         let option_file = directory.path().join("option.cnf");
         fs::write(&option_file, "[client]\n").unwrap();
         let program = directory.path().join("mysql");
-        let update_response = statement_error.map_or_else(
-            || {
-                "printf '%s\\n' '<resultset><row><field name=\"affected\">ok</field></row></resultset>'"
-                    .to_string()
-            },
-            |error| format!("printf '%s\\n' '{error}' >&2"),
-        );
+        let update_response = statement_error
+            .map_or_else(String::new, |error| format!("printf '%s\\n' '{error}' >&2"));
         let tail = if tail_error {
             "printf '%s\\n' input_closed >> \"$log\"\nprintf '%s\\n' 'ERROR 1054 (42S02): tail error' >&2\n  exit 1"
         } else {
@@ -706,14 +701,14 @@ exit 0
                 .to_string()
         } else {
             format!("marker=$(printf '%s\\n' \"$line\" | sed \"s/.*SELECT '\\\\([^']*\\\\)' AS __sabiql_marker.*/\\\\1/\")
-      rows=0
-      case \"$line\" in *ROW_COUNT\\(\\)* ) rows=3 ;; esac
-      printf '%s\\n' '<resultset><row><field name=\"__sabiql_marker\">'\"$marker\"'</field><field name=\"affected_rows\">'\"$rows\"'</field></row></resultset>'
-      if [ \"$pending_error\" = 1 ]; then
-        sleep 0.05
-        printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
-        pending_error=0
-      fi
+      case \"$line\" in
+        *ROW_COUNT\\(\\)*)
+          printf '%s\\n' '<resultset><row><field name=\"__sabiql_marker\">'\"$marker\"'</field><field name=\"affected_rows\">3</field></row></resultset>'
+          ;;
+        *)
+          printf '%s\\n' '<resultset><row><field name=\"__sabiql_marker\">'\"$marker\"'</field></row></resultset>'
+          ;;
+      esac
       {tail_after_create}")
         };
         let script = format!(
@@ -721,7 +716,6 @@ exit 0
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 printf 'process=%s\n' "$$" >> "$log"
-pending_error=0
 last_statement=none
 eof=$(printf '\004')
 while IFS= read -r line; do
@@ -750,7 +744,8 @@ while IFS= read -r line; do
       printf '%s\n' '<resultset></resultset>'
       ;;
     *missing_column*)
-      pending_error=1
+      printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
+      exit 1
       ;;
     *SELECT*)
       case "$line" in
@@ -770,7 +765,6 @@ while IFS= read -r line; do
       ;;
     *CREATE*)
       last_statement=create
-      printf '%s\n' '<resultset><row><field name="affected">ok</field></row></resultset>'
       ;;
     *)
       printf '%s\n' '<resultset></resultset>'
@@ -1373,11 +1367,38 @@ done
                     values: vec![vec![QueryValue::Text("two".to_string())]],
                 })
             );
-            assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
+            assert_eq!(result.command_tag, None);
             assert_eq!(result.refresh_scope, RefreshScope::Data);
             let log = fs::read_to_string(log_file).unwrap();
             assert!(log.contains("UPDATE items SET value = 1"));
-            assert!(log.matches("__sabiql_marker").count() >= 2);
+            assert_eq!(log.matches("__sabiql_marker").count(), 1);
+            assert!(!log.contains("ROW_COUNT()"));
+        }
+
+        #[tokio::test]
+        async fn single_dml_uses_the_submission_terminal_row_count() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements("UPDATE items SET value = 1")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("single DML execution");
+
+            assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert_eq!(log.matches("__sabiql_marker").count(), 1);
+            assert!(log.contains("ROW_COUNT()"));
         }
 
         #[tokio::test]
@@ -1522,7 +1543,7 @@ done
         }
 
         #[tokio::test]
-        async fn rejects_error_reported_after_row_count_marker() {
+        async fn rejects_error_reported_without_a_statement_marker() {
             let (_directory, program, option_file) = fake_mysql_multi();
             let statements = split_mysql_statements("SELECT missing_column FROM items")
                 .unwrap()

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -763,6 +763,9 @@ while IFS= read -r line; do
       last_statement=update
       {update_response}
       ;;
+    *"SHOW CREATE TABLE"*)
+      printf '%s\n' '<resultset><row><field name="Create Table">CREATE TABLE items (id INT)</field></row></resultset>'
+      ;;
     *CREATE*)
       last_statement=create
       ;;

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -108,6 +108,7 @@ async fn run_mysql_statement(
     statement: &MySqlStatement,
     access_mode: AccessMode,
     expected_columns: Option<&[&str]>,
+    defer_empty_result_metadata: bool,
     refresh_scope: RefreshScope,
 ) -> Result<MySqlStatementExecution, DbOperationError> {
     let statement_scope = mysql_refresh_scope(statement.kind());
@@ -115,13 +116,7 @@ async fn run_mysql_statement(
     if let Err(error) = write_mysql_statement(process, statement.sql()).await {
         return Err(query_failed_after_change(error, refresh_scope));
     }
-    if !matches!(
-        statement.kind(),
-        MySqlStatementKind::Select
-            | MySqlStatementKind::Table
-            | MySqlStatementKind::Show
-            | MySqlStatementKind::Describe
-    ) {
+    if !mysql_statement_returns_resultset(statement.kind()) {
         return Ok(MySqlStatementExecution {
             result_set: None,
             refresh_scope: possible_refresh_scope,
@@ -141,22 +136,37 @@ async fn run_mysql_statement(
         Ok(result) => result,
         Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
     };
-    let user_result = fill_mysql_empty_result_columns(
-        process,
-        result,
-        option_file,
-        statement.sql(),
-        statement.kind(),
-        access_mode,
-        expected_columns,
-    )
-    .await
-    .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
+
+    let result = if defer_empty_result_metadata {
+        result
+    } else {
+        fill_mysql_empty_result_columns(
+            process,
+            result,
+            option_file,
+            statement.sql(),
+            statement.kind(),
+            access_mode,
+            expected_columns,
+        )
+        .await
+        .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?
+    };
 
     Ok(MySqlStatementExecution {
-        result_set: Some(user_result),
+        result_set: Some(result),
         refresh_scope: possible_refresh_scope,
     })
+}
+
+fn mysql_statement_returns_resultset(kind: &MySqlStatementKind) -> bool {
+    matches!(
+        kind,
+        MySqlStatementKind::Select
+            | MySqlStatementKind::Table
+            | MySqlStatementKind::Show
+            | MySqlStatementKind::Describe
+    )
 }
 
 async fn run_mysql_adhoc_process(
@@ -183,14 +193,18 @@ async fn run_mysql_adhoc_process(
         .then_some(expected_columns)
         .flatten();
 
-    for statement in statements {
+    for (index, statement) in statements.iter().enumerate() {
         refresh_scope_before_last_statement = refresh_scope;
+        let defer_empty_result_metadata = statements[index + 1..]
+            .iter()
+            .any(|statement| mysql_statement_returns_resultset(statement.kind()));
         let execution = run_mysql_statement(
             process,
             option_file,
             statement,
             access_mode,
             expected_columns,
+            defer_empty_result_metadata,
             refresh_scope,
         )
         .await?;

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -7,15 +7,14 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{
     RefreshScope,
-    mysql_sql::{MySqlStatement, MySqlStatementKind},
+    mysql_sql::{MySqlStatement, MySqlStatementKind, mysql_statement_is_data_modifying},
 };
 
 use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
 use super::super::policy::{
-    MySqlCommandEvent, MySqlExecutionResult, aggregate_mysql_command_tag,
-    is_mysql_row_count_marker, mysql_command_tag,
-    mysql_metadata_fallback_has_unsupported_session_state, mysql_refresh_scope,
-    mysql_row_count_marker, query_failed_after_change, query_failed_after_mysql_statement,
+    MySqlExecutionResult, mysql_command_tag, mysql_metadata_fallback_has_unsupported_session_state,
+    mysql_refresh_scope, mysql_row_count_marker, query_failed_after_change,
+    query_failed_after_mysql_statement,
 };
 use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns;
@@ -70,7 +69,6 @@ pub(super) async fn run_mysql_adhoc_with_program_and_statements_and_expected_col
 
 struct MySqlStatementExecution {
     result_set: Option<MySqlResultSet>,
-    command_event: MySqlCommandEvent,
     refresh_scope: RefreshScope,
 }
 
@@ -112,18 +110,24 @@ async fn run_mysql_statement(
     expected_columns: Option<&[&str]>,
     refresh_scope: RefreshScope,
 ) -> Result<MySqlStatementExecution, DbOperationError> {
-    let marker = Uuid::new_v4().simple().to_string();
     let statement_scope = mysql_refresh_scope(statement.kind());
     let possible_refresh_scope = refresh_scope.merge(statement_scope);
     if let Err(error) = write_mysql_statement(process, statement.sql()).await {
         return Err(query_failed_after_change(error, refresh_scope));
     }
-    let marker_query =
-        format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
-    if let Err(error) = write_mysql_statement(process, &marker_query).await {
-        return Err(query_failed_after_change(error, possible_refresh_scope));
+    if !matches!(
+        statement.kind(),
+        MySqlStatementKind::Select
+            | MySqlStatementKind::Table
+            | MySqlStatementKind::Show
+            | MySqlStatementKind::Describe
+    ) {
+        return Ok(MySqlStatementExecution {
+            result_set: None,
+            refresh_scope: possible_refresh_scope,
+        });
     }
-    let first_xml = match read_one_mysql_resultset(process).await {
+    let xml = match read_one_mysql_resultset(process).await {
         Ok(xml) => xml,
         Err(error) => {
             return Err(query_failed_after_mysql_statement(
@@ -133,53 +137,24 @@ async fn run_mysql_statement(
             ));
         }
     };
-    let first_result = match super::parse_mysql_xml(&first_xml) {
+    let result = match super::parse_mysql_xml(&xml) {
         Ok(result) => result,
         Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
     };
-    let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
-        (None, first_result)
-    } else {
-        let xml = match read_one_mysql_resultset(process).await {
-            Ok(xml) => xml,
-            Err(error) => {
-                return Err(query_failed_after_mysql_statement(
-                    error,
-                    refresh_scope,
-                    possible_refresh_scope,
-                ));
-            }
-        };
-        let marker_result = match super::parse_mysql_xml(&xml) {
-            Ok(result) => result,
-            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
-        };
-        let user_result = fill_mysql_empty_result_columns(
-            process,
-            first_result,
-            option_file,
-            statement.sql(),
-            statement.kind(),
-            access_mode,
-            expected_columns,
-        )
-        .await
-        .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
-        (Some(user_result), marker_result)
-    };
-    let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
-        Ok(rows) => rows,
-        Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
-    };
-    let tag = mysql_command_tag(statement, affected_rows, user_result.as_ref());
+    let user_result = fill_mysql_empty_result_columns(
+        process,
+        result,
+        option_file,
+        statement.sql(),
+        statement.kind(),
+        access_mode,
+        expected_columns,
+    )
+    .await
+    .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
 
     Ok(MySqlStatementExecution {
-        result_set: user_result,
-        command_event: MySqlCommandEvent {
-            kind: statement.kind().clone(),
-            target: statement.target().map(str::to_string),
-            tag,
-        },
+        result_set: Some(user_result),
         refresh_scope: possible_refresh_scope,
     })
 }
@@ -202,13 +177,14 @@ async fn run_mysql_adhoc_process(
     configure_mysql_session(process, access_mode).await?;
 
     let mut last_result_set = None;
-    let mut command_tags = Vec::with_capacity(statements.len());
     let mut refresh_scope = RefreshScope::None;
+    let mut refresh_scope_before_last_statement = RefreshScope::None;
     let expected_columns = (statements.len() == 1)
         .then_some(expected_columns)
         .flatten();
 
     for statement in statements {
+        refresh_scope_before_last_statement = refresh_scope;
         let execution = run_mysql_statement(
             process,
             option_file,
@@ -221,9 +197,74 @@ async fn run_mysql_adhoc_process(
         if let Some(result) = execution.result_set {
             last_result_set = Some(result);
         }
-        command_tags.push(execution.command_event);
         refresh_scope = execution.refresh_scope;
     }
+
+    let marker = Uuid::new_v4().simple().to_string();
+    let marker_query =
+        if statements.len() == 1 && mysql_statement_is_data_modifying(statements[0].kind()) {
+            format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows")
+        } else {
+            format!("SELECT '{marker}' AS __sabiql_marker")
+        };
+    if let Err(error) = write_mysql_statement(process, &marker_query).await {
+        return Err(query_failed_after_change(error, refresh_scope));
+    }
+    let marker_xml = match read_one_mysql_resultset(process).await {
+        Ok(xml) => xml,
+        Err(error) => {
+            return Err(query_failed_after_mysql_statement(
+                error,
+                refresh_scope_before_last_statement,
+                refresh_scope,
+            ));
+        }
+    };
+    let marker_result = match super::parse_mysql_xml(&marker_xml) {
+        Ok(result) => result,
+        Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+    };
+    let command_tag = if statements.len() == 1 {
+        let affected_rows = if mysql_statement_is_data_modifying(statements[0].kind()) {
+            Some(
+                mysql_row_count_marker(&marker_result, &marker)
+                    .map_err(|error| query_failed_after_change(error, refresh_scope))?,
+            )
+        } else {
+            if marker_result.columns != ["__sabiql_marker"]
+                || marker_result.values.len() != 1
+                || marker_result.values[0].len() != 1
+                || marker_result.values[0][0].as_str() != Some(marker.as_str())
+            {
+                return Err(query_failed_after_change(
+                    DbOperationError::QueryFailed(
+                        "mysql adhoc completion marker did not match".to_string(),
+                    ),
+                    refresh_scope,
+                ));
+            }
+            None
+        };
+        Some(mysql_command_tag(
+            &statements[0],
+            affected_rows.unwrap_or_default(),
+            last_result_set.as_ref(),
+        ))
+    } else {
+        if marker_result.columns != ["__sabiql_marker"]
+            || marker_result.values.len() != 1
+            || marker_result.values[0].len() != 1
+            || marker_result.values[0][0].as_str() != Some(marker.as_str())
+        {
+            return Err(query_failed_after_change(
+                DbOperationError::QueryFailed(
+                    "mysql adhoc completion marker did not match".to_string(),
+                ),
+                refresh_scope,
+            ));
+        }
+        None
+    };
 
     let result = finish_mysql_session(process).await?;
     if has_mysql_cli_error(&result.error_bytes) {
@@ -241,7 +282,7 @@ async fn run_mysql_adhoc_process(
 
     Ok(MySqlExecutionResult {
         result_set: last_result_set,
-        command_tag: aggregate_mysql_command_tag(&command_tags),
+        command_tag,
         refresh_scope,
     })
 }

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -9,7 +9,7 @@ use crate::domain::{
     RefreshScope,
     mysql_sql::{
         MySqlStatement, MySqlStatementKind, mysql_statement_is_data_modifying,
-        mysql_statement_is_schema_modifying,
+        mysql_statement_is_schema_modifying, mysql_statement_reads_session_diagnostics,
     },
 };
 
@@ -152,18 +152,20 @@ fn mysql_statement_returns_resultset(kind: &MySqlStatementKind) -> bool {
     )
 }
 
-fn mysql_statement_is_safe_empty_result_metadata_tail(kind: &MySqlStatementKind) -> bool {
-    mysql_statement_is_schema_modifying(kind)
-        || matches!(
-            kind,
-            MySqlStatementKind::Begin
-                | MySqlStatementKind::StartTransaction
-                | MySqlStatementKind::Commit
-                | MySqlStatementKind::Rollback
-                | MySqlStatementKind::Savepoint
-                | MySqlStatementKind::RollbackToSavepoint
-                | MySqlStatementKind::ReleaseSavepoint
-        )
+fn mysql_statement_is_safe_empty_result_metadata_tail(statement: &MySqlStatement) -> bool {
+    if mysql_statement_is_schema_modifying(statement.kind()) {
+        return !mysql_statement_reads_session_diagnostics(statement.sql()).unwrap_or(true);
+    }
+    matches!(
+        statement.kind(),
+        MySqlStatementKind::Begin
+            | MySqlStatementKind::StartTransaction
+            | MySqlStatementKind::Commit
+            | MySqlStatementKind::Rollback
+            | MySqlStatementKind::Savepoint
+            | MySqlStatementKind::RollbackToSavepoint
+            | MySqlStatementKind::ReleaseSavepoint
+    )
 }
 
 fn mysql_result_needs_metadata(result: &MySqlResultSet) -> bool {
@@ -231,9 +233,9 @@ async fn run_mysql_adhoc_process(
         if last_result_set
             .as_ref()
             .is_some_and(mysql_result_needs_metadata)
-            && statements[index..].iter().all(|statement| {
-                mysql_statement_is_safe_empty_result_metadata_tail(statement.kind())
-            })
+            && statements[index..]
+                .iter()
+                .all(mysql_statement_is_safe_empty_result_metadata_tail)
         {
             fill_mysql_last_result_columns(
                 process,

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -150,7 +150,17 @@ fn mysql_statement_returns_resultset(kind: &MySqlStatementKind) -> bool {
 }
 
 fn mysql_statement_is_safe_empty_result_metadata_tail(kind: &MySqlStatementKind) -> bool {
-    matches!(kind, MySqlStatementKind::DropTable { temporary: true })
+    matches!(
+        kind,
+        MySqlStatementKind::DropTable { temporary: true }
+            | MySqlStatementKind::Begin
+            | MySqlStatementKind::StartTransaction
+            | MySqlStatementKind::Commit
+            | MySqlStatementKind::Rollback
+            | MySqlStatementKind::Savepoint
+            | MySqlStatementKind::RollbackToSavepoint
+            | MySqlStatementKind::ReleaseSavepoint
+    )
 }
 
 fn mysql_result_needs_metadata(result: &MySqlResultSet) -> bool {

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -104,11 +104,7 @@ pub(super) async fn fill_mysql_empty_result_columns(
 
 async fn run_mysql_statement(
     process: &mut MySqlProcess,
-    option_file: &Path,
     statement: &MySqlStatement,
-    access_mode: AccessMode,
-    expected_columns: Option<&[&str]>,
-    defer_empty_result_metadata: bool,
     refresh_scope: RefreshScope,
 ) -> Result<MySqlStatementExecution, DbOperationError> {
     let statement_scope = mysql_refresh_scope(statement.kind());
@@ -137,22 +133,6 @@ async fn run_mysql_statement(
         Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
     };
 
-    let result = if defer_empty_result_metadata {
-        result
-    } else {
-        fill_mysql_empty_result_columns(
-            process,
-            result,
-            option_file,
-            statement.sql(),
-            statement.kind(),
-            access_mode,
-            expected_columns,
-        )
-        .await
-        .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?
-    };
-
     Ok(MySqlStatementExecution {
         result_set: Some(result),
         refresh_scope: possible_refresh_scope,
@@ -167,6 +147,45 @@ fn mysql_statement_returns_resultset(kind: &MySqlStatementKind) -> bool {
             | MySqlStatementKind::Show
             | MySqlStatementKind::Describe
     )
+}
+
+fn mysql_statement_is_safe_empty_result_metadata_tail(kind: &MySqlStatementKind) -> bool {
+    matches!(kind, MySqlStatementKind::DropTable { temporary: true })
+}
+
+fn mysql_result_needs_metadata(result: &MySqlResultSet) -> bool {
+    result.columns.is_empty() && result.values.is_empty()
+}
+
+async fn fill_mysql_last_result_columns(
+    process: &mut MySqlProcess,
+    option_file: &Path,
+    last_result_set: &mut Option<MySqlResultSet>,
+    last_result_statement: Option<&MySqlStatement>,
+    access_mode: AccessMode,
+    expected_columns: Option<&[&str]>,
+    refresh_scope: RefreshScope,
+) -> Result<(), DbOperationError> {
+    let Some(result) = last_result_set.take() else {
+        return Ok(());
+    };
+    let Some(statement) = last_result_statement else {
+        *last_result_set = Some(result);
+        return Ok(());
+    };
+    let result = fill_mysql_empty_result_columns(
+        process,
+        result,
+        option_file,
+        statement.sql(),
+        statement.kind(),
+        access_mode,
+        expected_columns,
+    )
+    .await
+    .map_err(|error| query_failed_after_change(error, refresh_scope))?;
+    *last_result_set = Some(result);
+    Ok(())
 }
 
 async fn run_mysql_adhoc_process(
@@ -187,6 +206,7 @@ async fn run_mysql_adhoc_process(
     configure_mysql_session(process, access_mode).await?;
 
     let mut last_result_set = None;
+    let mut last_result_statement = None;
     let mut refresh_scope = RefreshScope::None;
     let mut refresh_scope_before_last_statement = RefreshScope::None;
     let expected_columns = (statements.len() == 1)
@@ -195,24 +215,42 @@ async fn run_mysql_adhoc_process(
 
     for (index, statement) in statements.iter().enumerate() {
         refresh_scope_before_last_statement = refresh_scope;
-        let defer_empty_result_metadata = statements[index + 1..]
-            .iter()
-            .any(|statement| mysql_statement_returns_resultset(statement.kind()));
-        let execution = run_mysql_statement(
-            process,
-            option_file,
-            statement,
-            access_mode,
-            expected_columns,
-            defer_empty_result_metadata,
-            refresh_scope,
-        )
-        .await?;
+        if last_result_set
+            .as_ref()
+            .is_some_and(mysql_result_needs_metadata)
+            && statements[index..].iter().all(|statement| {
+                mysql_statement_is_safe_empty_result_metadata_tail(statement.kind())
+            })
+        {
+            fill_mysql_last_result_columns(
+                process,
+                option_file,
+                &mut last_result_set,
+                last_result_statement,
+                access_mode,
+                expected_columns,
+                refresh_scope,
+            )
+            .await?;
+        }
+        let execution = run_mysql_statement(process, statement, refresh_scope).await?;
         if let Some(result) = execution.result_set {
             last_result_set = Some(result);
+            last_result_statement = Some(statement);
         }
         refresh_scope = execution.refresh_scope;
     }
+
+    fill_mysql_last_result_columns(
+        process,
+        option_file,
+        &mut last_result_set,
+        last_result_statement,
+        access_mode,
+        expected_columns,
+        refresh_scope,
+    )
+    .await?;
 
     let marker = Uuid::new_v4().simple().to_string();
     let marker_query =

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -7,7 +7,10 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{
     RefreshScope,
-    mysql_sql::{MySqlStatement, MySqlStatementKind, mysql_statement_is_data_modifying},
+    mysql_sql::{
+        MySqlStatement, MySqlStatementKind, mysql_statement_is_data_modifying,
+        mysql_statement_is_schema_modifying,
+    },
 };
 
 use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
@@ -150,17 +153,17 @@ fn mysql_statement_returns_resultset(kind: &MySqlStatementKind) -> bool {
 }
 
 fn mysql_statement_is_safe_empty_result_metadata_tail(kind: &MySqlStatementKind) -> bool {
-    matches!(
-        kind,
-        MySqlStatementKind::DropTable { temporary: true }
-            | MySqlStatementKind::Begin
-            | MySqlStatementKind::StartTransaction
-            | MySqlStatementKind::Commit
-            | MySqlStatementKind::Rollback
-            | MySqlStatementKind::Savepoint
-            | MySqlStatementKind::RollbackToSavepoint
-            | MySqlStatementKind::ReleaseSavepoint
-    )
+    mysql_statement_is_schema_modifying(kind)
+        || matches!(
+            kind,
+            MySqlStatementKind::Begin
+                | MySqlStatementKind::StartTransaction
+                | MySqlStatementKind::Commit
+                | MySqlStatementKind::Rollback
+                | MySqlStatementKind::Savepoint
+                | MySqlStatementKind::RollbackToSavepoint
+                | MySqlStatementKind::ReleaseSavepoint
+        )
 }
 
 fn mysql_result_needs_metadata(result: &MySqlResultSet) -> bool {

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1864,7 +1864,7 @@ mod query_execution {
     use sabiql_app::ports::outbound::{
         AccessMode, DbOperationError, QueryExecutor, UnsupportedOperationKind,
     };
-    use sabiql_domain::{CommandTag, QueryValue, RefreshScope};
+    use sabiql_domain::{QueryValue, RefreshScope};
     use sabiql_infra::adapters::mysql::{
         execute_mysql_adhoc_with_read_only_session_for_test,
         execute_mysql_adhoc_with_timeout_for_test,
@@ -2132,7 +2132,7 @@ mod query_execution {
                     .map_err(|error| format!("{error:?}"))?;
                 if result.columns != ["empty_text"]
                     || result.values() != [[QueryValue::Text("multi statement".to_string())]]
-                    || result.command_tag != Some(CommandTag::Update(1))
+                    || result.command_tag.is_some()
                     || result.refresh_scope != RefreshScope::Data
                 {
                     return Err(format!("unexpected multi-statement result: {result:?}"));
@@ -2153,6 +2153,95 @@ mod query_execution {
                 Err(error) => Err(error),
                 Ok(()) => cleanup.map(|_| ()),
             }
+        }))
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn preserves_session_row_count_and_omits_multi_statement_affected_rows() {
+        with_mysql_test_db(|db| Box::pin(async move {
+            let result = async {
+                let result = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'session state' WHERE id = 1; SELECT ROW_COUNT()"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("{error:?}"))?;
+                if result.columns != ["ROW_COUNT()"]
+                    || result.values() != [[QueryValue::Text("1".to_string())]]
+                    || result.command_tag.is_some()
+                    || result.refresh_scope != RefreshScope::Data
+                {
+                    return Err(format!("unexpected session-state result: {result:?}"));
+                }
+                Ok::<(), String>(())
+            }
+            .await;
+            let cleanup = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to restore fixture: {error:?}"));
+            match result {
+                Err(error) => Err(error),
+                Ok(()) => cleanup.map(|_| ()),
+            }
+        }))
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn preserves_multi_statement_warnings_and_found_rows() {
+        with_mysql_test_db(|db| Box::pin(async move {
+            let warnings = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "INSERT IGNORE INTO mysql_preview_composite (first_key, second_key, payload) VALUES (3, 30, 'first'); SHOW WARNINGS",
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("warning query failed: {error:?}"))?;
+            if warnings.columns != ["Level", "Code", "Message"]
+                || !warnings.values().iter().any(|row| {
+                    row.iter().any(|value| {
+                        value
+                            .as_str()
+                            .is_some_and(|value| value.contains("Duplicate entry"))
+                    })
+                })
+                || warnings.command_tag.is_some()
+            {
+                return Err(format!("unexpected warning result: {warnings:?}"));
+            }
+
+            let found_rows = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "SELECT SQL_CALC_FOUND_ROWS first_key FROM mysql_preview_composite; SELECT FOUND_ROWS()",
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("FOUND_ROWS query failed: {error:?}"))?;
+            if found_rows.columns != ["FOUND_ROWS()"]
+                || found_rows.values() != [[QueryValue::Text("2".to_string())]]
+                || found_rows.command_tag.is_some()
+            {
+                return Err(format!("unexpected FOUND_ROWS result: {found_rows:?}"));
+            }
+            Ok(())
         }))
         .await;
     }
@@ -2218,7 +2307,7 @@ mod query_execution {
                 .map_err(|error| format!("{error:?}"))?;
             if result.columns != ["empty_text"]
                 || result.values() != [[QueryValue::Text(String::new())]]
-                || result.command_tag != Some(CommandTag::Select(1))
+                || result.command_tag.is_some()
                 || result.refresh_scope != RefreshScope::Data
             {
                 return Err(format!("unexpected transaction result: {result:?}"));
@@ -2343,7 +2432,7 @@ mod query_execution {
                 .map_err(|error| format!("{error:?}"))?;
             if result.columns != ["id"]
                 || result.values() != [[QueryValue::Text("1".to_string())], [QueryValue::Text("2".to_string())]]
-                || result.command_tag != Some(CommandTag::Insert(2))
+                || result.command_tag.is_some()
                 || result.refresh_scope != RefreshScope::Data
             {
                 return Err(format!("unexpected temporary-table result: {result:?}"));
@@ -2362,7 +2451,7 @@ mod query_execution {
                 .await
                 .map_err(|error| format!("temporary-table DDL-only query failed: {error:?}"))?;
             if ddl_only_result.command_tag
-                    != Some(CommandTag::Other("DROP TEMPORARY TABLE".to_string()))
+                    .is_some()
                 || ddl_only_result.refresh_scope != RefreshScope::None
             {
                 return Err(format!(

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2265,7 +2265,7 @@ mod query_execution {
                 .execute_adhoc(
                     db.dsn(),
                     &format!(
-                        "SELECT SQL_CALC_FOUND_ROWS first_key FROM mysql_preview_composite WHERE first_key = 999; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = FOUND_ROWS() WHERE id = 1"
+                        "SELECT /*!80000 SQL_CALC_FOUND_ROWS */ first_key FROM mysql_preview_composite WHERE first_key = 999; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = FOUND_ROWS() WHERE id = 1"
                     ),
                     AccessMode::ReadWrite,
                 )

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2593,6 +2593,49 @@ mod query_execution {
                     "unexpected temporary DDL-tail result: {temporary_ddl_tail_result:?}"
                 ));
             }
+
+            let found_rows_capture_table = format!("sabiql_sab533_found_rows_{suffix}");
+            let found_rows_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT SQL_CALC_FOUND_ROWS id FROM {MYSQL_FIXTURE_TABLE} LIMIT 1000, 1; CREATE TABLE {found_rows_capture_table} AS SELECT FOUND_ROWS() AS n"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("CTAS diagnostic-tail query failed: {error:?}"))?;
+            if found_rows_result.columns != ["id"]
+                || !found_rows_result.values().is_empty()
+                || found_rows_result.command_tag.is_some()
+            {
+                return Err(format!(
+                    "unexpected CTAS diagnostic-tail result: {found_rows_result:?}"
+                ));
+            }
+            let captured_found_rows = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT n FROM {found_rows_capture_table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to read CTAS diagnostic result: {error:?}"))?;
+            if captured_found_rows.values() != [[QueryValue::Text("1".to_string())]] {
+                return Err(format!(
+                    "unexpected CTAS diagnostic value: {captured_found_rows:?}"
+                ));
+            }
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("DROP TABLE {found_rows_capture_table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to clean up CTAS table: {error:?}"))?;
             Ok(())
         }))
         .await;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2530,6 +2530,27 @@ mod query_execution {
             if empty_result.columns != ["id"] || !empty_result.values().is_empty() {
                 return Err(format!("unexpected empty temporary-table result: {empty_result:?}"));
             }
+
+            let transactional_empty_table = format!("sabiql_sab533_empty_tmp_{suffix}");
+            let transactional_empty_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "START TRANSACTION; CREATE TEMPORARY TABLE {transactional_empty_table} (id INT); SELECT id FROM {transactional_empty_table} WHERE FALSE; DROP TEMPORARY TABLE {transactional_empty_table}; COMMIT"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("transactional empty-table query failed: {error:?}"))?;
+            if transactional_empty_result.columns != ["id"]
+                || !transactional_empty_result.values().is_empty()
+                || transactional_empty_result.command_tag.is_some()
+            {
+                return Err(format!(
+                    "unexpected transactional empty-table result: {transactional_empty_result:?}"
+                ));
+            }
             Ok(())
         }))
         .await;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2551,6 +2551,48 @@ mod query_execution {
                     "unexpected transactional empty-table result: {transactional_empty_result:?}"
                 ));
             }
+
+            let persistent_ddl_tail_table = format!("sabiql_sab533_ddl_tail_{suffix}");
+            let persistent_ddl_tail_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "CREATE TABLE {persistent_ddl_tail_table} (id INT, retained INT); SELECT id FROM {persistent_ddl_tail_table} WHERE FALSE; ALTER TABLE {persistent_ddl_tail_table} DROP COLUMN id; DROP TABLE {persistent_ddl_tail_table}"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("persistent DDL-tail query failed: {error:?}"))?;
+            if persistent_ddl_tail_result.columns != ["id"]
+                || !persistent_ddl_tail_result.values().is_empty()
+                || persistent_ddl_tail_result.command_tag.is_some()
+            {
+                return Err(format!(
+                    "unexpected persistent DDL-tail result: {persistent_ddl_tail_result:?}"
+                ));
+            }
+
+            let temporary_ddl_tail_table = format!("sabiql_sab533_tmp_ddl_tail_{suffix}");
+            let temporary_ddl_tail_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "CREATE TEMPORARY TABLE {temporary_ddl_tail_table} (id INT, retained INT); SELECT id FROM {temporary_ddl_tail_table} WHERE FALSE; ALTER TABLE {temporary_ddl_tail_table} DROP COLUMN id; DROP TEMPORARY TABLE {temporary_ddl_tail_table}"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("temporary DDL-tail query failed: {error:?}"))?;
+            if temporary_ddl_tail_result.columns != ["id"]
+                || !temporary_ddl_tail_result.values().is_empty()
+                || temporary_ddl_tail_result.command_tag.is_some()
+            {
+                return Err(format!(
+                    "unexpected temporary DDL-tail result: {temporary_ddl_tail_result:?}"
+                ));
+            }
             Ok(())
         }))
         .await;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2241,6 +2241,24 @@ mod query_execution {
             {
                 return Err(format!("unexpected FOUND_ROWS result: {found_rows:?}"));
             }
+
+            let empty_found_rows = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "SELECT SQL_CALC_FOUND_ROWS first_key FROM mysql_preview_composite WHERE first_key = 999; SELECT FOUND_ROWS()",
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("empty FOUND_ROWS query failed: {error:?}"))?;
+            if empty_found_rows.columns != ["FOUND_ROWS()"]
+                || empty_found_rows.values() != [[QueryValue::Text("0".to_string())]]
+                || empty_found_rows.command_tag.is_some()
+            {
+                return Err(format!(
+                    "unexpected empty FOUND_ROWS result: {empty_found_rows:?}"
+                ));
+            }
             Ok(())
         }))
         .await;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2636,6 +2636,56 @@ mod query_execution {
                 )
                 .await
                 .map_err(|error| format!("failed to clean up CTAS table: {error:?}"))?;
+
+            let diagnostic_count_capture_table = format!("sabiql_sab533_diagnostic_{suffix}");
+            let diagnostic_count_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT SQL_CALC_FOUND_ROWS id FROM {MYSQL_FIXTURE_TABLE} LIMIT 1000, 1; CREATE TABLE {diagnostic_count_capture_table} AS SELECT @@warning_count AS warning_count, @@error_count AS error_count"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("diagnostic-count CTAS query failed: {error:?}"))?;
+            if diagnostic_count_result.columns != ["id"]
+                || !diagnostic_count_result.values().is_empty()
+                || diagnostic_count_result.command_tag.is_some()
+            {
+                return Err(format!(
+                    "unexpected diagnostic-count CTAS result: {diagnostic_count_result:?}"
+                ));
+            }
+            let captured_diagnostic_counts = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT warning_count, error_count FROM {diagnostic_count_capture_table}"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to read diagnostic counts: {error:?}"))?;
+            if captured_diagnostic_counts.values()
+                != [[
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("0".to_string()),
+                ]]
+            {
+                return Err(format!(
+                    "unexpected diagnostic counts: {captured_diagnostic_counts:?}"
+                ));
+            }
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("DROP TABLE {diagnostic_count_capture_table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to clean up diagnostic table: {error:?}"))?;
             Ok(())
         }))
         .await;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2259,6 +2259,44 @@ mod query_execution {
                     "unexpected empty FOUND_ROWS result: {empty_found_rows:?}"
                 ));
             }
+
+            let dml_found_rows = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT SQL_CALC_FOUND_ROWS first_key FROM mysql_preview_composite WHERE first_key = 999; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = FOUND_ROWS() WHERE id = 1"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("DML FOUND_ROWS query failed: {error:?}"))?;
+            let stored_found_rows = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("stored FOUND_ROWS query failed: {error:?}"))?;
+            if dml_found_rows.columns != ["first_key"]
+                || !dml_found_rows.values().is_empty()
+                || dml_found_rows.command_tag.is_some()
+                || stored_found_rows.values() != [[QueryValue::Text("0".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected DML FOUND_ROWS result: dml={dml_found_rows:?}, stored={stored_found_rows:?}"
+                ));
+            }
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to restore FOUND_ROWS fixture: {error:?}"))?;
             Ok(())
         }))
         .await;


### PR DESCRIPTION
## Problem
Per-statement marker queries changed MySQL session state before later statements in one adhoc submission.

## Background
This made ROW_COUNT(), FOUND_ROWS(), and warning diagnostics differ from Oracle MySQL semantics.

## Approach
Collect user result frames without issuing per-statement server markers. Use one terminal marker for submission completion, retaining an exact row count only for a single DML and generic completion for multi-statement submissions.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-533