### PR TITLE
fix(mysql): allow SELECT INTO user variables

### DIFF
--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -114,6 +114,10 @@ pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
     side_effect::has_top_level_into_clause(sql)
 }
 
+pub fn has_top_level_user_variable_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
+    side_effect::has_top_level_user_variable_into_clause(sql)
+}
+
 pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLexError> {
     side_effect::has_mysql_read_only_side_effect(sql)
 }

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -850,7 +850,6 @@ mod tests {
         for sql in [
             "SELECT id INTO OUTFILE '/tmp/result' FROM items",
             "SELECT id INTO DUMPFILE '/tmp/result' FROM items",
-            "SELECT id INTO @value FROM items",
             "TABLE items INTO OUTFILE '/tmp/result'",
             "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/result' FROM rows",
         ] {
@@ -860,6 +859,13 @@ mod tests {
         assert!(
             classify_mysql_multi_statement(
                 "WITH rows AS (SELECT 'INTO OUTFILE') SELECT * FROM rows",
+                Some("app")
+            )
+            .is_ok()
+        );
+        assert!(
+            classify_mysql_multi_statement(
+                "SELECT id INTO @value FROM items; SELECT @value",
                 Some("app")
             )
             .is_ok()

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -240,10 +240,13 @@ pub fn validate_mysql_statements_with_lower_case_table_names(
         if statement_contains_unsupported_mysql_control(&statement.sql) {
             return Err("unsupported MySQL session or table-lock statement".to_string());
         }
+        let has_unsupported_into_clause = has_top_level_into_clause(&statement.sql).unwrap_or(true)
+            && !(matches!(statement.kind, MySqlStatementKind::Select)
+                && has_top_level_user_variable_into_clause(&statement.sql).unwrap_or(false));
         if matches!(
             statement.kind,
             MySqlStatementKind::Select | MySqlStatementKind::Table
-        ) && has_top_level_into_clause(&statement.sql).unwrap_or(true)
+        ) && has_unsupported_into_clause
         {
             return Err("MySQL SELECT INTO clauses are not supported".to_string());
         }
@@ -855,6 +858,7 @@ mod tests {
             "SELECT id INTO OUTFILE '/tmp/result' FROM items",
             "SELECT id INTO DUMPFILE '/tmp/result' FROM items",
             "TABLE items INTO OUTFILE '/tmp/result'",
+            "TABLE items INTO @picked",
             "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/result' FROM rows",
         ] {
             let error = classify_mysql_multi_statement(sql, Some("app")).unwrap_err();

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -2,9 +2,26 @@ use super::{MySqlLexError, lexer, lexer::TokenKind, target};
 
 pub(super) fn has_top_level_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
     let tokens = lexer::lex_mysql_statement(sql)?;
-    Ok(tokens.iter().any(|token| {
-        token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
+    Ok(tokens.iter().enumerate().any(|(index, token)| {
+        token.depth == 0
+            && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
+            && !is_user_variable_into_clause(&tokens, index)
     }))
+}
+
+fn is_user_variable_into_clause(tokens: &[lexer::Token], index: usize) -> bool {
+    matches!(
+        tokens.get(index + 1).map(|token| &token.kind),
+        Some(TokenKind::Symbol('@'))
+    ) && tokens.get(index + 2).is_some_and(|token| {
+        matches!(
+            &token.kind,
+            TokenKind::Word(_)
+                | TokenKind::Identifier(_)
+                | TokenKind::Number
+                | TokenKind::StringLiteral
+        )
+    })
 }
 
 pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLexError> {
@@ -314,5 +331,32 @@ mod tests {
             );
         }
         assert!(!mysql_statement_reads_session_diagnostics("SELECT 'FOUND_ROWS()'").unwrap());
+    }
+
+    #[test]
+    fn ignores_top_level_user_variable_into_but_detects_file_output() {
+        for sql in [
+            "SELECT id INTO @picked FROM items",
+            "SELECT id INTO @picked, @other FROM items",
+        ] {
+            assert!(!has_top_level_into_clause(sql).unwrap(), "{sql}");
+        }
+        for sql in [
+            "SELECT id INTO OUTFILE '/tmp/result' FROM items",
+            "SELECT id INTO DUMPFILE '/tmp/result' FROM items",
+        ] {
+            assert!(has_top_level_into_clause(sql).unwrap(), "{sql}");
+        }
+    }
+
+    #[test]
+    fn ignores_quoted_commented_and_nested_into_tokens() {
+        for sql in [
+            "SELECT 'INTO @picked' FROM items",
+            "SELECT /* INTO OUTFILE '/tmp/result' */ id FROM items",
+            "WITH rows AS (SELECT id INTO @picked FROM items) SELECT * FROM rows",
+        ] {
+            assert!(!has_top_level_into_clause(sql).unwrap(), "{sql}");
+        }
     }
 }

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -2,10 +2,8 @@ use super::{MySqlLexError, lexer, lexer::TokenKind, target};
 
 pub(super) fn has_top_level_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
     let tokens = lexer::lex_mysql_statement(sql)?;
-    Ok(tokens.iter().enumerate().any(|(index, token)| {
-        token.depth == 0
-            && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
-            && !is_user_variable_into_clause(&tokens, index)
+    Ok(tokens.iter().any(|token| {
+        token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
     }))
 }
 
@@ -343,12 +341,12 @@ mod tests {
     }
 
     #[test]
-    fn ignores_top_level_user_variable_into_but_detects_file_output() {
+    fn detects_top_level_into_clauses_and_user_variable_shape() {
         for sql in [
             "SELECT id INTO @picked FROM items",
             "SELECT id INTO @picked, @other FROM items",
         ] {
-            assert!(!has_top_level_into_clause(sql).unwrap(), "{sql}");
+            assert!(has_top_level_into_clause(sql).unwrap(), "{sql}");
             assert!(
                 has_top_level_user_variable_into_clause(sql).unwrap(),
                 "{sql}"

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -9,6 +9,15 @@ pub(super) fn has_top_level_into_clause(sql: &str) -> Result<bool, MySqlLexError
     }))
 }
 
+pub(super) fn has_top_level_user_variable_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
+    let tokens = lexer::lex_mysql_statement(sql)?;
+    Ok(tokens.iter().enumerate().any(|(index, token)| {
+        token.depth == 0
+            && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
+            && is_user_variable_into_clause(&tokens, index)
+    }))
+}
+
 fn is_user_variable_into_clause(tokens: &[lexer::Token], index: usize) -> bool {
     matches!(
         tokens.get(index + 1).map(|token| &token.kind),
@@ -340,12 +349,20 @@ mod tests {
             "SELECT id INTO @picked, @other FROM items",
         ] {
             assert!(!has_top_level_into_clause(sql).unwrap(), "{sql}");
+            assert!(
+                has_top_level_user_variable_into_clause(sql).unwrap(),
+                "{sql}"
+            );
         }
         for sql in [
             "SELECT id INTO OUTFILE '/tmp/result' FROM items",
             "SELECT id INTO DUMPFILE '/tmp/result' FROM items",
         ] {
             assert!(has_top_level_into_clause(sql).unwrap(), "{sql}");
+            assert!(
+                !has_top_level_user_variable_into_clause(sql).unwrap(),
+                "{sql}"
+            );
         }
     }
 
@@ -357,6 +374,10 @@ mod tests {
             "WITH rows AS (SELECT id INTO @picked FROM items) SELECT * FROM rows",
         ] {
             assert!(!has_top_level_into_clause(sql).unwrap(), "{sql}");
+            assert!(
+                !has_top_level_user_variable_into_clause(sql).unwrap(),
+                "{sql}"
+            );
         }
     }
 }

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -544,6 +544,17 @@ mod tests {
     }
 
     #[test]
+    fn read_write_allows_user_variable_assignment_but_read_only_does_not() {
+        let query = "SELECT id INTO @picked FROM users; SELECT @picked";
+
+        assert!(validate_mysql_multi_query(query, Some("app"), AccessMode::ReadWrite).is_ok());
+        assert!(matches!(
+            validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly),
+            Err(DbOperationError::PermissionDenied(_))
+        ));
+    }
+
+    #[test]
     fn raw_sql_revalidation_honors_case_insensitive_database_modes() {
         for lower_case_table_names in [1, 2] {
             assert!(

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -865,6 +865,8 @@ while IFS= read -r line; do
     *SLEEP*)
       while :; do :; done
       ;;
+    *"INTO @"*)
+      ;;
     *SELECT*)
       case "$line" in
         *WHERE\ FALSE*)
@@ -872,7 +874,10 @@ while IFS= read -r line; do
           ;;
         *)
           value=one
-          case "$line" in *SELECT\ 2*) value=two ;; esac
+          case "$line" in
+            *SELECT\ 2*) value=two ;;
+            *SELECT\ @picked*) value=picked ;;
+          esac
           printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
           ;;
       esac
