### PR TITLE
refactor(mysql): unify input writer I/O

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -421,32 +421,17 @@ pub(super) async fn write_mysql_input(
     input: &[u8],
 ) -> Result<(), DbOperationError> {
     #[cfg(unix)]
-    process
-        .pty
-        .input
+    let writer = &mut process.pty.input;
+    #[cfg(not(unix))]
+    let writer = process
+        .stdin
+        .as_mut()
+        .ok_or_else(|| DbOperationError::ConnectionLost("mysql stdin was closed".to_string()))?;
+    writer
         .write_all(input)
         .await
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-    #[cfg(not(unix))]
-    process
-        .stdin
-        .as_mut()
-        .ok_or_else(|| DbOperationError::ConnectionLost("mysql stdin was closed".to_string()))?
-        .write_all(input)
-        .await
-        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-    #[cfg(unix)]
-    process
-        .pty
-        .input
-        .flush()
-        .await
-        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-    #[cfg(not(unix))]
-    process
-        .stdin
-        .as_mut()
-        .ok_or_else(|| DbOperationError::ConnectionLost("mysql stdin was closed".to_string()))?
+    writer
         .flush()
         .await
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;


### PR DESCRIPTION
## Problem

MySQL CLI input handling duplicates the write, flush, and error mapping paths for PTY and pipe writers.

## Background

Unix and non-Unix only differ in how the input writer is obtained, while the I/O behavior must remain identical.

## Approach

Bind the platform-specific writer once, then use one shared write-and-flush path that preserves the existing ownership, ordering, and error behavior.
