### PR TITLE
fix(mysql): preserve refresh scope after timeout

### DIFF
--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1461,6 +1461,30 @@ mod tests {
         }
 
         #[test]
+        fn adhoc_timeout_after_data_change_refreshes_preview() {
+            let mut state = state_with_table("public", "users");
+            let action = query_failed_action(
+                &mut state,
+                DbOperationError::QueryFailedAfterChange {
+                    source: Arc::new(DbOperationError::Timeout(
+                        "mysql query exceeded the execution timeout".to_string(),
+                    )),
+                    refresh_scope: RefreshScope::Data,
+                },
+                0,
+                QuerySource::Adhoc,
+            );
+
+            let effects =
+                dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ExecutePreview { table, .. } if table == "users"
+            )));
+        }
+
+        #[test]
         fn adhoc_failure_after_schema_change_refreshes_metadata() {
             let mut state = state_with_table("public", "users");
             let action = query_failed_action(

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use crate::adapters::csv_export::CsvFileWriter;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
-use crate::domain::mysql_sql::classify_mysql_statement;
+use crate::domain::{RefreshScope, mysql_sql::classify_mysql_statement};
 
 use super::super::{dsn::MySqlDsn, option_file::MySqlOptionFile};
 use super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
@@ -349,9 +349,12 @@ pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
 ) -> Result<(), DbOperationError> {
     let option_file = MySqlOptionFile::create(&target)?;
     let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
-    run_mysql_process_with_timeout(MYSQL_EXPORT_TIMEOUT, &mut process, async |process| {
-        run_mysql_export_process(process, &option_file.path, query, path).await
-    })
+    run_mysql_process_with_timeout(
+        MYSQL_EXPORT_TIMEOUT,
+        &mut process,
+        RefreshScope::None,
+        async |process| run_mysql_export_process(process, &option_file.path, query, path).await,
+    )
     .await
 }
 

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -390,7 +390,6 @@ pub(super) fn query_failed_after_change(
 
 pub(super) fn query_failed_after_mysql_statement(
     error: DbOperationError,
-    refresh_scope: RefreshScope,
     possible_refresh_scope: RefreshScope,
 ) -> DbOperationError {
     let refresh_scope = match &error {
@@ -398,23 +397,9 @@ pub(super) fn query_failed_after_mysql_statement(
             refresh_scope: existing_scope,
             ..
         } => *existing_scope,
-        error if is_mysql_statement_failure(error) => refresh_scope,
         _ => possible_refresh_scope,
     };
     query_failed_after_change(error, refresh_scope)
-}
-
-fn is_mysql_statement_failure(error: &DbOperationError) -> bool {
-    matches!(
-        error,
-        DbOperationError::PermissionDenied(_)
-            | DbOperationError::ForeignKeyViolation(_)
-            | DbOperationError::UniqueViolation(_)
-            | DbOperationError::LockTimeout(_)
-            | DbOperationError::ObjectMissing(_)
-            | DbOperationError::QueryFailed(_)
-            | DbOperationError::Canceled(_)
-    )
 }
 
 pub(super) fn is_mysql_row_count_marker(result: &MySqlResultSet, marker: &str) -> bool {

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -376,7 +376,9 @@ pub(super) fn query_failed_after_change(
     error: DbOperationError,
     refresh_scope: RefreshScope,
 ) -> DbOperationError {
-    if refresh_scope == RefreshScope::None {
+    if refresh_scope == RefreshScope::None
+        || matches!(&error, DbOperationError::QueryFailedAfterChange { .. })
+    {
         error
     } else {
         DbOperationError::QueryFailedAfterChange {
@@ -391,10 +393,13 @@ pub(super) fn query_failed_after_mysql_statement(
     refresh_scope: RefreshScope,
     possible_refresh_scope: RefreshScope,
 ) -> DbOperationError {
-    let refresh_scope = if is_mysql_statement_failure(&error) {
-        refresh_scope
-    } else {
-        possible_refresh_scope
+    let refresh_scope = match &error {
+        DbOperationError::QueryFailedAfterChange {
+            refresh_scope: existing_scope,
+            ..
+        } => *existing_scope,
+        error if is_mysql_statement_failure(error) => refresh_scope,
+        _ => possible_refresh_scope,
     };
     query_failed_after_change(error, refresh_scope)
 }
@@ -491,6 +496,14 @@ pub(super) fn mysql_refresh_scope(kind: &MySqlStatementKind) -> RefreshScope {
     } else {
         RefreshScope::None
     }
+}
+
+pub(super) fn mysql_possible_refresh_scope(statements: &[MySqlStatement]) -> RefreshScope {
+    statements
+        .iter()
+        .fold(RefreshScope::None, |scope, statement| {
+            scope.merge(mysql_refresh_scope(statement.kind()))
+        })
 }
 
 #[cfg(test)]
@@ -836,6 +849,25 @@ mod tests {
         assert_eq!(
             mysql_refresh_scope(&MySqlStatementKind::CreateTable { temporary: false }),
             RefreshScope::Metadata
+        );
+    }
+
+    #[test]
+    fn possible_refresh_scope_includes_all_classified_statements() {
+        let statements = classify_mysql_multi_statement(
+            "UPDATE items SET value = 1; CREATE TABLE created (id INT)",
+            Some("app"),
+        )
+        .unwrap();
+        assert_eq!(
+            mysql_possible_refresh_scope(&statements),
+            RefreshScope::Metadata
+        );
+
+        let statements = classify_mysql_multi_statement("SELECT SLEEP(40)", Some("app")).unwrap();
+        assert_eq!(
+            mysql_possible_refresh_scope(&statements),
+            RefreshScope::None
         );
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -12,13 +12,15 @@ use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
 use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DatabaseCli, DbOperationError};
-use crate::domain::MySqlDiagnostic;
+use crate::domain::{MySqlDiagnostic, RefreshScope};
 
 use super::args::{mysql_adhoc_args, mysql_query_args};
 use super::error::{classify_mysql_query_failure, has_mysql_cli_error};
 #[cfg(not(unix))]
 use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
-use super::policy::{MYSQL_SESSION_MARKER_COLUMN, validate_mysql_session_marker};
+use super::policy::{
+    MYSQL_SESSION_MARKER_COLUMN, query_failed_after_mysql_statement, validate_mysql_session_marker,
+};
 #[cfg(unix)]
 use super::pty::{
     MySqlPty, create_mysql_pty, read_one_pty_resultset, read_one_pty_resultset_with_diagnostics,
@@ -369,6 +371,7 @@ async fn drain_mysql_pty(pty: &mut MySqlPty) {
 pub(super) async fn run_mysql_process_with_timeout<T, F>(
     execution_timeout: Duration,
     process: &mut MySqlProcess,
+    possible_refresh_scope: RefreshScope,
     execute: F,
 ) -> Result<T, DbOperationError>
 where
@@ -378,12 +381,18 @@ where
         Ok(Ok(value)) => Ok(value),
         Ok(Err(error)) => {
             cleanup_mysql_process(process).await;
-            Err(error)
+            Err(query_failed_after_mysql_statement(
+                error,
+                RefreshScope::None,
+                possible_refresh_scope,
+            ))
         }
         Err(_) => {
             cleanup_mysql_process(process).await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
+            Err(query_failed_after_mysql_statement(
+                DbOperationError::Timeout("mysql query exceeded the execution timeout".to_string()),
+                RefreshScope::None,
+                possible_refresh_scope,
             ))
         }
     }
@@ -545,9 +554,12 @@ mod tests {
         execution_timeout: Duration,
     ) -> Result<(), DbOperationError> {
         let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
-        run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
-            run_mysql_export_process(process, option_file, query, path).await
-        })
+        run_mysql_process_with_timeout(
+            execution_timeout,
+            &mut process,
+            RefreshScope::None,
+            async |process| run_mysql_export_process(process, option_file, query, path).await,
+        )
         .await
     }
     async fn run_mysql_single_statement_with_program(
@@ -558,9 +570,12 @@ mod tests {
         execution_timeout: Duration,
     ) -> Result<MySqlResultSet, DbOperationError> {
         let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
-        run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
-            run_mysql_single_statement_process(process, query, access_mode).await
-        })
+        run_mysql_process_with_timeout(
+            execution_timeout,
+            &mut process,
+            RefreshScope::None,
+            async |process| run_mysql_single_statement_process(process, query, access_mode).await,
+        )
         .await
     }
 
@@ -572,9 +587,15 @@ mod tests {
         execution_timeout: Duration,
     ) -> Result<MySqlExecutionResult, DbOperationError> {
         let mut process = MySqlProcess::spawn_with_adhoc_program(program, option_file)?;
-        run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
-            run_mysql_single_statement_process_with_diagnostics(process, query, access_mode).await
-        })
+        run_mysql_process_with_timeout(
+            execution_timeout,
+            &mut process,
+            RefreshScope::None,
+            async |process| {
+                run_mysql_single_statement_process_with_diagnostics(process, query, access_mode)
+                    .await
+            },
+        )
         .await
     }
 
@@ -842,6 +863,9 @@ while IFS= read -r line; do
     *missing_column*)
       printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
       exit 1
+      ;;
+    *SLEEP*)
+      while :; do :; done
       ;;
     *SELECT*)
       case "$line" in
