### PR TITLE
fix(mysql): clear stale CA outside verify modes

### DIFF
--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -459,8 +459,7 @@ impl ConnectionSetupState {
                 if let Some(mode) =
                     MySqlSslMode::all_variants().get(self.ssl_dropdown.selected_index)
                 {
-                    self.mysql_ssl_mode = *mode;
-                    self.retain_validation_errors_for_visible_fields();
+                    self.set_mysql_ssl_mode(*mode);
                 }
             } else if let Some(mode) = SslMode::all_variants().get(self.ssl_dropdown.selected_index)
             {
@@ -477,6 +476,14 @@ impl ConnectionSetupState {
 
     pub fn has_open_dropdown(&self) -> bool {
         self.database_type_dropdown.is_open || self.ssl_dropdown.is_open
+    }
+
+    fn set_mysql_ssl_mode(&mut self, mode: MySqlSslMode) {
+        self.mysql_ssl_mode = mode;
+        if !mode.uses_ca() {
+            self.ssl_ca.clear();
+        }
+        self.retain_validation_errors_for_visible_fields();
     }
 
     pub fn record_sqlite_config_error(&mut self, error: SqliteConnectionConfigError) {
@@ -542,7 +549,8 @@ impl ConnectionSetupState {
                     self.mysql_ssl_mode,
                 )
                 .with_tls_paths(
-                    (!matches!(self.mysql_ssl_mode, MySqlSslMode::Disabled))
+                    self.mysql_ssl_mode
+                        .uses_ca()
                         .then(|| optional_path(&self.ssl_ca))
                         .flatten(),
                     (!matches!(self.mysql_ssl_mode, MySqlSslMode::Disabled))
@@ -616,7 +624,9 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
                 state.password =
                     TextInputState::new(&config.password, config.password.chars().count());
                 state.mysql_ssl_mode = config.ssl_mode;
-                if let Some(path) = config.ssl_ca.as_deref() {
+                if config.ssl_mode.uses_ca()
+                    && let Some(path) = config.ssl_ca.as_deref()
+                {
                     state.ssl_ca = TextInputState::new(path, path.chars().count());
                 }
                 if let Some(path) = config.ssl_cert.as_deref() {
@@ -807,6 +817,49 @@ mod tests {
                     ..
                 })
             ));
+        }
+
+        #[test]
+        fn mysql_config_drops_ca_for_non_verification_mode() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            state.mysql_ssl_mode = MySqlSslMode::Required;
+            state.ssl_ca.set_content("/tmp/old-ca.pem".to_string());
+
+            let ConnectionConfig::MySQL(config) = state.to_connection_config().unwrap() else {
+                panic!("expected MySQL config");
+            };
+
+            assert_eq!(config.ssl_ca, None);
+        }
+
+        #[test]
+        fn switching_to_non_verification_mode_clears_ca_without_restoring_it() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            state.mysql_ssl_mode = MySqlSslMode::VerifyCa;
+            state.ssl_ca.set_content("/tmp/old-ca.pem".to_string());
+            state.ssl_dropdown.is_open = true;
+            state.ssl_dropdown.selected_index = MySqlSslMode::all_variants()
+                .iter()
+                .position(|mode| *mode == MySqlSslMode::Required)
+                .unwrap();
+
+            state.confirm_dropdown();
+
+            assert_eq!(state.mysql_ssl_mode, MySqlSslMode::Required);
+            assert!(state.ssl_ca.content().is_empty());
+
+            state.focused_field = ConnectionField::SslMode;
+            state.toggle_focused_dropdown();
+            state.ssl_dropdown.selected_index = MySqlSslMode::all_variants()
+                .iter()
+                .position(|mode| *mode == MySqlSslMode::VerifyCa)
+                .unwrap();
+            state.confirm_dropdown();
+
+            assert_eq!(state.mysql_ssl_mode, MySqlSslMode::VerifyCa);
+            assert!(state.ssl_ca.content().is_empty());
         }
 
         #[test]

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -37,6 +37,10 @@ impl MySqlSslMode {
             Self::VerifyIdentity => "VERIFY_IDENTITY",
         }
     }
