### PR TITLE
fix(mysql): normalize session transaction defaults

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -364,6 +364,8 @@ pub(super) async fn run_mysql_export_process(
     query: &str,
     path: PathBuf,
 ) -> Result<(), DbOperationError> {
+    configure_mysql_session(process, AccessMode::ReadOnly).await?;
+
     let marker = Uuid::new_v4().simple().to_string();
     let probe_query =
         format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
@@ -371,7 +373,6 @@ pub(super) async fn run_mysql_export_process(
     let probe_xml = read_one_mysql_resultset(process).await?;
     let probe = parse_mysql_xml(&probe_xml)?;
     validate_mode_probe(&probe, &marker)?;
-    configure_mysql_session(process, AccessMode::ReadOnly).await?;
 
     write_mysql_statement(process, query).await?;
     let mut csv_writer = CsvFileWriter::create(path).await?;

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -42,6 +42,7 @@ pub(super) use metadata::mysql_metadata_columns;
 pub(in crate::adapters::mysql) const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
 #[cfg(unix)]
 const MYSQL_PTY_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+const MYSQL_SESSION_SETTINGS: &str = "SET SESSION autocommit=1, completion_type=NO_CHAIN";
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
 
 pub(in crate::adapters::mysql) struct MySqlProcess {
@@ -285,12 +286,11 @@ pub(super) async fn configure_mysql_session(
     process: &mut MySqlProcess,
     access_mode: AccessMode,
 ) -> Result<(), DbOperationError> {
-    if !access_mode.is_read_only() {
-        return Ok(());
-    }
-
     let marker = Uuid::new_v4().simple().to_string();
-    write_mysql_statement(process, MYSQL_READ_ONLY_STATEMENT).await?;
+    write_mysql_statement(process, MYSQL_SESSION_SETTINGS).await?;
+    if access_mode.is_read_only() {
+        write_mysql_statement(process, MYSQL_READ_ONLY_STATEMENT).await?;
+    }
     write_mysql_statement(
         process,
         &format!("SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"),
@@ -630,35 +630,40 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
         } else {
             ""
         };
+        let settings_timeout = if mode == "timeout" {
+            "while :; do :; done"
+        } else {
+            ""
+        };
         let script = format!(
             r#"#!/bin/sh
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
-phase=probe
 eof=$(printf '\004')
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
   [ "$line" = "$eof" ] && exit 0
   [ "$line" = ";" ] && continue
-  if [ "$phase" = probe ]; then
-    marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
-    {probe_response}
-    phase=user
-  else
-    case "$line" in
-      "SET SESSION TRANSACTION READ ONLY")
-        {session_failure}
-        ;;
-      *__sabiql_session_marker*)
-        marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
-        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
-        ;;
-      *)
-        {user_response}
-        exit 0
-        ;;
-    esac
-  fi
+  case "$line" in
+    "SET SESSION autocommit=1, completion_type=NO_CHAIN")
+      {settings_timeout}
+      ;;
+    "SET SESSION TRANSACTION READ ONLY")
+      {session_failure}
+      ;;
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
+      {probe_response}
+      ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      ;;
+    *)
+      {user_response}
+      exit 0
+      ;;
+  esac
 done
 "#,
         );
@@ -686,7 +691,7 @@ while IFS= read -r line; do
     *"$eof"*)
       exit 0
       ;;
-    ";"|"SET SESSION TRANSACTION READ ONLY"|"SET SESSION TRANSACTION READ WRITE")
+    ";"|"SET SESSION autocommit=1, completion_type=NO_CHAIN"|"SET SESSION TRANSACTION READ ONLY"|"SET SESSION TRANSACTION READ WRITE")
       ;;
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
@@ -760,6 +765,8 @@ while IFS= read -r line; do
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
       printf '%s\t%s\n' '__sabiql_probe' '__sabiql_sql_mode'
       printf '%s\t%s\n' "$marker" 'STRICT_TRANS_TABLES'
+      ;;
+    *"SET SESSION autocommit=1, completion_type=NO_CHAIN"*)
       ;;
     *"SET SESSION TRANSACTION READ ONLY"*)
       {read_only_failure}