@@ -1729,6 +1753,57 @@ done
                     ..
                 }) if matches!(&*source, DbOperationError::ObjectMissing(_))
             ));
+        }
+
+        #[tokio::test]
+        async fn timeout_after_a_data_change_is_wrapped_for_refresh() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements("UPDATE items SET value = 1; SELECT SLEEP(40)")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_millis(100),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    source,
+                    refresh_scope: RefreshScope::Data,
+                    ..
+                }) if matches!(&*source, DbOperationError::Timeout(_))
+            ));
+        }
+
+        #[tokio::test]
+        async fn read_only_timeout_does_not_request_refresh() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements("SELECT SLEEP(40)")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_millis(100),
+            )
+            .await;
+
+            assert!(matches!(result, Err(DbOperationError::Timeout(_))));
         }
 
         #[tokio::test]

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -383,7 +383,6 @@ where
             cleanup_mysql_process(process).await;
             Err(query_failed_after_mysql_statement(
                 error,
-                RefreshScope::None,
                 possible_refresh_scope,
             ))
         }
@@ -391,7 +390,6 @@ where
             cleanup_mysql_process(process).await;
             Err(query_failed_after_mysql_statement(
                 DbOperationError::Timeout("mysql query exceeded the execution timeout".to_string()),
-                RefreshScope::None,
                 possible_refresh_scope,
             ))
         }
