### PR TITLE
refactor(app): remove unused LoadTableDetail action

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -474,7 +474,6 @@ pub enum Action {
         run_id: u64,
         effective_user: Option<String>,
     },
-    LoadTableDetail(TableTarget),
     TableDetailLoaded {
         dsn: String,
         run_id: u64,

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::model::shared::input_mode::InputMode;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
     use crate::ports::outbound::DbOperationError;
-    use crate::update::action::{Action, TableTarget};
+    use crate::update::action::Action;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -161,30 +161,6 @@ mod tests {
             assert!(matches!(
                 state.session.table_detail_state(),
                 TableDetailState::Error(_)
-            ));
-            assert!(state.messages.last_error().is_some());
-        }
-
-        #[test]
-        fn table_detail_load_without_connection_ends_loading_state() {
-            let mut state = AppState::new("test".to_string());
-            let generation = state
-                .session
-                .select_table("public", "users", &mut state.query);
-
-            dispatch_metadata(
-                &mut state,
-                &Action::LoadTableDetail(TableTarget {
-                    schema: "public".to_string(),
-                    table: "users".to_string(),
-                    generation,
-                }),
-                Instant::now(),
-            );
-
-            assert!(matches!(
-                state.session.table_detail_state(),
-                TableDetailState::Error(message) if message == "No active connection"
             ));
             assert!(state.messages.last_error().is_some());
         }

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::update::action::{Action, TableTarget};
+use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn reduce_table_detail(
@@ -50,38 +50,6 @@ pub(super) fn reduce_table_detail(
                 return DispatchResult::handled_with(reveal_pending_preview(state, *generation));
             }
             DispatchResult::handled()
-        }
-        Action::LoadTableDetail(TableTarget {
-            schema,
-            table,
-            generation,
-        }) => {
-            if !state
-                .session
-                .is_current_table_selection(schema, table, *generation)
-            {
-                return DispatchResult::handled();
-            }
-
-            let Some(dsn) = state.session.dsn().map(String::from) else {
-                let message = "No active connection".to_string();
-                if state
-                    .session
-                    .mark_table_detail_failed(*generation, message.clone())
-                {
-                    state.messages.set_error_at(message, now);
-                }
-                return DispatchResult::handled();
-            };
-
-            let run_id = state.session.begin_table_detail_run();
-            DispatchResult::handled_with(vec![Effect::FetchTableDetail {
-                dsn,
-                schema: schema.clone(),
-                table: table.clone(),
-                generation: *generation,
-                run_id,
-            }])
         }
         _ => DispatchResult::pass(),
     }


### PR DESCRIPTION
## Problem
`Action::LoadTableDetail` has no production emitter, so its reducer arm and dedicated test preserve an obsolete table-detail entrypoint.

## Background
Table selection and metadata reload already issue `Effect::FetchTableDetail` directly, while stale completion handling remains in the table-detail reducer.

## Approach
Remove the unused action variant, reducer arm, and dedicated no-connection test while preserving direct table-detail fetches, stale-run guards, and reload refresh behavior.