### PR TITLE
feat(mysql): enable cleartext authentication over TLS

### DIFF
--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -21,6 +21,7 @@ pub enum ConnectionField {
     User,
     Password,
     SslMode,
+    CleartextAuth,
     SslCa,
     SslCert,
     SslKey,
@@ -54,6 +55,7 @@ impl ConnectionField {
                     Self::User,
                     Self::Password,
                     Self::SslMode,
+                    Self::CleartextAuth,
                     Self::ServerPublicKeyPath,
                 ],
                 MySqlSslMode::Preferred | MySqlSslMode::Required => &[
@@ -65,6 +67,7 @@ impl ConnectionField {
                     Self::User,
                     Self::Password,
                     Self::SslMode,
+                    Self::CleartextAuth,
                     Self::ServerPublicKeyPath,
                     Self::SslCert,
                     Self::SslKey,
@@ -78,6 +81,7 @@ impl ConnectionField {
                     Self::User,
                     Self::Password,
                     Self::SslMode,
+                    Self::CleartextAuth,
                     Self::ServerPublicKeyPath,
                     Self::SslCa,
                     Self::SslCert,
@@ -104,7 +108,7 @@ impl ConnectionField {
             | Self::ServerPublicKeyPath => Some(4096),
             Self::Host | Self::Database | Self::User | Self::Password => Some(255),
             Self::Port => Some(5),
-            Self::DatabaseType | Self::SslMode => None,
+            Self::DatabaseType | Self::SslMode | Self::CleartextAuth => None,
         }
     }
 
@@ -136,6 +140,7 @@ impl ConnectionField {
             Self::User => "User:",
             Self::Password => "Password:",
             Self::SslMode => "SSL Mode:",
+            Self::CleartextAuth => "Cleartext:",
             Self::SslCa => "CA Path:",
             Self::SslCert => "Cert Path:",
             Self::SslKey => "Key Path:",
@@ -192,6 +197,7 @@ pub struct ConnectionSetupState {
     pub(crate) server_public_key_path: TextInputState,
     pub(crate) ssl_mode: SslMode,
     pub(crate) mysql_ssl_mode: MySqlSslMode,
+    pub(crate) enable_cleartext_plugin: bool,
 
     pub(crate) focused_field: ConnectionField,
     pub(crate) database_type_dropdown: DatabaseTypeDropdown,
@@ -220,6 +226,7 @@ impl Default for ConnectionSetupState {
             server_public_key_path: TextInputState::default(),
             ssl_mode: SslMode::Prefer,
             mysql_ssl_mode: MySqlSslMode::Preferred,
+            enable_cleartext_plugin: false,
             focused_field: ConnectionField::DatabaseType,
             database_type_dropdown: DatabaseTypeDropdown::default(),
             ssl_dropdown: SslModeDropdown::default(),
@@ -241,6 +248,10 @@ impl ConnectionSetupState {
 
     pub fn mysql_ssl_mode(&self) -> MySqlSslMode {
         self.mysql_ssl_mode
+    }
+
+    pub fn cleartext_auth_plugin_enabled(&self) -> bool {
+        self.enable_cleartext_plugin
     }
 
     pub fn focused_field(&self) -> ConnectionField {
@@ -291,7 +302,9 @@ impl ConnectionSetupState {
 
     pub fn input(&self, field: ConnectionField) -> Option<&TextInputState> {
         match field {
-            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
+            ConnectionField::DatabaseType
+            | ConnectionField::SslMode
+            | ConnectionField::CleartextAuth => None,
             ConnectionField::Name => Some(&self.name),
             ConnectionField::SqlitePath => Some(&self.sqlite_path),
             ConnectionField::Host => Some(&self.host),
@@ -312,7 +325,9 @@ impl ConnectionSetupState {
 
     pub fn input_mut(&mut self, field: ConnectionField) -> Option<&mut TextInputState> {
         match field {
-            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
+            ConnectionField::DatabaseType
+            | ConnectionField::SslMode
+            | ConnectionField::CleartextAuth => None,
             ConnectionField::Name => Some(&mut self.name),
             ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
             ConnectionField::Host => Some(&mut self.host),
@@ -411,22 +426,24 @@ impl ConnectionSetupState {
                         .unwrap_or(0);
                 }
             }
-            ConnectionField::SslMode => {
+            ConnectionField::SslMode | ConnectionField::CleartextAuth => {
                 self.ssl_dropdown.is_open = !self.ssl_dropdown.is_open;
                 self.database_type_dropdown.is_open = false;
                 if self.ssl_dropdown.is_open {
-                    self.ssl_dropdown.selected_index = if self.database_type == DatabaseType::MySQL
-                    {
-                        MySqlSslMode::all_variants()
-                            .iter()
-                            .position(|v| *v == self.mysql_ssl_mode)
-                            .unwrap_or(1)
-                    } else {
-                        SslMode::all_variants()
-                            .iter()
-                            .position(|v| *v == self.ssl_mode)
-                            .unwrap_or(2)
-                    };
+                    self.ssl_dropdown.selected_index =
+                        if self.focused_field == ConnectionField::CleartextAuth {
+                            usize::from(self.enable_cleartext_plugin)
+                        } else if self.database_type == DatabaseType::MySQL {
+                            MySqlSslMode::all_variants()
+                                .iter()
+                                .position(|v| *v == self.mysql_ssl_mode)
+                                .unwrap_or(1)
+                        } else {
+                            SslMode::all_variants()
+                                .iter()
+                                .position(|v| *v == self.ssl_mode)
+                                .unwrap_or(2)
+                        };
                 }
             }
             _ => {}
@@ -440,7 +457,9 @@ impl ConnectionSetupState {
                 self.database_type_dropdown.selected_index += 1;
             }
         } else if self.ssl_dropdown.is_open {
-            let max = if self.database_type == DatabaseType::MySQL {
+            let max = if self.focused_field == ConnectionField::CleartextAuth {
+                1
+            } else if self.database_type == DatabaseType::MySQL {
                 MySqlSslMode::all_variants().len() - 1
             } else {
                 SslMode::all_variants().len() - 1
@@ -469,7 +488,9 @@ impl ConnectionSetupState {
             }
         } else if self.ssl_dropdown.is_open {
             if self.database_type == DatabaseType::MySQL {
-                if let Some(mode) =
+                if self.focused_field == ConnectionField::CleartextAuth {
+                    self.enable_cleartext_plugin = self.ssl_dropdown.selected_index == 1;
+                } else if let Some(mode) =
                     MySqlSslMode::all_variants().get(self.ssl_dropdown.selected_index)
                 {
                     self.set_mysql_ssl_mode(*mode);
@@ -573,7 +594,8 @@ impl ConnectionSetupState {
                         .then(|| optional_path(&self.ssl_key))
                         .flatten(),
                 )
-                .with_server_public_key_path(optional_path(&self.server_public_key_path)),
+                .with_server_public_key_path(optional_path(&self.server_public_key_path))
+                .with_cleartext_auth_plugin(self.enable_cleartext_plugin),
             ),
         })
     }
@@ -638,6 +660,7 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
                 state.password =
                     TextInputState::new(&config.password, config.password.chars().count());
                 state.mysql_ssl_mode = config.ssl_mode;
+                state.enable_cleartext_plugin = config.enable_cleartext_plugin;
                 if config.ssl_mode.uses_ca()
                     && let Some(path) = config.ssl_ca.as_deref()
                 {
@@ -680,6 +703,7 @@ mod tests {
         #[case(ConnectionField::User, false)]
         #[case(ConnectionField::Password, false)]
         #[case(ConnectionField::SslMode, false)]
+        #[case(ConnectionField::CleartextAuth, false)]
         #[case(ConnectionField::SslCa, false)]
         #[case(ConnectionField::SslCert, false)]
         #[case(ConnectionField::SslKey, false)]
@@ -724,6 +748,7 @@ mod tests {
                     ConnectionField::User,
                     ConnectionField::Password,
                     ConnectionField::SslMode,
+                    ConnectionField::CleartextAuth,
                     ConnectionField::ServerPublicKeyPath,
                     ConnectionField::SslCert,
                     ConnectionField::SslKey,
@@ -742,6 +767,7 @@ mod tests {
             assert_eq!(ConnectionField::Password.max_chars(), Some(255));
             assert_eq!(ConnectionField::DatabaseType.max_chars(), None);
             assert_eq!(ConnectionField::SslMode.max_chars(), None);
+            assert_eq!(ConnectionField::CleartextAuth.max_chars(), None);
             assert_eq!(ConnectionField::ServerPublicKeyPath.max_chars(), Some(4096));
         }
 
@@ -788,6 +814,22 @@ mod tests {
 
             state.mysql_ssl_mode = MySqlSslMode::Disabled;
             assert!(!state.visible_fields().contains(&ConnectionField::SslCert));
+        }
+
+        #[test]
+        fn cleartext_auth_dropdown_updates_config() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            state.focused_field = ConnectionField::CleartextAuth;
+            state.toggle_focused_dropdown();
+            state.dropdown_next();
+            state.confirm_dropdown();
+
+            assert!(state.cleartext_auth_plugin_enabled());
+            let ConnectionConfig::MySQL(config) = state.to_connection_config().unwrap() else {
+                panic!("expected MySQL config");
+            };
+            assert!(config.enable_cleartext_plugin);
         }
     }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -80,7 +80,9 @@ pub fn reduce_connection_setup(
                         port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
                 }
-                ConnectionField::DatabaseType | ConnectionField::SslMode => {}
+                ConnectionField::DatabaseType
+                | ConnectionField::SslMode
+                | ConnectionField::CleartextAuth => {}
                 _ => {
                     let field = setup.focused_field();
                     if let Some(input) = setup.focused_input_mut()
@@ -348,7 +350,9 @@ fn insert_form_text(setup: &mut ConnectionSetupState, text: &str) {
                     .update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
             }
         }
-        ConnectionField::DatabaseType | ConnectionField::SslMode => {}
+        ConnectionField::DatabaseType
+        | ConnectionField::SslMode
+        | ConnectionField::CleartextAuth => {}
         field => {
             if let Some(input) = setup.focused_input_mut() {
                 let remaining = remaining_input_capacity(field, input.char_count());

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -546,6 +546,13 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 state.set_validation_error(field, "Invalid path");
             }
         }
+        ConnectionField::CleartextAuth if state.database_type() == DatabaseType::MySQL => {
+            if state.cleartext_auth_plugin_enabled()
+                && !state.mysql_ssl_mode().allows_cleartext_auth()
+            {
+                state.set_validation_error(field, "Requires TLS");
+            }
+        }
         ConnectionField::Name => {
             let name = text_input_content(state, field).trim().to_string();
             if name.is_empty() {
@@ -560,7 +567,8 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
         | ConnectionField::SslCa
         | ConnectionField::SslCert
         | ConnectionField::SslKey
-        | ConnectionField::ServerPublicKeyPath => {}
+        | ConnectionField::ServerPublicKeyPath
+        | ConnectionField::CleartextAuth => {}
     }
 }
 
@@ -858,6 +866,25 @@ mod tests {
             state.validation_error(ConnectionField::SslCa),
             Some("Required for this TLS mode")
         );
+    }
+
+    #[test]
+    fn mysql_cleartext_auth_requires_tls() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state.enable_cleartext_plugin = true;
+
+        validate_all(&mut state);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::CleartextAuth),
+            Some("Requires TLS")
+        );
+
+        state.mysql_ssl_mode = MySqlSslMode::Required;
+        validate_all(&mut state);
+
+        assert_eq!(state.validation_error(ConnectionField::CleartextAuth), None);
     }
 
     #[test]

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -20,7 +20,9 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
         && !(combo.key == Key::Enter
             && matches!(
                 state.connection_setup.focused_field(),
-                ConnectionField::DatabaseType | ConnectionField::SslMode
+                ConnectionField::DatabaseType
+                    | ConnectionField::SslMode
+                    | ConnectionField::CleartextAuth
             ))
     {
         return Action::ConnectionSetupSave;
@@ -46,7 +48,9 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
         Key::Enter
             if matches!(
                 state.connection_setup.focused_field(),
-                ConnectionField::DatabaseType | ConnectionField::SslMode
+                ConnectionField::DatabaseType
+                    | ConnectionField::SslMode
+                    | ConnectionField::CleartextAuth
             ) =>
         {
             Action::ConnectionSetupToggleDropdown

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -41,6 +41,10 @@ impl MySqlSslMode {
     pub const fn uses_ca(self) -> bool {
         matches!(self, Self::VerifyCa | Self::VerifyIdentity)
     }
+
+    pub const fn allows_cleartext_auth(self) -> bool {
+        matches!(self, Self::Required | Self::VerifyCa | Self::VerifyIdentity)
+    }
 }
 
 impl std::fmt::Display for MySqlSslMode {
@@ -110,6 +114,8 @@ pub struct MySqlConnectionConfig {
     pub ssl_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_public_key_path: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub enable_cleartext_plugin: bool,
 }
 
 impl MySqlConnectionConfig {
@@ -132,6 +138,7 @@ impl MySqlConnectionConfig {
             ssl_cert: None,
             ssl_key: None,
             server_public_key_path: None,
+            enable_cleartext_plugin: false,
         }
     }
 
@@ -151,6 +158,12 @@ impl MySqlConnectionConfig {
     #[must_use]
     pub fn with_server_public_key_path(mut self, path: Option<String>) -> Self {
         self.server_public_key_path = path;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cleartext_auth_plugin(mut self, enabled: bool) -> Self {
+        self.enable_cleartext_plugin = enabled;
         self
     }
 
@@ -175,6 +188,14 @@ impl MySqlConnectionConfig {
     pub fn is_valid(&self) -> bool {
         Self::is_valid_host(&self.host)
     }
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires a reference predicate"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -336,6 +357,15 @@ mod tests {
     #[test]
     fn mysql_tls_modes_reject_unknown_names() {
         assert!("unknown".parse::<MySqlSslMode>().is_err());
+    }
+
+    #[test]
+    fn cleartext_auth_requires_a_tls_mode() {
+        assert!(!MySqlSslMode::Disabled.allows_cleartext_auth());
+        assert!(!MySqlSslMode::Preferred.allows_cleartext_auth());
+        assert!(MySqlSslMode::Required.allows_cleartext_auth());
+        assert!(MySqlSslMode::VerifyCa.allows_cleartext_auth());
+        assert!(MySqlSslMode::VerifyIdentity.allows_cleartext_auth());
     }
 
     mod sqlite_deserialize {

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -32,6 +32,10 @@ pub enum ConnectionProfileError {
     InvalidMySqlHost,
     #[error("MySQL connection port must be > 0")]
     InvalidMySqlPort,
+    #[error(
+        "MySQL cleartext authentication requires REQUIRED, VERIFY_CA, or VERIFY_IDENTITY TLS mode"
+    )]
+    MySqlCleartextAuthRequiresTls,
     #[error("{0}")]
     SqlitePath(#[from] SqlitePathError),
 }
@@ -149,6 +153,9 @@ impl ConnectionProfile {
             if !mysql.is_valid() {
                 return Err(ConnectionProfileError::InvalidMySqlHost);
             }
+            if mysql.enable_cleartext_plugin && !mysql.ssl_mode.allows_cleartext_auth() {
+                return Err(ConnectionProfileError::MySqlCleartextAuthRequiresTls);
+            }
         }
         Ok(Self {
             id,
@@ -252,6 +259,30 @@ mod tests {
             assert!(matches!(
                 result,
                 Err(ConnectionProfileError::InvalidMySqlPort)
+            ));
+        }
+
+        #[test]
+        fn cleartext_auth_requires_tls() {
+            let config = MySqlConnectionConfig::new(
+                "localhost",
+                3306,
+                None,
+                "user",
+                "password",
+                MySqlSslMode::Preferred,
+            )
+            .with_cleartext_auth_plugin(true);
+
+            let result = ConnectionProfile::with_id_and_config(
+                ConnectionId::new(),
+                "MySQL",
+                ConnectionConfig::MySQL(config),
+            );
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::MySqlCleartextAuthRequiresTls)
             ));
         }
     }

--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -11,6 +11,15 @@ mod process;
 mod pty;
 mod xml;
 
+use tokio::process::Command;
+
+pub(super) fn sanitize_mysql_command_environment(command: &mut Command) {
+    command
+        .env_remove("MYSQL_PWD")
+        .env_remove("MYSQL_PASSWORD")
+        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN");
+}
+
 pub(super) use export::export_mysql_csv_to_file;
 pub(super) use policy::{
     validate_mysql_export_query, validate_mysql_multi_query,
@@ -27,3 +36,40 @@ pub(super) use xml::MySqlResultSet;
 
 #[cfg(all(unix, feature = "test-support"))]
 pub(super) mod test_support;
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::*;
+
+    #[test]
+    fn mysql_command_environment_removes_ambient_credentials_and_cleartext_plugin() {
+        let mut command = Command::new("mysql");
+        command
+            .env("MYSQL_PWD", "password")
+            .env("MYSQL_PASSWORD", "password")
+            .env("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN", "1")
+            .env("SABIQL_TEST_ENVIRONMENT", "preserved");
+
+        sanitize_mysql_command_environment(&mut command);
+
+        for name in [
+            "MYSQL_PWD",
+            "MYSQL_PASSWORD",
+            "LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN",
+        ] {
+            assert!(
+                command
+                    .as_std()
+                    .get_envs()
+                    .any(|(key, value)| key == OsStr::new(name) && value.is_none())
+            );
+        }
+        assert!(command
+            .as_std()
+            .get_envs()
+            .any(|(key, value)| key == OsStr::new("SABIQL_TEST_ENVIRONMENT")
+                && value.is_some()));
+    }
+}

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -14,6 +14,7 @@ use crate::app::ports::outbound::{
 };
 
 use super::args::mysql_connection_args;
+use super::sanitize_mysql_command_environment;
 
 const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
 const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('version', VERSION(), 'sql_mode', @@SESSION.sql_mode, 'lower_case_table_names', @@lower_case_table_names)";
@@ -53,10 +54,8 @@ async fn run_mysql_version_command(
     command
         .args(MYSQL_VERSION_ARGS)
         .stdin(Stdio::null())
-        .env_remove("MYSQL_PWD")
-        .env_remove("MYSQL_PASSWORD")
-        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
         .kill_on_drop(true);
+    sanitize_mysql_command_environment(&mut command);
 
     match timeout(MYSQL_PROBE_TIMEOUT, command.output()).await {
         Ok(Ok(output)) => Ok(output),
@@ -192,13 +191,8 @@ where
     S: AsRef<OsStr>,
 {
     let mut command = Command::new("mysql");
-    command
-        .args(args)
-        .stdin(Stdio::null())
-        .env_remove("MYSQL_PWD")
-        .env_remove("MYSQL_PASSWORD")
-        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
-        .kill_on_drop(true);
+    command.args(args).stdin(Stdio::null()).kill_on_drop(true);
+    sanitize_mysql_command_environment(&mut command);
     if option_file.is_some() {
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
     }

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -55,6 +55,7 @@ async fn run_mysql_version_command(
         .stdin(Stdio::null())
         .env_remove("MYSQL_PWD")
         .env_remove("MYSQL_PASSWORD")
+        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
         .kill_on_drop(true);
 
     match timeout(MYSQL_PROBE_TIMEOUT, command.output()).await {
@@ -196,6 +197,7 @@ where
         .stdin(Stdio::null())
         .env_remove("MYSQL_PWD")
         .env_remove("MYSQL_PASSWORD")
+        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
         .kill_on_drop(true);
     if option_file.is_some() {
         command.stdout(Stdio::piped()).stderr(Stdio::piped());

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -28,6 +28,7 @@ use super::pty::{
     MySqlPty, create_mysql_pty, read_one_pty_resultset, read_one_pty_resultset_with_diagnostics,
     read_pty_all, read_pty_until_idle,
 };
+use super::sanitize_mysql_command_environment;
 use super::xml::{MySqlResultsetFrameScanner, parse_mysql_xml, trace_mysql_statement};
 
 mod session;
@@ -113,10 +114,8 @@ impl MySqlProcess {
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
-                .env_remove("MYSQL_PWD")
-                .env_remove("MYSQL_PASSWORD")
-                .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
                 .kill_on_drop(true);
+            sanitize_mysql_command_environment(&mut command);
             let mut child = command.spawn().map_err(|error| {
                 if error.kind() == io::ErrorKind::NotFound {
                     DbOperationError::CommandNotFound {
@@ -168,10 +167,8 @@ impl MySqlProcess {
                 DbOperationError::ConnectionFailed(error.to_string())
             })?))
             .stderr(Stdio::from(slave))
-            .env_remove("MYSQL_PWD")
-            .env_remove("MYSQL_PASSWORD")
-            .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
             .kill_on_drop(true);
+        sanitize_mysql_command_environment(&mut command);
         let child = command.spawn().map_err(|error| {
             if error.kind() == io::ErrorKind::NotFound {
                 DbOperationError::CommandNotFound {
@@ -510,7 +507,6 @@ mod statement_input_tests {
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
-    use std::ffi::OsString;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
@@ -533,29 +529,6 @@ mod tests {
     use crate::domain::{
         CommandTag, MySqlDiagnostic, MySqlDiagnosticLevel, QueryValue, RefreshScope,
     };
-
-    struct EnvironmentVariableGuard {
-        name: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl Drop for EnvironmentVariableGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match self.previous.take() {
-                    Some(value) => std::env::set_var(self.name, value),
-                    None => std::env::remove_var(self.name),
-                }
-            }
-        }
-    }
-
-    fn set_ambient_cleartext_plugin() -> EnvironmentVariableGuard {
-        let name = "LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN";
-        let previous = std::env::var_os(name);
-        unsafe { std::env::set_var(name, "1") };
-        EnvironmentVariableGuard { name, previous }
-    }
 
     mod cleanup {
         use super::*;
@@ -695,7 +668,6 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
             r#"#!/bin/sh
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
-printf 'cleartext_env=%s\n' "${{LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN-}}" >> "$log"
 eof=$(printf '\004')
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
@@ -980,27 +952,6 @@ done
 
     mod single_statement {
         use super::*;
-
-        #[tokio::test]
-        async fn mysql_process_removes_ambient_cleartext_plugin_setting() {
-            let _environment = set_ambient_cleartext_plugin();
-            let (_directory, program, log_file) = fake_mysql("success");
-            let option_file = log_file.with_extension("cnf");
-            fs::write(&option_file, "[client]\n").unwrap();
-
-            run_mysql_single_statement_with_program(
-                OsStr::new(&program),
-                &option_file,
-                "SELECT 123",
-                AccessMode::ReadWrite,
-                Duration::from_secs(5),
-            )
-            .await
-            .unwrap();
-
-            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-            assert!(log.contains("cleartext_env=\n"), "{log}");
-        }
 
         #[tokio::test]
         async fn diagnostics_use_adhoc_args_and_follow_resultset_to_marker() {

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -115,6 +115,7 @@ impl MySqlProcess {
                 .stderr(Stdio::piped())
                 .env_remove("MYSQL_PWD")
                 .env_remove("MYSQL_PASSWORD")
+                .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
                 .kill_on_drop(true);
             let mut child = command.spawn().map_err(|error| {
                 if error.kind() == io::ErrorKind::NotFound {
@@ -169,6 +170,7 @@ impl MySqlProcess {
             .stderr(Stdio::from(slave))
             .env_remove("MYSQL_PWD")
             .env_remove("MYSQL_PASSWORD")
+            .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
             .kill_on_drop(true);
         let child = command.spawn().map_err(|error| {
             if error.kind() == io::ErrorKind::NotFound {
@@ -508,6 +510,7 @@ mod statement_input_tests {
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
+    use std::ffi::OsString;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
@@ -530,6 +533,29 @@ mod tests {
     use crate::domain::{
         CommandTag, MySqlDiagnostic, MySqlDiagnosticLevel, QueryValue, RefreshScope,
     };
+
+    struct EnvironmentVariableGuard {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl Drop for EnvironmentVariableGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.name, value),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
+
+    fn set_ambient_cleartext_plugin() -> EnvironmentVariableGuard {
+        let name = "LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN";
+        let previous = std::env::var_os(name);
+        unsafe { std::env::set_var(name, "1") };
+        EnvironmentVariableGuard { name, previous }
+    }
 
     mod cleanup {
         use super::*;
@@ -669,6 +695,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
             r#"#!/bin/sh
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
+printf 'cleartext_env=%s\n' "${{LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN-}}" >> "$log"
 eof=$(printf '\004')
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
@@ -953,6 +980,27 @@ done
 
     mod single_statement {
         use super::*;
+
+        #[tokio::test]
+        async fn mysql_process_removes_ambient_cleartext_plugin_setting() {
+            let _environment = set_ambient_cleartext_plugin();
+            let (_directory, program, log_file) = fake_mysql("success");
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+
+            run_mysql_single_statement_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(log.contains("cleartext_env=\n"), "{log}");
+        }
 
         #[tokio::test]
         async fn diagnostics_use_adhoc_args_and_follow_resultset_to_marker() {

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -156,6 +156,7 @@ impl MySqlMetadataProcess {
             .stderr(Stdio::piped())
             .env_remove("MYSQL_PWD")
             .env_remove("MYSQL_PASSWORD")
+            .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
             .kill_on_drop(true);
         let mut child = command.spawn().map_err(|error| {
             if error.kind() == io::ErrorKind::NotFound {

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -19,6 +19,7 @@ use super::super::policy::{
     MYSQL_SESSION_MARKER_COLUMN, MySqlMetadataFallbackKind, mysql_metadata_select_query,
 };
 use super::super::probe::{run_mysql_command_with_timeout, validate_sql_mode};
+use super::super::sanitize_mysql_command_environment;
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, read_one_mysql_resultset_with_diagnostics,
     write_mysql_statement,
@@ -154,10 +155,8 @@ impl MySqlMetadataProcess {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .env_remove("MYSQL_PWD")
-            .env_remove("MYSQL_PASSWORD")
-            .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
             .kill_on_drop(true);
+        sanitize_mysql_command_environment(&mut command);
         let mut child = command.spawn().map_err(|error| {
             if error.kind() == io::ErrorKind::NotFound {
                 DbOperationError::CommandNotFound {

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -18,6 +18,7 @@ pub(super) struct MySqlDsn {
     pub(super) ssl_cert: Option<String>,
     pub(super) ssl_key: Option<String>,
     pub(super) server_public_key_path: Option<String>,
+    pub(super) enable_cleartext_plugin: bool,
 }
 
 impl fmt::Debug for MySqlDsn {
@@ -34,6 +35,7 @@ impl fmt::Debug for MySqlDsn {
             .field("ssl_cert", &self.ssl_cert)
             .field("ssl_key", &self.ssl_key)
             .field("server_public_key_path", &self.server_public_key_path)
+            .field("enable_cleartext_plugin", &self.enable_cleartext_plugin)
             .finish()
     }
 }
@@ -75,6 +77,10 @@ pub(super) fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
     if let Some(path) = config.server_public_key_path.as_deref() {
         url.query_pairs_mut()
             .append_pair("server-public-key-path", path);
+    }
+    if config.enable_cleartext_plugin {
+        url.query_pairs_mut()
+            .append_pair("enable-cleartext-plugin", "true");
     }
     url.to_string()
 }
@@ -128,6 +134,18 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
     let server_public_key_path = url
         .query_pairs()
         .find_map(|(key, value)| (key == "server-public-key-path").then(|| value.into_owned()));
+    let enable_cleartext_plugin = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "enable-cleartext-plugin").then(|| value.into_owned()))
+        .map(|value| match value.as_str() {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => Err(DbOperationError::ConnectionFailed(
+                "Invalid MySQL cleartext authentication setting".to_string(),
+            )),
+        })
+        .transpose()?
+        .unwrap_or(false);
 
     Ok(MySqlDsn {
         host,
@@ -140,6 +158,7 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         ssl_cert,
         ssl_key,
         server_public_key_path,
+        enable_cleartext_plugin,
     })
 }
 
@@ -193,6 +212,12 @@ pub(super) fn validate_mysql_tls_config(target: &MySqlDsn) -> Result<(), DbOpera
     if target.ssl_cert.is_some() != target.ssl_key.is_some() {
         return Err(DbOperationError::ConnectionFailed(
             "MySQL client certificate and key must be specified together".to_string(),
+        ));
+    }
+    if target.enable_cleartext_plugin && !target.ssl_mode.allows_cleartext_auth() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL cleartext authentication requires REQUIRED, VERIFY_CA, or VERIFY_IDENTITY TLS mode"
+                .to_string(),
         ));
     }
 
@@ -346,6 +371,39 @@ mod tests {
     }
 
     #[test]
+    fn builds_and_parses_mysql_dsn_with_cleartext_auth_plugin() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3306,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::Required,
+        )
+        .with_cleartext_auth_plugin(true);
+
+        let dsn = build_mysql_dsn(&config);
+        assert!(dsn.contains("enable-cleartext-plugin=true"));
+        let parsed = parse_and_validate_mysql_dsn(&dsn).unwrap();
+
+        assert!(parsed.enable_cleartext_plugin);
+    }
+
+    #[test]
+    fn rejects_cleartext_auth_plugin_without_required_tls() {
+        let error = parse_and_validate_mysql_dsn(
+            "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED&enable-cleartext-plugin=true",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "MySQL cleartext authentication requires REQUIRED, VERIFY_CA, or VERIFY_IDENTITY TLS mode"
+        ));
+    }
+
+    #[test]
     fn ignores_ca_when_building_or_parsing_non_verification_dsn() {
         let config = MySqlConnectionConfig::new(
             "db.example",
@@ -408,6 +466,7 @@ mod tests {
                 ssl_cert: None,
                 ssl_key: None,
                 server_public_key_path: None,
+                enable_cleartext_plugin: false,
             };
             match field {
                 "CA" => target.ssl_ca = Some("ca\n.pem".to_string()),

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -463,6 +463,9 @@ fn serialize_option_file(target: &MySqlDsn) -> String {
         push_option(&mut contents, "database", database);
     }
     push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
+    if target.enable_cleartext_plugin {
+        push_option(&mut contents, "enable-cleartext-plugin", "true");
+    }
     if target.ssl_mode.uses_ca()
         && let Some(path) = target.ssl_ca.as_deref()
     {
@@ -529,6 +532,7 @@ mod tests {
             ssl_cert: None,
             ssl_key: None,
             server_public_key_path: None,
+            enable_cleartext_plugin: false,
         }
     }
 
@@ -608,6 +612,21 @@ mod tests {
             "server-public-key-path = {}\n",
             quote_option_value(&key.display().to_string())
         )));
+    }
+
+    #[test]
+    fn option_file_serializes_cleartext_auth_plugin() {
+        let target = MySqlDsn {
+            ssl_mode: MySqlSslMode::Required,
+            enable_cleartext_plugin: true,
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        let contents = fs::read_to_string(&option_file.path).unwrap();
+
+        assert!(contents.contains("ssl-mode = \"REQUIRED\"\n"));
+        assert!(contents.contains("enable-cleartext-plugin = \"true\"\n"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/test_support.rs
+++ b/src/infra/adapters/mysql/test_support.rs
@@ -12,7 +12,7 @@ use tokio::time::timeout;
 
 use super::cli::{
     export_mysql_csv_to_file, run_mysql_adhoc, run_mysql_adhoc_with_timeout_for_test,
-    validate_mysql_multi_query,
+    sanitize_mysql_command_environment, validate_mysql_multi_query,
 };
 use super::dsn::parse_and_validate_mysql_dsn;
 use super::option_file::MySqlOptionFile;
@@ -48,10 +48,8 @@ pub async fn run_mysql_cli_query_for_test(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .env_remove("MYSQL_PWD")
-        .env_remove("MYSQL_PASSWORD")
-        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
         .kill_on_drop(true);
+    sanitize_mysql_command_environment(&mut command);
     let output = match timeout(Duration::from_secs(11), command.output()).await {
         Ok(Ok(output)) => output,
         Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => {

--- a/src/infra/adapters/mysql/test_support.rs
+++ b/src/infra/adapters/mysql/test_support.rs
@@ -50,6 +50,7 @@ pub async fn run_mysql_cli_query_for_test(
         .stderr(Stdio::piped())
         .env_remove("MYSQL_PWD")
         .env_remove("MYSQL_PASSWORD")
+        .env_remove("LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN")
         .kill_on_drop(true);
     let output = match timeout(Duration::from_secs(11), command.output()).await {
         Ok(Ok(output)) => output,

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -60,6 +60,8 @@ pub struct ConnectionConfigEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_server_public_key_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_enable_cleartext_plugin: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -104,6 +106,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_enable_cleartext_plugin: None,
             path: None,
         };
         match &profile.config {
@@ -133,6 +136,8 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry
                     .mysql_server_public_key_path
                     .clone_from(&config.server_public_key_path);
+                entry.mysql_enable_cleartext_plugin =
+                    config.enable_cleartext_plugin.then_some(true);
             }
         }
         entry
@@ -187,7 +192,10 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                             entry.mysql_ssl_cert.clone(),
                             entry.mysql_ssl_key.clone(),
                         )
-                        .with_server_public_key_path(entry.mysql_server_public_key_path.clone()),
+                        .with_server_public_key_path(entry.mysql_server_public_key_path.clone())
+                        .with_cleartext_auth_plugin(
+                            entry.mysql_enable_cleartext_plugin.unwrap_or(false),
+                        ),
                     ),
                 )
             }
@@ -269,6 +277,7 @@ mod tests {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_enable_cleartext_plugin: None,
             path: None,
         }
     }
@@ -289,6 +298,7 @@ mod tests {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_enable_cleartext_plugin: None,
             path: path.map(str::to_string),
         }
     }
@@ -309,6 +319,7 @@ mod tests {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_enable_cleartext_plugin: None,
             path: None,
         }
     }
@@ -418,6 +429,18 @@ mod tests {
         assert_eq!(serialized.mysql_ssl_mode, Some(MySqlSslMode::Required));
         assert_eq!(serialized.port, Some(3306));
         assert_eq!(serialized.password.as_deref(), Some("p@ss#word"));
+    }
+
+    #[test]
+    fn mysql_entry_round_trips_cleartext_auth_plugin() {
+        let mut entry = mysql_entry(Some("app"));
+        entry.mysql_enable_cleartext_plugin = Some(true);
+
+        let profile = ConnectionProfile::try_from(&entry).unwrap();
+        assert!(profile.mysql_config().unwrap().enable_cleartext_plugin);
+
+        let serialized = ConnectionConfigEntry::from(&profile);
+        assert_eq!(serialized.mysql_enable_cleartext_plugin, Some(true));
     }
 
     #[test]

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -86,6 +86,25 @@ fn connection_setup_mysql_form() {
 }
 
 #[test]
+fn connection_setup_mysql_cleartext_auth_notice() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state
+        .connection_setup
+        .set_database_type(DatabaseType::MySQL);
+    focus_connection_field(&mut state, ConnectionField::CleartextAuth);
+    state.connection_setup.toggle_focused_dropdown();
+    state.connection_setup.dropdown_next();
+    state.connection_setup.confirm_dropdown();
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn connection_setup_mysql_preview_does_not_mask_empty_password() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 104
+expression: output
+---
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││(select a table)                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  Type:       [ MySQL                    ▼ ]                │                                                  │
+│                                       ││          │  Name:       [                            ]                │                                                  │
+│                                       ││          │  Host:       [ localhost                  ]                │                                                  │
+│                                       ││          │  Port:       [ 3306                       ]                │                                                  │
+│                                       ││          │  Database:   [                            ]                │                                                  │
+│                                       ││          │  User:       [                            ]                │                                                  │
+│                                       │└──────────│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Cleartext:  [ enabled                  ▼ ]                │                                                  │
+│                                       ││          │  Server Key: [                            ]                │                                                  │
+│                                       ││          │  Cert Path:  [                            ]                │                                                  │
+│                                       ││          │  Key Path:   [                            ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  Note: password is sent via mysql_clear_password           │                                                  │
+│                                       ││          │  TLS required: REQUIRED, VERIFY_CA, or VERIFY_IDENTITY     │                                                  │
+│                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 85
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -26,9 +26,10 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
 │                                       ││          │  Database:   [ app                        ]                │                                                  │
-│                                       │└──────────│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
+│                                       ││          │  User:       [ mysql_user                 ]                │                                                  │
+│                                       │└──────────│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Server Key: [                            ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 112
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
@@ -28,7 +29,8 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  User:       [ mysql_user                 ]                │                                                  │
 │                                       │└──────────│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┘
 │                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Server Key: [                            ]                │                                                  │
+│                                       ││(select a │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
+│                                       ││          │  Server Key: [                            ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
@@ -37,7 +39,6 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -24,6 +24,7 @@ const FIELD_HEIGHT: u16 = 1;
 const MODAL_VERTICAL_CHROME: u16 = 6;
 const MODAL_HORIZONTAL_CHROME: u16 = 6;
 const MIN_PREVIEW_LINES: usize = 2;
+const CLEARTEXT_AUTH_OPTIONS: &[&str] = &["disabled", "enabled"];
 
 fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> Line<'static> {
     Line::from(vec![
@@ -51,17 +52,25 @@ impl ConnectionSetup {
         let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
         let preview = preview_text(form_state, services);
         let preview_width = modal_width.saturating_sub(MODAL_HORIZONTAL_CHROME) as usize;
+        let notice_height = if form_state.cleartext_auth_plugin_enabled() {
+            2
+        } else {
+            1
+        };
         let max_preview_lines = frame
             .area()
             .height
-            .saturating_sub(MODAL_VERTICAL_CHROME + visible_fields.len() as u16 + 2)
+            .saturating_sub(MODAL_VERTICAL_CHROME + visible_fields.len() as u16 + 1 + notice_height)
             .max(MIN_PREVIEW_LINES as u16) as usize;
         let preview_lines = preview
             .as_deref()
             .map(|preview| preview_lines(preview, preview_width, max_preview_lines))
             .unwrap_or_default();
-        let modal_height =
-            visible_fields.len() as u16 + preview_lines.len() as u16 + MODAL_VERTICAL_CHROME;
+        let modal_height = visible_fields.len() as u16
+            + preview_lines.len() as u16
+            + MODAL_VERTICAL_CHROME
+            + notice_height
+            - 1;
 
         let (title, submit_desc) = if form_state.is_edit_mode() {
             (" Edit Connection ", "Save")
@@ -90,7 +99,7 @@ impl ConnectionSetup {
         if !preview_lines.is_empty() {
             constraints.push(Constraint::Length(preview_lines.len() as u16));
         }
-        constraints.push(Constraint::Length(1));
+        constraints.push(Constraint::Length(notice_height));
         let chunks = Layout::vertical(constraints).split(inner);
 
         for (idx, field) in visible_fields.iter().enumerate() {
@@ -101,6 +110,7 @@ impl ConnectionSetup {
                     field.label(),
                     &form_state.database_type().to_string(),
                     form_state.focused_field() == ConnectionField::DatabaseType,
+                    None,
                     theme,
                 ),
                 ConnectionField::SslMode => Self::render_dropdown_field(
@@ -109,6 +119,16 @@ impl ConnectionSetup {
                     field.label(),
                     &ssl_mode_label(form_state),
                     form_state.focused_field() == ConnectionField::SslMode,
+                    form_state.validation_error(ConnectionField::SslMode),
+                    theme,
+                ),
+                ConnectionField::CleartextAuth => Self::render_dropdown_field(
+                    frame,
+                    chunks[idx],
+                    field.label(),
+                    cleartext_auth_label(form_state),
+                    form_state.focused_field() == ConnectionField::CleartextAuth,
+                    form_state.validation_error(ConnectionField::CleartextAuth),
                     theme,
                 ),
                 field => Self::render_text_field(
@@ -126,7 +146,16 @@ impl ConnectionSetup {
             Self::render_dsn_preview(frame, chunks[field_count + 1], &preview_lines, theme);
         }
 
-        let notice = "Note: Connection info is stored locally in plain text";
+        let notice = if form_state.cleartext_auth_plugin_enabled() {
+            vec![
+                Line::from("Note: password is sent via mysql_clear_password"),
+                Line::from("TLS required: REQUIRED, VERIFY_CA, or VERIFY_IDENTITY"),
+            ]
+        } else {
+            vec![Line::from(
+                "Note: Connection info is stored locally in plain text",
+            )]
+        };
         let notice_para =
             Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
         let notice_index = field_count + 1 + usize::from(!preview_lines.is_empty());
@@ -152,19 +181,33 @@ impl ConnectionSetup {
             && let Some(field_area) = Self::open_dropdown_field_area(
                 chunks.as_ref(),
                 visible_fields,
-                ConnectionField::SslMode,
+                if form_state.focused_field() == ConnectionField::CleartextAuth {
+                    ConnectionField::CleartextAuth
+                } else {
+                    ConnectionField::SslMode
+                },
             )
         {
             if form_state.database_type() == DatabaseType::MySQL {
-                Self::render_dropdown_list(
-                    frame,
-                    field_area,
-                    MySqlSslMode::all_variants()
-                        .iter()
-                        .map(MySqlSslMode::as_str),
-                    form_state.ssl_dropdown().selected_index(),
-                    theme,
-                );
+                if form_state.focused_field() == ConnectionField::CleartextAuth {
+                    Self::render_dropdown_list(
+                        frame,
+                        field_area,
+                        CLEARTEXT_AUTH_OPTIONS.iter().copied(),
+                        form_state.ssl_dropdown().selected_index(),
+                        theme,
+                    );
+                } else {
+                    Self::render_dropdown_list(
+                        frame,
+                        field_area,
+                        MySqlSslMode::all_variants()
+                            .iter()
+                            .map(MySqlSslMode::as_str),
+                        form_state.ssl_dropdown().selected_index(),
+                        theme,
+                    );
+                }
             } else {
                 Self::render_dropdown_list(
                     frame,
@@ -200,7 +243,9 @@ impl ConnectionSetup {
     ) -> Vec<(&'static str, &'static str)> {
         if matches!(
             form_state.focused_field(),
-            ConnectionField::DatabaseType | ConnectionField::SslMode
+            ConnectionField::DatabaseType
+                | ConnectionField::SslMode
+                | ConnectionField::CleartextAuth
         ) {
             vec![
                 connection_setup::ENTER_DROPDOWN.as_hint(),
@@ -328,6 +373,7 @@ impl ConnectionSetup {
         label: &str,
         value: &str,
         is_focused: bool,
+        error: Option<&str>,
         theme: &ThemePalette,
     ) {
         let chunks = Layout::horizontal([
@@ -348,10 +394,16 @@ impl ConnectionSetup {
         let content_width = CONNECTION_INPUT_VISIBLE_WIDTH;
         let display_content = format!("{:<1$} ▼", value, content_width - 2);
 
-        let border_style = theme.modal_input_border_style(is_focused, false);
+        let border_style = theme.modal_input_border_style(is_focused, error.is_some());
 
         let input_para = Paragraph::new(bracketed_input(&display_content, border_style, theme));
         frame.render_widget(input_para, chunks[1]);
+
+        if let Some(error) = error {
+            let error_para = Paragraph::new(format!(" {error}"))
+                .style(Style::default().fg(theme.semantic.status.error));
+            frame.render_widget(error_para, chunks[2]);
+        }
     }
 
     fn render_dropdown_list(
@@ -451,6 +503,14 @@ fn ssl_mode_label(state: &ConnectionSetupState) -> String {
         DatabaseType::PostgreSQL | DatabaseType::SQLite => {
             ssl_mode_label_text(state.ssl_mode()).to_string()
         }
+    }
+}
+
+fn cleartext_auth_label(state: &ConnectionSetupState) -> &'static str {
+    if state.cleartext_auth_plugin_enabled() {
+        "enabled"
+    } else {
+        "disabled"
     }
 }
 

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -53,7 +53,7 @@ impl ConnectionSetup {
         let preview = preview_text(form_state, services);
         let preview_width = modal_width.saturating_sub(MODAL_HORIZONTAL_CHROME) as usize;
         let notice_height = if form_state.cleartext_auth_plugin_enabled() {
-            2
+            3
         } else {
             1
         };
@@ -150,6 +150,7 @@ impl ConnectionSetup {
             vec![
                 Line::from("Note: password is sent via mysql_clear_password"),
                 Line::from("TLS required: REQUIRED, VERIFY_CA, or VERIFY_IDENTITY"),
+                Line::from("Note: Connection info is stored locally in plain text"),
             ]
         } else {
             vec![Line::from(


### PR DESCRIPTION
## Problem
MySQL accounts backed by Enterprise PAM or simple LDAP can require `mysql_clear_password`, but Sabiql had no explicit product setting for enabling that client plugin.

## Background
The plugin sends the password as cleartext at the authentication layer, so it must be an explicit opt-in restricted to encrypted transport.

## Approach
Persist the opt-in through connection profiles and option files, reject it unless TLS mode is `REQUIRED`, `VERIFY_CA`, or `VERIFY_IDENTITY`, and expose the same setting across probe, metadata, query, and export paths. The setup form explains both the password handling and TLS requirement.

## Screenshots