@@ -1676,7 +1674,7 @@ done
         }
 
         #[tokio::test]
-        async fn first_change_statement_failure_keeps_the_classified_error_unwrapped() {
+        async fn first_change_statement_failure_refreshes_possible_scope() {
             for (details, summary) in [
                 (
                     "ERROR 1142 (42000): command denied to user",
@@ -1717,9 +1715,18 @@ done
                 };
 
                 assert_eq!(error.summary(), summary);
-                assert!(!matches!(
+                assert!(matches!(
                     error,
-                    DbOperationError::QueryFailedAfterChange { .. }
+                    DbOperationError::QueryFailedAfterChange {
+                        source,
+                        refresh_scope: RefreshScope::Data,
+                    } if matches!(
+                        &*source,
+                        DbOperationError::PermissionDenied(_)
+                            | DbOperationError::UniqueViolation(_)
+                            | DbOperationError::ForeignKeyViolation(_)
+                            | DbOperationError::LockTimeout(_)
+                    )
                 ));
             }
         }

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -16,8 +16,8 @@ use crate::domain::{
 use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
 use super::super::policy::{
     MySqlExecutionResult, mysql_command_tag, mysql_metadata_fallback_has_unsupported_session_state,
-    mysql_refresh_scope, mysql_row_count_marker, query_failed_after_change,
-    query_failed_after_mysql_statement,
+    mysql_possible_refresh_scope, mysql_refresh_scope, mysql_row_count_marker,
+    query_failed_after_change, query_failed_after_mysql_statement,
 };
 use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns_with_diagnostics;
@@ -54,20 +54,26 @@ pub(super) async fn run_mysql_adhoc_with_program_and_statements_and_expected_col
     if mysql_metadata_fallback_has_unsupported_session_state(statements) {
         return Err(DbOperationError::UnsupportedOperation(
             "MySQL empty SHOW/DESCRIBE metadata fallback cannot preserve temporary-table session state"
-                .to_string(),
+            .to_string(),
         ));
     }
+    let possible_refresh_scope = mysql_possible_refresh_scope(statements);
     let mut process = MySqlProcess::spawn_with_adhoc_program(program, option_file)?;
-    run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
-        run_mysql_adhoc_process(
-            process,
-            option_file,
-            statements,
-            access_mode,
-            expected_columns,
-        )
-        .await
-    })
+    run_mysql_process_with_timeout(
+        execution_timeout,
+        &mut process,
+        possible_refresh_scope,
+        async |process| {
+            run_mysql_adhoc_process(
+                process,
+                option_file,
+                statements,
+                access_mode,
+                expected_columns,
+            )
+            .await
+        },
+    )
     .await
 }
 

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -144,7 +144,6 @@ async fn run_mysql_statement(
         Err(error) => {
             return Err(query_failed_after_mysql_statement(
                 error,
-                refresh_scope,
                 possible_refresh_scope,
             ));
         }
@@ -244,14 +243,12 @@ async fn run_mysql_adhoc_process(
     let mut last_result_set = None;
     let mut last_result_statement = None;
     let mut refresh_scope = RefreshScope::None;
-    let mut refresh_scope_before_last_statement = RefreshScope::None;
     let mut diagnostics = Vec::new();
     let expected_columns = (statements.len() == 1)
         .then_some(expected_columns)
         .flatten();
 
     for (index, statement) in statements.iter().enumerate() {
-        refresh_scope_before_last_statement = refresh_scope;
         if last_result_set
             .as_ref()
             .is_some_and(mysql_result_needs_metadata)
@@ -306,11 +303,7 @@ async fn run_mysql_adhoc_process(
         match read_one_mysql_resultset_with_diagnostics(process).await {
             Ok(result) => result,
             Err(error) => {
-                return Err(query_failed_after_mysql_statement(
-                    error,
-                    refresh_scope_before_last_statement,
-                    refresh_scope,
-                ));
+                return Err(query_failed_after_mysql_statement(error, refresh_scope));
             }
         };
     diagnostics.extend(marker_diagnostics);

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -21,9 +21,14 @@ pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
     access_mode: AccessMode,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     let mut process = MySqlProcess::spawn_with_adhoc_program(OsStr::new("mysql"), option_file)?;
-    run_mysql_process_with_timeout(MYSQL_QUERY_TIMEOUT, &mut process, async |process| {
-        run_mysql_single_statement_process_with_diagnostics(process, query, access_mode).await
-    })
+    run_mysql_process_with_timeout(
+        MYSQL_QUERY_TIMEOUT,
+        &mut process,
+        RefreshScope::None,
+        async |process| {
+            run_mysql_single_statement_process_with_diagnostics(process, query, access_mode).await
+        },
+    )
     .await
 }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -3144,7 +3144,13 @@ mod query_execution {
                     ),
                 )
                     .await;
-                if !matches!(write, Err(DbOperationError::QueryFailed(ref details)) if details.contains("READ ONLY"))
+                if !matches!(
+                    write.as_ref(),
+                    Err(DbOperationError::QueryFailedAfterChange {
+                        source,
+                        refresh_scope: RefreshScope::Data,
+                    }) if matches!(&**source, DbOperationError::QueryFailed(details) if details.contains("READ ONLY"))
+                )
                 {
                     return Err(format!("read-only adhoc write was not rejected: {write:?}"));
                 }


### PR DESCRIPTION
## Problem

An outer timeout can occur after an earlier MySQL statement has committed a data or schema change, but the timeout error loses that statement's refresh scope and leaves the UI stale.

## Background

MySQL multi-statement execution runs inside one timed process future, while statement-level refresh tracking is currently held inside that future.

## Approach

Compute a conservative refresh scope from all classified statements before starting the timed process. Preserve more precise statement-level classifications, and use the existing application refresh path for errors and timeouts while leaving read-only timeouts unwrapped.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-536
