### PR TITLE
refactor(test): inline runner fixture wrapper

### DIFF
--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -229,13 +229,14 @@ pub fn make_runner_with_cached_result_exporter(
     action_tx: mpsc::Sender<Action>,
     cached_result_exporter: Arc<dyn CachedResultExporter>,
 ) -> EffectRunner {
-    make_runner_with_dsn_and_cached_result_exporter(
+    make_runner_with_dsn_and_cached_result_exporter_and_probe(
         metadata_provider,
         query_executor,
         connection_store,
         cache,
         action_tx,
         Arc::new(NoopDsnBuilder),
+        Arc::new(NoopMySqlConnectionProbe),
         cached_result_exporter,
     )
 }
@@ -277,27 +278,6 @@ pub fn make_runner_with_dsn_and_probe(
         dsn_builder,
         mysql_connection_probe,
         Arc::new(TestCachedResultExporter),
-    )
-}
-
-fn make_runner_with_dsn_and_cached_result_exporter(
-    metadata_provider: Arc<dyn MetadataProvider>,
-    query_executor: Arc<dyn QueryExecutor>,
-    connection_store: Arc<dyn ConnectionStore>,
-    cache: TtlCache<String, Arc<DatabaseMetadata>>,
-    action_tx: mpsc::Sender<Action>,
-    dsn_builder: Arc<dyn DsnBuilder>,
-    cached_result_exporter: Arc<dyn CachedResultExporter>,
-) -> EffectRunner {
-    make_runner_with_dsn_and_cached_result_exporter_and_probe(
-        metadata_provider,
-        query_executor,
-        connection_store,
-        cache,
-        action_tx,
-        dsn_builder,
-        Arc::new(NoopMySqlConnectionProbe),
-        cached_result_exporter,
     )
 }
 


### PR DESCRIPTION
## Problem

The cached-result-exporter runner fixture passes through a private wrapper that only supplies the default MySQL connection probe.

## Background

The wrapper has one caller and adds no reusable behavior.

## Approach

Inline the final constructor call at the existing public fixture caller while preserving the DSN builder, default probe, cached result exporter, and dependency order.
