### PR TITLE
refactor(mysql): consolidate session exit validation

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -25,7 +25,7 @@ use super::policy::mysql_metadata_fallback_kind;
 use super::process::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
     mysql_metadata_columns, read_one_mysql_resultset, run_mysql_process_with_timeout,
-    write_mysql_statement,
+    validate_mysql_session_exit, write_mysql_statement,
 };
 #[cfg(unix)]
 use super::pty::MySqlExportPtySource;
@@ -401,35 +401,9 @@ pub(super) async fn run_mysql_export_process(
     }
 
     let result = finish_mysql_session(process).await?;
-    validate_mysql_export_exit(
-        result.status,
-        result.forcibly_stopped,
-        &result.error_bytes,
-        process.client_packet_limit_bytes,
-    )?;
+    validate_mysql_session_exit(&result, process.client_packet_limit_bytes)?;
 
     csv_writer.finish().await
-}
-
-fn validate_mysql_export_exit(
-    status: std::process::ExitStatus,
-    forcibly_stopped: bool,
-    error_bytes: &[u8],
-    client_packet_limit_bytes: Option<usize>,
-) -> Result<(), DbOperationError> {
-    if has_mysql_cli_error(error_bytes) {
-        return Err(classify_mysql_query_failure_with_packet_limit(
-            error_bytes,
-            client_packet_limit_bytes,
-        ));
-    }
-    if !status.success() && !forcibly_stopped {
-        return Err(classify_mysql_query_failure_with_packet_limit(
-            error_bytes,
-            client_packet_limit_bytes,
-        ));
-    }
-    Ok(())
 }
 
 pub(super) async fn stream_mysql_resultset_to_csv(
@@ -664,9 +638,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::fs;
-
-    #[cfg(unix)]
-    use std::os::unix::process::ExitStatusExt;
 
     use crate::adapters::csv_export::export_to_path;
     use tokio::io::AsyncWriteExt;
@@ -941,18 +912,5 @@ line2]]></field>
                 .unwrap();
             assert_eq!(output, xml.as_bytes());
         }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn rejects_cli_error_after_forced_stop() {
-        let result = validate_mysql_export_exit(
-            std::process::ExitStatus::from_raw(9),
-            true,
-            b"ERROR 1054 (42S02): Unknown column missing_column",
-            None,
-        );
-
-        assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
     }
 }

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -17,7 +17,7 @@ use crate::domain::{MySqlDiagnostic, RefreshScope};
 use super::args::{MYSQL_CLIENT_MAX_PACKET_BYTES, mysql_adhoc_args, mysql_query_args};
 #[cfg(not(unix))]
 use super::error::classify_mysql_query_failure;
