### PR TITLE
refactor(mysql): centralize CLI spawn error mapping

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -50,6 +50,17 @@ const MYSQL_PTY_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const MYSQL_SESSION_SETTINGS: &str = "SET SESSION autocommit=1, completion_type=NO_CHAIN";
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
 
+fn map_mysql_cli_spawn_error(error: io::Error) -> DbOperationError {
+    if error.kind() == io::ErrorKind::NotFound {
+        DbOperationError::CommandNotFound {
+            command: DatabaseCli::MySql,
+            details: error.to_string(),
+        }
+    } else {
+        DbOperationError::ConnectionFailed(error.to_string())
+    }
+}
+
 pub(in crate::adapters::mysql) struct MySqlProcess {
     pub(super) child: Child,
     pub(super) client_packet_limit_bytes: Option<usize>,
@@ -145,16 +156,7 @@ impl MySqlProcess {
                 .stderr(Stdio::piped())
                 .kill_on_drop(true);
             sanitize_mysql_command_environment(&mut command);
-            let mut child = command.spawn().map_err(|error| {
-                if error.kind() == io::ErrorKind::NotFound {
-                    DbOperationError::CommandNotFound {
-                        command: DatabaseCli::MySql,
-                        details: error.to_string(),
-                    }
-                } else {
-                    DbOperationError::ConnectionFailed(error.to_string())
-                }
-            })?;
+            let mut child = command.spawn().map_err(map_mysql_cli_spawn_error)?;
             let stdin = child.stdin.take().ok_or_else(|| {
                 DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
             })?;
@@ -200,16 +202,7 @@ impl MySqlProcess {
             .stderr(Stdio::from(slave))
             .kill_on_drop(true);
         sanitize_mysql_command_environment(&mut command);
-        let child = command.spawn().map_err(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
-                DbOperationError::CommandNotFound {
-                    command: DatabaseCli::MySql,
-                    details: error.to_string(),
-                }
-            } else {
-                DbOperationError::ConnectionFailed(error.to_string())
-            }
-        })?;
+        let child = command.spawn().map_err(map_mysql_cli_spawn_error)?;
         let output = TokioFile::from_std(
             master
                 .try_clone()
@@ -227,6 +220,41 @@ impl MySqlProcess {
                 frame_scanner: MySqlResultsetFrameScanner::default(),
             },
         })
+    }
+}
+
+#[cfg(test)]
+mod spawn_error_tests {
+    use super::*;
+
+    #[test]
+    fn maps_missing_mysql_cli_to_command_not_found() {
+        let error = map_mysql_cli_spawn_error(io::Error::new(
+            io::ErrorKind::NotFound,
+            "mysql executable was not found",
+        ));
+
+        assert!(matches!(
+            error,
+            DbOperationError::CommandNotFound {
+                command: DatabaseCli::MySql,
+                details,
+            } if details == "mysql executable was not found"
+        ));
+    }
+
+    #[test]
+    fn maps_other_mysql_cli_spawn_errors_to_connection_failed() {
+        let error = map_mysql_cli_spawn_error(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "mysql executable permission denied",
+        ));
+
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "mysql executable permission denied"
+        ));
     }
 }
 

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsStr;
-use std::io;
 use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
@@ -8,7 +7,7 @@ use tokio::process::{Child, Command};
 use tokio::time::timeout;
 use uuid::Uuid;
 
-use crate::app::ports::outbound::{AccessMode, DatabaseCli, DbOperationError};
+use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{MySqlDiagnostic, QueryValue};
 
 use super::super::args::mysql_metadata_args;
@@ -157,16 +156,7 @@ impl MySqlMetadataProcess {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         sanitize_mysql_command_environment(&mut command);
-        let mut child = command.spawn().map_err(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
-                DbOperationError::CommandNotFound {
-                    command: DatabaseCli::MySql,
-                    details: error.to_string(),
-                }
-            } else {
-                DbOperationError::ConnectionFailed(error.to_string())
-            }
-        })?;
+        let mut child = command.spawn().map_err(super::map_mysql_cli_spawn_error)?;
         let stdin = child.stdin.take().ok_or_else(|| {
             DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
         })?;


### PR DESCRIPTION
## Problem
MySQL CLI process creation duplicated the same `io::Error` conversion in the PTY, pipe, and external metadata paths.

## Background
Keeping the conversion at each spawn site makes the MySQL CLI error boundary harder to audit and maintain.

## Approach
Use one process-local mapper for all three `command.spawn()` calls while preserving the existing command identity, details, and classification for missing commands and other spawn failures.
