### PR TITLE
refactor: embed SQL modal result payloads

### DIFF
--- a/src/app/model/shared/help.rs
+++ b/src/app/model/shared/help.rs
@@ -291,15 +291,17 @@ impl SqlHelpMode {
             | SqlModalStatus::ConfirmingRisk { .. }
             | SqlModalStatus::ConfirmingAnalyzeRisk { .. } => Self::Confirm,
             SqlModalStatus::Running => Self::Running,
-            SqlModalStatus::Normal | SqlModalStatus::Success | SqlModalStatus::Error => match state
-                .session
-                .active_engine_feature_profile()
-                .normalize_sql_modal_tab(state.sql_modal.active_tab())
-            {
-                SqlModalTab::Sql => Self::Normal,
-                SqlModalTab::Plan => Self::Plan,
-                SqlModalTab::Compare => Self::Compare,
-            },
+            SqlModalStatus::Normal | SqlModalStatus::Success(_) | SqlModalStatus::Error(_) => {
+                match state
+                    .session
+                    .active_engine_feature_profile()
+                    .normalize_sql_modal_tab(state.sql_modal.active_tab())
+                {
+                    SqlModalTab::Sql => Self::Normal,
+                    SqlModalTab::Plan => Self::Plan,
+                    SqlModalTab::Compare => Self::Compare,
+                }
+            }
         }
     }
 

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -42,7 +42,7 @@ pub struct FailedPrefetchEntry {
     pub retry_count: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdhocSuccessSnapshot {
     pub command_tag: Option<CommandTag>,
     pub row_count: usize,
@@ -76,16 +76,14 @@ pub enum SqlModalStatus {
         reason: AcknowledgeReason,
     },
     Running,
-    Success,
-    Error,
+    Success(AdhocSuccessSnapshot),
+    Error(String),
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct SqlModalContext {
     pub(crate) editor: MultiLineInputState,
     pub(crate) status: SqlModalStatus,
-    pub(crate) last_adhoc_success: Option<AdhocSuccessSnapshot>,
-    pub(crate) last_adhoc_error: Option<String>,
     pub(crate) completion: CompletionState,
     pub(crate) completion_debounce: Option<Instant>,
     prefetch_queue: VecDeque<String>,
@@ -242,15 +240,11 @@ impl SqlModalContext {
     }
 
     pub fn finish_adhoc_error(&mut self, error: String) {
-        self.status = SqlModalStatus::Error;
-        self.last_adhoc_error = Some(error);
-        self.last_adhoc_success = None;
+        self.status = SqlModalStatus::Error(error);
     }
 
     pub fn finish_adhoc_success(&mut self, snapshot: AdhocSuccessSnapshot) {
-        self.status = SqlModalStatus::Success;
-        self.last_adhoc_success = Some(snapshot);
-        self.last_adhoc_error = None;
+        self.status = SqlModalStatus::Success(snapshot);
     }
 
     pub fn begin_confirming_high(&mut self, decision: AdhocRiskDecision, target_name: String) {
@@ -300,11 +294,17 @@ impl SqlModalContext {
     }
 
     pub fn last_adhoc_error(&self) -> Option<&str> {
-        self.last_adhoc_error.as_deref()
+        match &self.status {
+            SqlModalStatus::Error(error) => Some(error),
+            _ => None,
+        }
     }
 
     pub fn last_adhoc_success(&self) -> Option<&AdhocSuccessSnapshot> {
-        self.last_adhoc_success.as_ref()
+        match &self.status {
+            SqlModalStatus::Success(snapshot) => Some(snapshot),
+            _ => None,
+        }
     }
 
     pub fn active_tab(&self) -> SqlModalTab {
@@ -762,22 +762,37 @@ mod tests {
         use super::*;
 
         #[test]
-        fn finish_statuses_clear_opposite_snapshot() {
+        fn finish_statuses_store_payload_and_reset() {
             let mut ctx = SqlModalContext::default();
 
-            ctx.finish_adhoc_success(AdhocSuccessSnapshot {
+            let snapshot = AdhocSuccessSnapshot {
                 command_tag: None,
                 row_count: 1,
                 execution_time_ms: 10,
                 mysql_diagnostics: Vec::new(),
-            });
+            };
+            ctx.finish_adhoc_success(snapshot.clone());
+            assert!(matches!(
+                &ctx.status,
+                SqlModalStatus::Success(payload) if payload == &snapshot
+            ));
             assert!(ctx.last_adhoc_success().is_some());
             assert!(ctx.last_adhoc_error().is_none());
 
             ctx.finish_adhoc_error("syntax error".to_string());
 
+            assert!(matches!(
+                &ctx.status,
+                SqlModalStatus::Error(error) if error == "syntax error"
+            ));
             assert!(ctx.last_adhoc_success().is_none());
             assert_eq!(ctx.last_adhoc_error(), Some("syntax error"));
+
+            ctx.enter_normal();
+
+            assert_eq!(ctx.status, SqlModalStatus::Normal);
+            assert!(ctx.last_adhoc_success().is_none());
+            assert!(ctx.last_adhoc_error().is_none());
         }
     }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1876,7 +1876,10 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ExecutePreview { .. }))
             );
-            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Success);
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Success(_)
+            ));
         }
 
         #[test]

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -54,7 +54,7 @@ fn handle_sql_modal_keys_internal(
     // Normal / Success / Error share the same command set (no text editing)
     if matches!(
         status,
-        SqlModalStatus::Normal | SqlModalStatus::Success | SqlModalStatus::Error
+        SqlModalStatus::Normal | SqlModalStatus::Success(_) | SqlModalStatus::Error(_)
     ) {
         let ctrl = combo.modifiers.contains(Modifiers::CTRL);
         let alt = combo.modifiers.contains(Modifiers::ALT);
@@ -393,6 +393,7 @@ fn handle_sql_modal_keys_internal(
 mod tests {
     use super::*;
     use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
+    use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
     use crate::update::action::CursorMove;
     use crate::update::input::keybindings::{Key, KeyCombo};
     use rstest::rstest;
@@ -407,6 +408,19 @@ mod tests {
 
     fn combo_alt(k: Key) -> KeyCombo {
         KeyCombo::alt(k)
+    }
+
+    fn success_status() -> SqlModalStatus {
+        SqlModalStatus::Success(AdhocSuccessSnapshot {
+            command_tag: None,
+            row_count: 0,
+            execution_time_ms: 0,
+            mysql_diagnostics: Vec::new(),
+        })
+    }
+
+    fn error_status() -> SqlModalStatus {
+        SqlModalStatus::Error("error".to_string())
     }
 
     fn handle_sql_modal_keys(
@@ -1185,8 +1199,8 @@ mod tests {
         }
 
         #[rstest]
-        #[case(SqlModalStatus::Success)]
-        #[case(SqlModalStatus::Error)]
+        #[case(success_status())]
+        #[case(error_status())]
         fn success_error_share_normal_keybindings(#[case] status: SqlModalStatus) {
             let yank =
                 handle_sql_modal_keys(combo(Key::Char('y')), false, &status, SqlModalTab::Sql);
@@ -1470,8 +1484,8 @@ mod tests {
         }
 
         #[rstest]
-        #[case(SqlModalStatus::Success)]
-        #[case(SqlModalStatus::Error)]
+        #[case(success_status())]
+        #[case(error_status())]
         fn plan_tab_read_only_keys_work_in_success_error(#[case] status: SqlModalStatus) {
             let scroll =
                 handle_sql_modal_keys(combo(Key::Char('j')), false, &status, SqlModalTab::Plan);
@@ -1482,8 +1496,8 @@ mod tests {
         }
 
         #[rstest]
-        #[case(SqlModalStatus::Success)]
-        #[case(SqlModalStatus::Error)]
+        #[case(success_status())]
+        #[case(error_status())]
         fn compare_tab_read_only_keys_work_in_success_error(#[case] status: SqlModalStatus) {
             let scroll =
                 handle_sql_modal_keys(combo(Key::Char('j')), false, &status, SqlModalTab::Compare);

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -412,7 +412,7 @@ mod tests {
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error));
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
             assert_eq!(
                 state.sql_modal.last_adhoc_error(),
                 Some("No active connection")
@@ -521,7 +521,7 @@ mod tests {
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalConfirmExecute, Instant::now());
 
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error));
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
             assert_eq!(
                 state.sql_modal.last_adhoc_error(),
                 Some("No active connection")
@@ -732,7 +732,7 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(effects.is_empty());
-            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Error);
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
             assert_eq!(
                 state.sql_modal.last_adhoc_error(),
                 Some("Read-only mode: write operations are disabled")
@@ -764,7 +764,7 @@ mod tests {
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Error);
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
             assert!(state.sql_modal.last_adhoc_success().is_none());
             assert!(state.sql_modal.last_adhoc_error().is_some());
         }
@@ -820,7 +820,7 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(effects.is_empty());
-            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Error);
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
             assert_eq!(
                 state.sql_modal.last_adhoc_error(),
                 Some("Read-only mode: write operations are disabled")

--- a/src/ui/features/sql_modal/editor.rs
+++ b/src/ui/features/sql_modal/editor.rs
@@ -51,7 +51,7 @@ pub(super) fn render_editor(
 
     let is_normal = matches!(
         state.sql_modal.status(),
-        SqlModalStatus::Normal | SqlModalStatus::Success | SqlModalStatus::Error
+        SqlModalStatus::Normal | SqlModalStatus::Success(_) | SqlModalStatus::Error(_)
     );
 
     let (cursor_row, cursor_col) = state.sql_modal.editor().cursor_to_position();

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -6,7 +6,9 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::text_input::TextInputState;
-use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
+use crate::app::model::sql_editor::modal::{
+    AdhocSuccessSnapshot, HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus,
+};
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::policy::write::write_guardrails::AdhocRiskDecision;
 use crate::domain::MySqlDiagnostic;
@@ -15,11 +17,7 @@ use crate::primitives::utils::text_utils::{truncate_to_width_with, wrapped_line_
 use crate::theme::ThemePalette;
 
 pub(super) fn status_height(state: &AppState, width: u16) -> u16 {
-    if !matches!(state.sql_modal.status(), SqlModalStatus::Success) {
-        return 1;
-    }
-
-    let Some(snapshot) = state.sql_modal.last_adhoc_success() else {
+    let SqlModalStatus::Success(snapshot) = state.sql_modal.status() else {
         return 1;
     };
     if snapshot.mysql_diagnostics.is_empty() {
@@ -27,7 +25,7 @@ pub(super) fn status_height(state: &AppState, width: u16) -> u16 {
     }
 
     let status_width = width.saturating_sub(" [NORMAL]".len() as u16 + 1);
-    let base_lines = wrapped_line_count(&success_status_message(state), status_width);
+    let base_lines = wrapped_line_count(&success_status_message(snapshot), status_width);
     let diagnostic_lines = snapshot
         .mysql_diagnostics
         .iter()
@@ -52,13 +50,10 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
         return;
     }
 
-    if matches!(state.sql_modal.status(), SqlModalStatus::Success)
-        && state
-            .sql_modal
-            .last_adhoc_success()
-            .is_some_and(|snapshot| !snapshot.mysql_diagnostics.is_empty())
+    if let SqlModalStatus::Success(snapshot) = state.sql_modal.status()
+        && !snapshot.mysql_diagnostics.is_empty()
     {
-        render_success_status_with_diagnostics(frame, area, state, theme);
+        render_success_status_with_diagnostics(frame, area, snapshot, theme);
         return;
     }
 
@@ -104,8 +99,8 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
                 Style::default().fg(theme.semantic.text.accent),
             )
         }
-        SqlModalStatus::Success => {
-            let msg = success_status_message(state);
+        SqlModalStatus::Success(snapshot) => {
+            let msg = success_status_message(snapshot);
             (
                 "[NORMAL]",
                 Style::default().fg(theme.semantic.status.success),
@@ -115,8 +110,8 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
                     .add_modifier(Modifier::BOLD),
             )
         }
-        SqlModalStatus::Error => {
-            let msg = error_status_message(state);
+        SqlModalStatus::Error(error) => {
+            let msg = error_status_message(error);
             (
                 "[NORMAL]",
                 Style::default().fg(theme.semantic.status.error),
@@ -260,10 +255,7 @@ fn render_confirming_risk_status(
     frame.render_widget(Paragraph::new(vec![line1, line2]), area);
 }
 
-fn success_status_message(state: &AppState) -> String {
-    let Some(snapshot) = state.sql_modal.last_adhoc_success() else {
-        return "\u{2713} OK".to_string();
-    };
+fn success_status_message(snapshot: &AdhocSuccessSnapshot) -> String {
     let time_secs = snapshot.execution_time_ms as f64 / 1000.0;
 
     if let Some(tag) = snapshot.command_tag.as_ref() {
@@ -284,7 +276,7 @@ fn success_status_message(state: &AppState) -> String {
 fn render_success_status_with_diagnostics(
     frame: &mut Frame,
     area: Rect,
-    state: &AppState,
+    snapshot: &AdhocSuccessSnapshot,
     theme: &ThemePalette,
 ) {
     let badge_display = " [NORMAL]";
@@ -301,19 +293,17 @@ fn render_success_status_with_diagnostics(
     );
 
     let mut lines = vec![Line::from(Span::styled(
-        format!("{} ", success_status_message(state)),
+        format!("{} ", success_status_message(snapshot)),
         Style::default()
             .fg(theme.semantic.status.success)
             .add_modifier(Modifier::BOLD),
     ))];
-    if let Some(snapshot) = state.sql_modal.last_adhoc_success() {
-        lines.extend(snapshot.mysql_diagnostics.iter().map(|diagnostic| {
-            Line::from(Span::styled(
-                diagnostic_status_line(diagnostic),
-                Style::default().fg(theme.semantic.status.warning),
-            ))
-        }));
-    }
+    lines.extend(snapshot.mysql_diagnostics.iter().map(|diagnostic| {
+        Line::from(Span::styled(
+            diagnostic_status_line(diagnostic),
+            Style::default().fg(theme.semantic.status.warning),
+        ))
+    }));
     frame.render_widget(
         Paragraph::new(lines).wrap(Wrap { trim: false }),
         status_area,
@@ -324,21 +314,16 @@ fn diagnostic_status_line(diagnostic: &MySqlDiagnostic) -> String {
     format!("⚠ {}", diagnostic.display_message())
 }
 
-fn error_status_message(state: &AppState) -> String {
-    state
-        .sql_modal
-        .last_adhoc_error()
-        .and_then(|e| e.lines().next())
-        .map_or_else(
-            || "\u{2717} Error".to_string(),
-            |line| format!("\u{2717} {line}"),
-        )
+fn error_status_message(error: &str) -> String {
+    error.lines().next().map_or_else(
+        || "\u{2717} Error".to_string(),
+        |line| format!("\u{2717} {line}"),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::model::sql_editor::modal::AdhocSuccessSnapshot;
     use crate::domain::MySqlDiagnosticLevel;
 
     #[test]
@@ -360,7 +345,7 @@ mod tests {
             SqlModalStatus::Normal,
             SqlModalStatus::Editing,
             SqlModalStatus::Running,
-            SqlModalStatus::Error,
+            SqlModalStatus::Error("error".to_string()),
         ] {
             state.sql_modal.set_status_for_test(status);
             assert_eq!(status_height(&state, 80), 1);

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -258,8 +258,8 @@ impl Footer {
                 } else if matches!(
                     state.sql_modal.status(),
                     SqlModalStatus::Normal
-                        | SqlModalStatus::Success
-                        | SqlModalStatus::Error
+                        | SqlModalStatus::Success(_)
+                        | SqlModalStatus::Error(_)
                         | SqlModalStatus::ConfirmingAnalyzeHigh { .. }
                         | SqlModalStatus::ConfirmingAnalyzeRisk { .. }
                 ) {


### PR DESCRIPTION
## Problem
`SqlModalStatus` stores adhoc success and error payloads separately from the status variant, allowing the status and displayed payload to become inconsistent.

## Background
The SQL modal status renderer first checks the status and then reads a parallel `Option`, including fallback handling for missing payloads.

## Approach
Embed the success snapshot and error message directly in their status variants, derive the existing accessors from that single state, and render status payloads directly from the matched variant.
