### PR TITLE
refactor(app): derive query running state from start time

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -14,13 +14,6 @@ pub enum VisibleResultKind {
     Empty,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum QueryStatus {
-    #[default]
-    Idle,
-    Running,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct PaginationState {
     current_page: usize,
@@ -177,7 +170,6 @@ impl PendingPreview {
 
 #[derive(Debug, Clone, Default)]
 pub struct QueryExecution {
-    status: QueryStatus,
     start_time: Option<Instant>,
     current_result: Option<Arc<QueryResult>>,
     result_history: ResultHistory,
@@ -195,14 +187,12 @@ impl QueryExecution {
 
     #[must_use]
     pub fn begin_running(&mut self, now: Instant) -> u64 {
-        self.status = QueryStatus::Running;
         self.start_time = Some(now);
         self.pending_preview = None;
         self.run.begin()
     }
 
     pub fn mark_idle(&mut self) {
-        self.status = QueryStatus::Idle;
         self.start_time = None;
         self.run.clear_active();
     }
@@ -222,16 +212,12 @@ impl QueryExecution {
         self.run.is_current(run_id)
     }
 
-    pub fn status(&self) -> QueryStatus {
-        self.status
-    }
-
     pub fn start_time(&self) -> Option<Instant> {
         self.start_time
     }
 
     pub fn is_running(&self) -> bool {
-        self.status == QueryStatus::Running
+        self.start_time.is_some()
     }
 
     // ── Current result ──────────────────────────────────────────────
@@ -509,7 +495,7 @@ mod tests {
     fn default_creates_idle_state() {
         let execution = QueryExecution::default();
 
-        assert_eq!(execution.status(), QueryStatus::Idle);
+        assert!(!execution.is_running());
         assert!(execution.start_time().is_none());
         assert!(execution.current_result().is_none());
         assert_eq!(execution.result_generation(), 0);
@@ -563,11 +549,6 @@ mod tests {
     }
 
     #[test]
-    fn query_status_default_is_idle() {
-        assert_eq!(QueryStatus::default(), QueryStatus::Idle);
-    }
-
-    #[test]
     fn context_reset_clears_query_owned_write_state() {
         let mut execution = QueryExecution::default();
         let run_id = execution.begin_running(Instant::now());
@@ -577,7 +558,7 @@ mod tests {
 
         execution.reset_for_context_change();
 
-        assert_eq!(execution.status(), QueryStatus::Idle);
+        assert!(!execution.is_running());
         assert!(!execution.is_current_run(run_id));
         assert!(execution.pending_delete_refresh_target().is_none());
         assert!(!execution.has_pending_preview(1));

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -452,7 +452,7 @@ mod tests {
         ColumnAttributes, DatabaseType, QueryResult, QuerySource, QueryValue, WriteDiagnosticLevel,
     };
     use crate::model::browse::query_execution::{
-        DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
+        DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection,
     };
     use crate::policy::write::write_guardrails::{
         GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
@@ -1329,7 +1329,7 @@ mod tests {
                 dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(state.query.status(), QueryStatus::Running);
+            assert!(state.query.is_running());
             assert!(state.query.start_time().is_some());
             assert_eq!(effects.len(), 1);
             match &effects[0] {
@@ -1355,7 +1355,7 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(state.query.status(), QueryStatus::Running);
+            assert!(state.query.is_running());
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("UPDATE expected 1 row, but affected 0 rows")
@@ -1376,7 +1376,7 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(state.query.status(), QueryStatus::Running);
+            assert!(state.query.is_running());
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("UPDATE expected 1 row, but affected 2 rows")
@@ -1451,7 +1451,7 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(!state.result_interaction.cell_edit().is_active());
-            assert_eq!(state.query.status(), QueryStatus::Running);
+            assert!(state.query.is_running());
             assert!(effects.iter().any(|effect| matches!(
                 effect,
                 Effect::ExecutePreview { table, .. } if table == "users"
@@ -1482,7 +1482,7 @@ mod tests {
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(!state.result_interaction.cell_edit().is_active());
             assert!(state.session.table_detail().is_none());
-            assert_eq!(state.query.status(), QueryStatus::Idle);
+            assert!(!state.query.is_running());
             assert!(
                 effects
                     .iter()

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -9,7 +9,6 @@ use crate::domain::connection::{
 };
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
-use crate::model::browse::query_execution::QueryStatus;
 use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
 use crate::policy::write::inline_cell_edit::InlineCellEditError;
 use crate::policy::write::write_guardrails::{
@@ -218,7 +217,7 @@ pub fn build_bulk_delete_preview(
     if state.session.dsn().is_none() {
         return Err(EditGuardrailError::NoActiveConnection);
     }
-    if state.query.status() != QueryStatus::Idle {
+    if state.query.is_running() {
         return Err(EditGuardrailError::WriteUnavailableWhileQueryRunning);
     }
 


### PR DESCRIPTION
## Problem

`QueryExecution` stores whether a query is running in both `QueryStatus` and `start_time`, so lifecycle methods must keep duplicate state synchronized.

## Background

The query start timestamp already defines the same running interval used by elapsed-time rendering.

## Approach

Derive `is_running()` from `start_time` and remove the redundant status type, field, accessor, and assignments while preserving `AsyncRun`, run IDs, timing, rendering, and query lifecycle order.
