### PR TITLE
fix(mysql): bound preview XML frame and field bytes

### DIFF
--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -69,6 +69,8 @@ pub enum DbOperationError {
     ObjectMissing(String),
     #[error("Query failed")]
     QueryFailed(String),
+    #[error("Preview exceeded its byte budget")]
+    PreviewSizeExceeded(String),
     #[error("Query failed after a change")]
     QueryFailedAfterChange {
         #[source]
@@ -119,6 +121,7 @@ impl DbOperationError {
             Self::LockTimeout(_) => "Operation blocked by lock or timeout",
             Self::ObjectMissing(_) => "Database object not found",
             Self::QueryFailed(_) => "Query failed",
+            Self::PreviewSizeExceeded(_) => "Preview exceeded its byte budget",
             Self::QueryFailedAfterChange { source, .. } => source.summary(),
             Self::UnsupportedOperation(_) => "Unsupported operation",
             Self::UnsupportedOperationWithKind { kind, .. } => match kind {
@@ -164,6 +167,7 @@ impl DbOperationError {
             }
             Self::ObjectMissing(_) => "Check the table, column, or connected database",
             Self::QueryFailed(_) => "Review the database error details and SQL",
+            Self::PreviewSizeExceeded(_) => "Reduce the preview value size and retry",
             Self::QueryFailedAfterChange { source, .. } => source.hint(),
             Self::UnsupportedOperation(_) => "Use a supported operation for this database",
             Self::UnsupportedOperationWithKind { kind, .. } => match kind {
@@ -257,6 +261,7 @@ impl DbOperationError {
             | Self::LockTimeout(details)
             | Self::ObjectMissing(details)
             | Self::QueryFailed(details)
+            | Self::PreviewSizeExceeded(details)
             | Self::UnsupportedOperation(details)
             | Self::UnsupportedOperationWithKind { details, .. }
             | Self::ConnectionFailedWithKind { details, .. }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -96,6 +96,14 @@ pub fn reduce_execution(
             }
 
             if *source == QuerySource::Preview
+                && matches!(error, DbOperationError::PreviewSizeExceeded(_))
+            {
+                state.query.mark_idle();
+                state.messages.set_error_at(error.user_message(), now);
+                return DispatchResult::handled();
+            }
+
+            if *source == QuerySource::Preview
                 && *generation != 0
                 && *generation == state.session.selection_generation()
                 && state.session.selected_table_key().is_some()
@@ -1368,6 +1376,35 @@ mod tests {
                     .is_some_and(|message| message.contains("Permission denied"))
             );
             assert!(state.messages.last_error.is_none());
+        }
+
+        #[test]
+        fn preview_size_failure_keeps_the_current_result_and_sets_an_error_message() {
+            let mut state = state_with_table("public", "users");
+            let current_result = preview_result(1);
+            state.query.set_current_result(Arc::clone(&current_result));
+            state.session.set_selection_generation(1);
+            let action = query_failed_action(
+                &mut state,
+                DbOperationError::PreviewSizeExceeded("field exceeded".to_string()),
+                1,
+                QuerySource::Preview,
+            );
+
+            dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
+
+            assert!(
+                state
+                    .query
+                    .current_result()
+                    .is_some_and(|result| Arc::ptr_eq(result, &current_result))
+            );
+            assert_eq!(
+                state.messages.last_error(),
+                Some(
+                    "Preview exceeded its byte budget: field exceeded. Reduce the preview value size and retry."
+                )
+            );
         }
 
         #[test]

--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -8,7 +8,8 @@ use crate::app::ports::outbound::DbOperationError;
 
 use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
 use super::xml::{
-    MySqlResultsetFrameScanner, take_mysql_resultset_frame_after_error_check_with_diagnostics,
+    MySqlResultsetFrameScanner,
+    take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget,
     trace_mysql_frame,
 };
 
@@ -157,6 +158,7 @@ pub(super) async fn read_one_mysql_resultset_from_pipes<R, E>(
     pending_stderr: &mut Vec<u8>,
     frame_scanner: &mut MySqlResultsetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
+    preview_byte_budget: bool,
 ) -> Result<Vec<u8>, DbOperationError>
 where
     R: AsyncRead + Unpin,
@@ -170,6 +172,7 @@ where
         pending_stderr,
         frame_scanner,
         client_packet_limit_bytes,
+        preview_byte_budget,
     )
     .await?
     .0)
@@ -183,6 +186,7 @@ pub(super) async fn read_one_mysql_resultset_from_pipes_with_diagnostics<R, E>(
     pending_stderr: &mut Vec<u8>,
     frame_scanner: &mut MySqlResultsetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
+    preview_byte_budget: bool,
 ) -> Result<(Vec<u8>, Vec<crate::domain::MySqlDiagnostic>), DbOperationError>
 where
     R: AsyncRead + Unpin,
@@ -206,12 +210,15 @@ where
                 () = tokio::task::yield_now() => {}
             }
         }
-        if let Some(frame) = take_mysql_resultset_frame_after_error_check_with_diagnostics(
-            pending,
-            pending_stderr,
-            frame_scanner,
-            client_packet_limit_bytes,
-        )? {
+        if let Some(frame) =
+            take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(
+                pending,
+                pending_stderr,
+                frame_scanner,
+                client_packet_limit_bytes,
+                preview_byte_budget,
+            )?
+        {
             trace_mysql_frame("receive resultset", frame.0.len());
             return Ok(frame);
         }
@@ -386,6 +393,7 @@ mod tests {
             &mut Vec::new(),
             &mut frame_scanner,
             None,
+            false,
         )
         .await;
 
@@ -420,6 +428,7 @@ mod tests {
             &mut pending_stderr,
             &mut frame_scanner,
             None,
+            false,
         )
         .await;
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -51,6 +51,7 @@ const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
 pub(in crate::adapters::mysql) struct MySqlProcess {
     pub(super) child: Child,
     pub(super) client_packet_limit_bytes: Option<usize>,
+    pub(super) preview_byte_budget: bool,
     #[cfg(unix)]
     pub(super) pty: MySqlPty,
     #[cfg(not(unix))]
@@ -86,24 +87,37 @@ impl MySqlProcess {
         program: &OsStr,
         args: Vec<String>,
     ) -> Result<Self, DbOperationError> {
-        Self::spawn_with_args_and_packet_limit(program, args, Some(MYSQL_CLIENT_MAX_PACKET_BYTES))
+        Self::spawn_with_args_and_limits(program, args, Some(MYSQL_CLIENT_MAX_PACKET_BYTES), false)
+    }
+
+    pub(in crate::adapters::mysql) fn spawn_with_preview_program(
+        program: &OsStr,
+        args: Vec<String>,
+    ) -> Result<Self, DbOperationError> {
+        Self::spawn_with_args_and_limits(program, args, Some(MYSQL_CLIENT_MAX_PACKET_BYTES), true)
     }
 
     pub(in crate::adapters::mysql) fn spawn_with_args(
         program: &OsStr,
         args: Vec<String>,
     ) -> Result<Self, DbOperationError> {
-        Self::spawn_with_args_and_packet_limit(program, args, None)
+        Self::spawn_with_args_and_limits(program, args, None, false)
     }
 
-    fn spawn_with_args_and_packet_limit(
+    fn spawn_with_args_and_limits(
         program: &OsStr,
         args: Vec<String>,
         client_packet_limit_bytes: Option<usize>,
+        preview_byte_budget: bool,
     ) -> Result<Self, DbOperationError> {
         #[cfg(unix)]
         {
-            Self::spawn_with_pty(program, args, client_packet_limit_bytes)
+            Self::spawn_with_pty(
+                program,
+                args,
+                client_packet_limit_bytes,
+                preview_byte_budget,
+            )
         }
 
         #[cfg(not(unix))]
@@ -138,6 +152,7 @@ impl MySqlProcess {
             Ok(Self {
                 child,
                 client_packet_limit_bytes,
+                preview_byte_budget,
                 stdin: Some(stdin),
                 stdout,
                 stderr,
@@ -153,6 +168,7 @@ impl MySqlProcess {
         program: &OsStr,
         args: Vec<String>,
         client_packet_limit_bytes: Option<usize>,
+        preview_byte_budget: bool,
     ) -> Result<Self, DbOperationError> {
         let (master, slave) = create_mysql_pty().map_err(|error| {
             DbOperationError::ConnectionFailed(format!("Unable to create MySQL PTY: {error}"))
@@ -188,6 +204,7 @@ impl MySqlProcess {
         Ok(Self {
             child,
             client_packet_limit_bytes,
+            preview_byte_budget,
             pty: MySqlPty {
                 input,
                 output,
@@ -436,7 +453,12 @@ pub(super) async fn read_one_mysql_resultset(
 ) -> Result<Vec<u8>, DbOperationError> {
     #[cfg(unix)]
     {
-        return read_one_pty_resultset(&mut process.pty, process.client_packet_limit_bytes).await;
+        return read_one_pty_resultset(
+            &mut process.pty,
+            process.client_packet_limit_bytes,
+            process.preview_byte_budget,
+        )
+        .await;
     }
     #[cfg(not(unix))]
     read_one_mysql_resultset_from_pipes(
@@ -447,6 +469,7 @@ pub(super) async fn read_one_mysql_resultset(
         &mut process.pending_stderr,
         &mut process.frame_scanner,
         process.client_packet_limit_bytes,
+        process.preview_byte_budget,
     )
     .await
 }
@@ -459,6 +482,7 @@ pub(super) async fn read_one_mysql_resultset_with_diagnostics(
         return read_one_pty_resultset_with_diagnostics(
             &mut process.pty,
             process.client_packet_limit_bytes,
+            process.preview_byte_budget,
         )
         .await;
     }
@@ -471,6 +495,7 @@ pub(super) async fn read_one_mysql_resultset_with_diagnostics(
         &mut process.pending_stderr,
         &mut process.frame_scanner,
         process.client_packet_limit_bytes,
+        process.preview_byte_budget,
     )
     .await
 }
@@ -1955,6 +1980,7 @@ mod windows_tests {
         let mut process = MySqlProcess {
             child,
             client_packet_limit_bytes: None,
+            preview_byte_budget: false,
             stdin: Some(stdin),
             stdout,
             stderr,
@@ -2005,6 +2031,7 @@ mod windows_tests {
         let mut process = MySqlProcess {
             child,
             client_packet_limit_bytes: None,
+            preview_byte_budget: false,
             stdin: Some(stdin),
             stdout,
             stderr,
@@ -2043,6 +2070,7 @@ mod windows_tests {
         let mut process = MySqlProcess {
             child,
             client_packet_limit_bytes: None,
+            preview_byte_budget: false,
             stdin: Some(stdin),
             stdout,
             stderr,

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -7,7 +7,7 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use super::super::args::{mysql_metadata_session_args, mysql_query_args};
 use super::super::error::classify_mysql_query_failure_with_packet_limit;
 use super::super::probe::{validate_lower_case_table_names, validate_sql_mode};
-use super::super::xml::{MySqlResultSet, parse_mysql_xml};
+use super::super::xml::{MySqlResultSet, parse_mysql_preview_xml, parse_mysql_xml};
 use super::{
     MySqlProcess, cleanup_mysql_process, configure_mysql_session, finish_mysql_session,
     finish_mysql_session_after_preview_frame, read_one_mysql_resultset, write_mysql_statement,
@@ -24,7 +24,7 @@ impl MySqlMetadataSession {
         program: &OsStr,
         option_file: &std::path::Path,
     ) -> Result<Self, DbOperationError> {
-        MySqlProcess::spawn_with_query_args(program, mysql_query_args(option_file))
+        MySqlProcess::spawn_with_preview_program(program, mysql_query_args(option_file))
             .map(|process| Self { process })
     }
 
@@ -70,7 +70,11 @@ impl MySqlMetadataSession {
     ) -> Result<MySqlResultSet, DbOperationError> {
         write_mysql_statement(&mut self.process, query).await?;
         let xml = read_one_mysql_resultset(&mut self.process).await?;
-        let mut result = parse_mysql_xml(&xml)?;
+        let mut result = if self.process.preview_byte_budget {
+            parse_mysql_preview_xml(&xml)?
+        } else {
+            parse_mysql_xml(&xml)?
+        };
         if result.columns.is_empty() && result.values.is_empty() {
             result.columns = expected_columns
                 .iter()

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -14,7 +14,8 @@ use super::error::{
     classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, trace_mysql_error,
 };
 use super::xml::{
-    MySqlResultsetFrameScanner, take_mysql_pty_resultset_frame_with_diagnostics, trace_mysql_frame,
+    MySqlResultsetFrameScanner, take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget,
+    trace_mysql_frame,
 };
 
 pub(super) struct MySqlPty {
@@ -64,24 +65,31 @@ fn configure_mysql_pty(fd: RawFd) -> io::Result<()> {
 pub(super) async fn read_one_pty_resultset(
     pty: &mut MySqlPty,
     client_packet_limit_bytes: Option<usize>,
+    preview_byte_budget: bool,
 ) -> Result<Vec<u8>, DbOperationError> {
     Ok(
-        read_one_pty_resultset_with_diagnostics(pty, client_packet_limit_bytes)
-            .await?
-            .0,
+        read_one_pty_resultset_with_diagnostics(
+            pty,
+            client_packet_limit_bytes,
+            preview_byte_budget,
+        )
+        .await?
+        .0,
     )
 }
 
 pub(super) async fn read_one_pty_resultset_with_diagnostics(
     pty: &mut MySqlPty,
     client_packet_limit_bytes: Option<usize>,
+    preview_byte_budget: bool,
 ) -> Result<(Vec<u8>, Vec<MySqlDiagnostic>), DbOperationError> {
     let mut chunk = [0; 4096];
     loop {
-        if let Some(frame) = take_mysql_pty_resultset_frame_with_diagnostics(
+        if let Some(frame) = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
             &mut pty.pending,
             &mut pty.frame_scanner,
             client_packet_limit_bytes,
+            preview_byte_budget,
         )? {
             trace_mysql_frame("receive resultset", frame.0.len());
             return Ok(frame);

--- a/src/infra/adapters/mysql/cli/xml.rs
+++ b/src/infra/adapters/mysql/cli/xml.rs
@@ -119,14 +119,18 @@ fn ensure_mysql_resultset_frame_within_limit(
     scanner: &MySqlResultsetFrameScanner,
     buffer: &[u8],
     bounds: Option<(usize, usize)>,
+    preview_byte_budget: bool,
 ) -> Result<(), DbOperationError> {
+    if !preview_byte_budget {
+        return Ok(());
+    }
     let Some(start) = scanner.resultset_start else {
         return Ok(());
     };
     let end = bounds.map_or(buffer.len(), |(_, end)| end);
     let frame_bytes = end.saturating_sub(start);
     if frame_bytes > MYSQL_PREVIEW_MAX_FRAME_BYTES {
-        return Err(DbOperationError::QueryFailed(format!(
+        return Err(DbOperationError::PreviewSizeExceeded(format!(
             "MySQL preview XML frame exceeded the {MYSQL_PREVIEW_MAX_FRAME_BYTES}-byte limit"
         )));
     }
@@ -134,13 +138,13 @@ fn ensure_mysql_resultset_frame_within_limit(
 }
 
 #[cfg(any(unix, test))]
-pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics(
+pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
     buffer: &mut Vec<u8>,
     scanner: &mut MySqlResultsetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
+    preview_byte_budget: bool,
 ) -> Result<Option<MySqlResultsetFrameWithDiagnostics>, DbOperationError> {
     let bounds = scanner.frame_bounds(buffer);
-    ensure_mysql_resultset_frame_within_limit(scanner, buffer, bounds)?;
     let resultset_start = scanner.resultset_start.unwrap_or(buffer.len());
     if has_mysql_cli_error(&buffer[..resultset_start]) {
         trace_mysql_error(&buffer[..resultset_start]);
@@ -149,15 +153,17 @@ pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics(
             client_packet_limit_bytes,
         ));
     }
+    ensure_mysql_resultset_frame_within_limit(scanner, buffer, bounds, preview_byte_budget)?;
     Ok(bounds.map(|bounds| scanner.take_bounds_with_diagnostics(buffer, bounds)))
 }
 
 #[cfg(any(not(unix), test))]
-pub(super) fn take_mysql_resultset_frame_after_error_check_with_diagnostics(
+pub(super) fn take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(
     buffer: &mut Vec<u8>,
     error_output: &[u8],
     scanner: &mut MySqlResultsetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
+    preview_byte_budget: bool,
 ) -> Result<Option<MySqlResultsetFrameWithDiagnostics>, DbOperationError> {
     if has_mysql_cli_error(error_output) {
         trace_mysql_error(error_output);
@@ -167,7 +173,7 @@ pub(super) fn take_mysql_resultset_frame_after_error_check_with_diagnostics(
         ));
     }
     let bounds = scanner.frame_bounds(buffer);
-    ensure_mysql_resultset_frame_within_limit(scanner, buffer, bounds)?;
+    ensure_mysql_resultset_frame_within_limit(scanner, buffer, bounds, preview_byte_budget)?;
     Ok(bounds.map(|bounds| scanner.take_bounds_with_diagnostics(buffer, bounds)))
 }
 
@@ -224,8 +230,19 @@ pub(super) fn decode_mysql_xml_reference(
 }
 
 pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationError> {
-    if xml.len() > MYSQL_PREVIEW_MAX_FRAME_BYTES {
-        return Err(DbOperationError::QueryFailed(format!(
+    parse_mysql_xml_with_preview_budget(xml, false)
+}
+
+pub(super) fn parse_mysql_preview_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationError> {
+    parse_mysql_xml_with_preview_budget(xml, true)
+}
+
+fn parse_mysql_xml_with_preview_budget(
+    xml: &[u8],
+    preview_byte_budget: bool,
+) -> Result<MySqlResultSet, DbOperationError> {
+    if preview_byte_budget && xml.len() > MYSQL_PREVIEW_MAX_FRAME_BYTES {
+        return Err(DbOperationError::PreviewSizeExceeded(format!(
             "MySQL preview XML frame exceeded the {MYSQL_PREVIEW_MAX_FRAME_BYTES}-byte limit"
         )));
     }
@@ -286,7 +303,7 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationE
                     DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
                 })?;
                 if let Some(field) = current_field.as_mut() {
-                    field.append_value(&text)?;
+                    field.append_value(&text, preview_byte_budget)?;
                 } else if !text.chars().all(char::is_whitespace) {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
@@ -296,7 +313,7 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationE
             Event::GeneralRef(reference) => {
                 let text = decode_mysql_xml_reference(&reference)?;
                 if let Some(field) = current_field.as_mut() {
-                    field.append_value(&text)?;
+                    field.append_value(&text, preview_byte_budget)?;
                 } else if !text.chars().all(char::is_whitespace) {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
@@ -308,7 +325,7 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationE
                     let text = std::str::from_utf8(data.as_ref()).map_err(|error| {
                         DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
                     })?;
-                    field.append_value(text)?;
+                    field.append_value(text, preview_byte_budget)?;
                 } else {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected CDATA in MySQL XML result".to_string(),
@@ -388,12 +405,18 @@ pub(super) struct MySqlField {
 }
 
 impl MySqlField {
-    fn append_value(&mut self, value: &str) -> Result<(), DbOperationError> {
+    fn append_value(
+        &mut self,
+        value: &str,
+        preview_byte_budget: bool,
+    ) -> Result<(), DbOperationError> {
         if self.is_null {
             return Ok(());
         }
-        if self.value.len().saturating_add(value.len()) > MYSQL_PREVIEW_MAX_FIELD_BYTES {
-            return Err(DbOperationError::QueryFailed(format!(
+        if preview_byte_budget
+            && self.value.len().saturating_add(value.len()) > MYSQL_PREVIEW_MAX_FIELD_BYTES
+        {
+            return Err(DbOperationError::PreviewSizeExceeded(format!(
                 "MySQL preview field exceeded the {MYSQL_PREVIEW_MAX_FIELD_BYTES}-byte limit"
             )));
         }
@@ -466,7 +489,7 @@ mod tests {
 </row>
 </resultset>"#;
 
-        let result = parse_mysql_xml(xml.as_bytes()).unwrap();
+        let result = parse_mysql_preview_xml(xml.as_bytes()).unwrap();
 
         assert_eq!(
             result.columns,
@@ -501,7 +524,7 @@ mod tests {
 <field name="binary">0x00FF10</field>
 </row></resultset>"#;
 
-        let result = parse_mysql_xml(xml).unwrap();
+        let result = parse_mysql_preview_xml(xml).unwrap();
         assert!(
             result.values[0]
                 .iter()
@@ -536,7 +559,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_a_resultset_frame_before_it_can_grow_without_a_closing_tag() {
+    fn applies_frame_limit_only_to_preview_reader() {
         let mut buffer = MYSQL_RESULTSET_START.to_vec();
         buffer.extend(std::iter::repeat_n(
             b'x',
@@ -544,12 +567,27 @@ mod tests {
         ));
         let mut scanner = MySqlResultsetFrameScanner::default();
 
-        let result =
-            take_mysql_pty_resultset_frame_with_diagnostics(&mut buffer, &mut scanner, None);
+        assert!(
+            take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
+                &mut buffer,
+                &mut scanner,
+                None,
+                false,
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        let result = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
+            &mut buffer,
+            &mut scanner,
+            None,
+            true,
+        );
 
         assert!(matches!(
             result,
-            Err(DbOperationError::QueryFailed(details))
+            Err(DbOperationError::PreviewSizeExceeded(details))
                 if details.contains("XML frame") && details.contains("byte limit")
         ));
     }
@@ -560,11 +598,14 @@ mod tests {
         let xml =
             format!("<resultset><row><field name=\"value\">{value}</field></row></resultset>");
 
-        let result = parse_mysql_xml(xml.as_bytes());
+        let unrestricted = parse_mysql_xml(xml.as_bytes()).unwrap();
+        assert_eq!(unrestricted.values, vec![vec![QueryValue::Text(value)]]);
+
+        let result = parse_mysql_preview_xml(xml.as_bytes());
 
         assert!(matches!(
             result,
-            Err(DbOperationError::QueryFailed(details))
+            Err(DbOperationError::PreviewSizeExceeded(details))
                 if details.contains("field") && details.contains("byte limit")
         ));
     }
@@ -607,9 +648,14 @@ mod tests {
         let mut scanner = MySqlResultsetFrameScanner::default();
 
         let (frame, diagnostics) =
-            take_mysql_pty_resultset_frame_with_diagnostics(&mut buffer, &mut scanner, None)
-                .unwrap()
-                .unwrap();
+            take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
+                &mut buffer,
+                &mut scanner,
+                None,
+                false,
+            )
+            .unwrap()
+            .unwrap();
 
         assert_eq!(frame, b"<resultset></resultset>");
         assert_eq!(
@@ -635,14 +681,16 @@ mod tests {
         let mut buffer = b"Warning (Code 1265): truncated\n<resultset></resultset>".to_vec();
         let mut scanner = MySqlResultsetFrameScanner::default();
 
-        let (frame, diagnostics) = take_mysql_resultset_frame_after_error_check_with_diagnostics(
-            &mut buffer,
-            &[],
-            &mut scanner,
-            None,
-        )
-        .unwrap()
-        .unwrap();
+        let (frame, diagnostics) =
+            take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(
+                &mut buffer,
+                &[],
+                &mut scanner,
+                None,
+                false,
+            )
+            .unwrap()
+            .unwrap();
 
         assert_eq!(frame, b"<resultset></resultset>");
         assert_eq!(
@@ -738,10 +786,14 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
             .to_vec();
         let mut scanner = MySqlResultsetFrameScanner::default();
 
-        let frame =
-            take_mysql_pty_resultset_frame_with_diagnostics(&mut buffer, &mut scanner, None)
-                .unwrap()
-                .map(|(frame, _)| frame);
+        let frame = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
+            &mut buffer,
+            &mut scanner,
+            None,
+            false,
+        )
+        .unwrap()
+        .map(|(frame, _)| frame);
 
         assert!(frame.is_some());
         assert!(buffer.is_empty());
@@ -753,9 +805,13 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
             b"ERROR 1054 (42S22): Unknown column\n<resultset><row></row></resultset>".to_vec();
         let mut scanner = MySqlResultsetFrameScanner::default();
 
-        let result =
-            take_mysql_pty_resultset_frame_with_diagnostics(&mut buffer, &mut scanner, None)
-                .map(|result| result.map(|(frame, _)| frame));
+        let result = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
+            &mut buffer,
+            &mut scanner,
+            None,
+            false,
+        )
+        .map(|result| result.map(|(frame, _)| frame));
 
         assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
         assert_eq!(
@@ -771,11 +827,12 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
         let mut scanner = MySqlResultsetFrameScanner::default();
 
         assert!(matches!(
-            take_mysql_resultset_frame_after_error_check_with_diagnostics(
+            take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(
                 &mut buffer,
                 error,
                 &mut scanner,
                 None,
+                false,
             )
             .map(|result| result.map(|(frame, _)| frame)),
             Err(DbOperationError::ObjectMissing(_))

--- a/src/infra/adapters/mysql/cli/xml.rs
+++ b/src/infra/adapters/mysql/cli/xml.rs
@@ -22,6 +22,9 @@ const MYSQL_RESULTSET_END: &[u8] = b"</resultset>";
 
 type MySqlResultsetFrameWithDiagnostics = (Vec<u8>, Vec<MySqlDiagnostic>);
 
+pub(super) const MYSQL_PREVIEW_MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+const MYSQL_PREVIEW_MAX_FIELD_BYTES: usize = 4 * 1024 * 1024;
+
 #[derive(Debug, Default)]
 pub(super) struct MySqlResultsetFrameScanner {
     resultset_start: Option<usize>,
@@ -112,6 +115,24 @@ impl MySqlResultsetFrameScanner {
     }
 }
 
+fn ensure_mysql_resultset_frame_within_limit(
+    scanner: &MySqlResultsetFrameScanner,
+    buffer: &[u8],
+    bounds: Option<(usize, usize)>,
+) -> Result<(), DbOperationError> {
+    let Some(start) = scanner.resultset_start else {
+        return Ok(());
+    };
+    let end = bounds.map_or(buffer.len(), |(_, end)| end);
+    let frame_bytes = end.saturating_sub(start);
+    if frame_bytes > MYSQL_PREVIEW_MAX_FRAME_BYTES {
+        return Err(DbOperationError::QueryFailed(format!(
+            "MySQL preview XML frame exceeded the {MYSQL_PREVIEW_MAX_FRAME_BYTES}-byte limit"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(any(unix, test))]
 pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics(
     buffer: &mut Vec<u8>,
@@ -119,6 +140,7 @@ pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics(
     client_packet_limit_bytes: Option<usize>,
 ) -> Result<Option<MySqlResultsetFrameWithDiagnostics>, DbOperationError> {
     let bounds = scanner.frame_bounds(buffer);
+    ensure_mysql_resultset_frame_within_limit(scanner, buffer, bounds)?;
     let resultset_start = scanner.resultset_start.unwrap_or(buffer.len());
     if has_mysql_cli_error(&buffer[..resultset_start]) {
         trace_mysql_error(&buffer[..resultset_start]);
@@ -145,6 +167,7 @@ pub(super) fn take_mysql_resultset_frame_after_error_check_with_diagnostics(
         ));
     }
     let bounds = scanner.frame_bounds(buffer);
+    ensure_mysql_resultset_frame_within_limit(scanner, buffer, bounds)?;
     Ok(bounds.map(|bounds| scanner.take_bounds_with_diagnostics(buffer, bounds)))
 }
 
@@ -201,6 +224,11 @@ pub(super) fn decode_mysql_xml_reference(
 }
 
 pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationError> {
+    if xml.len() > MYSQL_PREVIEW_MAX_FRAME_BYTES {
+        return Err(DbOperationError::QueryFailed(format!(
+            "MySQL preview XML frame exceeded the {MYSQL_PREVIEW_MAX_FRAME_BYTES}-byte limit"
+        )));
+    }
     let mut reader = Reader::from_reader(xml);
     reader.config_mut().trim_text(false);
     let mut buffer = Vec::new();
@@ -258,7 +286,7 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationE
                     DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
                 })?;
                 if let Some(field) = current_field.as_mut() {
-                    field.value.push_str(&text);
+                    field.append_value(&text)?;
                 } else if !text.chars().all(char::is_whitespace) {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
@@ -268,7 +296,7 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationE
             Event::GeneralRef(reference) => {
                 let text = decode_mysql_xml_reference(&reference)?;
                 if let Some(field) = current_field.as_mut() {
-                    field.value.push_str(&text);
+                    field.append_value(&text)?;
                 } else if !text.chars().all(char::is_whitespace) {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
@@ -277,13 +305,10 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationE
             }
             Event::CData(data) => {
                 if let Some(field) = current_field.as_mut() {
-                    field
-                        .value
-                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
-                            DbOperationError::QueryFailed(format!(
-                                "invalid MySQL XML text: {error}"
-                            ))
-                        })?);
+                    let text = std::str::from_utf8(data.as_ref()).map_err(|error| {
+                        DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                    })?;
+                    field.append_value(text)?;
                 } else {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected CDATA in MySQL XML result".to_string(),
@@ -363,6 +388,19 @@ pub(super) struct MySqlField {
 }
 
 impl MySqlField {
+    fn append_value(&mut self, value: &str) -> Result<(), DbOperationError> {
+        if self.is_null {
+            return Ok(());
+        }
+        if self.value.len().saturating_add(value.len()) > MYSQL_PREVIEW_MAX_FIELD_BYTES {
+            return Err(DbOperationError::QueryFailed(format!(
+                "MySQL preview field exceeded the {MYSQL_PREVIEW_MAX_FIELD_BYTES}-byte limit"
+            )));
+        }
+        self.value.push_str(value);
+        Ok(())
+    }
+
     fn finish(self) -> (String, QueryValue) {
         let value = if self.is_null {
             QueryValue::Null
@@ -496,6 +534,41 @@ mod tests {
         assert!(result.columns.is_empty());
         assert!(result.values.is_empty());
     }
+
+    #[test]
+    fn rejects_a_resultset_frame_before_it_can_grow_without_a_closing_tag() {
+        let mut buffer = MYSQL_RESULTSET_START.to_vec();
+        buffer.extend(std::iter::repeat_n(
+            b'x',
+            MYSQL_PREVIEW_MAX_FRAME_BYTES + 1 - MYSQL_RESULTSET_START.len(),
+        ));
+        let mut scanner = MySqlResultsetFrameScanner::default();
+
+        let result =
+            take_mysql_pty_resultset_frame_with_diagnostics(&mut buffer, &mut scanner, None);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("XML frame") && details.contains("byte limit")
+        ));
+    }
+
+    #[test]
+    fn rejects_an_oversized_field_without_truncating_it() {
+        let value = "x".repeat(MYSQL_PREVIEW_MAX_FIELD_BYTES + 1);
+        let xml =
+            format!("<resultset><row><field name=\"value\">{value}</field></row></resultset>");
+
+        let result = parse_mysql_xml(xml.as_bytes());
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("field") && details.contains("byte limit")
+        ));
+    }
+
     #[test]
     fn frames_one_xml_resultset_and_preserves_following_output() {
         let mut buffer = b"    -> <?xml version=\"1.0\"?>\n<resultset></resultset>\r\n    -> <?xml version=\"1.0\"?>\n<resultset>"


### PR DESCRIPTION
## Problem

MySQL preview resultsets had no byte budget for pending XML frames or individual field values, so large text and binary values could accumulate in the CLI and Rust process.

## Background

The preview is limited to 500 rows, but that count does not bound the memory required by a few large values or by binary values represented as hexadecimal XML text.

## Approach

Reject oversized XML frames before extraction and oversized decoded field values during parsing. The limits fail closed with explicit query errors, preserving the existing displayed result instead of publishing a partial result.

## Screenshots

Not applicable.