@@ -843,7 +850,7 @@ while IFS= read -r line; do
         printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
       fi
       ;;
-    "SET SESSION TRANSACTION READ ONLY")
+    "SET SESSION autocommit=1, completion_type=NO_CHAIN"|"SET SESSION TRANSACTION READ ONLY")
       ;;
     ";")
       ;;
@@ -963,8 +970,16 @@ done
             assert_eq!(result.columns, vec!["value"]);
             assert_eq!(result.values[0][0].as_str(), Some("ok"));
             let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-            assert!(log.contains("__sabiql_probe"));
-            assert!(log.contains("SELECT 123"));
+            let positions = [
+                MYSQL_SESSION_SETTINGS,
+                MYSQL_SESSION_MARKER_COLUMN,
+                "__sabiql_probe",
+                "SELECT 123",
+            ]
+            .into_iter()
+            .map(|query| log.find(query).expect("query in transcript"))
+            .collect::<Vec<_>>();
+            assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
             assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
         }
 
@@ -1079,7 +1094,12 @@ done
             let session_index = log
                 .find(MYSQL_READ_ONLY_STATEMENT)
                 .expect("read-only session statement");
+            let settings_index = log.find(MYSQL_SESSION_SETTINGS).expect("session settings");
+            let probe_index = log.find("__sabiql_probe").expect("mode probe");
             let user_index = log.find("SELECT 2").expect("user statement");
+            assert!(settings_index < session_index, "{log}");
+            assert!(session_index < probe_index, "{log}");
+            assert!(probe_index < user_index, "{log}");
             assert!(session_index < user_index, "{log}");
             assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
         }
@@ -1195,11 +1215,11 @@ done
             )
             .expect("spawn fake mysql");
 
-            session.probe().await.expect("mode probe");
             session
                 .prepare_read_only()
                 .await
                 .expect("read-only session setup");