+
+    pub const fn uses_ca(self) -> bool {
+        matches!(self, Self::VerifyCa | Self::VerifyIdentity)
+    }
 }
 
 impl std::fmt::Display for MySqlSslMode {
@@ -135,7 +139,7 @@ impl MySqlConnectionConfig {
         ssl_cert: Option<String>,
         ssl_key: Option<String>,
     ) -> Self {
-        self.ssl_ca = ssl_ca;
+        self.ssl_ca = self.ssl_mode.uses_ca().then_some(ssl_ca).flatten();
         self.ssl_cert = ssl_cert;
         self.ssl_key = ssl_key;
         self
@@ -294,6 +298,29 @@ mod tests {
         for mode in MySqlSslMode::all_variants() {
             assert_eq!(mode.as_str(), mode.to_string());
             assert_eq!(mode.as_str().parse::<MySqlSslMode>().unwrap(), *mode);
+        }
+    }
+
+    #[test]
+    fn mysql_ca_is_only_kept_for_certificate_verification_modes() {
+        for mode in [
+            MySqlSslMode::Disabled,
+            MySqlSslMode::Preferred,
+            MySqlSslMode::Required,
+        ] {
+            let config =
+                MySqlConnectionConfig::new("localhost", 3306, None, "user", "password", mode)
+                    .with_tls_paths(Some("/tmp/ca.pem".to_string()), None, None);
+
+            assert_eq!(config.ssl_ca, None);
+        }
+
+        for mode in [MySqlSslMode::VerifyCa, MySqlSslMode::VerifyIdentity] {
+            let config =
+                MySqlConnectionConfig::new("localhost", 3306, None, "user", "password", mode)
+                    .with_tls_paths(Some("/tmp/ca.pem".to_string()), None, None);
+
+            assert_eq!(config.ssl_ca.as_deref(), Some("/tmp/ca.pem"));
         }
     }
 

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -59,7 +59,9 @@ pub(super) fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
     }
     url.query_pairs_mut()
         .append_pair("ssl-mode", &config.ssl_mode.to_string());
-    if let Some(path) = config.ssl_ca.as_deref() {
+    if config.ssl_mode.uses_ca()
+        && let Some(path) = config.ssl_ca.as_deref()
+    {
         url.query_pairs_mut().append_pair("ssl-ca", path);
     }
     if let Some(path) = config.ssl_cert.as_deref() {
@@ -106,9 +108,11 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         .find_map(|(key, value)| (key == "ssl-mode").then(|| parse_ssl_mode(&value)))
         .transpose()?
         .unwrap_or_default();
-    let ssl_ca = url
-        .query_pairs()
-        .find_map(|(key, value)| (key == "ssl-ca").then(|| value.into_owned()));
+    let ssl_ca = ssl_mode.uses_ca().then(|| {
+        url.query_pairs()
+            .find_map(|(key, value)| (key == "ssl-ca").then(|| value.into_owned()))
+    });
+    let ssl_ca = ssl_ca.flatten();
     let ssl_cert = url
         .query_pairs()
         .find_map(|(key, value)| (key == "ssl-cert").then(|| value.into_owned()));
@@ -306,6 +310,24 @@ mod tests {
         assert_eq!(parsed.ssl_ca.as_deref(), Some(r"C:\certs\ca #1.pem"));
         assert_eq!(parsed.ssl_cert.as_deref(), Some(r"C:\certs\client.pem"));
         assert_eq!(parsed.ssl_key.as_deref(), Some(r"C:\certs\client-key.pem"));
+    }
+
+    #[test]
+    fn ignores_ca_when_building_or_parsing_non_verification_dsn() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::Required,
+        );
+        let dsn = format!("{}&ssl-ca=%2Fmissing%2Fca.pem", build_mysql_dsn(&config));
+        let parsed = parse_mysql_dsn(&dsn).unwrap();
+
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::Required);
+        assert_eq!(parsed.ssl_ca, None);
+        assert!(!build_mysql_dsn(&config).contains("ssl-ca"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -65,8 +65,13 @@ impl MySqlOptionFile {
 fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
     validate_mysql_tls_config(target)?;
 
+    let ca_path = target
+        .ssl_mode
+        .uses_ca()
+        .then_some(target.ssl_ca.as_deref())
+        .flatten();
     for (kind, path) in [
-        ("CA", target.ssl_ca.as_deref()),
+        ("CA", ca_path),
         ("client certificate", target.ssl_cert.as_deref()),
         ("client key", target.ssl_key.as_deref()),
     ] {
@@ -244,7 +249,9 @@ fn serialize_option_file(target: &MySqlDsn) -> String {
         push_option(&mut contents, "database", database);
     }
     push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
-    if let Some(path) = target.ssl_ca.as_deref() {
+    if target.ssl_mode.uses_ca()
+        && let Some(path) = target.ssl_ca.as_deref()
+    {
         push_option(&mut contents, "ssl-ca", path);
     }
     if let Some(path) = target.ssl_cert.as_deref() {
@@ -355,6 +362,28 @@ mod tests {
         assert!(contents.contains(&format!("ssl-ca = {}\n", quote_option_value(ca_path))));
         assert!(contents.contains("ssl-cert = \"C:\\\\certs\\\\client.pem\"\n"));
         assert!(contents.contains("ssl-key = \"C:\\\\certs\\\\client-key.pem\"\n"));
+    }
+
+    #[test]
+    fn option_file_omits_non_verification_ca_without_validating_its_path() {
+        let target = MySqlDsn {
+            ssl_mode: MySqlSslMode::Required,
+            ssl_ca: Some("/missing/ca.pem".to_string()),
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        let contents = fs::read_to_string(&option_file.path).unwrap();
+
+        assert_eq!(
+            contents,
+            "[client]\n\
+host = \"localhost\"\n\
+port = \"3306\"\n\
+user = \"user\"\n\
+password = \"secret\"\n\
+ssl-mode = \"REQUIRED\"\n"
+        );
     }
 
     #[test]

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -122,7 +122,9 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry.username = Some(config.username.clone());
                 entry.password = Some(config.password.clone());
                 entry.mysql_ssl_mode = Some(config.ssl_mode);
-                entry.mysql_ssl_ca.clone_from(&config.ssl_ca);
+                if config.ssl_mode.uses_ca() {
+                    entry.mysql_ssl_ca.clone_from(&config.ssl_ca);
+                }
                 entry.mysql_ssl_cert.clone_from(&config.ssl_cert);
                 entry.mysql_ssl_key.clone_from(&config.ssl_key);
             }
@@ -427,6 +429,19 @@ mod tests {
         assert_eq!(serialized.mysql_ssl_ca, entry.mysql_ssl_ca);
         assert_eq!(serialized.mysql_ssl_cert, entry.mysql_ssl_cert);
         assert_eq!(serialized.mysql_ssl_key, entry.mysql_ssl_key);
+    }
+
+    #[test]
+    fn mysql_entry_drops_ca_for_non_verification_mode() {
+        let mut entry = mysql_entry(Some("app"));
+        entry.mysql_ssl_ca = Some("/tmp/old-ca.pem".to_string());
+
+        let profile = ConnectionProfile::try_from(&entry).unwrap();
+        let config = profile.mysql_config().unwrap();
+        assert_eq!(config.ssl_ca, None);
+
+        let serialized = ConnectionConfigEntry::from(&profile);
+        assert_eq!(serialized.mysql_ssl_ca, None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Changing MySQL SSL mode from VERIFY_CA or VERIFY_IDENTITY to a non-verify mode left the hidden CA path in the saved connection and option-file lifecycle.

## Background
A later connection attempt could validate a deleted CA file even though the selected mode did not use CA verification.

## Approach
Keep CA paths only for certificate-verification modes across the form, domain/config serialization, DSN, and option-file boundaries while preserving existing verify-mode validation and client certificate/key behavior.