### PR TITLE
refactor: consolidate split test modules

### DIFF
--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -391,63 +391,6 @@ fn require_non_empty(state: &mut ConnectionSetupState, field: ConnectionField, m
     }
 }
 
-#[cfg(test)]
-mod text_search_tests {
-    use super::find_text_matches;
-
-    #[test]
-    fn text_matches_return_first_match_offset_per_line_case_insensitively() {
-        let matches = find_text_matches(
-            "{\n  \"Theme\": \"dark\",\n  \"theme\": \"light\"\n}",
-            "theme",
-        );
-
-        assert_eq!(matches, vec![5, 24]);
-    }
-
-    #[test]
-    fn text_matches_return_empty_for_empty_query() {
-        let matches = find_text_matches("{\n  \"theme\": \"dark\"\n}", "");
-
-        assert!(matches.is_empty());
-    }
-
-    #[test]
-    fn text_matches_map_unicode_casefold_back_to_original_char_offset() {
-        let matches = find_text_matches("İx", "x");
-
-        assert_eq!(matches, vec![1]);
-    }
-
-    #[test]
-    fn text_matches_casefold_german_sharp_s() {
-        let matches = find_text_matches("Maße", "MASSE");
-
-        assert_eq!(matches, vec![0]);
-    }
-
-    #[test]
-    fn text_matches_do_not_duplicate_expanded_casefold_character() {
-        let matches = find_text_matches("Maße", "s");
-
-        assert_eq!(matches, vec![2]);
-    }
-
-    #[test]
-    fn text_matches_casefold_greek_final_sigma() {
-        let matches = find_text_matches("ὈΔΥΣΣΕΎΣ", "ὀδυσσεύς");
-
-        assert_eq!(matches, vec![0]);
-    }
-
-    #[test]
-    fn text_matches_return_all_matches_within_single_line() {
-        let matches = find_text_matches("theme theme", "theme");
-
-        assert_eq!(matches, vec![0, 6]);
-    }
-}
-
 pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) {
     state.clear_validation_error(field);
     if let Some(other_field) = match field {
@@ -1151,5 +1094,57 @@ mod tests {
                 Err(EditGuardrailError::SqliteNullPrimaryKey)
             ));
         }
+    }
+
+    #[test]
+    fn text_matches_return_first_match_offset_per_line_case_insensitively() {
+        let matches = find_text_matches(
+            "{\n  \"Theme\": \"dark\",\n  \"theme\": \"light\"\n}",
+            "theme",
+        );
+
+        assert_eq!(matches, vec![5, 24]);
+    }
+
+    #[test]
+    fn text_matches_return_empty_for_empty_query() {
+        let matches = find_text_matches("{\n  \"theme\": \"dark\"\n}", "");
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn text_matches_map_unicode_casefold_back_to_original_char_offset() {
+        let matches = find_text_matches("İx", "x");
+
+        assert_eq!(matches, vec![1]);
+    }
+
+    #[test]
+    fn text_matches_casefold_german_sharp_s() {
+        let matches = find_text_matches("Maße", "MASSE");
+
+        assert_eq!(matches, vec![0]);
+    }
+
+    #[test]
+    fn text_matches_do_not_duplicate_expanded_casefold_character() {
+        let matches = find_text_matches("Maße", "s");
+
+        assert_eq!(matches, vec![2]);
+    }
+
+    #[test]
+    fn text_matches_casefold_greek_final_sigma() {
+        let matches = find_text_matches("ὈΔΥΣΣΕΎΣ", "ὀδυσσεύς");
+
+        assert_eq!(matches, vec![0]);
+    }
+
+    #[test]
+    fn text_matches_return_all_matches_within_single_line() {
+        let matches = find_text_matches("theme theme", "theme");
+
+        assert_eq!(matches, vec![0, 6]);
     }
 }

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -1096,55 +1096,59 @@ mod tests {
         }
     }
 
