### PR TITLE
fix(mysql): surface non-strict write diagnostics

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -288,7 +288,7 @@ pub async fn run(
                             dsn,
                             run_id,
                             affected_rows: result.affected_rows,
-                            mysql_diagnostics: result.mysql_diagnostics,
+                            diagnostics: result.diagnostics,
                         })
                         .await
                         .ok();
@@ -436,7 +436,7 @@ mod tests {
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
     use crate::cmd::test_fixtures;
-    use crate::domain::WriteExecutionResult;
+    use crate::domain::{WriteDiagnostic, WriteDiagnosticLevel, WriteExecutionResult};
     use crate::model::app_state::AppState;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
@@ -897,7 +897,11 @@ mod tests {
                     Ok(WriteExecutionResult {
                         affected_rows: 1,
                         execution_time_ms: 0,
-                        mysql_diagnostics: Vec::new(),
+                        diagnostics: vec![WriteDiagnostic {
+                            level: WriteDiagnosticLevel::Warning,
+                            code: 1265,
+                            message: "Data truncated".to_string(),
+                        }],
                     })
                 });
 
@@ -912,14 +916,22 @@ mod tests {
             )
             .await;
 
-            assert!(matches!(
-                action,
+            match action {
                 Action::ExecuteWriteSucceeded {
                     run_id: 3,
                     affected_rows: 1,
+                    diagnostics,
                     ..
-                }
-            ));
+                } => assert_eq!(
+                    diagnostics,
+                    vec![WriteDiagnostic {
+                        level: WriteDiagnosticLevel::Warning,
+                        code: 1265,
+                        message: "Data truncated".to_string(),
+                    }]
+                ),
+                action => panic!("unexpected action: {action:?}"),
+            }
         }
     }
 }

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -288,6 +288,7 @@ pub async fn run(
                             dsn,
                             run_id,
                             affected_rows: result.affected_rows,
+                            mysql_diagnostics: result.mysql_diagnostics,
                         })
                         .await
                         .ok();
