### PR TITLE
refactor(mysql): centralize XML sql_mode probe

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -5,31 +5,27 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use crate::adapters::csv_export::CsvFileWriter;
+use crate::app::ports::outbound::{AccessMode, DbOperationError};
+use crate::domain::{RefreshScope, mysql_sql::classify_mysql_statement};
 use quick_xml::Reader;
 use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use tokio::io::{AsyncRead, BufReader, ReadBuf};
-use uuid::Uuid;
-
-use crate::adapters::csv_export::CsvFileWriter;
-use crate::app::ports::outbound::{AccessMode, DbOperationError};
-use crate::domain::{RefreshScope, mysql_sql::classify_mysql_statement};
 
 use super::super::{dsn::MySqlDsn, option_file::MySqlOptionFile};
-use super::error::{
-    classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, validate_mode_probe,
-};
+use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
 #[cfg(not(unix))]
 use super::pipe::MySqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
 use super::process::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
-    mysql_metadata_columns, read_one_mysql_resultset, run_mysql_process_with_timeout,
-    validate_mysql_session_exit, write_mysql_statement,
+    mysql_metadata_columns, run_mysql_process_with_timeout, validate_mysql_session_exit,
+    write_mysql_statement,
 };
 #[cfg(unix)]
 use super::pty::MySqlExportPtySource;
-use super::xml::{MySqlField, decode_mysql_xml_reference, parse_mysql_field, parse_mysql_xml};
+use super::xml::{MySqlField, decode_mysql_xml_reference, parse_mysql_field};
 
 const MYSQL_EXPORT_TIMEOUT: Duration = Duration::from_secs(MYSQL_QUERY_TIMEOUT.as_secs() * 10);
 const MYSQL_CSV_MAX_DECODED_FIELD_BYTES: usize = 16 * 1024 * 1024;