-    #[test]
-    fn text_matches_return_first_match_offset_per_line_case_insensitively() {
-        let matches = find_text_matches(
-            "{\n  \"Theme\": \"dark\",\n  \"theme\": \"light\"\n}",
-            "theme",
-        );
+    mod text_search {
+        use super::find_text_matches;
 
-        assert_eq!(matches, vec![5, 24]);
-    }
+        #[test]
+        fn text_matches_return_first_match_offset_per_line_case_insensitively() {
+            let matches = find_text_matches(
+                "{\n  \"Theme\": \"dark\",\n  \"theme\": \"light\"\n}",
+                "theme",
+            );
 
-    #[test]
-    fn text_matches_return_empty_for_empty_query() {
-        let matches = find_text_matches("{\n  \"theme\": \"dark\"\n}", "");
+            assert_eq!(matches, vec![5, 24]);
+        }
 
-        assert!(matches.is_empty());
-    }
+        #[test]
+        fn text_matches_return_empty_for_empty_query() {
+            let matches = find_text_matches("{\n  \"theme\": \"dark\"\n}", "");
 
-    #[test]
-    fn text_matches_map_unicode_casefold_back_to_original_char_offset() {
-        let matches = find_text_matches("İx", "x");
+            assert!(matches.is_empty());
+        }
 
-        assert_eq!(matches, vec![1]);
-    }
+        #[test]
+        fn text_matches_map_unicode_casefold_back_to_original_char_offset() {
+            let matches = find_text_matches("İx", "x");
 
-    #[test]
-    fn text_matches_casefold_german_sharp_s() {
-        let matches = find_text_matches("Maße", "MASSE");
+            assert_eq!(matches, vec![1]);
+        }
 
-        assert_eq!(matches, vec![0]);
-    }
+        #[test]
+        fn text_matches_casefold_german_sharp_s() {
+            let matches = find_text_matches("Maße", "MASSE");
 
-    #[test]
-    fn text_matches_do_not_duplicate_expanded_casefold_character() {
-        let matches = find_text_matches("Maße", "s");
+            assert_eq!(matches, vec![0]);
+        }
 
-        assert_eq!(matches, vec![2]);
-    }
+        #[test]
+        fn text_matches_do_not_duplicate_expanded_casefold_character() {
+            let matches = find_text_matches("Maße", "s");
 
-    #[test]
-    fn text_matches_casefold_greek_final_sigma() {
-        let matches = find_text_matches("ὈΔΥΣΣΕΎΣ", "ὀδυσσεύς");
+            assert_eq!(matches, vec![2]);
+        }
 
-        assert_eq!(matches, vec![0]);
-    }
+        #[test]
+        fn text_matches_casefold_greek_final_sigma() {
+            let matches = find_text_matches("ὈΔΥΣΣΕΎΣ", "ὀδυσσεύς");
 
-    #[test]
-    fn text_matches_return_all_matches_within_single_line() {
-        let matches = find_text_matches("theme theme", "theme");
+            assert_eq!(matches, vec![0]);
+        }
 
-        assert_eq!(matches, vec![0, 6]);
+        #[test]
+        fn text_matches_return_all_matches_within_single_line() {
+            let matches = find_text_matches("theme theme", "theme");
+
+            assert_eq!(matches, vec![0, 6]);
+        }
     }
 }

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -223,41 +223,6 @@ impl MySqlProcess {
     }
 }
 
-#[cfg(test)]
-mod spawn_error_tests {
-    use super::*;
-
-    #[test]
-    fn maps_missing_mysql_cli_to_command_not_found() {
-        let error = map_mysql_cli_spawn_error(io::Error::new(
-            io::ErrorKind::NotFound,
-            "mysql executable was not found",
-        ));
-
-        assert!(matches!(
-            error,
-            DbOperationError::CommandNotFound {
-                command: DatabaseCli::MySql,
-                details,
-            } if details == "mysql executable was not found"
-        ));
-    }
-
-    #[test]
-    fn maps_other_mysql_cli_spawn_errors_to_connection_failed() {
-        let error = map_mysql_cli_spawn_error(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "mysql executable permission denied",
-        ));
-
-        assert!(matches!(
-            error,
-            DbOperationError::ConnectionFailed(details)
-                if details == "mysql executable permission denied"
-        ));
-    }
-}
-
 #[cfg(unix)]
 pub(super) async fn stop_mysql_process(
     child: &mut Child,
@@ -498,66 +463,6 @@ where
     }
 }
 
