### PR TITLE
fix(mysql): support trusted server public key authentication

### DIFF
--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -14,6 +14,8 @@ mysql_port="${SABIQL_MYSQL_TEST_PORT:-}"
 readonly mysql_database="${SABIQL_MYSQL_TEST_DATABASE:-sabiql_test}"
 readonly mysql_user="${SABIQL_MYSQL_TEST_USER:-sabiql_test_runner}"
 readonly mysql_password="${SABIQL_MYSQL_TEST_PASSWORD:-p a#ss;=\"word}"
+readonly cache_miss_user="${SABIQL_MYSQL_TEST_CACHE_MISS_USER:-sabiql_cache_miss_runner}"
+readonly cache_miss_password="${SABIQL_MYSQL_TEST_CACHE_MISS_PASSWORD:-sabiql-cache-miss}"
 readonly mysql_client_label_key='com.sabiql.mysql.integration'
 
 run_dir=''
@@ -233,6 +235,17 @@ create_server_public_key_material() {
     chmod 644 "$tls_dir/server-public-key.pem"
 }
 
+reset_cache_miss_account() {
+    run_compose exec -T mysql mysql \
+        --protocol=socket \
+        --user=root \
+        --password=root \
+        --batch \
+        --raw \
+        --skip-column-names \
+        --execute="CREATE USER IF NOT EXISTS '$cache_miss_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_password'; ALTER USER '$cache_miss_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_password'; GRANT SELECT ON \`$mysql_database\`.* TO '$cache_miss_user'@'%';"
+}
+
 install_cli_wrapper() {
     mysql_bin_dir="$(mktemp -d "$temp_dir/mysql-bin.XXXXXX")"
     ln -s "$script_dir/mysql-docker-cli.sh" "$mysql_bin_dir/mysql"
@@ -277,6 +290,8 @@ run_tests() {
     export SABIQL_MYSQL_TEST_DATABASE="$mysql_database"
     export SABIQL_MYSQL_TEST_USER="$mysql_user"
     export SABIQL_MYSQL_TEST_PASSWORD="$mysql_password"
+    export SABIQL_MYSQL_TEST_CACHE_MISS_USER="$cache_miss_user"
+    export SABIQL_MYSQL_TEST_CACHE_MISS_PASSWORD="$cache_miss_password"
     export SABIQL_MYSQL_TEST_TLS_DIR="$tls_dir"
     export SABIQL_MYSQL_TEST_SSL_CA="$tls_dir/ca.pem"
     export SABIQL_MYSQL_TEST_SSL_CERT="$tls_dir/client-cert.pem"
@@ -300,6 +315,7 @@ case "${1:-test}" in
         install_cli_wrapper
         create_option_file
         assert_versions
+        reset_cache_miss_account
         run_tests
         ;;
     *)

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -214,6 +214,25 @@ create_tls_material() {
         "$tls_dir/client.csr" "$tls_dir/ca.srl"
 }
 
+create_server_public_key_material() {
+    local server_public_key_path
+    server_public_key_path="$(run_compose exec -T mysql mysql \
+        --protocol=socket \
+        --user=root \
+        --password=root \
+        --batch \
+        --raw \
+        --skip-column-names \
+        --execute="SELECT IF(@@GLOBAL.caching_sha2_password_public_key_path = '', CONCAT(@@GLOBAL.datadir, 'public_key.pem'), IF(LEFT(@@GLOBAL.caching_sha2_password_public_key_path, 1) = '/', @@GLOBAL.caching_sha2_password_public_key_path, CONCAT(@@GLOBAL.datadir, @@GLOBAL.caching_sha2_password_public_key_path)))" \
+        | tr -d '\r')"
+    if [[ -z "$server_public_key_path" ]]; then
+        printf 'MySQL server public key path is empty\n' >&2
+        return 1
+    fi
+    run_compose cp "mysql:$server_public_key_path" "$tls_dir/server-public-key.pem"
+    chmod 644 "$tls_dir/server-public-key.pem"
+}
+
 install_cli_wrapper() {
     mysql_bin_dir="$(mktemp -d "$temp_dir/mysql-bin.XXXXXX")"
     ln -s "$script_dir/mysql-docker-cli.sh" "$mysql_bin_dir/mysql"
@@ -262,6 +281,7 @@ run_tests() {
     export SABIQL_MYSQL_TEST_SSL_CA="$tls_dir/ca.pem"
     export SABIQL_MYSQL_TEST_SSL_CERT="$tls_dir/client-cert.pem"
     export SABIQL_MYSQL_TEST_SSL_KEY="$tls_dir/client-key.pem"
+    export SABIQL_MYSQL_TEST_SERVER_PUBLIC_KEY="$tls_dir/server-public-key.pem"
     export SABIQL_MYSQL_TRANSCRIPT=1
     cargo nextest run -p sabiql --run-ignored ignored-only \
         -E 'test(tests::adapter_mysql)' \
@@ -276,6 +296,7 @@ case "${1:-test}" in
         create_tls_material
         run_compose up --detach --wait mysql
         discover_mysql_port
+        create_server_public_key_material
         install_cli_wrapper
         create_option_file
         assert_versions

--- a/scripts/test_mysql_docker_cleanup.sh
+++ b/scripts/test_mysql_docker_cleanup.sh
@@ -57,7 +57,7 @@ case "${1:-}" in
                 --file)
                     shift 2
                     ;;
-                up|port|down|rm)
+                up|port|down|rm|exec|cp)
                     command="$1"
                     break
                     ;;