@@ -1539,6 +1544,39 @@ done
             assert!(log.contains("UPDATE items SET value = 1"));
             assert_eq!(log.matches("__sabiql_marker").count(), 1);
             assert!(!log.contains("ROW_COUNT()"));
+        }
+
+        #[tokio::test]
+        async fn skips_resultset_wait_for_select_into_user_variable() {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements =
+                split_mysql_statements("SELECT id INTO @picked FROM items; SELECT @picked")
+                    .unwrap()
+                    .into_iter()
+                    .map(|sql| classify_mysql_statement(&sql).unwrap())
+                    .collect::<Vec<_>>();
+
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+                OsStr::new(&program),
+                &option_file,
+                &statements,
+                AccessMode::ReadWrite,
+                None,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("SELECT INTO user variable execution");
+
+            assert_eq!(
+                result.result_set,
+                Some(MySqlResultSet {
+                    columns: vec!["value".to_string()],
+                    values: vec![vec![QueryValue::Text("picked".to_string())]],
+                })
+            );
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.contains("SELECT id INTO @picked FROM items"), "{log}");
+            assert!(log.contains("SELECT @picked"), "{log}");
         }
 
         #[tokio::test]

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -8,8 +8,9 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{
     MySqlDiagnostic, RefreshScope,
     mysql_sql::{
-        MySqlStatement, MySqlStatementKind, mysql_statement_is_data_modifying,
-        mysql_statement_is_schema_modifying, mysql_statement_reads_session_diagnostics,
+        MySqlStatement, MySqlStatementKind, has_top_level_user_variable_into_clause,
+        mysql_statement_is_data_modifying, mysql_statement_is_schema_modifying,
+        mysql_statement_reads_session_diagnostics,
     },
 };
 
