### PR TITLE
refactor(app): remove unused SQL context positions

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -2954,7 +2954,6 @@ mod tests {
                     schema: None,
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,
@@ -2976,7 +2975,6 @@ mod tests {
                     schema: None,
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,
@@ -2998,7 +2996,6 @@ mod tests {
                     schema: None,
                     table: "users".to_string(),
                     alias: None,
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,
@@ -3020,7 +3017,6 @@ mod tests {
                     schema: None,
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,
@@ -3050,7 +3046,6 @@ mod tests {
                 tables: vec![],
                 ctes: vec![CteDefinition {
                     name: "active_users".to_string(),
-                    position: 5,
                 }],
                 target_table: None,
             };
@@ -3068,7 +3063,6 @@ mod tests {
                 tables: vec![],
                 ctes: vec![CteDefinition {
                     name: "active_users".to_string(),
-                    position: 5,
                 }],
                 target_table: None,
             };
@@ -3097,11 +3091,9 @@ mod tests {
                 ctes: vec![
                     CteDefinition {
                         name: "active_users".to_string(),
-                        position: 5,
                     },
                     CteDefinition {
                         name: "banned_users".to_string(),
-                        position: 50,
                     },
                 ],
                 target_table: None,
@@ -3142,7 +3134,6 @@ mod tests {
                     schema: Some("public".to_string()),
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,
@@ -3178,7 +3169,6 @@ mod tests {
                     schema: None,
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,
@@ -3216,7 +3206,6 @@ mod tests {
                     schema: Some("public".to_string()),
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 0,
                 }],
                 ctes: vec![],
                 target_table: None,

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -27,13 +27,11 @@ pub struct TableReference {
     pub schema: Option<String>,
     pub table: String,
     pub alias: Option<String>,
-    pub position: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CteDefinition {
     pub name: String,
-    pub position: usize,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1008,7 +1006,6 @@ impl SqlLexer {
             return None;
         }
 
-        let position = tokens[*i].start;
         let mut schema = None;
         let mut table;
         let mut alias = None;
@@ -1121,7 +1118,6 @@ impl SqlLexer {
             schema,
             table,
             alias,
-            position,
         })
     }
 
@@ -1190,17 +1186,13 @@ impl SqlLexer {
                     }
 
                     // Get CTE name
-                    let position = tokens[i].start;
                     if let TokenKind::Identifier(name)
                     | TokenKind::BacktickIdentifier(name)
                     | TokenKind::Keyword(name) = &tokens[i].kind
                     {
                         // Don't treat SELECT as a CTE name
                         if name != "SELECT" {
-                            ctes.push(CteDefinition {
-                                name: name.clone(),
-                                position,
-                            });
+                            ctes.push(CteDefinition { name: name.clone() });
                         }
                         i += 1;
 
@@ -1854,7 +1846,6 @@ mod tests {
                     schema: Some("app".to_string()),
                     table: "users".to_string(),
                     alias: Some("u".to_string()),
-                    position: 14,
                 }]
             );
         }


### PR DESCRIPTION
<!-- Write all PR content in English. -->

## Problem

SQL context entries retain unused position data, adding fields and construction-only state to lexer and completion fixtures.

## Background

The values are produced but never read by lexer or completion logic.

## Approach

Remove the unused position fields and construction values while keeping token ranges, table/CTE/target extraction, cursor scoping, and completion behavior unchanged.