-use super::error::has_mysql_cli_error;
+use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
 #[cfg(not(unix))]
 use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
 use super::policy::{
@@ -241,6 +241,25 @@ pub(super) struct MySqlSessionResult {
     pub(super) error_bytes: Vec<u8>,
 }
 
+pub(super) fn validate_mysql_session_exit(
+    result: &MySqlSessionResult,
+    client_packet_limit_bytes: Option<usize>,
+) -> Result<(), DbOperationError> {
+    if has_mysql_cli_error(&result.error_bytes) {
+        return Err(classify_mysql_query_failure_with_packet_limit(
+            &result.error_bytes,
+            client_packet_limit_bytes,
+        ));
+    }
+    if !result.status.success() && !result.forcibly_stopped {
+        return Err(classify_mysql_query_failure_with_packet_limit(
+            &result.error_bytes,
+            client_packet_limit_bytes,
+        ));
+    }
+    Ok(())
+}
+
 async fn shutdown_mysql_input(process: &mut MySqlProcess) -> Result<(), DbOperationError> {
     #[cfg(unix)]
     {
@@ -445,6 +464,54 @@ mod timeout_tests {
     #[test]
     fn keeps_production_query_timeout_at_31_seconds() {
         assert_eq!(MYSQL_QUERY_TIMEOUT, Duration::from_secs(31));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod session_exit_tests {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::ExitStatus;
+
+    use crate::app::ports::outbound::DbOperationError;
+
+    use super::{MySqlSessionResult, validate_mysql_session_exit};
+
+    fn session(status: i32, forcibly_stopped: bool, error_bytes: &[u8]) -> MySqlSessionResult {
+        MySqlSessionResult {
+            status: ExitStatus::from_raw(status),
+            forcibly_stopped,
+            error_bytes: error_bytes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn preserves_mysql_session_exit_rules() {
+        assert!(validate_mysql_session_exit(&session(0, false, b""), None).is_ok());
+        assert!(matches!(
+            validate_mysql_session_exit(
+                &session(
+                    0,
+                    true,
+                    b"ERROR 1054 (42S22): Unknown column missing_column"
+                ),
+                None,
+            ),
+            Err(DbOperationError::ObjectMissing(_))
+        ));
+        assert!(validate_mysql_session_exit(&session(1, false, b""), None).is_err());
+        assert!(validate_mysql_session_exit(&session(9, true, b""), None).is_ok());
+        assert!(matches!(
+            validate_mysql_session_exit(
+                &session(
+                    1,
+                    false,
+                    b"ERROR 2020 (HY000): Got packet bigger than 'max_allowed_packet' bytes",
+                ),
+                Some(33_554_432),
+            ),
+            Err(DbOperationError::QueryFailed(details))
+                if details == "MySQL protocol packet exceeds the 33554432-byte client limit"
+        ));
     }
 }
 

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -14,9 +14,7 @@ use crate::domain::{
     },
 };
 
-use super::super::error::{
-    classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, validate_mode_probe,
-};
+use super::super::error::validate_mode_probe;
 use super::super::policy::{
     MySqlExecutionResult, mysql_command_tag, mysql_metadata_fallback_has_unsupported_session_state,
     mysql_possible_refresh_scope, mysql_refresh_scope, mysql_row_count_marker,
@@ -27,7 +25,7 @@ use super::metadata::mysql_metadata_columns_with_diagnostics;
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
     read_one_mysql_resultset, read_one_mysql_resultset_with_diagnostics,
-    run_mysql_process_with_timeout, write_mysql_statement,
+    run_mysql_process_with_timeout, validate_mysql_session_exit, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
@@ -363,24 +361,8 @@ async fn run_mysql_adhoc_process(
     };
 
     let result = finish_mysql_session(process).await?;
-    if has_mysql_cli_error(&result.error_bytes) {
-        return Err(query_failed_after_change(
-            classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                process.client_packet_limit_bytes,
-            ),
-            refresh_scope,
-        ));
-    }
-    if !result.status.success() && !result.forcibly_stopped {
-        return Err(query_failed_after_change(
-            classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                process.client_packet_limit_bytes,
-            ),
-            refresh_scope,
-        ));
-    }
+    validate_mysql_session_exit(&result, process.client_packet_limit_bytes)
+        .map_err(|error| query_failed_after_change(error, refresh_scope))?;
 
     Ok(MySqlExecutionResult {
         result_set: last_result_set,

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -5,12 +5,12 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
 use super::super::args::{mysql_metadata_session_args, mysql_query_args};
-use super::super::error::classify_mysql_query_failure_with_packet_limit;
 use super::super::probe::{validate_lower_case_table_names, validate_sql_mode};
 use super::super::xml::{MySqlResultSet, parse_mysql_preview_xml, parse_mysql_xml};
 use super::{
     MySqlProcess, cleanup_mysql_process, configure_mysql_session, finish_mysql_session,
-    finish_mysql_session_after_preview_frame, read_one_mysql_resultset, write_mysql_statement,
+    finish_mysql_session_after_preview_frame, read_one_mysql_resultset,
+    validate_mysql_session_exit, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) struct MySqlMetadataSession {
@@ -86,18 +86,7 @@ impl MySqlMetadataSession {
 
     pub(in crate::adapters::mysql) async fn finish(&mut self) -> Result<(), DbOperationError> {
         let result = finish_mysql_session(&mut self.process).await?;
-        if super::has_mysql_cli_error(&result.error_bytes) {
-            return Err(classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                self.process.client_packet_limit_bytes,
-            ));
-        }
-        if !result.status.success() && !result.forcibly_stopped {
-            return Err(classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                self.process.client_packet_limit_bytes,
-            ));
-        }
+        validate_mysql_session_exit(&result, self.process.client_packet_limit_bytes)?;
         Ok(())
     }
 
@@ -120,18 +109,7 @@ impl MySqlMetadataSession {
             ));
         }
         let result = finish_mysql_session_after_preview_frame(&mut self.process).await?;
-        if super::has_mysql_cli_error(&result.error_bytes) {
-            return Err(classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                self.process.client_packet_limit_bytes,
-            ));
-        }
-        if !result.status.success() && !result.forcibly_stopped {
-            return Err(classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                self.process.client_packet_limit_bytes,
-            ));
-        }
+        validate_mysql_session_exit(&result, self.process.client_packet_limit_bytes)?;
         Ok(())
     }
 

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -4,9 +4,7 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::RefreshScope;
 
-use super::super::error::{
-    classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, validate_mode_probe,
-};
+use super::super::error::validate_mode_probe;
 use super::super::policy::{
     MYSQL_SESSION_MARKER_COLUMN, MySqlExecutionResult, validate_mysql_session_marker,
 };
@@ -14,7 +12,7 @@ use super::super::xml::parse_mysql_xml;
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
     read_one_mysql_resultset, read_one_mysql_resultset_with_diagnostics,
-    run_mysql_process_with_timeout, write_mysql_statement,
+    run_mysql_process_with_timeout, validate_mysql_session_exit, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
@@ -67,18 +65,7 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
     validate_mysql_session_marker(&marker_result, &session_marker)?;
 
     let result = finish_mysql_session(process).await?;
-    if has_mysql_cli_error(&result.error_bytes) {
-        return Err(classify_mysql_query_failure_with_packet_limit(
-            &result.error_bytes,
-            process.client_packet_limit_bytes,
-        ));
-    }
-    if !result.status.success() && !result.forcibly_stopped {
-        return Err(classify_mysql_query_failure_with_packet_limit(
-            &result.error_bytes,
-            process.client_packet_limit_bytes,
-        ));
-    }
+    validate_mysql_session_exit(&result, process.client_packet_limit_bytes)?;
 
     Ok(MySqlExecutionResult {
         result_set: Some(result_set),
@@ -113,18 +100,7 @@ pub(super) mod test_support {
         #[cfg(unix)]
         let stdout = read_one_mysql_resultset(process).await?;
         let result = finish_mysql_session(process).await?;
-        if has_mysql_cli_error(&result.error_bytes) {
-            return Err(classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                process.client_packet_limit_bytes,
-            ));
-        }
-        if !result.status.success() && !result.forcibly_stopped {
-            return Err(classify_mysql_query_failure_with_packet_limit(
-                &result.error_bytes,
-                process.client_packet_limit_bytes,
-            ));
-        }
+        validate_mysql_session_exit(&result, process.client_packet_limit_bytes)?;
         #[cfg(unix)]
         return parse_mysql_xml(&stdout);
         #[cfg(not(unix))]


### PR DESCRIPTION
<!-- Write all PR content in English. -->

## Problem
MySQL CLI session exit validation is duplicated across six execution paths, making the shared error, exit-status, forced-stop, and packet-limit rules harder to verify consistently.

## Background
The duplicated branches must preserve the same validation order while adhoc execution adds its own refresh-scope wrapping.

## Approach
Introduce one pure validator for `MySqlSessionResult` and the client packet limit, then reuse it from single-statement, metadata-session, adhoc, and export execution. Keep adhoc refresh wrapping at its caller and remove the export-only validator.
