### PR TITLE
refactor: centralize EXPLAIN ANALYZE execution start

### DIFF
--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -100,14 +100,7 @@ pub(super) fn reduce_analyze(
                         finish_explain_unsupported_analyze(state);
                         return DispatchResult::handled();
                     };
-                    return start_analyze_execution(
-                        state,
-                        now,
-                        dsn,
-                        database_type,
-                        explain_query,
-                        content,
-                    );
+                    return start_analyze_execution(state, now, dsn, explain_query, content);
                 }
             }
 
@@ -145,14 +138,7 @@ pub(super) fn reduce_analyze(
                     finish_explain_unsupported_analyze(state);
                     return DispatchResult::handled();
                 };
-                return start_analyze_execution(
-                    state,
-                    now,
-                    dsn,
-                    database_type,
-                    explain_query,
-                    query,
-                );
+                return start_analyze_execution(state, now, dsn, explain_query, query);
             }
             DispatchResult::handled()
         }
@@ -175,10 +161,10 @@ fn start_analyze_execution(
     state: &mut AppState,
     now: Instant,
     dsn: String,
-    database_type: DatabaseType,
     query: String,
     source_query: String,
 ) -> DispatchResult {
+    let database_type = state.session.active_database_type_or_default();
     let run_id = begin_explain_running(state, now);
     let database_generation = state.session.database_generation();
     DispatchResult::handled_with(vec![Effect::ExecuteExplain {
@@ -189,10 +175,8 @@ fn start_analyze_execution(
         query,
         source_query,
         is_analyze: true,
-        access_mode: if database_type == DatabaseType::MySQL {
-            AccessMode::ReadOnly
-        } else {
-            AccessMode::from_read_only(state.session.is_read_only())
-        },
+        access_mode: AccessMode::from_read_only(
+            database_type == DatabaseType::MySQL || state.session.is_read_only(),
+        ),
     }])
 }

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -93,12 +93,19 @@ pub(super) fn reduce_analyze(
                         .begin_confirming_analyze_risk(content, reason);
                 }
                 ConfirmationType::Immediate => {
+                    let Some(explain_query) = services
+                        .sql_dialect
+                        .build_explain_analyze_sql(database_type, &content)
+                    else {
+                        finish_explain_unsupported_analyze(state);
+                        return DispatchResult::handled();
+                    };
                     return start_analyze_execution(
                         state,
                         now,
-                        services,
                         dsn,
                         database_type,
+                        explain_query,
                         content,
                     );
                 }
@@ -131,7 +138,21 @@ pub(super) fn reduce_analyze(
                     finish_explain_unsupported_analyze(state);
                     return DispatchResult::handled();
                 }
-                return start_analyze_execution(state, now, services, dsn, database_type, query);
+                let Some(explain_query) = services
+                    .sql_dialect
+                    .build_explain_analyze_sql(database_type, &query)
+                else {
+                    finish_explain_unsupported_analyze(state);
+                    return DispatchResult::handled();
+                };
+                return start_analyze_execution(
+                    state,
+                    now,
+                    dsn,
+                    database_type,
+                    explain_query,
+                    query,
+                );
             }
             DispatchResult::handled()
         }
@@ -153,18 +174,11 @@ pub(super) fn reduce_analyze(
 fn start_analyze_execution(
     state: &mut AppState,
     now: Instant,
-    services: &AppServices,
     dsn: String,
     database_type: DatabaseType,
+    query: String,
     source_query: String,
 ) -> DispatchResult {
-    let Some(query) = services
-        .sql_dialect
-        .build_explain_analyze_sql(database_type, &source_query)
-    else {
-        finish_explain_unsupported_analyze(state);
-        return DispatchResult::handled();
-    };
     let run_id = begin_explain_running(state, now);
     let database_generation = state.session.database_generation();
     DispatchResult::handled_with(vec![Effect::ExecuteExplain {

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -93,29 +93,14 @@ pub(super) fn reduce_analyze(
                         .begin_confirming_analyze_risk(content, reason);
                 }
                 ConfirmationType::Immediate => {
-                    let Some(explain_query) = services
-                        .sql_dialect
-                        .build_explain_analyze_sql(database_type, &content)
-                    else {
-                        finish_explain_unsupported_analyze(state);
-                        return DispatchResult::handled();
-                    };
-                    let run_id = begin_explain_running(state, now);
-                    let database_generation = state.session.database_generation();
-                    return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
+                    return start_analyze_execution(
+                        state,
+                        now,
+                        services,
                         dsn,
                         database_type,
-                        database_generation,
-                        run_id,
-                        query: explain_query,
-                        source_query: content,
-                        is_analyze: true,
-                        access_mode: if database_type == DatabaseType::MySQL {
-                            AccessMode::ReadOnly
-                        } else {
-                            AccessMode::from_read_only(state.session.is_read_only())
-                        },
-                    }]);
+                        content,
+                    );
                 }
             }
 
@@ -146,29 +131,7 @@ pub(super) fn reduce_analyze(
                     finish_explain_unsupported_analyze(state);
                     return DispatchResult::handled();
                 }
-                let Some(explain_query) = services
-                    .sql_dialect
-                    .build_explain_analyze_sql(database_type, &query)
-                else {
-                    finish_explain_unsupported_analyze(state);
-                    return DispatchResult::handled();
-                };
-                let run_id = begin_explain_running(state, now);
-                let database_generation = state.session.database_generation();
-                return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
-                    dsn,
-                    database_type,
-                    database_generation,
-                    run_id,
-                    query: explain_query,
-                    source_query: query,
-                    is_analyze: true,
-                    access_mode: if database_type == DatabaseType::MySQL {
-                        AccessMode::ReadOnly
-                    } else {
-                        AccessMode::from_read_only(state.session.is_read_only())
-                    },
-                }]);
+                return start_analyze_execution(state, now, services, dsn, database_type, query);
             }
             DispatchResult::handled()
         }
@@ -185,4 +148,37 @@ pub(super) fn reduce_analyze(
         }
         _ => DispatchResult::pass(),
     }
+}
+
+fn start_analyze_execution(
+    state: &mut AppState,
+    now: Instant,
+    services: &AppServices,
+    dsn: String,
+    database_type: DatabaseType,
+    source_query: String,
+) -> DispatchResult {
+    let Some(query) = services
+        .sql_dialect
+        .build_explain_analyze_sql(database_type, &source_query)
+    else {
+        finish_explain_unsupported_analyze(state);
+        return DispatchResult::handled();
+    };
+    let run_id = begin_explain_running(state, now);
+    let database_generation = state.session.database_generation();
+    DispatchResult::handled_with(vec![Effect::ExecuteExplain {
+        dsn,
+        database_type,
+        database_generation,
+        run_id,
+        query,
+        source_query,
+        is_analyze: true,
+        access_mode: if database_type == DatabaseType::MySQL {
+            AccessMode::ReadOnly
+        } else {
+            AccessMode::from_read_only(state.session.is_read_only())
+        },
+    }])
 }


### PR DESCRIPTION
## Problem
`reduce_analyze` duplicated the EXPLAIN ANALYZE execution-start path, making the generated effect and run state harder to compare.

## Background
Immediate execution and post-confirmation execution must share the same query construction and execution metadata while retaining their separate safety checks.

## Approach
Added a private helper for building the EXPLAIN ANALYZE query, starting the run, and creating `Effect::ExecuteExplain`. Risk evaluation remains in the request path, and MySQL target revalidation remains in the confirmation path.