@@ -74,6 +74,13 @@ case "${1:-}" in
         if [[ "$command" == port ]]; then
             port="$(printf '%s' "$project" | cksum | awk '{ print 30000 + ($1 % 20000) }')"
             printf '127.0.0.1:%s\n' "$port"
+        fi
+        if [[ "$command" == exec ]]; then
+            printf '%s\n' '/var/lib/mysql/public_key.pem'
+        fi
+        if [[ "$command" == cp ]]; then
+            printf '%s\n' '-----BEGIN PUBLIC KEY-----' 'AQID' \
+                '-----END PUBLIC KEY-----' >"${!#}"
         fi
         exit 0
         ;;

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -24,6 +24,7 @@ pub enum ConnectionField {
     SslCa,
     SslCert,
     SslKey,
+    ServerPublicKeyPath,
 }
 
 impl ConnectionField {
@@ -53,6 +54,7 @@ impl ConnectionField {
                     Self::User,
                     Self::Password,
                     Self::SslMode,
+                    Self::ServerPublicKeyPath,
                 ],
                 MySqlSslMode::Preferred | MySqlSslMode::Required => &[
                     Self::DatabaseType,
@@ -63,6 +65,7 @@ impl ConnectionField {
                     Self::User,
                     Self::Password,
                     Self::SslMode,
+                    Self::ServerPublicKeyPath,
                     Self::SslCert,
                     Self::SslKey,
                 ],
@@ -75,6 +78,7 @@ impl ConnectionField {
                     Self::User,
                     Self::Password,
                     Self::SslMode,
+                    Self::ServerPublicKeyPath,
                     Self::SslCa,
                     Self::SslCert,
                     Self::SslKey,
@@ -93,7 +97,11 @@ impl ConnectionField {
     pub fn max_chars(self) -> Option<usize> {
         match self {
             Self::Name => Some(50),
-            Self::SqlitePath | Self::SslCa | Self::SslCert | Self::SslKey => Some(4096),
+            Self::SqlitePath
+            | Self::SslCa
+            | Self::SslCert
+            | Self::SslKey
+            | Self::ServerPublicKeyPath => Some(4096),
             Self::Host | Self::Database | Self::User | Self::Password => Some(255),
             Self::Port => Some(5),
             Self::DatabaseType | Self::SslMode => None,
@@ -131,6 +139,7 @@ impl ConnectionField {
             Self::SslCa => "CA Path:",
             Self::SslCert => "Cert Path:",
             Self::SslKey => "Key Path:",
+            Self::ServerPublicKeyPath => "Server Key:",
         }
     }
 }
@@ -180,6 +189,7 @@ pub struct ConnectionSetupState {
     pub(crate) ssl_ca: TextInputState,
     pub(crate) ssl_cert: TextInputState,
     pub(crate) ssl_key: TextInputState,
+    pub(crate) server_public_key_path: TextInputState,
     pub(crate) ssl_mode: SslMode,
     pub(crate) mysql_ssl_mode: MySqlSslMode,
 
@@ -207,6 +217,7 @@ impl Default for ConnectionSetupState {
             ssl_ca: TextInputState::default(),
             ssl_cert: TextInputState::default(),
             ssl_key: TextInputState::default(),
+            server_public_key_path: TextInputState::default(),
             ssl_mode: SslMode::Prefer,
             mysql_ssl_mode: MySqlSslMode::Preferred,
             focused_field: ConnectionField::DatabaseType,
@@ -291,6 +302,7 @@ impl ConnectionSetupState {
             ConnectionField::SslCa => Some(&self.ssl_ca),
             ConnectionField::SslCert => Some(&self.ssl_cert),
             ConnectionField::SslKey => Some(&self.ssl_key),
+            ConnectionField::ServerPublicKeyPath => Some(&self.server_public_key_path),
         }
     }
 
@@ -311,6 +323,7 @@ impl ConnectionSetupState {
             ConnectionField::SslCa => Some(&mut self.ssl_ca),
             ConnectionField::SslCert => Some(&mut self.ssl_cert),
             ConnectionField::SslKey => Some(&mut self.ssl_key),
+            ConnectionField::ServerPublicKeyPath => Some(&mut self.server_public_key_path),
         }
     }
 
@@ -559,7 +572,8 @@ impl ConnectionSetupState {
                     (!matches!(self.mysql_ssl_mode, MySqlSslMode::Disabled))
                         .then(|| optional_path(&self.ssl_key))
                         .flatten(),
-                ),
+                )
+                .with_server_public_key_path(optional_path(&self.server_public_key_path)),
             ),
         })
     }
@@ -635,6 +649,9 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
                 if let Some(path) = config.ssl_key.as_deref() {
                     state.ssl_key = TextInputState::new(path, path.chars().count());
                 }
