### PR TITLE
refactor(app): unify LivePreview JSON detail routing (SAB-500)

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -7,7 +7,7 @@ use crate::domain::{Column, DatabaseType, TableSummary, mysql_sql::mysql_export_
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::browse::inspector_view_model::InspectorViewModel;
 use crate::model::browse::json_detail::JsonDetailState;
-use crate::model::browse::query_execution::QueryExecution;
+use crate::model::browse::query_execution::{QueryExecution, VisibleResultKind};
 use crate::model::browse::result_interaction::ResultInteraction;
 use crate::model::browse::row_detail::RowDetailState;
 use crate::model::browse::session::BrowseSession;
@@ -391,6 +391,10 @@ impl AppState {
     }
 
     pub fn visible_preview_column(&self, col_idx: usize) -> Option<&Column> {
+        if self.query.visible_result_kind() != VisibleResultKind::LivePreview {
+            return None;
+        }
+
         let result = self.query.visible_result()?;
         let column_name = result.columns.get(col_idx)?;
         let table_detail = self.session.table_detail()?;

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -4,7 +4,6 @@ use crate::cmd::effect::Effect;
 use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::cell_detail::CellDetailState;
-use crate::model::browse::query_execution::VisibleResultKind;
 use crate::model::shared::detail_view::DetailDisplayMode;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
@@ -161,10 +160,6 @@ fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String
 }
 
 fn selected_cell_uses_json_detail_modal(state: &AppState) -> bool {
-    if state.query.visible_result_kind() != VisibleResultKind::LivePreview {
-        return false;
-    }
-
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
@@ -189,10 +184,6 @@ fn selected_cell_uses_json_detail_modal(state: &AppState) -> bool {
 }
 
 fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
-    if state.query.visible_result_kind() != VisibleResultKind::LivePreview {
-        return None;
-    }
-
     let table_detail = state.session.table_detail()?;
     if !state.query.pagination.matches_table(table_detail) {
         return None;

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -1,5 +1,5 @@
 use crate::cmd::effect::Effect;
-use crate::domain::{QuerySource, QueryValue};
+use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::json_detail::{JsonDetailMode, JsonDetailState};
 use crate::model::shared::flash_timer::FlashId;
@@ -19,9 +19,8 @@ use std::time::Instant;
 pub fn reduce_json(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::JsonDetail) => {
-            let result = match state.query.visible_result() {
-                Some(r) if r.source == QuerySource::Preview && !r.is_error() => r,
-                _ => return DispatchResult::handled(),
+            let Some(result) = state.query.visible_result().filter(|r| !r.is_error()) else {
+                return DispatchResult::handled();
             };
 
             let Some(table_detail) = state.session.table_detail() else {


### PR DESCRIPTION
## Problem

JSON detail/edit routing retained duplicated result-source checks after adhoc JSON results were moved to Cell Detail.

## Background

SAB-500: https://linear.app/sabiql/issue/SAB-500

## Approach

Make the visible preview-column boundary LivePreview-only, so JSON modal eligibility and preview editing share one source boundary. Keep adhoc JSON results on ordinary Cell Detail and preserve SQL NULL and JSON document null behavior.

## Validation

Focused reducer tests, app crate Clippy, fmt, and scripts/lint_all.sh pass.