@@ -132,7 +133,7 @@ async fn run_mysql_statement(
     if let Err(error) = write_mysql_statement(process, statement.sql()).await {
         return Err(query_failed_after_change(error, refresh_scope));
     }
-    if !mysql_statement_returns_resultset(statement.kind()) {
+    if !mysql_statement_returns_resultset(statement) {
         return Ok(MySqlStatementExecution {
             result_set: None,
             refresh_scope: possible_refresh_scope,
@@ -160,9 +161,14 @@ async fn run_mysql_statement(
     })
 }
 
-fn mysql_statement_returns_resultset(kind: &MySqlStatementKind) -> bool {
+fn mysql_statement_returns_resultset(statement: &MySqlStatement) -> bool {
+    if matches!(statement.kind(), MySqlStatementKind::Select)
+        && has_top_level_user_variable_into_clause(statement.sql()).unwrap_or(false)
+    {
+        return false;
+    }
     matches!(
-        kind,
+        statement.kind(),
         MySqlStatementKind::Select
             | MySqlStatementKind::Table
             | MySqlStatementKind::Show

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2384,6 +2384,32 @@ mod query_execution {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn executes_select_into_user_variable_and_reads_it_later_in_the_submission() {
+        with_mysql_test_db(|db| Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT id INTO @picked FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1; SELECT @picked"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("SELECT INTO user variable failed: {error:?}"))?;
+            if result.columns != ["@picked"]
+                || result.values() != [[QueryValue::Text("1".to_string())]]
+                || result.command_tag.is_some()
+            {
+                return Err(format!("unexpected SELECT INTO result: {result:?}"));
+            }
+            Ok::<(), String>(())
+        }))
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
     async fn preserves_session_row_count_and_omits_multi_statement_affected_rows() {
         with_mysql_test_db(|db| Box::pin(async move {
             let result = async {


### PR DESCRIPTION
## Problem

ReadWrite MySQL submissions reject `SELECT ... INTO @user_var`, preventing later statements from reading the assigned value.

## Background

Top-level `INTO` rejection is still required for `OUTFILE` and `DUMPFILE`, while user-variable assignment is session-local state supported within the same submission. ReadOnly execution must continue to reject it.

## Approach

Recognize only a top-level `INTO` followed by a valid `@` variable token as an allowed assignment. Preserve the existing file-output rejection and ReadOnly side-effect gate, with coverage for same-submission references and quoted, commented, and nested `INTO` tokens.

## How Has This Been Tested?

- local

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-539