+                if let Some(path) = config.server_public_key_path.as_deref() {
+                    state.server_public_key_path = TextInputState::new(path, path.chars().count());
+                }
             }
         }
         state
@@ -666,6 +683,7 @@ mod tests {
         #[case(ConnectionField::SslCa, false)]
         #[case(ConnectionField::SslCert, false)]
         #[case(ConnectionField::SslKey, false)]
+        #[case(ConnectionField::ServerPublicKeyPath, false)]
         fn is_required_returns_correct_value(
             #[case] field: ConnectionField,
             #[case] expected: bool,
@@ -706,6 +724,7 @@ mod tests {
                     ConnectionField::User,
                     ConnectionField::Password,
                     ConnectionField::SslMode,
+                    ConnectionField::ServerPublicKeyPath,
                     ConnectionField::SslCert,
                     ConnectionField::SslKey,
                 ]
@@ -723,6 +742,7 @@ mod tests {
             assert_eq!(ConnectionField::Password.max_chars(), Some(255));
             assert_eq!(ConnectionField::DatabaseType.max_chars(), None);
             assert_eq!(ConnectionField::SslMode.max_chars(), None);
+            assert_eq!(ConnectionField::ServerPublicKeyPath.max_chars(), Some(4096));
         }
 
         #[rstest]
@@ -757,6 +777,11 @@ mod tests {
             state.set_database_type(DatabaseType::MySQL);
             assert!(!state.visible_fields().contains(&ConnectionField::SslCa));
             assert!(state.visible_fields().contains(&ConnectionField::SslCert));
+            assert!(
+                state
+                    .visible_fields()
+                    .contains(&ConnectionField::ServerPublicKeyPath)
+            );
 
             state.mysql_ssl_mode = MySqlSslMode::VerifyIdentity;
             assert!(state.visible_fields().contains(&ConnectionField::SslCa));

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -540,6 +540,12 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 state.set_validation_error(other_field, "Both client paths are required");
             }
         }
+        ConnectionField::ServerPublicKeyPath if state.database_type() == DatabaseType::MySQL => {
+            let path = text_input_content(state, field);
+            if path.chars().any(char::is_control) {
+                state.set_validation_error(field, "Invalid path");
+            }
+        }
         ConnectionField::Name => {
             let name = text_input_content(state, field).trim().to_string();
             if name.is_empty() {
@@ -553,7 +559,8 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
         | ConnectionField::SslMode
         | ConnectionField::SslCa
         | ConnectionField::SslCert
-        | ConnectionField::SslKey => {}
+        | ConnectionField::SslKey
+        | ConnectionField::ServerPublicKeyPath => {}
     }
 }
 

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -108,6 +108,8 @@ pub struct MySqlConnectionConfig {
     pub ssl_cert: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ssl_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_public_key_path: Option<String>,
 }
 
 impl MySqlConnectionConfig {
@@ -129,6 +131,7 @@ impl MySqlConnectionConfig {
             ssl_ca: None,
             ssl_cert: None,
             ssl_key: None,
+            server_public_key_path: None,
         }
     }
 
@@ -142,6 +145,12 @@ impl MySqlConnectionConfig {
         self.ssl_ca = self.ssl_mode.uses_ca().then_some(ssl_ca).flatten();
         self.ssl_cert = ssl_cert;
         self.ssl_key = ssl_key;
+        self
+    }
+
+    #[must_use]
+    pub fn with_server_public_key_path(mut self, path: Option<String>) -> Self {
+        self.server_public_key_path = path;
         self
     }
 

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -17,6 +17,7 @@ pub(super) struct MySqlDsn {
     pub(super) ssl_ca: Option<String>,
     pub(super) ssl_cert: Option<String>,
     pub(super) ssl_key: Option<String>,
+    pub(super) server_public_key_path: Option<String>,
 }
 
 impl fmt::Debug for MySqlDsn {
@@ -32,6 +33,7 @@ impl fmt::Debug for MySqlDsn {
             .field("ssl_ca", &self.ssl_ca)
             .field("ssl_cert", &self.ssl_cert)
             .field("ssl_key", &self.ssl_key)
+            .field("server_public_key_path", &self.server_public_key_path)
             .finish()
     }
 }
@@ -69,6 +71,10 @@ pub(super) fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
     }
     if let Some(path) = config.ssl_key.as_deref() {
         url.query_pairs_mut().append_pair("ssl-key", path);
+    }
+    if let Some(path) = config.server_public_key_path.as_deref() {
+        url.query_pairs_mut()
+            .append_pair("server-public-key-path", path);
     }
     url.to_string()
 }
@@ -119,6 +125,9 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
     let ssl_key = url
         .query_pairs()
         .find_map(|(key, value)| (key == "ssl-key").then(|| value.into_owned()));
+    let server_public_key_path = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "server-public-key-path").then(|| value.into_owned()));
 
     Ok(MySqlDsn {
         host,
@@ -130,6 +139,7 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         ssl_ca,
         ssl_cert,
         ssl_key,
+        server_public_key_path,
     })
 }
 
@@ -149,6 +159,7 @@ pub(super) fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperation
         target.ssl_ca.as_deref(),
         target.ssl_cert.as_deref(),
         target.ssl_key.as_deref(),