@@ -369,14 +365,7 @@ pub(super) async fn run_mysql_export_process(
     path: PathBuf,
 ) -> Result<(), DbOperationError> {
     configure_mysql_session(process, AccessMode::ReadOnly).await?;
-
-    let marker = Uuid::new_v4().simple().to_string();
-    let probe_query =
-        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
-    write_mysql_statement(process, &probe_query).await?;
-    let probe_xml = read_one_mysql_resultset(process).await?;
-    let probe = parse_mysql_xml(&probe_xml)?;
-    validate_mode_probe(&probe, &marker)?;
+    process.probe_sql_mode().await?;
 
     write_mysql_statement(process, query).await?;
     let mut csv_writer = CsvFileWriter::create(path).await?;

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -17,7 +17,9 @@ use crate::domain::{MySqlDiagnostic, RefreshScope};
 use super::args::{MYSQL_CLIENT_MAX_PACKET_BYTES, mysql_adhoc_args, mysql_query_args};
 #[cfg(not(unix))]
 use super::error::classify_mysql_query_failure;
-use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
+use super::error::{
+    classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, validate_mode_probe,
+};
 #[cfg(not(unix))]
 use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
 use super::policy::{
@@ -81,6 +83,19 @@ impl MySqlProcess {
         option_file: &std::path::Path,
     ) -> Result<Self, DbOperationError> {
         Self::spawn_with_query_args(program, mysql_adhoc_args(option_file))
+    }
+
+    pub(in crate::adapters::mysql::cli) async fn probe_sql_mode(
+        &mut self,
+    ) -> Result<(), DbOperationError> {
+        let probe_marker = Uuid::new_v4().simple().to_string();
+        let probe_query = format!(
+            "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
+        );
+        write_mysql_statement(self, &probe_query).await?;
+        let probe_xml = read_one_mysql_resultset(self).await?;
+        let probe = parse_mysql_xml(&probe_xml)?;
+        validate_mode_probe(&probe, &probe_marker)
     }
 
     pub(in crate::adapters::mysql) fn spawn_with_query_args(

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -14,7 +14,6 @@ use crate::domain::{
     },
 };
 
-use super::super::error::validate_mode_probe;
 use super::super::policy::{
     MySqlExecutionResult, mysql_command_tag, mysql_metadata_fallback_has_unsupported_session_state,
     mysql_possible_refresh_scope, mysql_refresh_scope, mysql_row_count_marker,
@@ -24,8 +23,8 @@ use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns_with_diagnostics;
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
-    read_one_mysql_resultset, read_one_mysql_resultset_with_diagnostics,
-    run_mysql_process_with_timeout, validate_mysql_session_exit, write_mysql_statement,
+    read_one_mysql_resultset_with_diagnostics, run_mysql_process_with_timeout,
+    validate_mysql_session_exit, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
@@ -237,15 +236,7 @@ async fn run_mysql_adhoc_process(
     expected_columns: Option<&[&str]>,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     configure_mysql_session(process, access_mode).await?;
-
-    let probe_marker = Uuid::new_v4().simple().to_string();
-    let probe_query = format!(
-        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
-    );
-    write_mysql_statement(process, &probe_query).await?;
-    let probe_xml = read_one_mysql_resultset(process).await?;
-    let probe = super::parse_mysql_xml(&probe_xml)?;
-    validate_mode_probe(&probe, &probe_marker)?;
+    process.probe_sql_mode().await?;
 
     let mut last_result_set = None;
     let mut last_result_statement = None;

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -4,15 +4,14 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::RefreshScope;
 
-use super::super::error::validate_mode_probe;
 use super::super::policy::{
     MYSQL_SESSION_MARKER_COLUMN, MySqlExecutionResult, validate_mysql_session_marker,
 };
 use super::super::xml::parse_mysql_xml;
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
-    read_one_mysql_resultset, read_one_mysql_resultset_with_diagnostics,
-    run_mysql_process_with_timeout, validate_mysql_session_exit, write_mysql_statement,
+    read_one_mysql_resultset_with_diagnostics, run_mysql_process_with_timeout,
+    validate_mysql_session_exit, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
@@ -38,15 +37,7 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
     access_mode: AccessMode,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     configure_mysql_session(process, access_mode).await?;
-
-    let probe_marker = Uuid::new_v4().simple().to_string();
-    let probe_query = format!(
-        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
-    );
-    write_mysql_statement(process, &probe_query).await?;
-    let probe_xml = read_one_mysql_resultset(process).await?;
-    let probe = parse_mysql_xml(&probe_xml)?;
-    validate_mode_probe(&probe, &probe_marker)?;
+    process.probe_sql_mode().await?;
 
     write_mysql_statement(process, query).await?;
     let (stdout, mut diagnostics) = read_one_mysql_resultset_with_diagnostics(process).await?;
@@ -78,6 +69,7 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
 #[cfg(test)]
 pub(super) mod test_support {
     use super::super::super::xml::MySqlResultSet;
+    use super::super::read_one_mysql_resultset;
     use super::*;
 
     pub async fn run_mysql_single_statement_process(
@@ -86,14 +78,7 @@ pub(super) mod test_support {
         access_mode: AccessMode,
     ) -> Result<MySqlResultSet, DbOperationError> {
         configure_mysql_session(process, access_mode).await?;
-
-        let marker = Uuid::new_v4().simple().to_string();
-        let probe_query =
-            format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
-        write_mysql_statement(process, &probe_query).await?;
-        let probe_xml = read_one_mysql_resultset(process).await?;
-        let probe = parse_mysql_xml(&probe_xml)?;
-        validate_mode_probe(&probe, &marker)?;
+        process.probe_sql_mode().await?;
 
         write_mysql_statement(process, query).await?;
 


### PR DESCRIPTION
## Summary

- Centralize the XML `sql_mode` probe on `MySqlProcess`.
- Reuse it from adhoc execution, single-statement execution, CSV export, and the single-statement test helper.
- Keep the external metadata pipe probe separate.

## Testing

- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-009-target cargo check -p sabiql-infra`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-009-target cargo test -p sabiql-infra configures_read_only_session_before_user_sql -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-009-target cargo test -p sabiql-infra sends_user_sql_only_after_a_valid_mode_probe -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-009-target cargo test -p sabiql-infra diagnostics_use_adhoc_args_and_follow_resultset_to_marker -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-009-target cargo clippy -p sabiql-infra --all-targets -- -D warnings`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-009-target cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR= bash scripts/lint_all.sh`
