### PR TITLE
fix(mysql): accept ordered single-table deletes

### DIFF
--- a/src/domain/mysql_sql/classifier.rs
+++ b/src/domain/mysql_sql/classifier.rs
@@ -94,10 +94,13 @@ fn classify_mysql_crud_statement(
                 ));
             }
             let target_index = index + 1;
-            let where_index =
-                target::find_word(tokens, "WHERE", target_index).unwrap_or(tokens.len());
-            if has_multi_table_reference(tokens, target_index, where_index)
-                || has_top_level_word(tokens, "USING", target_index, where_index)
+            let table_reference_end = ["WHERE", "ORDER", "LIMIT"]
+                .into_iter()
+                .filter_map(|word| target::find_word(tokens, word, target_index))
+                .min()
+                .unwrap_or(tokens.len());
+            if has_multi_table_reference(tokens, target_index, table_reference_end)
+                || has_top_level_word(tokens, "USING", target_index, table_reference_end)
             {
                 return Err(MySqlLexError(
                     "MySQL multiple-table DELETE statements are not supported".to_string(),

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -731,9 +731,30 @@ mod tests {
             "DELETE items, prices FROM items JOIN prices ON items.id = prices.id",
             "DELETE FROM items, prices USING items JOIN prices ON items.id = prices.id",
             "DELETE items FROM items JOIN prices ON items.id = prices.id",
+            "DELETE FROM items USING items JOIN prices ON items.id = prices.id",
+            "DELETE FROM items JOIN prices ON items.id = prices.id",
         ] {
             let error = classify_mysql_statement(sql).unwrap_err();
             assert!(error.0.contains("multiple-table"), "{sql}: {error}");
+        }
+    }
+
+    #[test]
+    fn accepts_single_table_delete_clause_boundaries_and_nested_commas() {
+        for sql in [
+            "DELETE FROM items ORDER BY created_at, id LIMIT 10",
+            "DELETE FROM items WHERE id IN (SELECT item_id FROM prices, currencies)",
+            "DELETE FROM items LIMIT 10",
+            "DELETE FROM `items,archive` ORDER BY id LIMIT 10",
+        ] {
+            let statement = classify_mysql_statement(sql).expect(sql);
+            assert_eq!(
+                statement.kind,
+                MySqlStatementKind::Delete {
+                    has_where: sql.contains("WHERE")
+                },
+                "{sql}"
+            );
         }
     }
 


### PR DESCRIPTION
## Problem
MySQL single-table DELETE statements with a multi-column ORDER BY are classified as multiple-table statements because the top-level comma is scanned as a table separator.

## Background
The classifier currently scans through ORDER BY and LIMIT when a DELETE has no WHERE clause.

## Approach
Stop the DELETE table-reference scan at the first top-level WHERE, ORDER, or LIMIT token. Existing quoted-identifier, nested-token, USING, JOIN, and multi-target boundaries remain unchanged.

## Validation
Focused MySQL classifier tests, targeted sabiql-domain Clippy, cargo fmt, git diff --check, and scripts/lint_all.sh.