+        target.server_public_key_path.as_deref(),
     ];
     if values
         .into_iter()
@@ -313,6 +324,28 @@ mod tests {
     }
 
     #[test]
+    fn builds_and_parses_mysql_dsn_with_server_public_key_path() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3306,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        )
+        .with_server_public_key_path(Some(r"C:\keys\server-public.pem".to_string()));
+
+        let dsn = build_mysql_dsn(&config);
+        assert!(dsn.contains("server-public-key-path="));
+        let parsed = parse_mysql_dsn(&dsn).unwrap();
+
+        assert_eq!(
+            parsed.server_public_key_path.as_deref(),
+            Some(r"C:\keys\server-public.pem")
+        );
+    }
+
+    #[test]
     fn ignores_ca_when_building_or_parsing_non_verification_dsn() {
         let config = MySqlConnectionConfig::new(
             "db.example",
@@ -358,7 +391,12 @@ mod tests {
 
     #[test]
     fn rejects_control_characters_in_tls_paths() {
-        for field in ["CA", "client certificate", "client key"] {
+        for field in [
+            "CA",
+            "client certificate",
+            "client key",
+            "server public key",
+        ] {
             let mut target = MySqlDsn {
                 host: "localhost".to_string(),
                 port: 3306,
@@ -369,11 +407,15 @@ mod tests {
                 ssl_ca: None,
                 ssl_cert: None,
                 ssl_key: None,
+                server_public_key_path: None,
             };
             match field {
                 "CA" => target.ssl_ca = Some("ca\n.pem".to_string()),
                 "client certificate" => target.ssl_cert = Some("client\r.pem".to_string()),
                 "client key" => target.ssl_key = Some("client\0-key.pem".to_string()),
+                "server public key" => {
+                    target.server_public_key_path = Some("server\n-key.pem".to_string());
+                }
                 _ => unreachable!(),
             }
 

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -175,31 +175,165 @@ fn is_valid_pem_public_key(contents: &str) -> bool {
             .bytes()
             .filter(|byte| !byte.is_ascii_whitespace())
             .collect();
-        if encoded.is_empty() || !is_valid_base64(&encoded) {
+        let Some(decoded) = decode_base64(&encoded) else {
             return false;
-        }
-        contents[body_end + end.len()..]
+        };
+        if !contents[body_end + end.len()..]
             .chars()
             .all(char::is_whitespace)
+        {
+            return false;
+        }
+        match *label {
+            "PUBLIC KEY" => is_valid_subject_public_key_info(&decoded),
+            "RSA PUBLIC KEY" => is_valid_rsa_public_key(&decoded),
+            _ => false,
+        }
     })
 }
 
-fn is_valid_base64(encoded: &[u8]) -> bool {
-    if !encoded.len().is_multiple_of(4) {
+fn decode_base64(encoded: &[u8]) -> Option<Vec<u8>> {
+    if encoded.is_empty() || !encoded.len().is_multiple_of(4) {
+        return None;
+    }
+    let mut decoded = Vec::with_capacity(encoded.len() / 4 * 3);
+    for (chunk_index, chunk) in encoded.chunks_exact(4).enumerate() {
+        let last_chunk = chunk_index + 1 == encoded.len() / 4;
+        let first = base64_value(chunk[0])?;
+        let second = base64_value(chunk[1])?;
+        let third = match chunk[2] {
+            b'=' if last_chunk => None,
+            byte => Some(base64_value(byte)?),
+        };
+        let fourth = match chunk[3] {
+            b'=' if last_chunk => None,
+            byte => Some(base64_value(byte)?),
+        };
+        if third.is_none() && fourth.is_some() {
+            return None;
+        }
+        if third.is_none() && second & 0x0f != 0 {
+            return None;
+        }
+        if fourth.is_none() && third.is_some_and(|value| value & 0x03 != 0) {
+            return None;
+        }
+        decoded.push((first << 2) | (second >> 4));
+        if let Some(third) = third {
+            decoded.push((second << 4) | (third >> 2));
+            if let Some(fourth) = fourth {
+                decoded.push((third << 6) | fourth);
+            }
+        }
+    }
+    Some(decoded)
+}
+
+fn base64_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'A'..=b'Z' => Some(byte - b'A'),
+        b'a'..=b'z' => Some(byte - b'a' + 26),
+        b'0'..=b'9' => Some(byte - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}
+
+fn is_valid_subject_public_key_info(der: &[u8]) -> bool {
+    let Some((subject_public_key_info, remainder)) = der_element(der, 0x30) else {
+        return false;
+    };
+    if !remainder.is_empty() {
         return false;
     }
-    let padding = encoded.iter().position(|byte| *byte == b'=');
-    let content_end = padding.unwrap_or(encoded.len());
-    if encoded[..content_end]
-        .iter()
-        .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/')))
-    {
+    let Some((algorithm, remainder)) = der_element(subject_public_key_info, 0x30) else {
+        return false;
+    };
+    let Some((algorithm_oid, algorithm_remainder)) = der_element(algorithm, 0x06) else {
+        return false;
+    };
+    if algorithm_oid != [0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01] {
         return false;
     }
-    padding.is_none_or(|padding_start| {
-        encoded[padding_start..].iter().all(|byte| *byte == b'=')
-            && encoded.len() - padding_start <= 2
-    })
+    let Some((parameters, parameters_remainder)) = der_element(algorithm_remainder, 0x05) else {
+        return false;
+    };
+    if !parameters.is_empty() || !parameters_remainder.is_empty() {
+        return false;
+    }
+    let Some((bit_string, remainder)) = der_element(remainder, 0x03) else {
+        return false;
+    };
+    bit_string.first() == Some(&0)
+        && is_valid_rsa_public_key(&bit_string[1..])
+        && remainder.is_empty()
+}
+
+fn is_valid_rsa_public_key(der: &[u8]) -> bool {
+    let Some((sequence, remainder)) = der_element(der, 0x30) else {
+        return false;
+    };
+    if !remainder.is_empty() {
+        return false;
+    }
+    let Some((modulus, remainder)) = der_element(sequence, 0x02) else {
+        return false;
+    };
+    let Some((exponent, remainder)) = der_element(remainder, 0x02) else {
+        return false;
+    };
+    remainder.is_empty() && is_valid_positive_integer(modulus) && is_valid_exponent(exponent)
+}
+
+fn is_valid_positive_integer(value: &[u8]) -> bool {
+    if value.is_empty() || value[0] & 0x80 != 0 {
+        return false;
+    }
+    if value.first() == Some(&0) && (value.get(1).is_none() || value[1] & 0x80 == 0) {
+        return false;
+    }
+    let value = value.strip_prefix(&[0]).unwrap_or(value);
+    !value.is_empty() && value.iter().any(|byte| *byte != 0)
+}
+
+fn is_valid_exponent(value: &[u8]) -> bool {
+    if !is_valid_positive_integer(value) {
+        return false;
+    }
+    let value = value.strip_prefix(&[0]).unwrap_or(value);
+    value != [1]
+        && value.last().is_some_and(|byte| byte & 1 == 1)
+        && value.iter().any(|byte| *byte != 0)
+}
+
+fn der_element(input: &[u8], expected_tag: u8) -> Option<(&[u8], &[u8])> {
+    let (&tag, remainder) = input.split_first()?;
+    if tag != expected_tag {
+        return None;
+    }
+    let (&length_byte, remainder) = remainder.split_first()?;
+    let (length, remainder) = if length_byte & 0x80 == 0 {
+        (usize::from(length_byte), remainder)
+    } else {
+        let length_bytes = usize::from(length_byte & 0x7f);
+        if length_bytes == 0 || length_bytes > std::mem::size_of::<usize>() {
+            return None;
+        }
+        let (encoded_length, remainder) = remainder.split_at_checked(length_bytes)?;
+        if encoded_length.first() == Some(&0) {
+            return None;
+        }
+        let length = encoded_length.iter().try_fold(0usize, |length, byte| {
+            length.checked_mul(256)?.checked_add(usize::from(*byte))
+        })?;
+        if length < 128 {
+            return None;
+        }
+        (length, remainder)
+    };
+    let (value, remainder) = remainder.split_at_checked(length)?;
+    Some((value, remainder))
 }
 
 #[cfg(windows)]
@@ -374,6 +508,15 @@ mod tests {
 
     use super::*;
 
+    const VALID_PUBLIC_KEY_PEM: &str = "-----BEGIN PUBLIC KEY-----\n\
+        MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMFq4IBzAF/EE08SN5Bo3KKt/CRaKoGi\n\
+        CT442dzvVfjkV0ZyuztDm2mNd06SHguqWYDc7nDaY9qgEDrlNHnp2QkCAwEAAQ==\n\
+        -----END PUBLIC KEY-----\n";
+    const VALID_RSA_PUBLIC_KEY_PEM: &str = "-----BEGIN RSA PUBLIC KEY-----\n\
+        MEgCQQCkUPNQeEgyJX6XS2qlrU20cleKptQX/Llyrm6tzLzVI8JF3wcCiQ0R4KgX\n\
+        x/4oCDpO8lWDRl+SFkUlLz4xJ4zdAgMBAAE=\n\
+        -----END RSA PUBLIC KEY-----\n";
+
     fn target() -> MySqlDsn {
         MySqlDsn {
             host: "localhost".to_string(),
@@ -452,11 +595,7 @@ mod tests {
     fn option_file_serializes_server_public_key_path() {
         let directory = tempfile::tempdir().unwrap();
         let key = directory.path().join("server-key.pem");
-        fs::write(
-            &key,
-            "-----BEGIN PUBLIC KEY-----\nAQID\n-----END PUBLIC KEY-----\n\0",
-        )
-        .unwrap();
+        fs::write(&key, format!("{VALID_PUBLIC_KEY_PEM}\0")).unwrap();
         let target = MySqlDsn {
             server_public_key_path: Some(key.display().to_string()),
             ..target()
@@ -472,12 +611,26 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_server_public_key_before_creating_option_file() {
+    fn accepts_rsa_public_key_pem_before_creating_option_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = directory.path().join("server-key.pem");
+        fs::write(&key, VALID_RSA_PUBLIC_KEY_PEM).unwrap();
+        let target = MySqlDsn {
+            server_public_key_path: Some(key.display().to_string()),
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        assert!(option_file.path.exists());
+    }
+
+    #[test]
+    fn rejects_base64_that_is_not_an_rsa_public_key_before_creating_option_file() {
         let directory = tempfile::tempdir().unwrap();
         let key = directory.path().join("server-key.pem");
         fs::write(
             &key,
-            "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----\n",
+            "-----BEGIN PUBLIC KEY-----\nAQID\n-----END PUBLIC KEY-----\n",
         )
         .unwrap();
         let target = MySqlDsn {

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -20,6 +20,7 @@ impl MySqlOptionFile {
     pub(super) fn create(target: &MySqlDsn) -> Result<Self, DbOperationError> {
         validate_mysql_values(target)?;
         validate_mysql_tls_files(target)?;
+        validate_mysql_server_public_key(target)?;
         let mut path = std::env::temp_dir();
         path.push(format!("sabiql-mysql-{}.cnf", Uuid::new_v4()));
         if !path.is_absolute() {
@@ -120,6 +121,85 @@ fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
         }
     }
     Ok(())
+}
+
+fn validate_mysql_server_public_key(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let Some(path) = target.server_public_key_path.as_deref() else {
+        return Ok(());
+    };
+    let metadata = fs::metadata(path).map_err(|error| {
+        DbOperationError::ConnectionFailed(format!(
+            "MySQL server public key path cannot be accessed: {error}"
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL server public key path is not a regular file".to_string(),
+        ));
+    }
+    let contents = fs::read(path).map_err(|error| {
+        DbOperationError::ConnectionFailed(format!(
+            "MySQL server public key cannot be read: {error}"
+        ))
+    })?;
+    let contents = String::from_utf8(contents).map_err(|_| {
+        DbOperationError::ConnectionFailed(
+            "MySQL server public key is not a valid PEM public key".to_string(),
+        )
+    })?;
+    let contents = contents.trim_end_matches('\0');
+    if !is_valid_pem_public_key(contents) {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL server public key is not a valid PEM public key".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_valid_pem_public_key(contents: &str) -> bool {
+    ["PUBLIC KEY", "RSA PUBLIC KEY"].iter().any(|label| {
+        let begin = format!("-----BEGIN {label}-----");
+        let end = format!("-----END {label}-----");
+        let Some(begin_offset) = contents.find(&begin) else {
+            return false;
+        };
+        if !contents[..begin_offset].chars().all(char::is_whitespace) {
+            return false;
+        }
+        let body_start = begin_offset + begin.len();
+        let Some(end_offset) = contents[body_start..].find(&end) else {
+            return false;
+        };
+        let body_end = body_start + end_offset;
+        let encoded: Vec<u8> = contents[body_start..body_end]
+            .bytes()
+            .filter(|byte| !byte.is_ascii_whitespace())
+            .collect();
+        if encoded.is_empty() || !is_valid_base64(&encoded) {
+            return false;
+        }
+        contents[body_end + end.len()..]
+            .chars()
+            .all(char::is_whitespace)
+    })
+}
+
+fn is_valid_base64(encoded: &[u8]) -> bool {
+    if !encoded.len().is_multiple_of(4) {
+        return false;
+    }
+    let padding = encoded.iter().position(|byte| *byte == b'=');
+    let content_end = padding.unwrap_or(encoded.len());
+    if encoded[..content_end]
+        .iter()
+        .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/')))
+    {
+        return false;
+    }
+    padding.is_none_or(|padding_start| {
+        encoded[padding_start..].iter().all(|byte| *byte == b'=')
+            && encoded.len() - padding_start <= 2
+    })
 }
 
 #[cfg(windows)]
@@ -260,6 +340,9 @@ fn serialize_option_file(target: &MySqlDsn) -> String {
     if let Some(path) = target.ssl_key.as_deref() {
         push_option(&mut contents, "ssl-key", path);
     }
+    if let Some(path) = target.server_public_key_path.as_deref() {
+        push_option(&mut contents, "server-public-key-path", path);
+    }
     contents
 }
 
@@ -302,6 +385,7 @@ mod tests {
             ssl_ca: None,
             ssl_cert: None,
             ssl_key: None,
+            server_public_key_path: None,
         }
     }
 
@@ -362,6 +446,64 @@ mod tests {
         assert!(contents.contains(&format!("ssl-ca = {}\n", quote_option_value(ca_path))));
         assert!(contents.contains("ssl-cert = \"C:\\\\certs\\\\client.pem\"\n"));
         assert!(contents.contains("ssl-key = \"C:\\\\certs\\\\client-key.pem\"\n"));
+    }
+
+    #[test]
+    fn option_file_serializes_server_public_key_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = directory.path().join("server-key.pem");
+        fs::write(
+            &key,
+            "-----BEGIN PUBLIC KEY-----\nAQID\n-----END PUBLIC KEY-----\n\0",
+        )
+        .unwrap();
+        let target = MySqlDsn {
+            server_public_key_path: Some(key.display().to_string()),
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        let contents = fs::read_to_string(&option_file.path).unwrap();
+
+        assert!(contents.contains(&format!(
+            "server-public-key-path = {}\n",
+            quote_option_value(&key.display().to_string())
+        )));
+    }
+
+    #[test]
+    fn rejects_invalid_server_public_key_before_creating_option_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = directory.path().join("server-key.pem");
+        fs::write(
+            &key,
+            "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap();
+        let target = MySqlDsn {
+            server_public_key_path: Some(key.display().to_string()),
+            ..target()
+        };
+
+        assert!(matches!(
+            MySqlOptionFile::create(&target),
+            Err(DbOperationError::ConnectionFailed(details))
+                if details == "MySQL server public key is not a valid PEM public key"
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_server_public_key_before_connecting() {
+        let target = MySqlDsn {
+            server_public_key_path: Some("/missing/server-key.pem".to_string()),
+            ..target()
+        };
+
+        assert!(matches!(
+            MySqlOptionFile::create(&target),
+            Err(DbOperationError::ConnectionFailed(details))
+                if details.starts_with("MySQL server public key path cannot be accessed:")
+        ));
     }
 
     #[test]

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -58,6 +58,8 @@ pub struct ConnectionConfigEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_ssl_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_server_public_key_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -101,6 +103,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
             mysql_ssl_ca: None,
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
+            mysql_server_public_key_path: None,
             path: None,
         };
         match &profile.config {
@@ -127,6 +130,9 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 }
                 entry.mysql_ssl_cert.clone_from(&config.ssl_cert);
                 entry.mysql_ssl_key.clone_from(&config.ssl_key);
+                entry
+                    .mysql_server_public_key_path
+                    .clone_from(&config.server_public_key_path);
             }
         }
         entry
@@ -180,7 +186,8 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                             entry.mysql_ssl_ca.clone(),
                             entry.mysql_ssl_cert.clone(),
                             entry.mysql_ssl_key.clone(),
-                        ),
+                        )
+                        .with_server_public_key_path(entry.mysql_server_public_key_path.clone()),
                     ),
                 )
             }
@@ -261,6 +268,7 @@ mod tests {
             mysql_ssl_ca: None,
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
+            mysql_server_public_key_path: None,
             path: None,
         }
     }
@@ -280,6 +288,7 @@ mod tests {
             mysql_ssl_ca: None,
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
+            mysql_server_public_key_path: None,
             path: path.map(str::to_string),
         }
     }
@@ -299,6 +308,7 @@ mod tests {
             mysql_ssl_ca: None,
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
+            mysql_server_public_key_path: None,
             path: None,
         }
     }
@@ -429,6 +439,28 @@ mod tests {
         assert_eq!(serialized.mysql_ssl_ca, entry.mysql_ssl_ca);
         assert_eq!(serialized.mysql_ssl_cert, entry.mysql_ssl_cert);
         assert_eq!(serialized.mysql_ssl_key, entry.mysql_ssl_key);
+    }
+
+    #[test]
+    fn mysql_entry_round_trips_server_public_key_path() {
+        let mut entry = mysql_entry(Some("app"));
+        entry.mysql_server_public_key_path = Some(r"C:\keys\server-public.pem".to_string());
+
+        let profile = ConnectionProfile::try_from(&entry).unwrap();
+        assert_eq!(
+            profile
+                .mysql_config()
+                .unwrap()
+                .server_public_key_path
+                .as_deref(),
+            Some(r"C:\keys\server-public.pem")
+        );
+
+        let serialized = ConnectionConfigEntry::from(&profile);
+        assert_eq!(
+            serialized.mysql_server_public_key_path,
+            entry.mysql_server_public_key_path
+        );
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -12,11 +12,12 @@ mod shared {
 mod connection {
 
     use crate::tests::harness::mysql::{
-        MYSQL_FIXTURE_TABLE, mysql_integration_config, mysql_tls_config, with_mysql_test_db,
+        MYSQL_FIXTURE_TABLE, mysql_cache_miss_config, mysql_integration_config, mysql_tls_config,
+        with_mysql_test_db,
     };
     use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use sabiql_app::ports::outbound::{
-        AccessMode, DsnBuilder, MySqlConnectionProbe, QueryExecutor,
+        AccessMode, DbOperationError, DsnBuilder, MySqlConnectionProbe, QueryExecutor,
     };
     use sabiql_domain::QueryValue;
     use sabiql_domain::connection::{
@@ -109,12 +110,32 @@ mod connection {
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
     async fn connects_to_oracle_mysql_84_without_tls_with_trusted_server_public_key() {
-        let config = mysql_integration_config();
-        assert_eq!(config.ssl_mode, MySqlSslMode::Disabled);
-        assert!(config.server_public_key_path.is_some());
-        let profile = mysql_profile("mysql-caching-sha2-public-key", config);
         let adapter = MySqlAdapter::new();
-        let dsn = adapter.build_dsn(&profile);
+        let trusted_config = mysql_cache_miss_config();
+        assert_eq!(trusted_config.ssl_mode, MySqlSslMode::Disabled);
+        assert!(trusted_config.server_public_key_path.is_some());
+        let no_key_config = trusted_config.clone().with_server_public_key_path(None);
+        let no_key_dsn = adapter.build_dsn(&mysql_profile(
+            "mysql-caching-sha2-public-key-without-key",
+            no_key_config,
+        ));
+        let error = adapter
+            .probe(&no_key_dsn)
+            .await
+            .expect_err("a cache-miss auth without the trusted key must fail");
+        match error {
+            DbOperationError::ConnectionFailed(details)
+            | DbOperationError::QueryFailed(details) => {
+                assert!(
+                    details.contains("ERROR 2061"),
+                    "unexpected error: {details}"
+                );
+            }
+            error => panic!("unexpected error kind: {error:?}"),
+        }
+
+        let trusted_profile = mysql_profile("mysql-caching-sha2-public-key", trusted_config);
+        let dsn = adapter.build_dsn(&trusted_profile);
 
         adapter.probe(&dsn).await.unwrap();
         let result = adapter

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -108,6 +108,28 @@ mod connection {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn connects_to_oracle_mysql_84_without_tls_with_trusted_server_public_key() {
+        let config = mysql_integration_config();
+        assert_eq!(config.ssl_mode, MySqlSslMode::Disabled);
+        assert!(config.server_public_key_path.is_some());
+        let profile = mysql_profile("mysql-caching-sha2-public-key", config);
+        let adapter = MySqlAdapter::new();
+        let dsn = adapter.build_dsn(&profile);
+
+        adapter.probe(&dsn).await.unwrap();
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
     async fn connects_to_oracle_mysql_84_fixture_with_ca_and_client_certificate() {
         let config = mysql_tls_test_config();
         let profile = mysql_profile("mysql-tls-integration", config);

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -99,6 +99,7 @@ pub fn mysql_integration_config() -> MySqlConnectionConfig {
             .unwrap_or_else(|_| "p a#ss;=\"word".to_string()),
         MySqlSslMode::Disabled,
     )
+    .with_server_public_key_path(std::env::var("SABIQL_MYSQL_TEST_SERVER_PUBLIC_KEY").ok())
 }
 
 pub fn mysql_tls_config() -> MySqlConnectionConfig {

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -102,6 +102,15 @@ pub fn mysql_integration_config() -> MySqlConnectionConfig {
     .with_server_public_key_path(std::env::var("SABIQL_MYSQL_TEST_SERVER_PUBLIC_KEY").ok())
 }
 
+pub fn mysql_cache_miss_config() -> MySqlConnectionConfig {
+    let mut config = mysql_integration_config();
+    config.username = std::env::var("SABIQL_MYSQL_TEST_CACHE_MISS_USER")
+        .unwrap_or_else(|_| "sabiql_cache_miss_runner".to_string());
+    config.password = std::env::var("SABIQL_MYSQL_TEST_CACHE_MISS_PASSWORD")
+        .unwrap_or_else(|_| "sabiql-cache-miss".to_string());
+    config
+}
+
 pub fn mysql_tls_config() -> MySqlConnectionConfig {
     MySqlConnectionConfig::new(
         std::env::var("SABIQL_MYSQL_TEST_HOST")

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
@@ -29,6 +29,7 @@ test_project ▸ - ▸ -                                                        
 │                                       │└──────────│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┘
 │                                       │┌ [3] Resul│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┐
 │                                       ││(select a │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
+│                                       ││          │  Server Key: [                            ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
@@ -36,7 +37,6 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
@@ -18,7 +18,6 @@ test_project ▸ - ▸ -                                                        
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Type:       [ MySQL                    ▼ ]                │                                                  │
@@ -26,9 +25,10 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
 │                                       ││          │  Database:   [ app                        ]                │                                                  │
-│                                       │└──────────│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
+│                                       ││          │  User:       [ mysql_user                 ]                │                                                  │
+│                                       │└──────────│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Server Key: [                            ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -686,6 +686,10 @@ mod tests {
             .input_mut(ConnectionField::SslKey)
             .unwrap()
             .set_content("/etc/mysql/client-key.pem".to_string());
+        form_state
+            .input_mut(ConnectionField::ServerPublicKeyPath)
+            .unwrap()
+            .set_content("/etc/mysql/server-public.pem".to_string());
 
         let profile = preview_profile(&form_state).unwrap();
 
@@ -696,6 +700,10 @@ mod tests {
         assert_eq!(config.ssl_ca.as_deref(), Some("/etc/mysql/ca.pem"));
         assert_eq!(config.ssl_cert.as_deref(), Some("/etc/mysql/client.pem"));
         assert_eq!(config.ssl_key.as_deref(), Some("/etc/mysql/client-key.pem"));
+        assert_eq!(
+            config.server_public_key_path.as_deref(),
+            Some("/etc/mysql/server-public.pem")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

MySQL `caching_sha2_password` authentication cannot complete a first non-TLS login when the server has no cached authentication key and no trusted server public key can be configured.

## Background

This affects connections using disabled TLS or falling back from preferred TLS. Enabling `--get-server-public-key` implicitly would weaken the requested trust model.

## Approach

Expose an optional trusted server public key path through MySQL connection settings, saved profiles, DSNs, the setup form, and the shared option file used by every MySQL CLI route. Validate the path and PEM contents before starting a connection, and cover the cache-miss flow against Oracle MySQL 8.4.
