### PR TITLE
test: remove duplicate task cancellation test

### DIFF
--- a/src/app/cmd/query_task.rs
+++ b/src/app/cmd/query_task.rs
@@ -80,29 +80,4 @@ mod tests {
         .await
         .expect("cancelled query task should be dropped");
     }
-
-    #[tokio::test]
-    async fn cancel_drops_active_table_detail_task() {
-        let registry = TableDetailTaskRegistry::default();
-        let dropped = Arc::new(AtomicBool::new(false));
-        let (started_tx, started_rx) = oneshot::channel();
-        let guard = DropSignal(Arc::clone(&dropped));
-
-        registry.spawn(async move {
-            let _guard = guard;
-            started_tx.send(()).ok();
-            std::future::pending::<()>().await;
-        });
-
-        started_rx.await.expect("table detail task should start");
-        registry.cancel();
-
-        timeout(Duration::from_secs(1), async {
-            while !dropped.load(Ordering::SeqCst) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("cancelled table detail task should be dropped");
-    }
 }


### PR DESCRIPTION
## Problem
Two unit tests verify the same concrete `TaskRegistry` through different type aliases.

## Background
`QueryTaskRegistry` and `TableDetailTaskRegistry` are aliases of `TaskRegistry`, so the cancellation lifecycle guarantee is duplicated.

## Approach
Keep the query-task cancellation lifecycle test as the representative coverage and remove only the table-detail alias duplicate. Production aliases, registry behavior, and task ownership remain unchanged.