-#[cfg(test)]
-mod timeout_tests {
-    use std::time::Duration;
-
-    use super::MYSQL_QUERY_TIMEOUT;
-
-    #[test]
-    fn keeps_production_query_timeout_at_31_seconds() {
-        assert_eq!(MYSQL_QUERY_TIMEOUT, Duration::from_secs(31));
-    }
-}
-
-#[cfg(all(test, unix))]
-mod session_exit_tests {
-    use std::os::unix::process::ExitStatusExt;
-    use std::process::ExitStatus;
-
-    use crate::app::ports::outbound::DbOperationError;
-
-    use super::{MySqlSessionResult, validate_mysql_session_exit};
-
-    fn session(status: i32, forcibly_stopped: bool, error_bytes: &[u8]) -> MySqlSessionResult {
-        MySqlSessionResult {
-            status: ExitStatus::from_raw(status),
-            forcibly_stopped,
-            error_bytes: error_bytes.to_vec(),
-        }
-    }
-
-    #[test]
-    fn preserves_mysql_session_exit_rules() {
-        assert!(validate_mysql_session_exit(&session(0, false, b""), None).is_ok());
-        assert!(matches!(
-            validate_mysql_session_exit(
-                &session(
-                    0,
-                    true,
-                    b"ERROR 1054 (42S22): Unknown column missing_column"
-                ),
-                None,
-            ),
-            Err(DbOperationError::ObjectMissing(_))
-        ));
-        assert!(validate_mysql_session_exit(&session(1, false, b""), None).is_err());
-        assert!(validate_mysql_session_exit(&session(9, true, b""), None).is_ok());
-        assert!(matches!(
-            validate_mysql_session_exit(
-                &session(
-                    1,
-                    false,
-                    b"ERROR 2020 (HY000): Got packet bigger than 'max_allowed_packet' bytes",
-                ),
-                Some(33_554_432),
-            ),
-            Err(DbOperationError::QueryFailed(details))
-                if details == "MySQL protocol packet exceeds the 33554432-byte client limit"
-        ));
-    }
-}
-
 pub(super) async fn read_one_mysql_resultset(
     process: &mut MySqlProcess,
 ) -> Result<Vec<u8>, DbOperationError> {
@@ -616,8 +521,85 @@ fn mysql_statement_input(query: &str) -> Vec<u8> {
 }
 
 #[cfg(test)]
-mod statement_input_tests {
-    use super::mysql_statement_input;
+mod process_tests {
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+
+    use super::*;
+
+    #[test]
+    fn maps_missing_mysql_cli_to_command_not_found() {
+        let error = map_mysql_cli_spawn_error(io::Error::new(
+            io::ErrorKind::NotFound,
+            "mysql executable was not found",
+        ));
+
+        assert!(matches!(
+            error,
+            DbOperationError::CommandNotFound {
+                command: DatabaseCli::MySql,
+                details,
+            } if details == "mysql executable was not found"
+        ));
+    }
+
+    #[test]
+    fn maps_other_mysql_cli_spawn_errors_to_connection_failed() {
+        let error = map_mysql_cli_spawn_error(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "mysql executable permission denied",
+        ));
+
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "mysql executable permission denied"
+        ));
+    }
+    #[test]
+    fn keeps_production_query_timeout_at_31_seconds() {
+        assert_eq!(MYSQL_QUERY_TIMEOUT, Duration::from_secs(31));
+    }
+
+    #[cfg(unix)]
+    fn session(status: i32, forcibly_stopped: bool, error_bytes: &[u8]) -> MySqlSessionResult {
+        MySqlSessionResult {
+            status: ExitStatus::from_raw(status),
+            forcibly_stopped,
+            error_bytes: error_bytes.to_vec(),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_mysql_session_exit_rules() {
+        assert!(validate_mysql_session_exit(&session(0, false, b""), None).is_ok());
+        assert!(matches!(
+            validate_mysql_session_exit(
+                &session(
+                    0,
+                    true,
+                    b"ERROR 1054 (42S22): Unknown column missing_column"
+                ),
+                None,
+            ),
+            Err(DbOperationError::ObjectMissing(_))
+        ));
+        assert!(validate_mysql_session_exit(&session(1, false, b""), None).is_err());
+        assert!(validate_mysql_session_exit(&session(9, true, b""), None).is_ok());
+        assert!(matches!(
+            validate_mysql_session_exit(
+                &session(
+                    1,
+                    false,
+                    b"ERROR 2020 (HY000): Got packet bigger than 'max_allowed_packet' bytes",
+                ),
+                Some(33_554_432),
+            ),
+            Err(DbOperationError::QueryFailed(details))
+                if details == "MySQL protocol packet exceeds the 33554432-byte client limit"
+        ));
+    }
 
     #[test]
     fn separates_statements_after_line_comments_with_semicolons() {

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -541,6 +541,7 @@ mod process_tests {
                 if details == "mysql executable permission denied"
         ));
     }
+
     #[test]
     fn keeps_production_query_timeout_at_31_seconds() {
         assert_eq!(MYSQL_QUERY_TIMEOUT, Duration::from_secs(31));

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -340,6 +340,32 @@ impl MySqlConnectionProbe for DbAdapterRegistry {
     }
 }
 
+#[async_trait]
+impl SqliteDiagnosticsProvider for DbAdapterRegistry {
+    async fn fetch_diagnostics_core(
+        &self,
+        dsn: &str,
+    ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
+        match Self::db_type_from_dsn(dsn)? {
+            DatabaseType::PostgreSQL | DatabaseType::MySQL => {
+                Err(DbOperationError::ConnectionFailed(
+                    "SQLite diagnostics are unavailable for non-SQLite connections".to_string(),
+                ))
+            }
+            DatabaseType::SQLite => self.sqlite.fetch_diagnostics_core(dsn).await,
+        }
+    }
+
+    async fn fetch_quick_check(&self, dsn: &str) -> DiagnosticField {
+        match Self::db_type_from_dsn(dsn) {
+            Ok(DatabaseType::SQLite) => self.sqlite.fetch_quick_check(dsn).await,
+            Ok(DatabaseType::PostgreSQL | DatabaseType::MySQL) | Err(_) => DiagnosticField::err(
+                "SQLite diagnostics are unavailable for non-SQLite connections",
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::adapters::test_support;
@@ -595,37 +621,6 @@ mod tests {
         assert_eq!(detail.schema, "main");
         assert_eq!(detail.name, "users");
     }
-}
-
-#[async_trait]
-impl SqliteDiagnosticsProvider for DbAdapterRegistry {
-    async fn fetch_diagnostics_core(
-        &self,
-        dsn: &str,
-    ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
-        match Self::db_type_from_dsn(dsn)? {
-            DatabaseType::PostgreSQL | DatabaseType::MySQL => {
-                Err(DbOperationError::ConnectionFailed(
-                    "SQLite diagnostics are unavailable for non-SQLite connections".to_string(),
-                ))
-            }
-            DatabaseType::SQLite => self.sqlite.fetch_diagnostics_core(dsn).await,
-        }
-    }
-
-    async fn fetch_quick_check(&self, dsn: &str) -> DiagnosticField {
-        match Self::db_type_from_dsn(dsn) {
-            Ok(DatabaseType::SQLite) => self.sqlite.fetch_quick_check(dsn).await,
-            Ok(DatabaseType::PostgreSQL | DatabaseType::MySQL) | Err(_) => DiagnosticField::err(
-                "SQLite diagnostics are unavailable for non-SQLite connections",
-            ),
-        }
-    }
-}
-
-#[cfg(test)]
-mod sqlite_diagnostics_registry {
-    use super::*;
 
     #[tokio::test]
     async fn postgres_dsn_is_rejected() {


### PR DESCRIPTION
## Problem
Rust test coverage in several modules was split into multiple test blocks without a scope or platform boundary, leaving tests separated from the surrounding test suite.

## Background
The same placement pattern appeared in the MySQL process, update helper, and adapter registry modules.

## Approach
Consolidate tests with the existing test module for the same scope and retain separate modules only where platform or fixture boundaries require them. No production behavior, test assertions, or public API changes are intended.

## Screenshots

<!-- Not applicable. -->

## Linear Issue Link (optional)

<!-- No related Linear issue. -->
