### PR TITLE
feat(mysql): support Unix sockets and Windows named pipes

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -6,7 +6,7 @@ sabiql supports Oracle MySQL server 8.4 LTS through the Oracle `mysql` CLI from 
 
 ## Connection requirements
 
-MySQL connections use TCP. Unix sockets and Windows named pipes are not supported. When connecting to a remote server, install the local `mysql` CLI; a local MySQL server is not required.
+MySQL connections can use TCP, a Unix socket file on Unix-like systems, or a Windows named pipe. Select the transport explicitly and provide its socket or pipe path when required. Shared-memory transport and automatic transport fallback are not supported. When connecting to a remote server, install the local `mysql` CLI; a local MySQL server is not required.
 
 Passphrase-protected TLS client keys are not supported. An unencrypted PEM private key can be used, but it weakens at-rest protection; store it with restrictive file permissions.
 

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -570,7 +570,7 @@ fn connection_setup_current_rows(
 ) -> Vec<HelpRow> {
     let is_dropdown_field = matches!(
         focused_field,
-        ConnectionField::DatabaseType | ConnectionField::SslMode
+        ConnectionField::DatabaseType | ConnectionField::Transport | ConnectionField::SslMode
     );
     let submit = if is_dropdown_field {
         &connection_setup::ENTER_DROPDOWN

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use crate::domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, MySqlConnectionConfig,
-    MySqlSslMode, PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError,
-    SqlitePathError, SslMode,
+    MySqlSslMode, MySqlTransport, PostgresConnectionConfig, SqliteConnectionConfig,
+    SqliteConnectionConfigError, SqlitePathError, SslMode,
 };
 use crate::model::shared::text_input::TextInputState;
 
@@ -15,6 +15,8 @@ pub enum ConnectionField {
     DatabaseType,
     Name,
     SqlitePath,
+    Transport,
+    TransportPath,
     Host,
     Port,
     Database,
@@ -31,10 +33,11 @@ pub enum ConnectionField {
 impl ConnectionField {
     pub fn fields_for(
         database_type: DatabaseType,
+        mysql_transport: MySqlTransport,
         mysql_ssl_mode: MySqlSslMode,
-    ) -> &'static [Self] {
+    ) -> Vec<Self> {
         match database_type {
-            DatabaseType::PostgreSQL => &[
+            DatabaseType::PostgreSQL => vec![
                 Self::DatabaseType,
                 Self::Name,
                 Self::Host,
@@ -44,57 +47,36 @@ impl ConnectionField {
                 Self::Password,
                 Self::SslMode,
             ],
-            DatabaseType::SQLite => &[Self::DatabaseType, Self::Name, Self::SqlitePath],
-            DatabaseType::MySQL => match mysql_ssl_mode {
-                MySqlSslMode::Disabled => &[
-                    Self::DatabaseType,
-                    Self::Name,
-                    Self::Host,
-                    Self::Port,
-                    Self::Database,
-                    Self::User,
-                    Self::Password,
-                    Self::SslMode,
-                    Self::CleartextAuth,
-                    Self::ServerPublicKeyPath,
-                ],
-                MySqlSslMode::Preferred | MySqlSslMode::Required => &[
-                    Self::DatabaseType,
-                    Self::Name,
-                    Self::Host,
-                    Self::Port,
-                    Self::Database,
-                    Self::User,
-                    Self::Password,
-                    Self::SslMode,
-                    Self::CleartextAuth,
-                    Self::ServerPublicKeyPath,
-                    Self::SslCert,
-                    Self::SslKey,
-                ],
-                MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity => &[
-                    Self::DatabaseType,
-                    Self::Name,
-                    Self::Host,
-                    Self::Port,
-                    Self::Database,
-                    Self::User,
-                    Self::Password,
-                    Self::SslMode,
-                    Self::CleartextAuth,
-                    Self::ServerPublicKeyPath,
-                    Self::SslCa,
-                    Self::SslCert,
-                    Self::SslKey,
-                ],
-            },
+            DatabaseType::SQLite => vec![Self::DatabaseType, Self::Name, Self::SqlitePath],
+            DatabaseType::MySQL => {
+                let mut fields = vec![Self::DatabaseType, Self::Name, Self::Transport];
+                match mysql_transport {
+                    MySqlTransport::Tcp => fields.extend([Self::Host, Self::Port]),
+                    MySqlTransport::UnixSocket | MySqlTransport::NamedPipe => {
+                        fields.push(Self::TransportPath);
+                    }
+                }
+                fields.extend([Self::Database, Self::User, Self::Password, Self::SslMode]);
+                fields.push(Self::CleartextAuth);
+                fields.push(Self::ServerPublicKeyPath);
+                match mysql_ssl_mode {
+                    MySqlSslMode::Disabled => {}
+                    MySqlSslMode::Preferred | MySqlSslMode::Required => {
+                        fields.extend([Self::SslCert, Self::SslKey]);
+                    }
+                    MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity => {
+                        fields.extend([Self::SslCa, Self::SslCert, Self::SslKey]);
+                    }
+                }
+                fields
+            }
         }
     }
 
     pub fn is_required(self) -> bool {
         matches!(
             self,
-            Self::Name | Self::SqlitePath | Self::Port | Self::Database
+            Self::Name | Self::SqlitePath | Self::TransportPath | Self::Port | Self::Database
         )
     }
 
@@ -102,13 +84,14 @@ impl ConnectionField {
         match self {
             Self::Name => Some(50),
             Self::SqlitePath
+            | Self::TransportPath
             | Self::SslCa
             | Self::SslCert
             | Self::SslKey
             | Self::ServerPublicKeyPath => Some(4096),
             Self::Host | Self::Database | Self::User | Self::Password => Some(255),
             Self::Port => Some(5),
-            Self::DatabaseType | Self::SslMode | Self::CleartextAuth => None,
+            Self::DatabaseType | Self::Transport | Self::SslMode | Self::CleartextAuth => None,
         }
     }
 
@@ -133,7 +116,8 @@ impl ConnectionField {
         match self {
             Self::DatabaseType => "Type:",
             Self::Name => "Name:",
-            Self::SqlitePath => "Path:",
+            Self::SqlitePath | Self::TransportPath => "Path:",
+            Self::Transport => "Transport:",
             Self::Host => "Host:",
             Self::Port => "Port:",
             Self::Database => "Database:",
@@ -161,6 +145,12 @@ pub struct DatabaseTypeDropdown {
     selected_index: usize,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct TransportDropdown {
+    is_open: bool,
+    selected_index: usize,
+}
+
 impl SslModeDropdown {
     pub fn is_open(&self) -> bool {
         self.is_open
@@ -181,11 +171,22 @@ impl DatabaseTypeDropdown {
     }
 }
 
+impl TransportDropdown {
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    pub fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ConnectionSetupState {
     pub(crate) database_type: DatabaseType,
     pub(crate) name: TextInputState,
     pub(crate) sqlite_path: TextInputState,
+    pub(crate) transport_path: TextInputState,
     pub(crate) host: TextInputState,
     pub(crate) port: TextInputState,
     pub(crate) database: TextInputState,
@@ -197,10 +198,12 @@ pub struct ConnectionSetupState {
     pub(crate) server_public_key_path: TextInputState,
     pub(crate) ssl_mode: SslMode,
     pub(crate) mysql_ssl_mode: MySqlSslMode,
+    pub(crate) mysql_transport: MySqlTransport,
     pub(crate) enable_cleartext_plugin: bool,
 
     pub(crate) focused_field: ConnectionField,
     pub(crate) database_type_dropdown: DatabaseTypeDropdown,
+    pub(crate) transport_dropdown: TransportDropdown,
     pub(crate) ssl_dropdown: SslModeDropdown,
     pub(crate) validation_errors: HashMap<ConnectionField, String>,
 
@@ -215,6 +218,7 @@ impl Default for ConnectionSetupState {
             database_type: DatabaseType::PostgreSQL,
             name: TextInputState::default(),
             sqlite_path: TextInputState::default(),
+            transport_path: TextInputState::default(),
             host: TextInputState::new("localhost", 9),
             port: TextInputState::new("5432", 4),
             database: TextInputState::default(),
@@ -226,9 +230,11 @@ impl Default for ConnectionSetupState {
             server_public_key_path: TextInputState::default(),
             ssl_mode: SslMode::Prefer,
             mysql_ssl_mode: MySqlSslMode::Preferred,
+            mysql_transport: MySqlTransport::Tcp,
             enable_cleartext_plugin: false,
             focused_field: ConnectionField::DatabaseType,
             database_type_dropdown: DatabaseTypeDropdown::default(),
+            transport_dropdown: TransportDropdown::default(),
             ssl_dropdown: SslModeDropdown::default(),
             validation_errors: HashMap::new(),
             is_first_run: true,
@@ -250,6 +256,10 @@ impl ConnectionSetupState {
         self.mysql_ssl_mode
     }
 
+    pub fn mysql_transport(&self) -> MySqlTransport {
+        self.mysql_transport
+    }
+
     pub fn cleartext_auth_plugin_enabled(&self) -> bool {
         self.enable_cleartext_plugin
     }
@@ -268,6 +278,10 @@ impl ConnectionSetupState {
 
     pub fn database_type_dropdown(&self) -> &DatabaseTypeDropdown {
         &self.database_type_dropdown
+    }
+
+    pub fn transport_dropdown(&self) -> &TransportDropdown {
+        &self.transport_dropdown
     }
 
     pub fn ssl_dropdown(&self) -> &SslModeDropdown {
@@ -303,10 +317,12 @@ impl ConnectionSetupState {
     pub fn input(&self, field: ConnectionField) -> Option<&TextInputState> {
         match field {
             ConnectionField::DatabaseType
+            | ConnectionField::Transport
             | ConnectionField::SslMode
             | ConnectionField::CleartextAuth => None,
             ConnectionField::Name => Some(&self.name),
             ConnectionField::SqlitePath => Some(&self.sqlite_path),
+            ConnectionField::TransportPath => Some(&self.transport_path),
             ConnectionField::Host => Some(&self.host),
             ConnectionField::Port => Some(&self.port),
             ConnectionField::Database => Some(&self.database),
@@ -326,10 +342,12 @@ impl ConnectionSetupState {
     pub fn input_mut(&mut self, field: ConnectionField) -> Option<&mut TextInputState> {
         match field {
             ConnectionField::DatabaseType
+            | ConnectionField::Transport
             | ConnectionField::SslMode
             | ConnectionField::CleartextAuth => None,
             ConnectionField::Name => Some(&mut self.name),
             ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
+            ConnectionField::TransportPath => Some(&mut self.transport_path),
             ConnectionField::Host => Some(&mut self.host),
             ConnectionField::Port => Some(&mut self.port),
             ConnectionField::Database => Some(&mut self.database),
@@ -370,16 +388,20 @@ impl ConnectionSetupState {
         self.editing_id.is_some()
     }
 
-    pub fn visible_fields(&self) -> &'static [ConnectionField] {
-        ConnectionField::fields_for(self.database_type, self.mysql_ssl_mode)
+    pub fn visible_fields(&self) -> Vec<ConnectionField> {
+        ConnectionField::fields_for(
+            self.database_type,
+            self.mysql_transport,
+            self.mysql_ssl_mode,
+        )
     }
 
     pub fn next_field(&self) -> Option<ConnectionField> {
-        next_visible_field(self.visible_fields(), self.focused_field)
+        next_visible_field(&self.visible_fields(), self.focused_field)
     }
 
     pub fn prev_field(&self) -> Option<ConnectionField> {
-        prev_visible_field(self.visible_fields(), self.focused_field)
+        prev_visible_field(&self.visible_fields(), self.focused_field)
     }
 
     pub fn focus_next_field(&mut self) {
@@ -407,6 +429,7 @@ impl ConnectionSetupState {
             }
         }
         self.database_type_dropdown.is_open = false;
+        self.transport_dropdown.is_open = false;
         self.ssl_dropdown.is_open = false;
         if !self.visible_fields().contains(&self.focused_field) {
             self.focused_field = ConnectionField::DatabaseType;
@@ -418,6 +441,7 @@ impl ConnectionSetupState {
         match self.focused_field {
             ConnectionField::DatabaseType => {
                 self.database_type_dropdown.is_open = !self.database_type_dropdown.is_open;
+                self.transport_dropdown.is_open = false;
                 self.ssl_dropdown.is_open = false;
                 if self.database_type_dropdown.is_open {
                     self.database_type_dropdown.selected_index = DatabaseType::all()
@@ -426,9 +450,21 @@ impl ConnectionSetupState {
                         .unwrap_or(0);
                 }
             }
+            ConnectionField::Transport => {
+                self.transport_dropdown.is_open = !self.transport_dropdown.is_open;
+                self.database_type_dropdown.is_open = false;
+                self.ssl_dropdown.is_open = false;
+                if self.transport_dropdown.is_open {
+                    self.transport_dropdown.selected_index = MySqlTransport::all_variants()
+                        .iter()
+                        .position(|v| *v == self.mysql_transport)
+                        .unwrap_or(0);
+                }
+            }
             ConnectionField::SslMode | ConnectionField::CleartextAuth => {
                 self.ssl_dropdown.is_open = !self.ssl_dropdown.is_open;
                 self.database_type_dropdown.is_open = false;
+                self.transport_dropdown.is_open = false;
                 if self.ssl_dropdown.is_open {
                     self.ssl_dropdown.selected_index =
                         if self.focused_field == ConnectionField::CleartextAuth {
@@ -456,6 +492,11 @@ impl ConnectionSetupState {
             if self.database_type_dropdown.selected_index < max {
                 self.database_type_dropdown.selected_index += 1;
             }
+        } else if self.transport_dropdown.is_open {
+            let max = MySqlTransport::all_variants().len() - 1;
+            if self.transport_dropdown.selected_index < max {
+                self.transport_dropdown.selected_index += 1;
+            }
         } else if self.ssl_dropdown.is_open {
             let max = if self.focused_field == ConnectionField::CleartextAuth {
                 1
@@ -474,6 +515,9 @@ impl ConnectionSetupState {
         if self.database_type_dropdown.is_open {
             self.database_type_dropdown.selected_index =
                 self.database_type_dropdown.selected_index.saturating_sub(1);
+        } else if self.transport_dropdown.is_open {
+            self.transport_dropdown.selected_index =
+                self.transport_dropdown.selected_index.saturating_sub(1);
         } else if self.ssl_dropdown.is_open {
             self.ssl_dropdown.selected_index = self.ssl_dropdown.selected_index.saturating_sub(1);
         }
@@ -486,6 +530,13 @@ impl ConnectionSetupState {
             {
                 self.set_database_type(*database_type);
             }
+        } else if self.transport_dropdown.is_open {
+            if let Some(transport) =
+                MySqlTransport::all_variants().get(self.transport_dropdown.selected_index)
+            {
+                self.set_mysql_transport(*transport);
+            }
+            self.transport_dropdown.is_open = false;
         } else if self.ssl_dropdown.is_open {
             if self.database_type == DatabaseType::MySQL {
                 if self.focused_field == ConnectionField::CleartextAuth {
@@ -505,17 +556,28 @@ impl ConnectionSetupState {
 
     pub fn cancel_dropdown(&mut self) {
         self.database_type_dropdown.is_open = false;
+        self.transport_dropdown.is_open = false;
         self.ssl_dropdown.is_open = false;
     }
 
     pub fn has_open_dropdown(&self) -> bool {
-        self.database_type_dropdown.is_open || self.ssl_dropdown.is_open
+        self.database_type_dropdown.is_open
+            || self.transport_dropdown.is_open
+            || self.ssl_dropdown.is_open
     }
 
     fn set_mysql_ssl_mode(&mut self, mode: MySqlSslMode) {
         self.mysql_ssl_mode = mode;
         if !mode.uses_ca() {
             self.ssl_ca.clear();
+        }
+        self.retain_validation_errors_for_visible_fields();
+    }
+
+    fn set_mysql_transport(&mut self, transport: MySqlTransport) {
+        self.mysql_transport = transport;
+        if !transport.requires_path() {
+            self.transport_path.clear();
         }
         self.retain_validation_errors_for_visible_fields();
     }
@@ -570,10 +632,14 @@ impl ConnectionSetupState {
             DatabaseType::MySQL => ConnectionConfig::MySQL(
                 MySqlConnectionConfig::new(
                     self.host.content().trim().to_string(),
-                    self.port
-                        .content()
-                        .parse()
-                        .expect("port validated before building connection config"),
+                    if self.mysql_transport == MySqlTransport::Tcp {
+                        self.port
+                            .content()
+                            .parse()
+                            .expect("port validated before building connection config")
+                    } else {
+                        3306
+                    },
                     match self.database.content().trim() {
                         "" => None,
                         database => Some(database.to_string()),
@@ -582,6 +648,7 @@ impl ConnectionSetupState {
                     self.password.content().to_string(),
                     self.mysql_ssl_mode,
                 )
+                .with_transport(self.mysql_transport, optional_path(&self.transport_path))
                 .with_tls_paths(
                     self.mysql_ssl_mode
                         .uses_ca()
@@ -651,6 +718,7 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
             }
             ConnectionConfig::MySQL(config) => {
                 state.database_type = DatabaseType::MySQL;
+                state.mysql_transport = config.transport;
                 state.host = TextInputState::new(&config.host, config.host.chars().count());
                 let port_str = config.port.to_string();
                 state.port = TextInputState::new(&port_str, port_str.chars().count());
@@ -675,6 +743,9 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
                 if let Some(path) = config.server_public_key_path.as_deref() {
                     state.server_public_key_path = TextInputState::new(path, path.chars().count());
                 }
+                if let Some(path) = config.transport_path.as_deref() {
+                    state.transport_path = TextInputState::new(path, path.chars().count());
+                }
             }
         }
         state
@@ -695,8 +766,10 @@ mod tests {
 
         #[rstest]
         #[case(ConnectionField::DatabaseType, false)]
+        #[case(ConnectionField::Transport, false)]
         #[case(ConnectionField::Name, true)]
         #[case(ConnectionField::SqlitePath, true)]
+        #[case(ConnectionField::TransportPath, true)]
         #[case(ConnectionField::Host, false)]
         #[case(ConnectionField::Port, true)]
         #[case(ConnectionField::Database, true)]
@@ -716,8 +789,11 @@ mod tests {
         }
         #[test]
         fn fields_for_returns_postgres_fields_in_order() {
-            let fields =
-                ConnectionField::fields_for(DatabaseType::PostgreSQL, MySqlSslMode::Preferred);
+            let fields = ConnectionField::fields_for(
+                DatabaseType::PostgreSQL,
+                MySqlTransport::Tcp,
+                MySqlSslMode::Preferred,
+            );
             assert_eq!(fields.len(), 8);
             assert_eq!(fields[0], ConnectionField::DatabaseType);
             assert_eq!(fields[7], ConnectionField::SslMode);
@@ -726,7 +802,11 @@ mod tests {
         #[test]
         fn fields_for_returns_sqlite_fields_in_order() {
             assert_eq!(
-                ConnectionField::fields_for(DatabaseType::SQLite, MySqlSslMode::Preferred),
+                ConnectionField::fields_for(
+                    DatabaseType::SQLite,
+                    MySqlTransport::Tcp,
+                    MySqlSslMode::Preferred,
+                ),
                 &[
                     ConnectionField::DatabaseType,
                     ConnectionField::Name,
@@ -738,10 +818,15 @@ mod tests {
         #[test]
         fn fields_for_returns_mysql_fields_in_order() {
             assert_eq!(
-                ConnectionField::fields_for(DatabaseType::MySQL, MySqlSslMode::Preferred),
-                &[
+                ConnectionField::fields_for(
+                    DatabaseType::MySQL,
+                    MySqlTransport::Tcp,
+                    MySqlSslMode::Preferred,
+                ),
+                vec![
                     ConnectionField::DatabaseType,
                     ConnectionField::Name,
+                    ConnectionField::Transport,
                     ConnectionField::Host,
                     ConnectionField::Port,
                     ConnectionField::Database,
@@ -752,6 +837,30 @@ mod tests {
                     ConnectionField::ServerPublicKeyPath,
                     ConnectionField::SslCert,
                     ConnectionField::SslKey,
+                ]
+            );
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn fields_for_unix_socket_replaces_host_and_port_with_path() {
+            assert_eq!(
+                ConnectionField::fields_for(
+                    DatabaseType::MySQL,
+                    MySqlTransport::UnixSocket,
+                    MySqlSslMode::Disabled,
+                ),
+                vec![
+                    ConnectionField::DatabaseType,
+                    ConnectionField::Name,
+                    ConnectionField::Transport,
+                    ConnectionField::TransportPath,
+                    ConnectionField::Database,
+                    ConnectionField::User,
+                    ConnectionField::Password,
+                    ConnectionField::SslMode,
+                    ConnectionField::CleartextAuth,
+                    ConnectionField::ServerPublicKeyPath,
                 ]
             );
         }
@@ -884,6 +993,28 @@ mod tests {
                     ..
                 })
             ));
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn mysql_socket_config_does_not_parse_hidden_tcp_port() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            state.mysql_transport = MySqlTransport::UnixSocket;
+            state.port.set_content("not-a-port".to_string());
+            state
+                .transport_path
+                .set_content("/run/mysqld/mysqld.sock".to_string());
+
+            let ConnectionConfig::MySQL(config) = state.to_connection_config().unwrap() else {
+                panic!("expected MySQL config");
+            };
+            assert_eq!(config.transport, MySqlTransport::UnixSocket);
+            assert_eq!(config.port, 3306);
+            assert_eq!(
+                config.transport_path.as_deref(),
+                Some("/run/mysqld/mysqld.sock")
+            );
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -81,6 +81,7 @@ pub fn reduce_connection_setup(
                     }
                 }
                 ConnectionField::DatabaseType
+                | ConnectionField::Transport
                 | ConnectionField::SslMode
                 | ConnectionField::CleartextAuth => {}
                 _ => {
@@ -351,6 +352,7 @@ fn insert_form_text(setup: &mut ConnectionSetupState, text: &str) {
             }
         }
         ConnectionField::DatabaseType
+        | ConnectionField::Transport
         | ConnectionField::SslMode
         | ConnectionField::CleartextAuth => {}
         field => {

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -4,7 +4,9 @@ use unicode_casefold::UnicodeCaseFold;
 
 use crate::cmd::effect::Effect;
 use crate::domain::DatabaseType;
-use crate::domain::connection::{MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig};
+use crate::domain::connection::{
+    MySqlConnectionConfig, MySqlSslMode, MySqlTransport, SqliteConnectionConfig,
+};
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::QueryStatus;
@@ -475,7 +477,10 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 Err(error) => state.record_sqlite_config_error(error),
             }
         }
-        ConnectionField::Port => {
+        ConnectionField::Port
+            if state.database_type() != DatabaseType::MySQL
+                || state.mysql_transport() == MySqlTransport::Tcp =>
+        {
             let port = text_input_content(state, field).trim();
             if port.is_empty() {
                 state.set_validation_error(field, "Required");
@@ -499,7 +504,10 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 require_non_empty(state, field, "Required");
             }
         }
-        ConnectionField::Host if state.database_type() == DatabaseType::MySQL => {
+        ConnectionField::Host
+            if state.database_type() == DatabaseType::MySQL
+                && state.mysql_transport() == MySqlTransport::Tcp =>
+        {
             let host = text_input_content(state, field).trim();
             if host.is_empty() {
                 state.set_validation_error(field, "Required");
@@ -509,6 +517,14 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
         }
         ConnectionField::User if state.database_type() == DatabaseType::MySQL => {
             require_non_empty(state, field, "Required");
+        }
+        ConnectionField::TransportPath if state.database_type() == DatabaseType::MySQL => {
+            let path = text_input_content(state, field);
+            if state.mysql_transport().requires_path() && path.trim().is_empty() {
+                state.set_validation_error(field, "Required");
+            } else if path.chars().any(char::is_control) {
+                state.set_validation_error(field, "Invalid path");
+            }
         }
         ConnectionField::SslCa if state.database_type() == DatabaseType::MySQL => {
             let path = text_input_content(state, field).to_string();
@@ -553,6 +569,16 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 state.set_validation_error(field, "Requires TLS");
             }
         }
+        ConnectionField::SslMode if state.database_type() == DatabaseType::MySQL => {
+            if state.mysql_transport() == MySqlTransport::NamedPipe
+                && !matches!(
+                    state.mysql_ssl_mode(),
+                    MySqlSslMode::Disabled | MySqlSslMode::Preferred
+                )
+            {
+                state.set_validation_error(field, "Named pipes do not support TLS");
+            }
+        }
         ConnectionField::Name => {
             let name = text_input_content(state, field).trim().to_string();
             if name.is_empty() {
@@ -560,6 +586,9 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
             }
         }
         ConnectionField::DatabaseType
+        | ConnectionField::Transport
+        | ConnectionField::TransportPath
+        | ConnectionField::Port
         | ConnectionField::Host
         | ConnectionField::User
         | ConnectionField::Password
@@ -573,10 +602,14 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
 }
 
 pub fn validate_all(state: &mut ConnectionSetupState) {
-    let active_fields = ConnectionField::fields_for(state.database_type(), state.mysql_ssl_mode());
+    let active_fields = ConnectionField::fields_for(
+        state.database_type(),
+        state.mysql_transport(),
+        state.mysql_ssl_mode(),
+    );
     state.retain_validation_errors_for_visible_fields();
     for field in active_fields {
-        validate_field(state, *field);
+        validate_field(state, field);
     }
 }
 
@@ -852,6 +885,32 @@ mod tests {
             state.validation_error(ConnectionField::Host),
             Some("Invalid host")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mysql_unix_socket_validation_uses_path_instead_of_host_and_port() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state.mysql_transport = MySqlTransport::UnixSocket;
+        state
+            .input_mut(ConnectionField::Host)
+            .unwrap()
+            .set_content(" ".to_string());
+        state
+            .input_mut(ConnectionField::Port)
+            .unwrap()
+            .set_content("not-a-port".to_string());
+        state
+            .input_mut(ConnectionField::TransportPath)
+            .unwrap()
+            .set_content("/run/mysqld/mysqld.sock".to_string());
+
+        validate_field(&mut state, ConnectionField::TransportPath);
+
+        assert_eq!(state.validation_error(ConnectionField::TransportPath), None);
+        assert_eq!(state.validation_error(ConnectionField::Host), None);
+        assert_eq!(state.validation_error(ConnectionField::Port), None);
     }
 
     #[test]

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -21,6 +21,7 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
             && matches!(
                 state.connection_setup.focused_field(),
                 ConnectionField::DatabaseType
+                    | ConnectionField::Transport
                     | ConnectionField::SslMode
                     | ConnectionField::CleartextAuth
             ))
@@ -49,6 +50,7 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
             if matches!(
                 state.connection_setup.focused_field(),
                 ConnectionField::DatabaseType
+                    | ConnectionField::Transport
                     | ConnectionField::SslMode
                     | ConnectionField::CleartextAuth
             ) =>

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -6,6 +6,87 @@ use super::ssl_mode::SslMode;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
+pub enum MySqlTransport {
+    #[default]
+    Tcp,
+    #[serde(rename = "UNIX_SOCKET")]
+    UnixSocket,
+    #[serde(rename = "NAMED_PIPE")]
+    NamedPipe,
+}
+
+impl MySqlTransport {
+    pub const fn all_variants() -> &'static [Self] {
+        #[cfg(unix)]
+        {
+            &[Self::Tcp, Self::UnixSocket]
+        }
+        #[cfg(windows)]
+        {
+            &[Self::Tcp, Self::NamedPipe]
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            &[Self::Tcp]
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "TCP",
+            Self::UnixSocket => "UNIX_SOCKET",
+            Self::NamedPipe => "NAMED_PIPE",
+        }
+    }
+
+    pub const fn protocol(self) -> &'static str {
+        match self {
+            Self::Tcp => "TCP",
+            Self::UnixSocket => "SOCKET",
+            Self::NamedPipe => "PIPE",
+        }
+    }
+
+    pub const fn requires_path(self) -> bool {
+        !matches!(self, Self::Tcp)
+    }
+
+    pub const fn is_supported_on_current_platform(self) -> bool {
+        match self {
+            Self::Tcp => true,
+            #[cfg(unix)]
+            Self::UnixSocket => true,
+            #[cfg(not(unix))]
+            Self::UnixSocket => false,
+            #[cfg(windows)]
+            Self::NamedPipe => true,
+            #[cfg(not(windows))]
+            Self::NamedPipe => false,
+        }
+    }
+}
+
+impl std::fmt::Display for MySqlTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for MySqlTransport {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TCP" => Ok(Self::Tcp),
+            "UNIX_SOCKET" => Ok(Self::UnixSocket),
+            "NAMED_PIPE" => Ok(Self::NamedPipe),
+            _ => Err(format!("Unknown MySQL transport: {s}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum MySqlSslMode {
     Disabled,
     #[default]
@@ -100,6 +181,8 @@ impl PostgresConnectionConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MySqlConnectionConfig {
+    #[serde(default)]
+    pub transport: MySqlTransport,
     pub host: String,
     pub port: u16,
     pub database: Option<String>,
@@ -116,6 +199,8 @@ pub struct MySqlConnectionConfig {
     pub server_public_key_path: Option<String>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub enable_cleartext_plugin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_path: Option<String>,
 }
 
 impl MySqlConnectionConfig {
@@ -128,6 +213,7 @@ impl MySqlConnectionConfig {
         ssl_mode: MySqlSslMode,
     ) -> Self {
         Self {
+            transport: MySqlTransport::Tcp,
             host: host.into(),
             port,
             database,
@@ -139,6 +225,7 @@ impl MySqlConnectionConfig {
             ssl_key: None,
             server_public_key_path: None,
             enable_cleartext_plugin: false,
+            transport_path: None,
         }
     }
 
@@ -167,6 +254,13 @@ impl MySqlConnectionConfig {
         self
     }
 
+    #[must_use]
+    pub fn with_transport(mut self, transport: MySqlTransport, path: Option<String>) -> Self {
+        self.transport = transport;
+        self.transport_path = transport.requires_path().then_some(path).flatten();
+        self
+    }
+
     pub fn is_valid_host(host: &str) -> bool {
         let trimmed_host = host.trim();
         if trimmed_host.is_empty() || trimmed_host != host {
@@ -186,7 +280,15 @@ impl MySqlConnectionConfig {
     }
 
     pub fn is_valid(&self) -> bool {
-        Self::is_valid_host(&self.host)
+        self.transport.is_supported_on_current_platform()
+            && match self.transport {
+                MySqlTransport::Tcp => Self::is_valid_host(&self.host) && self.port > 0,
+                MySqlTransport::UnixSocket | MySqlTransport::NamedPipe => {
+                    self.transport_path.as_deref().is_some_and(|path| {
+                        !path.trim().is_empty() && !path.chars().any(char::is_control)
+                    })
+                }
+            }
     }
 }
 
@@ -357,6 +459,47 @@ mod tests {
     #[test]
     fn mysql_tls_modes_reject_unknown_names() {
         assert!("unknown".parse::<MySqlSslMode>().is_err());
+    }
+
+    #[test]
+    fn mysql_transports_round_trip_through_canonical_names() {
+        let expected = [
+            (MySqlTransport::Tcp, "TCP"),
+            (MySqlTransport::UnixSocket, "UNIX_SOCKET"),
+            (MySqlTransport::NamedPipe, "NAMED_PIPE"),
+        ];
+
+        for (transport, name) in expected {
+            assert_eq!(transport.as_str(), name);
+            assert_eq!(name.parse::<MySqlTransport>().unwrap(), transport);
+            assert_eq!(
+                serde_json::to_string(&transport).unwrap(),
+                format!("\"{name}\"")
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_socket_config_uses_path_instead_of_tcp_values() {
+        let config = MySqlConnectionConfig::new(
+            "ignored-host",
+            3306,
+            None,
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        )
+        .with_transport(
+            MySqlTransport::UnixSocket,
+            Some("/run/mysqld/mysqld.sock".to_string()),
+        );
+
+        assert!(config.is_valid());
+        assert_eq!(
+            config.transport_path.as_deref(),
+            Some("/run/mysqld/mysqld.sock")
+        );
     }
 
     #[test]

--- a/src/domain/connection/mod.rs
+++ b/src/domain/connection/mod.rs
@@ -8,8 +8,8 @@ mod sqlite_path;
 mod ssl_mode;
 
 pub use config::{
-    ConnectionConfig, MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig,
-    SqliteConnectionConfig, SqliteConnectionConfigError,
+    ConnectionConfig, MySqlConnectionConfig, MySqlSslMode, MySqlTransport,
+    PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError,
 };
 pub use database_type::DatabaseType;
 pub use id::ConnectionId;

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::config::{
-    ConnectionConfig, MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig,
-    SqliteConnectionConfig, SqliteConnectionConfigError,
+    ConnectionConfig, MySqlConnectionConfig, MySqlSslMode, MySqlTransport,
+    PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError,
 };
 use super::database_type::DatabaseType;
 use super::id::ConnectionId;
@@ -32,6 +32,14 @@ pub enum ConnectionProfileError {
     InvalidMySqlHost,
     #[error("MySQL connection port must be > 0")]
     InvalidMySqlPort,
+    #[error("MySQL connection transport is not supported on this platform")]
+    UnsupportedMySqlTransport,
+    #[error("MySQL connection transport path is required")]
+    MissingMySqlTransportPath,
+    #[error("MySQL connection transport path is invalid")]
+    InvalidMySqlTransportPath,
+    #[error("MySQL named pipe transport does not support the selected TLS mode")]
+    MySqlNamedPipeRequiresNonTls,
     #[error(
         "MySQL cleartext authentication requires REQUIRED, VERIFY_CA, or VERIFY_IDENTITY TLS mode"
     )]
@@ -147,11 +155,34 @@ impl ConnectionProfile {
         config: ConnectionConfig,
     ) -> Result<Self, ConnectionProfileError> {
         if let ConnectionConfig::MySQL(mysql) = &config {
-            if mysql.port == 0 {
-                return Err(ConnectionProfileError::InvalidMySqlPort);
+            if !mysql.transport.is_supported_on_current_platform() {
+                return Err(ConnectionProfileError::UnsupportedMySqlTransport);
             }
-            if !mysql.is_valid() {
-                return Err(ConnectionProfileError::InvalidMySqlHost);
+            match mysql.transport {
+                MySqlTransport::Tcp => {
+                    if mysql.port == 0 {
+                        return Err(ConnectionProfileError::InvalidMySqlPort);
+                    }
+                    if !MySqlConnectionConfig::is_valid_host(&mysql.host) {
+                        return Err(ConnectionProfileError::InvalidMySqlHost);
+                    }
+                }
+                MySqlTransport::UnixSocket | MySqlTransport::NamedPipe => {
+                    let Some(path) = mysql.transport_path.as_deref() else {
+                        return Err(ConnectionProfileError::MissingMySqlTransportPath);
+                    };
+                    if path.trim().is_empty() || path.chars().any(char::is_control) {
+                        return Err(ConnectionProfileError::InvalidMySqlTransportPath);
+                    }
+                    if mysql.transport == MySqlTransport::NamedPipe
+                        && !matches!(
+                            mysql.ssl_mode,
+                            MySqlSslMode::Disabled | MySqlSslMode::Preferred
+                        )
+                    {
+                        return Err(ConnectionProfileError::MySqlNamedPipeRequiresNonTls);
+                    }
+                }
             }
             if mysql.enable_cleartext_plugin && !mysql.ssl_mode.allows_cleartext_auth() {
                 return Err(ConnectionProfileError::MySqlCleartextAuthRequiresTls);
@@ -259,6 +290,48 @@ mod tests {
             assert!(matches!(
                 result,
                 Err(ConnectionProfileError::InvalidMySqlPort)
+            ));
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn unix_socket_profile_requires_a_valid_path() {
+            let config = MySqlConnectionConfig::new(
+                "ignored-host",
+                3306,
+                None,
+                "user",
+                "password",
+                MySqlSslMode::Disabled,
+            )
+            .with_transport(MySqlTransport::UnixSocket, None);
+            let result = ConnectionProfile::with_id_and_config(
+                ConnectionId::new(),
+                "MySQL",
+                ConnectionConfig::MySQL(config),
+            );
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::MissingMySqlTransportPath)
+            ));
+
+            let config = MySqlConnectionConfig::new(
+                "ignored-host",
+                3306,
+                None,
+                "user",
+                "password",
+                MySqlSslMode::Disabled,
+            )
+            .with_transport(MySqlTransport::UnixSocket, Some("\n".to_string()));
+            let result = ConnectionProfile::with_id_and_config(
+                ConnectionId::new(),
+                "MySQL",
+                ConnectionConfig::MySQL(config),
+            );
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::InvalidMySqlTransportPath)
             ));
         }
 

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -45,7 +45,7 @@ pub use write_result::{WriteDiagnostic, WriteDiagnosticLevel, WriteExecutionResu
 
 pub use connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
-    MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig, SqliteConnectionConfig,
-    SqliteConnectionConfigError, SqlitePathError, SslMode, classify_sqlite_metadata_error,
-    classify_sqlite_read_error, sqlite_path_from_dsn,
+    MySqlConnectionConfig, MySqlSslMode, MySqlTransport, PostgresConnectionConfig,
+    SqliteConnectionConfig, SqliteConnectionConfigError, SqlitePathError, SslMode,
+    classify_sqlite_metadata_error, classify_sqlite_read_error, sqlite_path_from_dsn,
 };

--- a/src/infra/adapters/mysql/cli/args.rs
+++ b/src/infra/adapters/mysql/cli/args.rs
@@ -6,7 +6,6 @@ pub(super) fn mysql_connection_args(option_file: &Path) -> Vec<String> {
     vec![
         format!("--defaults-file={}", option_file.display()),
         "--no-login-paths".to_string(),
-        "--protocol=TCP".to_string(),
         "--connect-timeout=10".to_string(),
         "--skip-reconnect".to_string(),
     ]
@@ -77,7 +76,6 @@ mod tests {
             vec![
                 "--defaults-file=/tmp/sabiql-mysql.cnf",
                 "--no-login-paths",
-                "--protocol=TCP",
                 "--connect-timeout=10",
                 "--skip-reconnect",
             ]
@@ -93,7 +91,6 @@ mod tests {
             vec![
                 "--defaults-file=/tmp/sabiql-mysql.cnf",
                 "--no-login-paths",
-                "--protocol=TCP",
                 "--connect-timeout=10",
                 "--skip-reconnect",
                 "--xml",
@@ -120,7 +117,6 @@ mod tests {
             vec![
                 "--defaults-file=/tmp/sabiql-mysql.cnf",
                 "--no-login-paths",
-                "--protocol=TCP",
                 "--connect-timeout=10",
                 "--skip-reconnect",
                 "--batch",
@@ -146,7 +142,6 @@ mod tests {
             vec![
                 "--defaults-file=/tmp/sabiql-mysql.cnf",
                 "--no-login-paths",
-                "--protocol=TCP",
                 "--connect-timeout=10",
                 "--skip-reconnect",
                 "--xml",

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -368,7 +368,6 @@ mod probe_tests {
             vec![
                 "--defaults-file=/tmp/sabiql-mysql.cnf".to_string(),
                 "--no-login-paths".to_string(),
-                "--protocol=TCP".to_string(),
                 "--connect-timeout=10".to_string(),
                 "--skip-reconnect".to_string(),
                 "--batch".to_string(),

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -3,11 +3,15 @@ use std::fmt;
 use url::Url;
 
 use crate::app::ports::outbound::{DbOperationError, DsnBuilder};
-use crate::domain::connection::{ConnectionProfile, MySqlConnectionConfig, MySqlSslMode};
+use crate::domain::connection::{
+    ConnectionProfile, MySqlConnectionConfig, MySqlSslMode, MySqlTransport,
+};
 
 use super::adapter::MySqlAdapter;
 
 pub(super) struct MySqlDsn {
+    pub(super) transport: MySqlTransport,
+    pub(super) transport_path: Option<String>,
     pub(super) host: String,
     pub(super) port: u16,
     pub(super) database: Option<String>,
@@ -25,6 +29,8 @@ impl fmt::Debug for MySqlDsn {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("MySqlDsn")
+            .field("transport", &self.transport)
+            .field("transport_path", &self.transport_path)
             .field("host", &self.host)
             .field("port", &self.port)
             .field("database", &self.database)
@@ -81,6 +87,13 @@ pub(super) fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
     if config.enable_cleartext_plugin {
         url.query_pairs_mut()
             .append_pair("enable-cleartext-plugin", "true");
+    }
+    if config.transport != MySqlTransport::Tcp {
+        url.query_pairs_mut()
+            .append_pair("transport", config.transport.as_str());
+        if let Some(path) = config.transport_path.as_deref() {
+            url.query_pairs_mut().append_pair("transport-path", path);
+        }
     }
     url.to_string()
 }
@@ -146,8 +159,21 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         })
         .transpose()?
         .unwrap_or(false);
+    let transport = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "transport").then(|| value.parse()))
+        .transpose()
+        .map_err(|error: String| {
+            DbOperationError::ConnectionFailed(format!("Invalid MySQL transport: {error}"))
+        })?
+        .unwrap_or_default();
+    let transport_path = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "transport-path").then(|| value.into_owned()));
 
     Ok(MySqlDsn {
+        transport,
+        transport_path,
         host,
         port: url.port().unwrap_or(3306),
         database,
@@ -165,6 +191,7 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
 pub(super) fn parse_and_validate_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
     let target = parse_mysql_dsn(dsn)?;
     validate_mysql_values(&target)?;
+    validate_mysql_transport(&target)?;
     validate_mysql_tls_config(&target)?;
     Ok(target)
 }
@@ -179,6 +206,7 @@ pub(super) fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperation
         target.ssl_cert.as_deref(),
         target.ssl_key.as_deref(),
         target.server_public_key_path.as_deref(),
+        target.transport_path.as_deref(),
     ];
     if values
         .into_iter()
@@ -188,6 +216,46 @@ pub(super) fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperation
         return Err(DbOperationError::ConnectionFailed(
             "MySQL connection settings contain a control character".to_string(),
         ));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_mysql_transport(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    if !target.transport.is_supported_on_current_platform() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL transport is not supported on this platform".to_string(),
+        ));
+    }
+    match target.transport {
+        MySqlTransport::Tcp => {
+            if target.transport_path.is_some() {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL transport path is only valid for socket or named-pipe transport"
+                        .to_string(),
+                ));
+            }
+        }
+        MySqlTransport::UnixSocket | MySqlTransport::NamedPipe => {
+            if target
+                .transport_path
+                .as_deref()
+                .is_none_or(|path| path.trim().is_empty())
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL transport path is required".to_string(),
+                ));
+            }
+            if target.transport == MySqlTransport::NamedPipe
+                && !matches!(
+                    target.ssl_mode,
+                    MySqlSslMode::Disabled | MySqlSslMode::Preferred
+                )
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL named pipe transport does not support the selected TLS mode".to_string(),
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -389,6 +457,46 @@ mod tests {
         assert!(parsed.enable_cleartext_plugin);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn builds_and_parses_unix_socket_transport() {
+        let config = MySqlConnectionConfig::new(
+            "ignored-host",
+            3306,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        )
+        .with_transport(
+            MySqlTransport::UnixSocket,
+            Some("/run/mysqld/mysqld.sock".to_string()),
+        );
+
+        let dsn = build_mysql_dsn(&config);
+        let parsed = parse_and_validate_mysql_dsn(&dsn).unwrap();
+
+        assert_eq!(parsed.transport, MySqlTransport::UnixSocket);
+        assert_eq!(
+            parsed.transport_path.as_deref(),
+            Some("/run/mysqld/mysqld.sock")
+        );
+    }
+
+    #[test]
+    fn rejects_transport_path_for_tcp_dsn() {
+        let error = parse_and_validate_mysql_dsn(
+            "mysql://user:password@localhost:3306/app?transport=TCP&transport-path=%2Ftmp%2Fmysql.sock",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "MySQL transport path is only valid for socket or named-pipe transport"
+        ));
+    }
+
     #[test]
     fn rejects_cleartext_auth_plugin_without_required_tls() {
         let error = parse_and_validate_mysql_dsn(
@@ -456,6 +564,8 @@ mod tests {
             "server public key",
         ] {
             let mut target = MySqlDsn {
+                transport: MySqlTransport::Tcp,
+                transport_path: None,
                 host: "localhost".to_string(),
                 port: 3306,
                 database: None,

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -52,16 +52,18 @@ pub(super) fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
         .expect("MySQL username is valid URL data");
     url.set_password(Some(&config.password))
         .expect("MySQL password is valid URL data");
-    let host = normalize_mysql_host(&config.host);
-    let host = if host.contains(':') && !host.starts_with('[') {
-        format!("[{host}]")
-    } else {
-        host
-    };
-    url.set_host(Some(&host))
-        .expect("validated MySQL host is valid URL data");
-    url.set_port(Some(config.port))
-        .expect("MySQL port is valid URL data");
+    if config.transport == MySqlTransport::Tcp {
+        let host = normalize_mysql_host(&config.host);
+        let host = if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]")
+        } else {
+            host
+        };
+        url.set_host(Some(&host))
+            .expect("validated MySQL host is valid URL data");
+        url.set_port(Some(config.port))
+            .expect("MySQL port is valid URL data");
+    }
     if let Some(database) = config.database.as_deref() {
         url.path_segments_mut()
             .expect("MySQL URL supports path segments")
@@ -461,8 +463,8 @@ mod tests {
     #[test]
     fn builds_and_parses_unix_socket_transport() {
         let config = MySqlConnectionConfig::new(
-            "ignored-host",
-            3306,
+            "db example",
+            0,
             Some("app".to_string()),
             "user",
             "password",
@@ -477,6 +479,8 @@ mod tests {
         let parsed = parse_and_validate_mysql_dsn(&dsn).unwrap();
 
         assert_eq!(parsed.transport, MySqlTransport::UnixSocket);
+        assert_eq!(parsed.host, "localhost");
+        assert_eq!(parsed.port, 3306);
         assert_eq!(
             parsed.transport_path.as_deref(),
             Some("/run/mysqld/mysqld.sock")

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -9,8 +9,11 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use crate::app::ports::outbound::DbOperationError;
+use crate::domain::connection::MySqlTransport;
 
-use super::dsn::{MySqlDsn, validate_mysql_tls_config, validate_mysql_values};
+use super::dsn::{
+    MySqlDsn, validate_mysql_tls_config, validate_mysql_transport, validate_mysql_values,
+};
 
 pub(super) struct MySqlOptionFile {
     pub(super) path: PathBuf,
@@ -19,6 +22,7 @@ pub(super) struct MySqlOptionFile {
 impl MySqlOptionFile {
     pub(super) fn create(target: &MySqlDsn) -> Result<Self, DbOperationError> {
         validate_mysql_values(target)?;
+        validate_mysql_transport(target)?;
         validate_mysql_tls_files(target)?;
         validate_mysql_server_public_key(target)?;
         let mut path = std::env::temp_dir();
@@ -455,8 +459,19 @@ impl Drop for MySqlOptionFile {
 
 fn serialize_option_file(target: &MySqlDsn) -> String {
     let mut contents = String::from("[client]\n");
-    push_option(&mut contents, "host", &target.host);
-    push_option(&mut contents, "port", &target.port.to_string());
+    match target.transport {
+        MySqlTransport::Tcp => {
+            push_option(&mut contents, "host", &target.host);
+            push_option(&mut contents, "port", &target.port.to_string());
+            push_option(&mut contents, "protocol", target.transport.protocol());
+        }
+        MySqlTransport::UnixSocket | MySqlTransport::NamedPipe => {
+            push_option(&mut contents, "protocol", target.transport.protocol());
+            if let Some(path) = target.transport_path.as_deref() {
+                push_option(&mut contents, "socket", path);
+            }
+        }
+    }
     push_option(&mut contents, "user", &target.username);
     push_option(&mut contents, "password", &target.password);
     if let Some(database) = target.database.as_deref() {
@@ -522,6 +537,8 @@ mod tests {
 
     fn target() -> MySqlDsn {
         MySqlDsn {
+            transport: MySqlTransport::Tcp,
+            transport_path: None,
             host: "localhost".to_string(),
             port: 3306,
             database: None,
@@ -629,6 +646,31 @@ mod tests {
         assert!(contents.contains("enable-cleartext-plugin = \"true\"\n"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn option_file_serializes_unix_socket_without_tcp_fields() {
+        let target = MySqlDsn {
+            transport: MySqlTransport::UnixSocket,
+            transport_path: Some("/run/mysqld/mysqld.sock".to_string()),
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        let contents = fs::read_to_string(&option_file.path).unwrap();
+
+        assert_eq!(
+            contents,
+            "[client]\n\
+protocol = \"SOCKET\"\n\
+socket = \"/run/mysqld/mysqld.sock\"\n\
+user = \"user\"\n\
+password = \"secret\"\n\
+ssl-mode = \"DISABLED\"\n"
+        );
+        assert!(!contents.contains("host ="));
+        assert!(!contents.contains("port ="));
+    }
+
     #[test]
     fn accepts_rsa_public_key_pem_before_creating_option_file() {
         let directory = tempfile::tempdir().unwrap();
@@ -694,6 +736,7 @@ mod tests {
             "[client]\n\
 host = \"localhost\"\n\
 port = \"3306\"\n\
+protocol = \"TCP\"\n\
 user = \"user\"\n\
 password = \"secret\"\n\
 ssl-mode = \"REQUIRED\"\n"

--- a/src/infra/adapters/mysql/test_support.rs
+++ b/src/infra/adapters/mysql/test_support.rs
@@ -33,13 +33,12 @@ pub async fn run_mysql_cli_query_for_test(
     let args = [
         format!("--defaults-file={}", option_file.path.display()),
         "--no-login-paths".to_string(),
-        "--protocol=TCP".to_string(),
         "--connect-timeout=10".to_string(),
+        "--skip-reconnect".to_string(),
         "--batch".to_string(),
         "--raw".to_string(),
         "--skip-column-names".to_string(),
         "--binary-mode".to_string(),
-        "--skip-reconnect".to_string(),
         format!("--execute={query}"),
     ];
     let mut command = Command::new("mysql");

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionName, ConnectionProfile, ConnectionProfileError,
-    DatabaseType, MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig,
+    DatabaseType, MySqlConnectionConfig, MySqlSslMode, MySqlTransport, PostgresConnectionConfig,
     SqliteConnectionConfig, SslMode,
 };
 
@@ -62,6 +62,10 @@ pub struct ConnectionConfigEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_enable_cleartext_plugin: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_transport: Option<MySqlTransport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_transport_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -107,6 +111,8 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
             mysql_enable_cleartext_plugin: None,
+            mysql_transport: None,
+            mysql_transport_path: None,
             path: None,
         };
         match &profile.config {
@@ -122,8 +128,12 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry.path = Some(config.path().to_string());
             }
             ConnectionConfig::MySQL(config) => {
-                entry.host = Some(config.host.clone());
-                entry.port = Some(config.port);
+                entry.mysql_transport = Some(config.transport)
+                    .filter(|transport| !matches!(transport, MySqlTransport::Tcp));
+                if config.transport == MySqlTransport::Tcp {
+                    entry.host = Some(config.host.clone());
+                    entry.port = Some(config.port);
+                }
                 entry.database.clone_from(&config.database);
                 entry.username = Some(config.username.clone());
                 entry.password = Some(config.password.clone());
@@ -138,6 +148,9 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                     .clone_from(&config.server_public_key_path);
                 entry.mysql_enable_cleartext_plugin =
                     config.enable_cleartext_plugin.then_some(true);
+                entry
+                    .mysql_transport_path
+                    .clone_from(&config.transport_path);
             }
         }
         entry
@@ -174,13 +187,19 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                 )?)?),
             ),
             DatabaseType::MySQL => {
+                let transport = entry.mysql_transport.unwrap_or_default();
                 let database = entry.database.clone().filter(|value| !value.is_empty());
                 Self::with_id_and_config(
                     id,
                     name.as_str().to_string(),
                     ConnectionConfig::MySQL(
                         MySqlConnectionConfig::new(
-                            required_mysql_host(entry.host.as_ref())?,
+                            match transport {
+                                MySqlTransport::Tcp => required_mysql_host(entry.host.as_ref())?,
+                                MySqlTransport::UnixSocket | MySqlTransport::NamedPipe => {
+                                    entry.host.clone().unwrap_or_default()
+                                }
+                            },
                             entry.port.unwrap_or(3306),
                             database,
                             required_mysql_field(entry.username.as_ref(), "username")?,
@@ -193,6 +212,7 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                             entry.mysql_ssl_key.clone(),
                         )
                         .with_server_public_key_path(entry.mysql_server_public_key_path.clone())
+                        .with_transport(transport, entry.mysql_transport_path.clone())
                         .with_cleartext_auth_plugin(
                             entry.mysql_enable_cleartext_plugin.unwrap_or(false),
                         ),
@@ -278,6 +298,8 @@ mod tests {
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
             mysql_enable_cleartext_plugin: None,
+            mysql_transport: None,
+            mysql_transport_path: None,
             path: None,
         }
     }
@@ -299,6 +321,8 @@ mod tests {
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
             mysql_enable_cleartext_plugin: None,
+            mysql_transport: None,
+            mysql_transport_path: None,
             path: path.map(str::to_string),
         }
     }
@@ -320,6 +344,8 @@ mod tests {
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
             mysql_enable_cleartext_plugin: None,
+            mysql_transport: None,
+            mysql_transport_path: None,
             path: None,
         }
     }
@@ -429,6 +455,28 @@ mod tests {
         assert_eq!(serialized.mysql_ssl_mode, Some(MySqlSslMode::Required));
         assert_eq!(serialized.port, Some(3306));
         assert_eq!(serialized.password.as_deref(), Some("p@ss#word"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mysql_socket_entry_round_trips_transport_path_without_tcp_fields() {
+        let mut entry = mysql_entry(Some("app"));
+        entry.mysql_transport = Some(MySqlTransport::UnixSocket);
+        entry.mysql_transport_path = Some("/run/mysqld/mysqld.sock".to_string());
+
+        let profile = ConnectionProfile::try_from(&entry).unwrap();
+        let config = profile.mysql_config().unwrap();
+        assert_eq!(config.transport, MySqlTransport::UnixSocket);
+        assert_eq!(
+            config.transport_path.as_deref(),
+            Some("/run/mysqld/mysqld.sock")
+        );
+
+        let serialized = ConnectionConfigEntry::from(&profile);
+        assert_eq!(serialized.host, None);
+        assert_eq!(serialized.port, None);
+        assert_eq!(serialized.mysql_transport, entry.mysql_transport);
+        assert_eq!(serialized.mysql_transport_path, entry.mysql_transport_path);
     }
 
     #[test]

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -266,6 +266,8 @@ fn required_mysql_host(value: Option<&String>) -> Result<String, ConnectionProfi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapters::mysql::MySqlAdapter;
+    use crate::app::ports::outbound::DsnBuilder;
 
     #[test]
     fn supported_versions_are_accepted() {
@@ -477,6 +479,11 @@ mod tests {
         assert_eq!(serialized.port, None);
         assert_eq!(serialized.mysql_transport, entry.mysql_transport);
         assert_eq!(serialized.mysql_transport_path, entry.mysql_transport_path);
+
+        let round_tripped = ConnectionProfile::try_from(&serialized).unwrap();
+        let dsn = MySqlAdapter::new().build_dsn(&round_tripped);
+        assert!(dsn.contains("transport=UNIX_SOCKET"));
+        assert!(dsn.contains("transport-path=%2Frun%2Fmysqld%2Fmysqld.sock"));
     }
 
     #[test]

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
@@ -18,11 +18,11 @@ test_project ▸ - ▸ -                                                        
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Type:       [ MySQL                    ▼ ]                │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
+│                                       ││          │  Transport:  [ TCP                      ▼ ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
 │                                       ││          │  Database:   [                            ]                │                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
@@ -23,13 +23,14 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Type:       [ MySQL                    ▼ ]                │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
+│                                       ││          │  Transport:  [ TCP                      ▼ ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
 │                                       ││          │  Database:   [ app                        ]                │                                                  │
-│                                       ││          │  User:       [ mysql_user                 ]                │                                                  │
-│                                       │└──────────│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
+│                                       │└──────────│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
+│                                       ││          │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Server Key: [                            ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
@@ -38,7 +39,6 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
-assertion_line: 112
+assertion_line: 131
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
@@ -18,11 +18,11 @@ test_project ▸ - ▸ -                                                        
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Type:       [ MySQL                    ▼ ]                │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
+│                                       ││          │  Transport:  [ TCP                      ▼ ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
 │                                       ││          │  Database:   [ app                        ]                │                                                  │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -10,7 +10,7 @@ use crate::app::policy::mask_password;
 use crate::app::services::AppServices;
 use crate::app::update::input::keybindings::{connection_setup, connection_setup_save};
 use crate::domain::connection::{
-    ConnectionId, ConnectionProfile, DatabaseType, MySqlSslMode, SslMode,
+    ConnectionId, ConnectionProfile, DatabaseType, MySqlSslMode, MySqlTransport, SslMode,
 };
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::{FooterHintBar, render_modal};
@@ -113,6 +113,15 @@ impl ConnectionSetup {
                     None,
                     theme,
                 ),
+                ConnectionField::Transport => Self::render_dropdown_field(
+                    frame,
+                    chunks[idx],
+                    field.label(),
+                    &form_state.mysql_transport().to_string(),
+                    form_state.focused_field() == ConnectionField::Transport,
+                    form_state.validation_error(ConnectionField::Transport),
+                    theme,
+                ),
                 ConnectionField::SslMode => Self::render_dropdown_field(
                     frame,
                     chunks[idx],
@@ -165,7 +174,7 @@ impl ConnectionSetup {
         if form_state.database_type_dropdown().is_open()
             && let Some(field_area) = Self::open_dropdown_field_area(
                 chunks.as_ref(),
-                visible_fields,
+                &visible_fields,
                 ConnectionField::DatabaseType,
             )
         {
@@ -178,10 +187,26 @@ impl ConnectionSetup {
                 form_state.database_type_dropdown().selected_index(),
                 theme,
             );
+        } else if form_state.transport_dropdown().is_open()
+            && let Some(field_area) = Self::open_dropdown_field_area(
+                chunks.as_ref(),
+                visible_fields.as_slice(),
+                ConnectionField::Transport,
+            )
+        {
+            Self::render_dropdown_list(
+                frame,
+                field_area,
+                MySqlTransport::all_variants()
+                    .iter()
+                    .map(|transport| transport.as_str()),
+                form_state.transport_dropdown().selected_index(),
+                theme,
+            );
         } else if form_state.ssl_dropdown().is_open()
             && let Some(field_area) = Self::open_dropdown_field_area(
                 chunks.as_ref(),
-                visible_fields,
+                &visible_fields,
                 if form_state.focused_field() == ConnectionField::CleartextAuth {
                     ConnectionField::CleartextAuth
                 } else {
@@ -245,6 +270,7 @@ impl ConnectionSetup {
         if matches!(
             form_state.focused_field(),
             ConnectionField::DatabaseType
+                | ConnectionField::Transport
                 | ConnectionField::SslMode
                 | ConnectionField::CleartextAuth
         ) {

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -571,11 +571,15 @@ fn focused_placeholder_spans(
 }
 
 fn preview_profile(state: &ConnectionSetupState) -> Option<ConnectionProfile> {
-    state
-        .field_value(ConnectionField::Port)
-        .trim()
-        .parse::<u16>()
-        .ok()?;
+    let uses_hidden_tcp_values = state.database_type() == DatabaseType::MySQL
+        && state.mysql_transport() != MySqlTransport::Tcp;
+    if !uses_hidden_tcp_values {
+        state
+            .field_value(ConnectionField::Port)
+            .trim()
+            .parse::<u16>()
+            .ok()?;
+    }
     let config = state.to_connection_config().ok()?;
     ConnectionProfile::with_id_and_config(ConnectionId::from_string("preview"), "preview", config)
         .ok()

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -277,7 +277,9 @@ impl Footer {
             InputMode::ConnectionSetup => {
                 let mut hints = if matches!(
                     state.connection_setup.focused_field(),
-                    ConnectionField::DatabaseType | ConnectionField::SslMode
+                    ConnectionField::DatabaseType
+                        | ConnectionField::Transport
+                        | ConnectionField::SslMode
                 ) {
                     vec![
                         connection_setup::ENTER_DROPDOWN.as_hint(),


### PR DESCRIPTION
## Problem
MySQL connections were forced to TCP, preventing connections to local servers available only through a Unix socket or Windows named pipe.

## Background
The selected transport must remain consistent across probing, metadata, queries, previews, and exports while preserving existing TCP profiles.

## Approach
Add an explicit MySQL transport and path to the domain, saved configuration, setup form, validation, and DSN. Serialize the selected transport into the shared secure MySQL option file so every CLI path uses the same connection transport.

## How Has This Been Tested?
- local