+            session.probe().await.expect("mode probe");
             for query in [
                 "SELECT TABLES",
                 "SELECT COLUMNS",
@@ -1228,9 +1248,10 @@ done
             let argv = log.lines().find(|line| line.starts_with("argv=")).unwrap();
             assert!(!argv.contains("--quick"), "{argv}");
             let positions = [
-                "__sabiql_probe",
+                MYSQL_SESSION_SETTINGS,
                 MYSQL_READ_ONLY_STATEMENT,
                 MYSQL_SESSION_MARKER_COLUMN,
+                "__sabiql_probe",
                 "SELECT TABLES",
                 "SELECT COLUMNS",
                 "SELECT INDEXES",
@@ -1263,9 +1284,10 @@ done
             assert_eq!(columns, ["Database"]);
             let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
             let positions = [
-                "__sabiql_probe",
+                MYSQL_SESSION_SETTINGS,
                 MYSQL_READ_ONLY_STATEMENT,
                 MYSQL_SESSION_MARKER_COLUMN,
+                "__sabiql_probe",
                 "SHOW DATABASES",
             ]
             .into_iter()

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -230,6 +230,8 @@ async fn run_mysql_adhoc_process(
     access_mode: AccessMode,
     expected_columns: Option<&[&str]>,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
+    configure_mysql_session(process, access_mode).await?;
+
     let probe_marker = Uuid::new_v4().simple().to_string();
     let probe_query = format!(
         "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
@@ -238,7 +240,6 @@ async fn run_mysql_adhoc_process(
     let probe_xml = read_one_mysql_resultset(process).await?;
     let probe = super::parse_mysql_xml(&probe_xml)?;
     validate_mode_probe(&probe, &probe_marker)?;
-    configure_mysql_session(process, access_mode).await?;
 
     let mut last_result_set = None;
     let mut last_result_statement = None;

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -300,15 +300,10 @@ async fn run_mysql_metadata_query_with_read_only_session_process(
     process: &mut MySqlMetadataProcess,
     query: &str,
 ) -> Result<Vec<String>, DbOperationError> {
-    let probe_marker = Uuid::new_v4().simple().to_string();
-    let probe_query = format!(
-        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
-    );
-    process.write_statement(&probe_query).await?;
-    let probe_output = process.read_until_marker(&probe_marker).await?;
-    validate_metadata_mode_probe(&probe_output, &probe_marker)?;
-
     let session_marker = Uuid::new_v4().simple().to_string();
+    process
+        .write_statement(super::MYSQL_SESSION_SETTINGS)
+        .await?;
     process
         .write_statement(super::MYSQL_READ_ONLY_STATEMENT)
         .await?;
@@ -319,6 +314,14 @@ async fn run_mysql_metadata_query_with_read_only_session_process(
         .await?;
     let session_output = process.read_until_marker(&session_marker).await?;
     validate_metadata_session_marker(&session_output, &session_marker)?;
+
+    let probe_marker = Uuid::new_v4().simple().to_string();
+    let probe_query = format!(
+        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
+    );
+    process.write_statement(&probe_query).await?;
+    let probe_output = process.read_until_marker(&probe_marker).await?;
+    validate_metadata_mode_probe(&probe_output, &probe_marker)?;
 
     process.write_statement(query).await?;
     let mut stdin = process

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -37,6 +37,8 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
     query: &str,
     access_mode: AccessMode,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
+    configure_mysql_session(process, access_mode).await?;
+
     let probe_marker = Uuid::new_v4().simple().to_string();
     let probe_query = format!(
         "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
@@ -45,7 +47,6 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
     let probe_xml = read_one_mysql_resultset(process).await?;
     let probe = parse_mysql_xml(&probe_xml)?;
     validate_mode_probe(&probe, &probe_marker)?;
-    configure_mysql_session(process, access_mode).await?;
 
     write_mysql_statement(process, query).await?;
     let (stdout, mut diagnostics) = read_one_mysql_resultset_with_diagnostics(process).await?;
@@ -89,6 +90,8 @@ pub(super) mod test_support {
         query: &str,
         access_mode: AccessMode,
     ) -> Result<MySqlResultSet, DbOperationError> {
+        configure_mysql_session(process, access_mode).await?;
+
         let marker = Uuid::new_v4().simple().to_string();
         let probe_query =
             format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
@@ -96,7 +99,6 @@ pub(super) mod test_support {
         let probe_xml = read_one_mysql_resultset(process).await?;
         let probe = parse_mysql_xml(&probe_xml)?;
         validate_mode_probe(&probe, &marker)?;
-        configure_mysql_session(process, access_mode).await?;
 
         write_mysql_statement(process, query).await?;
 

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -214,8 +214,8 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
     let mut session =
         MySqlMetadataSession::spawn_with_metadata_program(program, &option_file.path)?;
     let result = tokio::time::timeout(timeout, async {
-        let lower_case_table_names = session.probe().await?;
         session.prepare_read_only().await?;
+        let lower_case_table_names = session.probe().await?;
         let mut results = Vec::with_capacity(queries.len());
         for (query, expected_columns) in queries {
             results.push(

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -108,9 +108,9 @@ async fn execute_preview_with_session(
     limit: usize,
     offset: usize,
 ) -> Result<PreviewExecution, DbOperationError> {
+    session.prepare_read_only().await?;
     let lower_case_table_names = session.probe().await?;
     validate_selected_schema_name(database, schema, lower_case_table_names)?;
-    session.prepare_read_only().await?;
 
     let column_result = session
         .execute_with_expected_columns(
@@ -594,8 +594,9 @@ done
         let argv = log.lines().find(|line| line.starts_with("argv=")).unwrap();
         assert!(argv.contains("--quick"), "{argv}");
         let positions = [
-            "__sabiql_probe",
+            "SET SESSION autocommit=1, completion_type=NO_CHAIN",
             "SET SESSION TRANSACTION READ ONLY",
+            "__sabiql_probe",
             "INFORMATION_SCHEMA.COLUMNS",
             "LIMIT 2 OFFSET 1",
             "__sabiql_preview_completion",

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -184,8 +184,8 @@ async fn fetch_table_detail_with_session(
     schema: &str,
     table: &str,
 ) -> Result<Table, DbOperationError> {
-    let lower_case_table_names = session.probe().await?;
     session.prepare_read_only().await?;
+    let lower_case_table_names = session.probe().await?;
     let tables_result = session
         .execute_with_expected_columns(&table_query(schema, table), TABLES_RESULT_COLUMNS)
         .await?;
@@ -710,9 +710,10 @@ done
             );
             let labels = if mode == "view" {
                 [
-                    "__sabiql_probe",
+                    "SET SESSION autocommit=1, completion_type=NO_CHAIN",
                     "SET SESSION TRANSACTION READ ONLY",
                     "__sabiql_session_marker",
+                    "__sabiql_probe",
                     "INFORMATION_SCHEMA.TABLES",
                     "INFORMATION_SCHEMA.COLUMNS",
                     "INFORMATION_SCHEMA.STATISTICS",
@@ -722,9 +723,10 @@ done
                 ]
             } else {
                 [
-                    "__sabiql_probe",
+                    "SET SESSION autocommit=1, completion_type=NO_CHAIN",
                     "SET SESSION TRANSACTION READ ONLY",
                     "__sabiql_session_marker",
+                    "__sabiql_probe",
                     "INFORMATION_SCHEMA.TABLES",
                     "INFORMATION_SCHEMA.COLUMNS",
                     "INFORMATION_SCHEMA.STATISTICS",

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2600,6 +2600,73 @@ mod query_execution {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn normalizes_server_transaction_defaults_before_adhoc_sql() {
+        with_mysql_test_db(|db| Box::pin(async move {
+            let defaults = db
+                .run_cli_script("SELECT @@GLOBAL.autocommit, @@GLOBAL.completion_type")
+                .await
+                .map_err(|error| format!("failed to read MySQL transaction defaults: {error}"))?;
+            let mut defaults = defaults.split_whitespace();
+            let original_autocommit = defaults
+                .next()
+                .ok_or_else(|| "MySQL did not return autocommit default".to_string())?;
+            let original_completion_type = defaults
+                .next()
+                .ok_or_else(|| "MySQL did not return completion type default".to_string())?;
+
+            db.run_cli_script("SET GLOBAL autocommit = 0; SET GLOBAL completion_type = 'CHAIN'")
+                .await
+                .map_err(|error| format!("failed to change MySQL transaction defaults: {error}"))?;
+
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'normalized defaults' WHERE id = 1; SELECT @@SESSION.autocommit = 1 AS autocommit_normalized, @@SESSION.completion_type = 'NO_CHAIN' AS completion_type_normalized, empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await;
+
+            let fixture_restore = db
+                .run_cli_script(&format!(
+                    "SET SESSION autocommit = 1; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"
+                ))
+                .await
+                .map_err(|error| format!("failed to restore fixture: {error:?}"));
+            let restore = db
+                .run_cli_script(&format!(
+                    "SET GLOBAL autocommit = {original_autocommit}; SET GLOBAL completion_type = '{original_completion_type}'"
+                ))
+                .await
+                .map_err(|error| format!("failed to restore MySQL transaction defaults: {error}"));
+            restore?;
+            fixture_restore?;
+            let result = result
+                .map_err(|error| format!("normalized-default execution failed: {error:?}"))?;
+
+            if result.columns != [
+                "autocommit_normalized",
+                "completion_type_normalized",
+                "empty_text",
+            ] || result.values()
+                != [[
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("normalized defaults".to_string()),
+                ]]
+            {
+                return Err(format!("unexpected normalized-default result: {result:?}"));
+            }
+
+            Ok(())
+        }))
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
     async fn rejects_implicit_commit_transaction_and_matches_oracle_mysql_behavior() {
         with_mysql_test_db(|db| Box::pin(async move {
             let suffix = std::time::SystemTime::now()


### PR DESCRIPTION
## Problem
Sabiql could inherit server or account defaults with autocommit disabled or chained completion, allowing a probe or user statement to begin a transaction before the TUI establishes its transaction boundary.

## Background
The MySQL CLI paths must provide one-statement commits and explicit transaction boundaries regardless of those server-side defaults.

## Approach
Normalize `autocommit=1` and `completion_type=NO_CHAIN` before any probe, user statement, or internal read. Apply read-only after normalization and before probing, while preserving explicit `START TRANSACTION`, `COMMIT`, and `ROLLBACK` handling.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-534
