### PR TITLE
refactor: remove unused MySQL target wrappers

### DIFF
--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -126,13 +126,6 @@ pub fn mysql_statement_reads_session_diagnostics(sql: &str) -> Result<bool, MySq
     side_effect::mysql_statement_reads_session_diagnostics(sql)
 }
 
-pub fn target_is_selected_database(
-    statement: &MySqlStatement,
-    selected_database: Option<&str>,
-) -> bool {
-    target::target_is_selected_database(statement, selected_database)
-}
-
 pub fn target_is_selected_database_with_lower_case_table_names(
     statement: &MySqlStatement,
     selected_database: Option<&str>,

--- a/src/domain/mysql_sql/target.rs
+++ b/src/domain/mysql_sql/target.rs
@@ -33,13 +33,6 @@ pub(super) fn effective_start(tokens: &[Token]) -> usize {
     cte_body_start(tokens).unwrap_or(0)
 }
 
-pub(super) fn target_is_selected_database(
-    statement: &MySqlStatement,
-    selected_database: Option<&str>,
-) -> bool {
-    target_is_selected_database_with_lower_case_table_names(statement, selected_database, 0)
-}
-
 pub(super) fn target_is_selected_database_with_lower_case_table_names(
     statement: &MySqlStatement,
     selected_database: Option<&str>,


### PR DESCRIPTION
## Summary
- Remove the unused public and internal forwarding target wrappers.
- Keep the explicit lower_case_table_names-aware predicate and matching behavior unchanged.

## Tests
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-029-target cargo test -p sabiql-domain qualified_mysql_mutations -- --nocapture
- cargo fmt --all -- --check
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-029-target cargo check -p sabiql-domain
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-029-target cargo clippy -p sabiql-domain --all-targets -- -D warnings
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-read-029-target cargo check --workspace
- RUSTC_WRAPPER= CARGO_TARGET_DIR= bash scripts/lint_all.sh