### PR TITLE
fix(app): preserve preview page at end

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -124,6 +124,10 @@ impl PaginationState {
         self.reached_end = false;
     }
 
+    pub fn mark_reached_end(&mut self) {
+        self.reached_end = true;
+    }
+
     pub fn set_total_rows_estimate(&mut self, estimate: Option<i64>) {
         self.total_rows_estimate = estimate;
     }
@@ -737,6 +741,19 @@ mod tests {
 
             assert_eq!(p.current_page(), 3);
             assert!(!p.reached_end());
+        }
+
+        #[test]
+        fn mark_reached_end_only_sets_that_flag() {
+            let mut p = PaginationState {
+                current_page: 3,
+                ..Default::default()
+            };
+
+            p.mark_reached_end();
+
+            assert_eq!(p.current_page(), 3);
+            assert!(p.reached_end());
         }
     }
 }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -334,13 +334,28 @@ fn apply_preview_result(
             .set_result_highlight(now + Duration::from_millis(500));
     }
 
-    if let Some(page) = target_page {
-        state
-            .query
-            .pagination
-            .set_page_result(page, result.data_row_count() < PREVIEW_PAGE_SIZE);
+    let should_apply_result = match target_page {
+        Some(page)
+            if !result.is_error()
+                && result.data_row_count() == 0
+                && page > state.query.pagination.current_page() =>
+        {
+            state.query.pagination.mark_reached_end();
+            false
+        }
+        Some(page) => {
+            state
+                .query
+                .pagination
+                .set_page_result(page, result.data_row_count() < PREVIEW_PAGE_SIZE);
+            true
+        }
+        None => true,
+    };
+
+    if should_apply_result {
+        state.query.set_current_result(Arc::clone(result));
     }
-    state.query.set_current_result(Arc::clone(result));
 
     match state.query.post_delete_row_selection() {
         PostDeleteRowSelection::Keep => {}
@@ -833,6 +848,117 @@ mod tests {
 
             assert_eq!(state.query.pagination.current_page(), 0);
             assert!(!state.query.pagination.reached_end());
+        }
+
+        #[test]
+        fn applies_empty_initial_preview_at_page_zero() {
+            let mut state = create_test_state();
+            state.session.set_selection_generation(1);
+            let action = query_completed_action(&mut state, preview_result(0), 1, Some(0));
+
+            dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
+
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(state.query.pagination.reached_end());
+            assert_eq!(state.query.visible_result().unwrap().data_row_count(), 0);
+        }
+
+        #[test]
+        fn applies_non_empty_forward_page() {
+            let mut state = create_test_state();
+            state.session.set_selection_generation(1);
+            let first_page = preview_result(PREVIEW_PAGE_SIZE);
+            let first_action = query_completed_action(&mut state, first_page, 1, Some(0));
+            dispatch_query(
+                &mut state,
+                &first_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let next_action = query_completed_action(&mut state, preview_result(1), 1, Some(1));
+            dispatch_query(
+                &mut state,
+                &next_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.query.pagination.current_page(), 1);
+            assert!(state.query.pagination.reached_end());
+            assert_eq!(state.query.visible_result().unwrap().data_row_count(), 1);
+        }
+
+        #[test]
+        fn preserves_last_page_when_forward_preview_is_empty() {
+            let mut state = create_test_state();
+            state.session.set_selection_generation(1);
+            let last_page = preview_result(PREVIEW_PAGE_SIZE);
+            let first_action =
+                query_completed_action(&mut state, Arc::clone(&last_page), 1, Some(0));
+            dispatch_query(
+                &mut state,
+                &first_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let empty_action = query_completed_action(&mut state, preview_result(0), 1, Some(1));
+            dispatch_query(
+                &mut state,
+                &empty_action,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(state.query.pagination.reached_end());
+            assert!(Arc::ptr_eq(
+                state.query.current_result().unwrap(),
+                &last_page
+            ));
+            assert_eq!(
+                state.query.visible_result().unwrap().data_row_count(),
+                PREVIEW_PAGE_SIZE
+            );
+        }
+
+        #[test]
+        fn exact_page_boundaries_keep_next_available_until_empty() {
+            for total_rows in [PREVIEW_PAGE_SIZE, PREVIEW_PAGE_SIZE * 2] {
+                let mut state = create_test_state();
+                state.session.set_selection_generation(1);
+                let page_count = total_rows / PREVIEW_PAGE_SIZE;
+
+                for page in 0..page_count {
+                    let action = query_completed_action(
+                        &mut state,
+                        preview_result(PREVIEW_PAGE_SIZE),
+                        1,
+                        Some(page),
+                    );
+                    dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
+                    assert!(!state.query.pagination.reached_end());
+                    assert!(state.query.pagination.can_next());
+                }
+
+                let empty_action =
+                    query_completed_action(&mut state, preview_result(0), 1, Some(page_count));
+                dispatch_query(
+                    &mut state,
+                    &empty_action,
+                    Instant::now(),
+                    &AppServices::stub(),
+                );
+
+                assert_eq!(state.query.pagination.current_page(), page_count - 1);
+                assert!(state.query.pagination.reached_end());
+                assert!(!state.query.pagination.can_next());
+                assert_eq!(
+                    state.query.visible_result().unwrap().data_row_count(),
+                    PREVIEW_PAGE_SIZE
+                );
+            }
         }
 
         #[test]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -601,6 +601,81 @@ mod tests {
             assert!(state.result_interaction.selection().cell().is_none());
             assert!(state.result_interaction.staged_delete_rows().is_empty());
         }
+
+        #[test]
+        fn prev_then_next_reopens_the_page_after_an_empty_forward_result() {
+            let mut state = create_test_state();
+            state
+                .query
+                .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
+            state.query.pagination.reset_for_table("public", "users");
+
+            let next_effects = dispatch_query(
+                &mut state,
+                &Action::ResultNextPage,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+            assert!(matches!(
+                next_effects.first(),
+                Some(Effect::ExecutePreview { target_page: 1, .. })
+            ));
+
+            let next_result =
+                query_completed_action(&mut state, preview_result(PREVIEW_PAGE_SIZE), 0, Some(1));
+            dispatch_query(
+                &mut state,
+                &next_result,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let empty_next_result =
+                query_completed_action(&mut state, preview_result(0), 0, Some(2));
+            dispatch_query(
+                &mut state,
+                &empty_next_result,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert_eq!(state.query.pagination.current_page(), 1);
+            assert!(state.query.pagination.reached_end());
+
+            let prev_effects = dispatch_query(
+                &mut state,
+                &Action::ResultPrevPage,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+            assert!(matches!(
+                prev_effects.first(),
+                Some(Effect::ExecutePreview { target_page: 0, .. })
+            ));
+            assert!(!state.query.pagination.reached_end());
+
+            let prev_result =
+                query_completed_action(&mut state, preview_result(PREVIEW_PAGE_SIZE), 0, Some(0));
+            dispatch_query(
+                &mut state,
+                &prev_result,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let next_effects = dispatch_query(
+                &mut state,
+                &Action::ResultNextPage,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+            assert!(matches!(
+                next_effects.first(),
+                Some(Effect::ExecutePreview { target_page: 1, .. })
+            ));
+        }
     }
 
     mod prev_page {


### PR DESCRIPTION
## Problem
A full preview page followed by an empty forward fetch was displayed as an empty page.

## Background
Pagination cannot know that a full page is the final page until the following fetch returns no rows.

## Approach
Keep the current page and result when a successful forward fetch returns zero rows, and record only that the end was reached. Initial empty results and non-empty page transitions retain their existing behavior.