### PR TITLE
refactor: remove completion candidate forwarding wrapper

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -367,27 +367,6 @@ impl CompletionEngine {
         recent_columns: &[String],
         scope: CompletionDatabaseScope<'_>,
     ) -> Vec<CompletionCandidate> {
-        self.get_candidates_inner(
-            content,
-            cursor_pos,
-            prep,
-            metadata,
-            table_detail,
-            recent_columns,
-            scope,
-        )
-    }
-
-    fn get_candidates_inner(
-        &self,
-        content: &str,
-        cursor_pos: usize,
-        prep: &PreparedCompletion,
-        metadata: Option<&DatabaseMetadata>,
-        table_detail: Option<&Table>,
-        recent_columns: &[String],
-        scope: CompletionDatabaseScope<'_>,
-    ) -> Vec<CompletionCandidate> {
         if prep.in_string_or_comment {
             return vec![];
         }


### PR DESCRIPTION
<!-- Write all PR content in English. -->

## Problem
Completion candidate generation passes through a private forwarding wrapper before reaching its implementation.

## Background
The extra call edge adds no behavior and makes the completion path harder to read.

## Approach
Promote the existing prepared-candidate implementation to the retained `pub(crate)` entry point while preserving its signature, scope, and behavior.

## Screenshots
<!-- Screenshots/GIF. Optional -->