@@ -896,6 +897,7 @@ mod tests {
                     Ok(WriteExecutionResult {
                         affected_rows: 1,
                         execution_time_ms: 0,
+                        mysql_diagnostics: Vec::new(),
                     })
                 });
 

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -887,7 +887,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn execute_write_forwards_access_mode() {
+        async fn execute_write_forwards_access_mode_and_diagnostics() {
             let mut executor = MockQueryExecutor::new();
             executor
                 .expect_execute_write()

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
+use crate::domain::MySqlDiagnostic;
 use crate::domain::connection::{
     ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
@@ -609,6 +610,7 @@ pub enum Action {
         dsn: String,
         run_id: u64,
         affected_rows: usize,
+        mysql_diagnostics: Vec<MySqlDiagnostic>,
     },
     ExecuteWriteFailed {
         dsn: String,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::sync::Arc;
 
-use crate::domain::MySqlDiagnostic;
 use crate::domain::connection::{
     ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
@@ -25,6 +24,7 @@ use std::collections::HashMap;
 use crate::domain::SqliteDiagnosticsSnapshot;
 use crate::domain::{
     DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table, TableSignatureSnapshot,
+    WriteDiagnostic,
 };
 
 #[derive(Clone, thiserror::Error)]
@@ -610,7 +610,7 @@ pub enum Action {
         dsn: String,
         run_id: u64,
         affected_rows: usize,
-        mysql_diagnostics: Vec<MySqlDiagnostic>,
+        diagnostics: Vec<WriteDiagnostic>,
     },
     ExecuteWriteFailed {
         dsn: String,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::RefreshScope;
+use crate::domain::{MySqlDiagnostic, RefreshScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::confirm_dialog::ConfirmIntent;
@@ -248,6 +248,7 @@ pub fn reduce_write(
             dsn,
             run_id,
             affected_rows,
+            mysql_diagnostics,
         } => {
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
@@ -263,7 +264,10 @@ pub fn reduce_write(
                 WriteOperation::Update => {
                     if *affected_rows != 1 {
                         state.messages.set_error_at(
-                            format!("UPDATE expected 1 row, but affected {affected_rows} rows"),
+                            write_message_with_diagnostics(
+                                format!("UPDATE expected 1 row, but affected {affected_rows} rows"),
+                                mysql_diagnostics,
+                            ),
                             now,
                         );
                         state.result_interaction.clear_cell_edit();
@@ -278,9 +282,13 @@ pub fn reduce_write(
                         };
                     }
 
-                    state
-                        .messages
-                        .set_success_at("Updated 1 row".to_string(), now);
+                    state.messages.set_success_at(
+                        write_message_with_diagnostics(
+                            "Updated 1 row".to_string(),
+                            mysql_diagnostics,
+                        ),
+                        now,
+                    );
                     state.result_interaction.clear_cell_edit();
                     state.modal.set_mode(InputMode::Normal);
 
@@ -307,17 +315,23 @@ pub fn reduce_write(
                     let row_word = |n: usize| if n == 1 { "row" } else { "rows" };
                     if *affected_rows == expected {
                         state.messages.set_success_at(
-                            format!("Deleted {} {}", expected, row_word(expected)),
+                            write_message_with_diagnostics(
+                                format!("Deleted {} {}", expected, row_word(expected)),
+                                mysql_diagnostics,
+                            ),
                             now,
                         );
                     } else {
                         state.messages.set_error_at(
-                            format!(
-                                "DELETE expected {} {}, but affected {} {}",
-                                expected,
-                                row_word(expected),
-                                affected_rows,
-                                row_word(*affected_rows),
+                            write_message_with_diagnostics(
+                                format!(
+                                    "DELETE expected {} {}, but affected {} {}",
+                                    expected,
+                                    row_word(expected),
+                                    affected_rows,
+                                    row_word(*affected_rows),
+                                ),
+                                mysql_diagnostics,
                             ),
                             now,
                         );
@@ -372,6 +386,19 @@ pub fn reduce_write(
 
         _ => DispatchResult::pass(),
     }
+}
+
+fn write_message_with_diagnostics(message: String, diagnostics: &[MySqlDiagnostic]) -> String {
+    if diagnostics.is_empty() {
+        return message;
+    }
+
+    let details = diagnostics
+        .iter()
+        .map(MySqlDiagnostic::display_message)
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!("{message}; {details}")
 }
 
 fn open_write_preview_confirm(
@@ -430,7 +457,9 @@ mod tests {
     use crate::update::test_fixtures;
 
     use crate::domain::connection::ConnectionId;
-    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource, QueryValue};
+    use crate::domain::{
+        ColumnAttributes, DatabaseType, MySqlDiagnosticLevel, QueryResult, QuerySource, QueryValue,
+    };
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
     };
@@ -444,11 +473,24 @@ mod tests {
     use std::sync::Arc;
 
     fn write_succeeded_action(state: &mut AppState, affected_rows: usize) -> Action {
+        write_succeeded_action_with_diagnostics(state, affected_rows, Vec::new())
+    }
+
+    fn write_succeeded_action_with_diagnostics(
+        state: &mut AppState,
+        affected_rows: usize,
+        mysql_diagnostics: Vec<MySqlDiagnostic>,
+    ) -> Action {
+        let dsn = state
+            .session
+            .dsn()
+            .map_or_else(|| "postgres://localhost/test".to_string(), str::to_string);
         let run_id = begin_query_run(state);
         Action::ExecuteWriteSucceeded {
-            dsn: "postgres://localhost/test".to_string(),
+            dsn,
             run_id,
             affected_rows,
+            mysql_diagnostics,
         }
     }
 
@@ -1344,6 +1386,7 @@ mod tests {
                     dsn: "mysql://localhost/test".to_string(),
                     run_id,
                     affected_rows: 0,
+                    mysql_diagnostics: Vec::new(),
                 },
                 Instant::now(),
                 &AppServices::stub(),
@@ -1354,6 +1397,27 @@ mod tests {
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("UPDATE expected 1 row, but affected 0 rows")
+            );
+        }
+
+        #[test]
+        fn mysql_write_diagnostic_is_visible_in_update_success() {
+            let mut state = mysql_editable_state("enum", QueryValue::text("before"), "after");
+            let action = write_succeeded_action_with_diagnostics(
+                &mut state,
+                1,
+                vec![MySqlDiagnostic {
+                    level: MySqlDiagnosticLevel::Warning,
+                    code: 1265,
+                    message: "Data truncated".to_string(),
+                }],
+            );
+
+            dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
+
+            assert_eq!(
+                state.messages.last_success.as_deref(),
+                Some("Updated 1 row; Warning (Code 1265): Data truncated")
             );
         }
 
@@ -1455,6 +1519,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: old_run_id,
                     affected_rows: 1,
+                    mysql_diagnostics: Vec::new(),
                 },
                 Instant::now(),
                 &AppServices::stub(),

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::{MySqlDiagnostic, RefreshScope};
+use crate::domain::{RefreshScope, WriteDiagnostic};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::confirm_dialog::ConfirmIntent;
@@ -248,7 +248,7 @@ pub fn reduce_write(
             dsn,
             run_id,
             affected_rows,
-            mysql_diagnostics,
+            diagnostics,
         } => {
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
@@ -266,7 +266,7 @@ pub fn reduce_write(
                         state.messages.set_error_at(
                             write_message_with_diagnostics(
                                 format!("UPDATE expected 1 row, but affected {affected_rows} rows"),
-                                mysql_diagnostics,
+                                diagnostics,
                             ),
                             now,
                         );
@@ -283,10 +283,7 @@ pub fn reduce_write(
                     }
 
                     state.messages.set_success_at(
-                        write_message_with_diagnostics(
-                            "Updated 1 row".to_string(),
-                            mysql_diagnostics,
-                        ),
+                        write_message_with_diagnostics("Updated 1 row".to_string(), diagnostics),
                         now,
                     );
                     state.result_interaction.clear_cell_edit();
@@ -317,7 +314,7 @@ pub fn reduce_write(
                         state.messages.set_success_at(
                             write_message_with_diagnostics(
                                 format!("Deleted {} {}", expected, row_word(expected)),
-                                mysql_diagnostics,
+                                diagnostics,
                             ),
                             now,
                         );
@@ -331,7 +328,7 @@ pub fn reduce_write(
                                     affected_rows,
                                     row_word(*affected_rows),
                                 ),
-                                mysql_diagnostics,
+                                diagnostics,
                             ),
                             now,
                         );
@@ -388,14 +385,14 @@ pub fn reduce_write(
     }
 }
 
-fn write_message_with_diagnostics(message: String, diagnostics: &[MySqlDiagnostic]) -> String {
+fn write_message_with_diagnostics(message: String, diagnostics: &[WriteDiagnostic]) -> String {
     if diagnostics.is_empty() {
         return message;
     }
 
     let details = diagnostics
         .iter()
-        .map(MySqlDiagnostic::display_message)
+        .map(WriteDiagnostic::display_message)
         .collect::<Vec<_>>()
         .join("; ");
     format!("{message}; {details}")
@@ -458,7 +455,7 @@ mod tests {
 
     use crate::domain::connection::ConnectionId;
     use crate::domain::{
-        ColumnAttributes, DatabaseType, MySqlDiagnosticLevel, QueryResult, QuerySource, QueryValue,
+        ColumnAttributes, DatabaseType, QueryResult, QuerySource, QueryValue, WriteDiagnosticLevel,
     };
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
@@ -479,7 +476,7 @@ mod tests {
     fn write_succeeded_action_with_diagnostics(
         state: &mut AppState,
         affected_rows: usize,
-        mysql_diagnostics: Vec<MySqlDiagnostic>,
+        diagnostics: Vec<WriteDiagnostic>,
     ) -> Action {
         let dsn = state
             .session
@@ -490,7 +487,7 @@ mod tests {
             dsn,
             run_id,
             affected_rows,
-            mysql_diagnostics,
+            diagnostics,
         }
     }
 
@@ -1386,7 +1383,7 @@ mod tests {
                     dsn: "mysql://localhost/test".to_string(),
                     run_id,
                     affected_rows: 0,
-                    mysql_diagnostics: Vec::new(),
+                    diagnostics: Vec::new(),
                 },
                 Instant::now(),
                 &AppServices::stub(),
@@ -1406,8 +1403,8 @@ mod tests {
             let action = write_succeeded_action_with_diagnostics(
                 &mut state,
                 1,
-                vec![MySqlDiagnostic {
-                    level: MySqlDiagnosticLevel::Warning,
+                vec![WriteDiagnostic {
+                    level: WriteDiagnosticLevel::Warning,
                     code: 1265,
                     message: "Data truncated".to_string(),
                 }],
@@ -1519,7 +1516,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: old_run_id,
                     affected_rows: 1,
-                    mysql_diagnostics: Vec::new(),
+                    diagnostics: Vec::new(),
                 },
                 Instant::now(),
                 &AppServices::stub(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2241,6 +2241,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     affected_rows: 1,
+                    mysql_diagnostics: Vec::new(),
                 },
                 now,
                 &AppServices::stub(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2241,7 +2241,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     affected_rows: 1,
-                    mysql_diagnostics: Vec::new(),
+                    diagnostics: Vec::new(),
                 },
                 now,
                 &AppServices::stub(),

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -41,7 +41,7 @@ pub use table::{
 };
 pub use table_kind::{TableKind, TableKindInfo};
 pub use trigger::{Trigger, TriggerCreationContext, TriggerEvent, TriggerTiming};
-pub use write_result::WriteExecutionResult;
+pub use write_result::{WriteDiagnostic, WriteDiagnosticLevel, WriteExecutionResult};
 
 pub use connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,

--- a/src/domain/mysql_diagnostics.rs
+++ b/src/domain/mysql_diagnostics.rs
@@ -11,6 +11,18 @@ pub struct MySqlDiagnostic {
     pub message: String,
 }
 
+impl MySqlDiagnostic {
+    #[must_use]
+    pub fn display_message(&self) -> String {
+        format!(
+            "{} (Code {}): {}",
+            self.level.as_str(),
+            self.code,
+            self.message
+        )
+    }
+}
+
 impl MySqlDiagnosticLevel {
     #[must_use]
     pub fn as_str(&self) -> &'static str {
@@ -18,5 +30,23 @@ impl MySqlDiagnosticLevel {
             Self::Warning => "Warning",
             Self::Note => "Note",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_level_code_and_message_for_statuses() {
+        assert_eq!(
+            MySqlDiagnostic {
+                level: MySqlDiagnosticLevel::Warning,
+                code: 1265,
+                message: "Data truncated".to_string(),
+            }
+            .display_message(),
+            "Warning (Code 1265): Data truncated"
+        );
     }
 }

--- a/src/domain/write_result.rs
+++ b/src/domain/write_result.rs
@@ -1,8 +1,41 @@
-use super::MySqlDiagnostic;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteDiagnosticLevel {
+    Warning,
+    Note,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteDiagnostic {
+    pub level: WriteDiagnosticLevel,
+    pub code: u32,
+    pub message: String,
+}
+
+impl WriteDiagnostic {
+    #[must_use]
+    pub fn display_message(&self) -> String {
+        format!(
+            "{} (Code {}): {}",
+            self.level.as_str(),
+            self.code,
+            self.message
+        )
+    }
+}
+
+impl WriteDiagnosticLevel {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Warning => "Warning",
+            Self::Note => "Note",
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteExecutionResult {
     pub affected_rows: usize,
     pub execution_time_ms: u64,
-    pub mysql_diagnostics: Vec<MySqlDiagnostic>,
+    pub diagnostics: Vec<WriteDiagnostic>,
 }

--- a/src/domain/write_result.rs
+++ b/src/domain/write_result.rs
@@ -1,5 +1,8 @@
+use super::MySqlDiagnostic;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteExecutionResult {
     pub affected_rows: usize,
     pub execution_time_ms: u64,
+    pub mysql_diagnostics: Vec<MySqlDiagnostic>,
 }

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -330,6 +330,7 @@ mod probe_tests {
             })
         ));
         assert!(validate_sql_mode("STRICT_TRANS_TABLES").is_ok());
+        assert!(validate_sql_mode("").is_ok());
         assert!(matches!(
             validate_sql_mode("STRICT_TRANS_TABLES,ANSI_QUOTES"),
             Err(DbOperationError::UnsupportedOperationWithKind {

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -3,7 +3,8 @@ use std::time::Instant;
 use crate::adapters::csv_export::export_to_downloads;
 use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use crate::domain::{
-    QueryResult, QuerySource, WriteExecutionResult, mysql_sql::mysql_tree_explain_query_kind,
+    MySqlDiagnostic, MySqlDiagnosticLevel, QueryResult, QuerySource, WriteDiagnostic,
+    WriteDiagnosticLevel, WriteExecutionResult, mysql_sql::mysql_tree_explain_query_kind,
 };
 use async_trait::async_trait;
 
@@ -186,7 +187,11 @@ impl QueryExecutor for MySqlAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms: start.elapsed().as_millis() as u64,
-            mysql_diagnostics: execution.diagnostics,
+            diagnostics: execution
+                .diagnostics
+                .into_iter()
+                .map(write_diagnostic_from_mysql)
+                .collect(),
         })
     }
 
@@ -212,6 +217,17 @@ impl QueryExecutor for MySqlAdapter {
             export_mysql_csv_to_file(target, &query, path).await
         })
         .await
+    }
+}
+
+fn write_diagnostic_from_mysql(diagnostic: MySqlDiagnostic) -> WriteDiagnostic {
+    WriteDiagnostic {
+        level: match diagnostic.level {
+            MySqlDiagnosticLevel::Warning => WriteDiagnosticLevel::Warning,
+            MySqlDiagnosticLevel::Note => WriteDiagnosticLevel::Note,
+        },
+        code: diagnostic.code,
+        message: diagnostic.message,
     }
 }
 

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -186,6 +186,7 @@ impl QueryExecutor for MySqlAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms: start.elapsed().as_millis() as u64,
+            mysql_diagnostics: execution.diagnostics,
         })
     }
 

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -436,7 +436,7 @@ impl PostgresAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms: elapsed,
-            mysql_diagnostics: Vec::new(),
+            diagnostics: Vec::new(),
         })
     }
 

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -436,6 +436,7 @@ impl PostgresAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms: elapsed,
+            mysql_diagnostics: Vec::new(),
         })
     }
 

--- a/src/infra/adapters/sqlite/executor.rs
+++ b/src/infra/adapters/sqlite/executor.rs
@@ -128,7 +128,7 @@ impl QueryExecutor for SqliteAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms,
-            mysql_diagnostics: Vec::new(),
+            diagnostics: Vec::new(),
         })
     }
 

--- a/src/infra/adapters/sqlite/executor.rs
+++ b/src/infra/adapters/sqlite/executor.rs
@@ -128,6 +128,7 @@ impl QueryExecutor for SqliteAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms,
+            mysql_diagnostics: Vec::new(),
         })
     }
 

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -9,7 +9,7 @@ use crate::app::model::shared::text_input::TextInputState;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::policy::write::write_guardrails::AdhocRiskDecision;
-use crate::domain::{MySqlDiagnostic, MySqlDiagnosticLevel};
+use crate::domain::MySqlDiagnostic;
 use crate::primitives::atoms::{spinner_char, text_cursor_spans};
 use crate::primitives::utils::text_utils::{truncate_to_width_with, wrapped_line_count};
 use crate::theme::ThemePalette;
@@ -321,14 +321,7 @@ fn render_success_status_with_diagnostics(
 }
 
 fn diagnostic_status_line(diagnostic: &MySqlDiagnostic) -> String {
-    let level = match diagnostic.level {
-        MySqlDiagnosticLevel::Warning => "Warning",
-        MySqlDiagnosticLevel::Note => "Note",
-    };
-    format!(
-        "⚠ {level} (Code {}): {}",
-        diagnostic.code, diagnostic.message
-    )
+    format!("⚠ {}", diagnostic.display_message())
 }
 
 fn error_status_message(state: &AppState) -> String {
@@ -346,6 +339,7 @@ fn error_status_message(state: &AppState) -> String {
 mod tests {
     use super::*;
     use crate::app::model::sql_editor::modal::AdhocSuccessSnapshot;
+    use crate::domain::MySqlDiagnosticLevel;
 
     #[test]
     fn diagnostics_height_only_applies_to_success_status() {


### PR DESCRIPTION
## Problem

MySQL non-strict writes can coerce invalid ENUM/SET values while returning a successful affected-row count, leaving the UI unaware of the stored-value change.

## Background

C04 already collects MySQL warning and note diagnostics for successful statements, but write execution discarded them before grid and JSON edit completion was rendered.

## Approach

Preserve the existing MySQL diagnostics through the write execution result and action flow, then append them to grid and JSON completion messages while keeping non-strict `sql_mode` accepted and non-MySQL adapters unchanged.
