### PR TITLE
refactor(test): isolate test-only items

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -223,13 +223,6 @@ impl CompletionEngine {
         }
     }
 
-    #[cfg(test)]
-    fn new_with_capacity(capacity: usize) -> Self {
-        let mut engine = Self::new();
-        engine.table_detail_cache = BoundedLruCache::new(capacity);
-        engine
-    }
-
     pub(crate) fn cache_table_detail(&mut self, qualified_name: String, table: Table) {
         self.table_detail_cache.insert(qualified_name, table);
     }
@@ -254,28 +247,6 @@ impl CompletionEngine {
 
     pub(crate) fn table_details_iter(&self) -> impl Iterator<Item = (&String, &Table)> {
         self.table_detail_cache.iter()
-    }
-
-    #[cfg(test)]
-    fn get_candidates_for_database(
-        &self,
-        content: &str,
-        cursor_pos: usize,
-        metadata: Option<&DatabaseMetadata>,
-        table_detail: Option<&Table>,
-        recent_columns: &[String],
-        scope: CompletionDatabaseScope<'_>,
-    ) -> Vec<CompletionCandidate> {
-        let prep = self.prepare_for_database(content, cursor_pos, scope.database_type);
-        self.get_candidates_prepared_for_database(
-            content,
-            cursor_pos,
-            &prep,
-            metadata,
-            table_detail,
-            recent_columns,
-            scope,
-        )
     }
 
     pub(crate) fn prepare_for_database(
@@ -544,26 +515,6 @@ impl CompletionEngine {
         quote_mysql_identifiers(&mut candidates, scope.database_type);
 
         candidates
-    }
-
-    #[cfg(test)]
-    fn analyze_with_context(
-        &self,
-        content: &str,
-        cursor_pos: usize,
-        sql_context: &SqlContext,
-        tokens: &[Token],
-    ) -> (String, CompletionContext) {
-        let before_cursor: String = content.chars().take(cursor_pos).collect();
-        let current_token = self.extract_current_token(&before_cursor);
-        self.analyze_with_precomputed(
-            &before_cursor,
-            &current_token,
-            sql_context,
-            sql_context,
-            tokens,
-            cursor_pos,
-        )
     }
 
     fn analyze_with_precomputed(
@@ -921,11 +872,6 @@ impl CompletionEngine {
         written
     }
 
-    #[cfg(test)]
-    fn keyword_candidates(&self, prefix: &str) -> Vec<CompletionCandidate> {
-        self.keyword_candidates_for_database(prefix, DatabaseType::PostgreSQL)
-    }
-
     fn keyword_candidates_for_database(
         &self,
         prefix: &str,
@@ -1006,22 +952,6 @@ impl CompletionEngine {
                 score: 200, // Higher than column scores (max ~170)
             })
             .collect()
-    }
-
-    #[cfg(test)]
-    fn table_candidates(
-        &self,
-        metadata: Option<&DatabaseMetadata>,
-        prefix: &str,
-    ) -> Vec<CompletionCandidate> {
-        self.table_candidates_for_database(
-            metadata,
-            prefix,
-            CompletionDatabaseScope {
-                database_type: DatabaseType::PostgreSQL,
-                active_database: None,
-            },
-        )
     }
 
     fn table_candidates_for_database(
@@ -1191,16 +1121,6 @@ impl CompletionEngine {
             .collect()
     }
 
-    #[cfg(test)]
-    fn schema_qualified_candidates(
-        &self,
-        metadata: Option<&DatabaseMetadata>,
-        schema: &str,
-        prefix: &str,
-    ) -> Vec<CompletionCandidate> {
-        self.schema_qualified_candidates_for_database(metadata, schema, prefix)
-    }
-
     fn schema_qualified_candidates_for_database(
         &self,
         metadata: Option<&DatabaseMetadata>,
@@ -1312,24 +1232,6 @@ impl CompletionEngine {
             },
             _ => None,
         }
-    }
-
-    #[cfg(test)]
-    fn cte_or_table_candidates(
-        &self,
-        sql_context: &SqlContext,
-        metadata: Option<&DatabaseMetadata>,
-        prefix: &str,
-    ) -> Vec<CompletionCandidate> {
-        self.cte_or_table_candidates_for_database(
-            sql_context,
-            metadata,
-            prefix,
-            CompletionDatabaseScope {
-                database_type: DatabaseType::PostgreSQL,
-                active_database: None,
-            },
-        )
     }
 
     fn cte_or_table_candidates_for_database(
@@ -1487,6 +1389,97 @@ mod tests {
     use super::*;
 
     impl CompletionEngine {
+        fn new_with_capacity(capacity: usize) -> Self {
+            let mut engine = Self::new();
+            engine.table_detail_cache = BoundedLruCache::new(capacity);
+            engine
+        }
+
+        fn get_candidates_for_database(
+            &self,
+            content: &str,
+            cursor_pos: usize,
+            metadata: Option<&DatabaseMetadata>,
+            table_detail: Option<&Table>,
+            recent_columns: &[String],
+            scope: CompletionDatabaseScope<'_>,
+        ) -> Vec<CompletionCandidate> {
+            let prep = self.prepare_for_database(content, cursor_pos, scope.database_type);
+            self.get_candidates_prepared_for_database(
+                content,
+                cursor_pos,
+                &prep,
+                metadata,
+                table_detail,
+                recent_columns,
+                scope,
+            )
+        }
+
+        fn analyze_with_context(
+            &self,
+            content: &str,
+            cursor_pos: usize,
+            sql_context: &SqlContext,
+            tokens: &[Token],
+        ) -> (String, CompletionContext) {
+            let before_cursor: String = content.chars().take(cursor_pos).collect();
+            let current_token = self.extract_current_token(&before_cursor);
+            self.analyze_with_precomputed(
+                &before_cursor,
+                &current_token,
+                sql_context,
+                sql_context,
+                tokens,
+                cursor_pos,
+            )
+        }
+
+        fn keyword_candidates(&self, prefix: &str) -> Vec<CompletionCandidate> {
+            self.keyword_candidates_for_database(prefix, DatabaseType::PostgreSQL)
+        }
+
+        fn table_candidates(
+            &self,
+            metadata: Option<&DatabaseMetadata>,
+            prefix: &str,
+        ) -> Vec<CompletionCandidate> {
+            self.table_candidates_for_database(
+                metadata,
+                prefix,
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::PostgreSQL,
+                    active_database: None,
+                },
+            )
+        }
+
+        fn schema_qualified_candidates(
+            &self,
+            metadata: Option<&DatabaseMetadata>,
+            schema: &str,
+            prefix: &str,
+        ) -> Vec<CompletionCandidate> {
+            self.schema_qualified_candidates_for_database(metadata, schema, prefix)
+        }
+
+        fn cte_or_table_candidates(
+            &self,
+            sql_context: &SqlContext,
+            metadata: Option<&DatabaseMetadata>,
+            prefix: &str,
+        ) -> Vec<CompletionCandidate> {
+            self.cte_or_table_candidates_for_database(
+                sql_context,
+                metadata,
+                prefix,
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::PostgreSQL,
+                    active_database: None,
+                },
+            )
+        }
+
         fn analyze(&self, content: &str, cursor_pos: usize) -> (String, CompletionContext) {
             let lexer = SqlLexer::default();
             let tokens = lexer.tokenize(content, cursor_pos);

--- a/src/app/model/browse/json_detail.rs
+++ b/src/app/model/browse/json_detail.rs
@@ -23,11 +23,6 @@ pub struct JsonDetailState {
 }
 
 impl JsonDetailState {
-    #[cfg(test)]
-    pub fn set_mode(&mut self, mode: JsonDetailMode) {
-        self.mode = mode;
-    }
-
     pub fn open_pretty(
         row: usize,
         col: usize,
@@ -155,6 +150,17 @@ impl JsonDetailState {
                 Ok(_) => None,
                 Err(e) => Some(format!("Invalid JSON: {e}")),
             };
+    }
+}
+
+#[cfg(test)]
+mod test_support {
+    use super::{JsonDetailMode, JsonDetailState};
+
+    impl JsonDetailState {
+        pub(crate) fn set_mode(&mut self, mode: JsonDetailMode) {
+            self.mode = mode;
+        }
     }
 }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -471,23 +471,6 @@ impl BrowseSession {
         self.clear_mysql_connection_probe();
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_active_connection_identity_for_test(
-        &mut self,
-        id: &ConnectionId,
-        name: &str,
-        database_type: DatabaseType,
-    ) {
-        self.active_connection = Some(ActiveConnection {
-            id: id.clone(),
-            name: name.to_string(),
-            database_type,
-            origin: ConnectionOrigin::Profile,
-            database: None,
-        });
-    }
-
     pub fn clear_connection(&mut self) {
         self.dsn = None;
         self.active_connection = None;
@@ -841,16 +824,6 @@ impl BrowseSession {
         !self.is_service_connection() && !self.is_ephemeral_connection()
     }
 
-    #[cfg(test)]
-    pub(crate) fn set_metadata_state(&mut self, state: MetadataState) {
-        self.metadata_state = state;
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_connection_state(&mut self, state: ConnectionState) {
-        self.connection_state = state;
-    }
-
     pub(crate) fn set_metadata(&mut self, metadata: Option<Arc<DatabaseMetadata>>) {
         self.metadata = metadata;
     }
@@ -862,10 +835,52 @@ impl BrowseSession {
             None => TableDetailState::NotSelected,
         };
     }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use super::{ActiveConnection, BrowseSession, ConnectionId, ConnectionOrigin, DatabaseType};
+
+    impl BrowseSession {
+        #[doc(hidden)]
+        pub fn set_active_connection_identity_for_test(
+            &mut self,
+            id: &ConnectionId,
+            name: &str,
+            database_type: DatabaseType,
+        ) {
+            self.active_connection = Some(ActiveConnection {
+                id: id.clone(),
+                name: name.to_string(),
+                database_type,
+                origin: ConnectionOrigin::Profile,
+                database: None,
+            });
+        }
+    }
 
     #[cfg(test)]
-    pub(crate) fn set_selection_generation(&mut self, value: u64) {
-        self.selection_generation = value;
+    mod unit_tests {
+        use super::BrowseSession;
+        use crate::domain::MetadataState;
+        use crate::model::connection::state::ConnectionState;
+
+        impl BrowseSession {
+            #[doc(hidden)]
+            pub(crate) fn set_metadata_state(&mut self, state: MetadataState) {
+                self.metadata_state = state;
+            }
+
+            #[doc(hidden)]
+            pub(crate) fn set_connection_state(&mut self, state: ConnectionState) {
+                self.connection_state = state;
+            }
+
+            #[doc(hidden)]
+            pub(crate) fn set_selection_generation(&mut self, value: u64) {
+                self.selection_generation = value;
+            }
+        }
     }
 }
 

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -60,30 +60,6 @@ impl ErPreparationState {
             .collect()
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn pending_tables(&self) -> &HashSet<String> {
-        &self.pending_tables
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn fetching_tables(&self) -> &HashSet<String> {
-        &self.fetching_tables
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn failed_tables(&self) -> &HashMap<String, String> {
-        &self.failed_tables
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn total_tables(&self) -> usize {
-        self.total_tables
-    }
-
     pub fn target_tables(&self) -> &[String] {
         &self.target_tables
     }
@@ -171,12 +147,6 @@ impl ErPreparationState {
         self.status = ErStatus::Idle;
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn mark_waiting_for_test(&mut self) {
-        self.status = ErStatus::Waiting;
-    }
-
     pub fn is_current_run(&self, run_id: u64) -> bool {
         self.run.is_current(run_id)
     }
@@ -258,6 +228,40 @@ impl ErPreparationState {
         self.fetching_tables.remove(&table);
         self.failed_tables.remove(&table);
         self.pending_tables.insert(table)
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use std::collections::{HashMap, HashSet};
+
+    use super::{ErPreparationState, ErStatus};
+
+    impl ErPreparationState {
+        #[doc(hidden)]
+        pub fn pending_tables(&self) -> &HashSet<String> {
+            &self.pending_tables
+        }
+
+        #[doc(hidden)]
+        pub fn fetching_tables(&self) -> &HashSet<String> {
+            &self.fetching_tables
+        }
+
+        #[doc(hidden)]
+        pub fn failed_tables(&self) -> &HashMap<String, String> {
+            &self.failed_tables
+        }
+
+        #[doc(hidden)]
+        pub fn total_tables(&self) -> usize {
+            self.total_tables
+        }
+
+        #[doc(hidden)]
+        pub fn mark_waiting_for_test(&mut self) {
+            self.status = ErStatus::Waiting;
+        }
     }
 }
 

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -86,18 +86,6 @@ impl ExplainContext {
         self.left.is_some() && self.right.is_some()
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn left(&self) -> Option<&CompareSlot> {
-        self.left.as_ref()
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn right(&self) -> Option<&CompareSlot> {
-        self.right.as_ref()
-    }
-
     pub fn history(&self) -> &VecDeque<CompareSlot> {
         &self.history
     }
@@ -231,6 +219,23 @@ impl ExplainContext {
             .compare_viewport_height
             .map_or_else(|| Self::modal_inner_height(terminal_height), |h| h as usize);
         self.compare_line_count().saturating_sub(viewport)
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::{CompareSlot, ExplainContext};
+
+    impl ExplainContext {
+        #[doc(hidden)]
+        pub fn left(&self) -> Option<&CompareSlot> {
+            self.left.as_ref()
+        }
+
+        #[doc(hidden)]
+        pub fn right(&self) -> Option<&CompareSlot> {
+            self.right.as_ref()
+        }
     }
 }
 

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -256,12 +256,6 @@ impl UiState {
         self.explorer_scroll_offset = offset;
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_explorer_selected_raw(&mut self, selected: usize) {
-        self.explorer_selected = selected;
-    }
-
     pub fn scroll_explorer_page_down(&mut self, item_count: usize, delta: usize) {
         if item_count == 0 {
             return;
@@ -313,12 +307,6 @@ impl UiState {
 
     pub fn set_connection_list_pane_height(&mut self, height: u16) {
         self.connection_list_pane_height = height;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_connection_list_selected_raw(&mut self, selected: usize) {
-        self.connection_list_selected = selected;
     }
 
     pub fn set_connection_list_scroll_offset(&mut self, offset: usize) {
@@ -601,6 +589,23 @@ impl UiState {
     pub fn reset_er_picker_request(&mut self) {
         self.er_selected_tables.clear();
         self.pending_er_picker = false;
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::UiState;
+
+    impl UiState {
+        #[doc(hidden)]
+        pub fn set_explorer_selected_raw(&mut self, selected: usize) {
+            self.explorer_selected = selected;
+        }
+
+        #[doc(hidden)]
+        pub fn set_connection_list_selected_raw(&mut self, selected: usize) {
+            self.connection_list_selected = selected;
+        }
     }
 }
 

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -96,16 +96,6 @@ pub struct SqlModalContext {
 }
 
 impl SqlModalContext {
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn set_status_for_test(&mut self, status: SqlModalStatus) {
-        self.status = status;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn completion_mut_for_test(&mut self) -> &mut CompletionState {
-        &mut self.completion
-    }
-
     pub fn editor(&self) -> &MultiLineInputState {
         &self.editor
     }
@@ -463,12 +453,26 @@ impl SqlModalContext {
     }
 }
 
-impl SqlModalContext {
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn clear_content(&mut self) {
-        self.editor.clear();
-        self.reset_completion();
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use super::{CompletionState, SqlModalContext, SqlModalStatus};
+
+    impl SqlModalContext {
+        #[doc(hidden)]
+        pub fn set_status_for_test(&mut self, status: SqlModalStatus) {
+            self.status = status;
+        }
+
+        #[doc(hidden)]
+        pub fn completion_mut_for_test(&mut self) -> &mut CompletionState {
+            &mut self.completion
+        }
+
+        #[doc(hidden)]
+        pub fn clear_content(&mut self) {
+            self.editor.clear();
+            self.reset_completion();
+        }
     }
 }
 

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -467,11 +467,18 @@ pub mod test_support {
         pub fn completion_mut_for_test(&mut self) -> &mut CompletionState {
             &mut self.completion
         }
+    }
 
-        #[doc(hidden)]
-        pub fn clear_content(&mut self) {
-            self.editor.clear();
-            self.reset_completion();
+    #[cfg(test)]
+    mod unit_tests {
+        use super::super::SqlModalContext;
+
+        impl SqlModalContext {
+            #[doc(hidden)]
+            pub(crate) fn clear_content(&mut self) {
+                self.editor.clear();
+                self.reset_completion();
+            }
         }
     }
 }

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -468,19 +468,6 @@ pub mod test_support {
             &mut self.completion
         }
     }
-
-    #[cfg(test)]
-    mod unit_tests {
-        use super::super::SqlModalContext;
-
-        impl SqlModalContext {
-            #[doc(hidden)]
-            pub(crate) fn clear_content(&mut self) {
-                self.editor.clear();
-                self.reset_completion();
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -493,6 +480,14 @@ mod tests {
             text: text.to_string(),
             kind: CompletionKind::Keyword,
             score: 1,
+        }
+    }
+
+    impl SqlModalContext {
+        #[doc(hidden)]
+        pub(crate) fn clear_content(&mut self) {
+            self.editor.clear();
+            self.reset_completion();
         }
     }
 

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -126,11 +126,6 @@ impl QueryHistoryPickerState {
         self.selected = index;
     }
 
-    #[cfg(test)]
-    pub(crate) fn set_selection_for_test(&mut self, selected: usize) {
-        self.selected = selected;
-    }
-
     pub fn filtered_entries(&self) -> Vec<FilteredEntry<'_>> {
         let filter = self.filter_input.content();
 
@@ -206,6 +201,12 @@ impl QueryHistoryPickerState {
 mod tests {
     use super::*;
     use crate::domain::ConnectionId;
+
+    impl QueryHistoryPickerState {
+        pub(crate) fn set_selection_for_test(&mut self, selected: usize) {
+            self.selected = selected;
+        }
+    }
 
     fn state_with_selection() -> QueryHistoryPickerState {
         QueryHistoryPickerState {

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -1,217 +1,221 @@
-#[cfg(any(test, feature = "test-support"))]
-use std::fmt::Write as _;
 use std::sync::Arc;
 
 use super::ports::outbound::{DdlGenerator, DsnBuilder, SqlDialect};
-#[cfg(any(test, feature = "test-support"))]
-use crate::domain::{ConnectionProfile, DatabaseType, QueryValue, Table};
 pub struct AppServices {
     pub ddl_generator: Arc<dyn DdlGenerator>,
     pub sql_dialect: Arc<dyn SqlDialect>,
     pub dsn_builder: Arc<dyn DsnBuilder>,
 }
 
-impl AppServices {
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn stub() -> Self {
-        use crate::domain::mysql_sql::{
-            mysql_explain_rejection_message, mysql_tree_explain_query_kind,
-        };
-        use crate::domain::sqlite_sql::build_sqlite_explain_query_plan_sql;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use std::fmt::Write as _;
+    use std::sync::Arc;
 
-        fn quote_identifier(database_type: DatabaseType, value: &str) -> String {
-            match database_type {
-                DatabaseType::MySQL => {
-                    format!("`{}`", value.replace('`', "``"))
-                }
-                DatabaseType::PostgreSQL | DatabaseType::SQLite => {
-                    format!("\"{}\"", value.replace('"', "\"\""))
-                }
-            }
-        }
+    use super::{AppServices, DdlGenerator, DsnBuilder, SqlDialect};
+    use crate::domain::{ConnectionProfile, DatabaseType, QueryValue, Table};
 
-        fn quote_literal(database_type: DatabaseType, value: &str) -> String {
-            if database_type != DatabaseType::MySQL {
-                return format!("'{}'", value.replace('\'', "''"));
-            }
+    impl AppServices {
+        #[doc(hidden)]
+        pub fn stub() -> Self {
+            use crate::domain::mysql_sql::{
+                mysql_explain_rejection_message, mysql_tree_explain_query_kind,
+            };
+            use crate::domain::sqlite_sql::build_sqlite_explain_query_plan_sql;
 
-            let mut escaped = String::with_capacity(value.len());
-            for character in value.chars() {
-                match character {
-                    '\0' => escaped.push_str("\\0"),
-                    '\n' => escaped.push_str("\\n"),
-                    '\r' => escaped.push_str("\\r"),
-                    '\t' => escaped.push_str("\\t"),
-                    '\u{0008}' => escaped.push_str("\\b"),
-                    '\u{001a}' => escaped.push_str("\\Z"),
-                    '\\' => escaped.push_str("\\\\"),
-                    '\'' => escaped.push_str("\\'"),
-                    _ => escaped.push(character),
-                }
-            }
-            format!("'{escaped}'")
-        }
-
-        fn sql_literal(database_type: DatabaseType, value: &QueryValue) -> String {
-            match value {
-                QueryValue::Null => "NULL".to_string(),
-                QueryValue::Text(value) => quote_literal(database_type, value),
-                QueryValue::SqlLiteral(value) => value.clone(),
-                QueryValue::Blob(bytes) => {
-                    let mut hex = String::with_capacity(bytes.len() * 2);
-                    for byte in bytes {
-                        let _ = write!(hex, "{byte:02x}");
+            fn quote_identifier(database_type: DatabaseType, value: &str) -> String {
+                match database_type {
+                    DatabaseType::MySQL => {
+                        format!("`{}`", value.replace('`', "``"))
                     }
-                    match database_type {
-                        DatabaseType::PostgreSQL => format!("'\\x{hex}'"),
-                        DatabaseType::SQLite | DatabaseType::MySQL => {
-                            format!("X'{}'", hex.to_uppercase())
+                    DatabaseType::PostgreSQL | DatabaseType::SQLite => {
+                        format!("\"{}\"", value.replace('"', "\"\""))
+                    }
+                }
+            }
+
+            fn quote_literal(database_type: DatabaseType, value: &str) -> String {
+                if database_type != DatabaseType::MySQL {
+                    return format!("'{}'", value.replace('\'', "''"));
+                }
+
+                let mut escaped = String::with_capacity(value.len());
+                for character in value.chars() {
+                    match character {
+                        '\0' => escaped.push_str("\\0"),
+                        '\n' => escaped.push_str("\\n"),
+                        '\r' => escaped.push_str("\\r"),
+                        '\t' => escaped.push_str("\\t"),
+                        '\u{0008}' => escaped.push_str("\\b"),
+                        '\u{001a}' => escaped.push_str("\\Z"),
+                        '\\' => escaped.push_str("\\\\"),
+                        '\'' => escaped.push_str("\\'"),
+                        _ => escaped.push(character),
+                    }
+                }
+                format!("'{escaped}'")
+            }
+
+            fn sql_literal(database_type: DatabaseType, value: &QueryValue) -> String {
+                match value {
+                    QueryValue::Null => "NULL".to_string(),
+                    QueryValue::Text(value) => quote_literal(database_type, value),
+                    QueryValue::SqlLiteral(value) => value.clone(),
+                    QueryValue::Blob(bytes) => {
+                        let mut hex = String::with_capacity(bytes.len() * 2);
+                        for byte in bytes {
+                            let _ = write!(hex, "{byte:02x}");
+                        }
+                        match database_type {
+                            DatabaseType::PostgreSQL => format!("'\\x{hex}'"),
+                            DatabaseType::SQLite | DatabaseType::MySQL => {
+                                format!("X'{}'", hex.to_uppercase())
+                            }
                         }
                     }
                 }
             }
-        }
 
-        fn equality_predicate(
-            database_type: DatabaseType,
-            key: &str,
-            value: &QueryValue,
-        ) -> String {
-            match value {
-                QueryValue::Null => {
-                    format!("{} IS NULL", quote_identifier(database_type, key))
-                }
-                _ => format!(
-                    "{} = {}",
-                    quote_identifier(database_type, key),
-                    sql_literal(database_type, value)
-                ),
-            }
-        }
-
-        struct StubDdlGenerator;
-        impl DdlGenerator for StubDdlGenerator {
-            fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
-                String::new()
-            }
-        }
-
-        struct StubSqlDialect;
-        impl SqlDialect for StubSqlDialect {
-            fn build_explain_sql(
-                &self,
+            fn equality_predicate(
                 database_type: DatabaseType,
-                query: &str,
-            ) -> Option<String> {
-                match database_type {
-                    DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
-                    DatabaseType::SQLite => build_sqlite_explain_query_plan_sql(query),
-                    DatabaseType::MySQL => mysql_explain_rejection_message(query)
-                        .is_none()
-                        .then(|| format!("EXPLAIN FORMAT=TREE {query}")),
-                }
-            }
-
-            fn build_explain_analyze_sql(
-                &self,
-                database_type: DatabaseType,
-                query: &str,
-            ) -> Option<String> {
-                match database_type {
-                    DatabaseType::PostgreSQL => Some(format!("EXPLAIN ANALYZE {query}")),
-                    DatabaseType::SQLite => None,
-                    DatabaseType::MySQL => {
-                        let explain = format!("EXPLAIN ANALYZE FORMAT=TREE {query}");
-                        mysql_tree_explain_query_kind(&explain)
-                            .is_some()
-                            .then_some(explain)
-                    }
-                }
-            }
-
-            fn build_update_sql(
-                &self,
-                database_type: DatabaseType,
-                schema: &str,
-                table: &str,
-                column: &str,
-                new_value: &QueryValue,
-                pk_pairs: &[(String, QueryValue)],
+                key: &str,
+                value: &QueryValue,
             ) -> String {
-                let set_clause = format!(
-                    "{} = {}",
-                    quote_identifier(database_type, column),
-                    sql_literal(database_type, new_value)
-                );
-                let where_clause = pk_pairs
-                    .iter()
-                    .map(|(key, value)| equality_predicate(database_type, key, value))
-                    .collect::<Vec<_>>()
-                    .join(" AND ");
-                match database_type {
-                    DatabaseType::PostgreSQL | DatabaseType::MySQL => {
-                        format!(
-                            "UPDATE {}.{} SET {set_clause} WHERE {where_clause}",
-                            quote_identifier(database_type, schema),
-                            quote_identifier(database_type, table)
-                        )
+                match value {
+                    QueryValue::Null => {
+                        format!("{} IS NULL", quote_identifier(database_type, key))
                     }
-                    DatabaseType::SQLite => {
-                        format!(
-                            "UPDATE {} SET {set_clause} WHERE {where_clause}",
-                            quote_identifier(database_type, table)
-                        )
+                    _ => format!(
+                        "{} = {}",
+                        quote_identifier(database_type, key),
+                        sql_literal(database_type, value)
+                    ),
+                }
+            }
+
+            struct StubDdlGenerator;
+            impl DdlGenerator for StubDdlGenerator {
+                fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
+                    String::new()
+                }
+            }
+
+            struct StubSqlDialect;
+            impl SqlDialect for StubSqlDialect {
+                fn build_explain_sql(
+                    &self,
+                    database_type: DatabaseType,
+                    query: &str,
+                ) -> Option<String> {
+                    match database_type {
+                        DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
+                        DatabaseType::SQLite => build_sqlite_explain_query_plan_sql(query),
+                        DatabaseType::MySQL => mysql_explain_rejection_message(query)
+                            .is_none()
+                            .then(|| format!("EXPLAIN FORMAT=TREE {query}")),
+                    }
+                }
+
+                fn build_explain_analyze_sql(
+                    &self,
+                    database_type: DatabaseType,
+                    query: &str,
+                ) -> Option<String> {
+                    match database_type {
+                        DatabaseType::PostgreSQL => Some(format!("EXPLAIN ANALYZE {query}")),
+                        DatabaseType::SQLite => None,
+                        DatabaseType::MySQL => {
+                            let explain = format!("EXPLAIN ANALYZE FORMAT=TREE {query}");
+                            mysql_tree_explain_query_kind(&explain)
+                                .is_some()
+                                .then_some(explain)
+                        }
+                    }
+                }
+
+                fn build_update_sql(
+                    &self,
+                    database_type: DatabaseType,
+                    schema: &str,
+                    table: &str,
+                    column: &str,
+                    new_value: &QueryValue,
+                    pk_pairs: &[(String, QueryValue)],
+                ) -> String {
+                    let set_clause = format!(
+                        "{} = {}",
+                        quote_identifier(database_type, column),
+                        sql_literal(database_type, new_value)
+                    );
+                    let where_clause = pk_pairs
+                        .iter()
+                        .map(|(key, value)| equality_predicate(database_type, key, value))
+                        .collect::<Vec<_>>()
+                        .join(" AND ");
+                    match database_type {
+                        DatabaseType::PostgreSQL | DatabaseType::MySQL => {
+                            format!(
+                                "UPDATE {}.{} SET {set_clause} WHERE {where_clause}",
+                                quote_identifier(database_type, schema),
+                                quote_identifier(database_type, table)
+                            )
+                        }
+                        DatabaseType::SQLite => {
+                            format!(
+                                "UPDATE {} SET {set_clause} WHERE {where_clause}",
+                                quote_identifier(database_type, table)
+                            )
+                        }
+                    }
+                }
+                fn build_bulk_delete_sql(
+                    &self,
+                    database_type: DatabaseType,
+                    schema: &str,
+                    table: &str,
+                    pk_pairs_per_row: &[Vec<(String, QueryValue)>],
+                ) -> String {
+                    let where_clause = pk_pairs_per_row
+                        .iter()
+                        .map(|pk_pairs| {
+                            pk_pairs
+                                .iter()
+                                .map(|(key, value)| equality_predicate(database_type, key, value))
+                                .collect::<Vec<_>>()
+                                .join(" AND ")
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" OR ");
+                    match database_type {
+                        DatabaseType::PostgreSQL | DatabaseType::MySQL => {
+                            format!(
+                                "DELETE FROM {}.{} WHERE {where_clause}",
+                                quote_identifier(database_type, schema),
+                                quote_identifier(database_type, table)
+                            )
+                        }
+                        DatabaseType::SQLite => {
+                            format!(
+                                "DELETE FROM {} WHERE {where_clause}",
+                                quote_identifier(database_type, table)
+                            )
+                        }
                     }
                 }
             }
-            fn build_bulk_delete_sql(
-                &self,
-                database_type: DatabaseType,
-                schema: &str,
-                table: &str,
-                pk_pairs_per_row: &[Vec<(String, QueryValue)>],
-            ) -> String {
-                let where_clause = pk_pairs_per_row
-                    .iter()
-                    .map(|pk_pairs| {
-                        pk_pairs
-                            .iter()
-                            .map(|(key, value)| equality_predicate(database_type, key, value))
-                            .collect::<Vec<_>>()
-                            .join(" AND ")
-                    })
-                    .collect::<Vec<_>>()
-                    .join(" OR ");
-                match database_type {
-                    DatabaseType::PostgreSQL | DatabaseType::MySQL => {
-                        format!(
-                            "DELETE FROM {}.{} WHERE {where_clause}",
-                            quote_identifier(database_type, schema),
-                            quote_identifier(database_type, table)
-                        )
-                    }
-                    DatabaseType::SQLite => {
-                        format!(
-                            "DELETE FROM {} WHERE {where_clause}",
-                            quote_identifier(database_type, table)
-                        )
-                    }
+
+            struct StubDsnBuilder;
+            impl DsnBuilder for StubDsnBuilder {
+                fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
+                    "stub-dsn".to_string()
                 }
             }
-        }
 
-        struct StubDsnBuilder;
-        impl DsnBuilder for StubDsnBuilder {
-            fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
-                "stub-dsn".to_string()
+            Self {
+                ddl_generator: Arc::new(StubDdlGenerator),
+                sql_dialect: Arc::new(StubSqlDialect),
+                dsn_builder: Arc::new(StubDsnBuilder),
             }
-        }
-
-        Self {
-            ddl_generator: Arc::new(StubDdlGenerator),
-            sql_dialect: Arc::new(StubSqlDialect),
-            dsn_builder: Arc::new(StubDsnBuilder),
         }
     }
 }
@@ -219,6 +223,7 @@ impl AppServices {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{DatabaseType, QueryValue};
 
     #[test]
     fn stub_sqlite_explain_passes_through_existing_query_plan_prefix() {

--- a/src/app/update/dispatch_result.rs
+++ b/src/app/update/dispatch_result.rs
@@ -60,15 +60,20 @@ impl DispatchResult {
             Self::Pass => false,
         }
     }
+}
 
-    #[cfg(test)]
-    pub fn unwrap(self) -> Vec<Effect> {
-        self.into_effects().unwrap()
-    }
+#[cfg(test)]
+mod test_support {
+    use super::{DispatchResult, Effect};
 
-    #[cfg(test)]
-    pub fn expect(self, msg: &str) -> Vec<Effect> {
-        self.into_effects().expect(msg)
+    impl DispatchResult {
+        pub fn unwrap(self) -> Vec<Effect> {
+            self.into_effects().unwrap()
+        }
+
+        pub fn expect(self, msg: &str) -> Vec<Effect> {
+            self.into_effects().expect(msg)
+        }
     }
 }
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -156,7 +156,8 @@ mod tests {
         CursorPosition, ScrollAmount, ScrollDirection, ScrollTarget, ScrollToCursorTarget,
         SelectMotion,
     };
-    use crate::update::input::keybindings::{Key, KeyCombo, same_payload_free_action};
+    use crate::update::input::keybindings::test_support::same_payload_free_action;
+    use crate::update::input::keybindings::{Key, KeyCombo};
     use rstest::rstest;
 
     fn combo(k: Key) -> KeyCombo {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -163,21 +163,26 @@ pub fn global_action_for_with_policy(
         .map(|binding| binding.action.clone())
 }
 
-// Action has payload variants without PartialEq, so tests compare by
-// discriminant — except modal actions, where several bindings differ only by
-// ModalKind and the kind must participate in equality.
-#[cfg(any(test, feature = "test-support"))]
-pub fn same_payload_free_action(actual: &Action, expected: &Action) -> bool {
-    match (actual, expected) {
-        (Action::OpenModal(a), Action::OpenModal(b))
-        | (Action::CloseModal(a), Action::CloseModal(b))
-        | (Action::ToggleModal(a), Action::ToggleModal(b)) => a == b,
-        _ => std::mem::discriminant(actual) == std::mem::discriminant(expected),
+#[cfg(test)]
+pub mod test_support {
+    use super::Action;
+
+    // Action has payload variants without PartialEq, so tests compare by
+    // discriminant — except modal actions, where several bindings differ only by
+    // ModalKind and the kind must participate in equality.
+    pub fn same_payload_free_action(actual: &Action, expected: &Action) -> bool {
+        match (actual, expected) {
+            (Action::OpenModal(a), Action::OpenModal(b))
+            | (Action::CloseModal(a), Action::CloseModal(b))
+            | (Action::ToggleModal(a), Action::ToggleModal(b)) => a == b,
+            _ => std::mem::discriminant(actual) == std::mem::discriminant(expected),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::test_support::same_payload_free_action;
     use super::*;
 
     mod catalog_semantics {

--- a/src/app/update/input/palette.rs
+++ b/src/app/update/input/palette.rs
@@ -83,9 +83,8 @@ fn palette_command_supported(kb: &KeyBinding, feature_policy: &FeaturePolicy) ->
 mod tests {
     use super::*;
     use crate::update::action::ModalKind;
-    use crate::update::input::keybindings::{
-        GLOBAL_KEYS, IDE_GLOBAL_KEYS, same_payload_free_action,
-    };
+    use crate::update::input::keybindings::test_support::same_payload_free_action;
+    use crate::update::input::keybindings::{GLOBAL_KEYS, IDE_GLOBAL_KEYS};
 
     // Global keys deliberately kept out of the palette:
     // - COMMAND_LINE: command-line mode is a separate entry mechanism

--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -6,7 +6,7 @@ mod export;
 mod pipe;
 mod policy;
 mod probe;
-mod process;
+pub(super) mod process;
 #[cfg(unix)]
 mod pty;
 mod xml;
@@ -26,8 +26,6 @@ pub(super) use policy::{
     validate_mysql_multi_query_with_lower_case_table_names,
 };
 pub(super) use probe::{check_mysql_cli_version, probe_mysql_server};
-#[cfg(feature = "test-support")]
-pub(super) use process::test_support::run_mysql_adhoc_with_timeout_for_test;
 pub(super) use process::{
     MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, run_mysql_adhoc, run_mysql_single_statement,
 };

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -39,7 +39,7 @@ mod adhoc;
 pub(in crate::adapters::mysql) use adhoc::run_mysql_adhoc;
 mod single;
 #[cfg(feature = "test-support")]
-pub(super) mod test_support;
+pub(in crate::adapters::mysql) mod test_support;
 pub(in crate::adapters::mysql) use single::run_mysql_single_statement;
 mod metadata;
 pub(super) use metadata::mysql_metadata_columns;

--- a/src/infra/adapters/mysql/cli/xml.rs
+++ b/src/infra/adapters/mysql/cli/xml.rs
@@ -77,17 +77,6 @@ impl MySqlResultsetFrameScanner {
         self.resultset_end.map(|end| (start, end))
     }
 
-    #[cfg(test)]
-    fn take(&mut self, buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
-        let bounds = self.frame_bounds(buffer)?;
-        Some(self.take_bounds(buffer, bounds))
-    }
-
-    #[cfg(test)]
-    fn take_bounds(&mut self, buffer: &mut Vec<u8>, (start, end): (usize, usize)) -> Vec<u8> {
-        self.take_bounds_with_diagnostics(buffer, (start, end)).0
-    }
-
     fn take_bounds_with_diagnostics(
         &mut self,
         buffer: &mut Vec<u8>,
@@ -474,6 +463,17 @@ pub(super) fn parse_mysql_field(
 mod tests {
     use super::*;
     use crate::domain::MySqlDiagnosticLevel;
+
+    impl MySqlResultsetFrameScanner {
+        fn take(&mut self, buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
+            let bounds = self.frame_bounds(buffer)?;
+            Some(self.take_bounds(buffer, bounds))
+        }
+
+        fn take_bounds(&mut self, buffer: &mut Vec<u8>, (start, end): (usize, usize)) -> Vec<u8> {
+            self.take_bounds_with_diagnostics(buffer, (start, end)).0
+        }
+    }
 
     #[test]
     fn parses_mysql_xml_without_collapsing_value_boundaries() {

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -8,15 +8,6 @@ mod option_file;
 mod sql;
 
 #[cfg(feature = "test-support")]
-mod test_support;
+pub mod test_support;
 
 pub use adapter::MySqlAdapter;
-
-#[cfg(all(unix, feature = "test-support"))]
-pub use test_support::run_mysql_cli_script_for_test;
-
-#[cfg(feature = "test-support")]
-pub use test_support::{
-    execute_mysql_adhoc_with_read_only_session_for_test, execute_mysql_adhoc_with_timeout_for_test,
-    export_mysql_csv_to_path_for_test, run_mysql_cli_query_for_test,
-};

--- a/src/infra/adapters/mysql/test_support.rs
+++ b/src/infra/adapters/mysql/test_support.rs
@@ -10,9 +10,10 @@ use crate::app::ports::outbound::{AccessMode, DatabaseCli, DbOperationError};
 use tokio::process::Command;
 use tokio::time::timeout;
 
+use super::cli::process::test_support::run_mysql_adhoc_with_timeout_for_test;
 use super::cli::{
-    export_mysql_csv_to_file, run_mysql_adhoc, run_mysql_adhoc_with_timeout_for_test,
-    sanitize_mysql_command_environment, validate_mysql_multi_query,
+    export_mysql_csv_to_file, run_mysql_adhoc, sanitize_mysql_command_environment,
+    validate_mysql_multi_query,
 };
 use super::dsn::parse_and_validate_mysql_dsn;
 use super::option_file::MySqlOptionFile;

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -513,13 +513,19 @@ impl PostgresAdapter {
             })
     }
 
-    #[cfg(test)]
-    pub(in crate::adapters::postgres) fn parse_affected_rows(stdout: &str) -> Option<usize> {
-        Self::parse_affected_rows_with_source(stdout).ok()
-    }
-
     fn classify_psql_error(stderr: &str) -> DbOperationError {
         classify_query_error(stderr)
+    }
+}
+
+#[cfg(test)]
+mod test_support {
+    use super::PostgresAdapter;
+
+    impl PostgresAdapter {
+        pub(in crate::adapters::postgres) fn parse_affected_rows(stdout: &str) -> Option<usize> {
+            Self::parse_affected_rows_with_source(stdout).ok()
+        }
     }
 }
 

--- a/src/infra/adapters/postgres/psql/parser/command_tag.rs
+++ b/src/infra/adapters/postgres/psql/parser/command_tag.rs
@@ -88,11 +88,6 @@ impl PostgresAdapter {
             .and_then(Self::parse_command_tag_str)
     }
 
-    #[cfg(test)]
-    pub(in crate::adapters::postgres) fn extract_command_tag(stdout: &str) -> Option<CommandTag> {
-        Self::parse_command_tag(stdout).ok()
-    }
-
     fn is_known_tcl_tag(s: &str) -> bool {
         matches!(
             s.split_whitespace().next().unwrap_or(""),
@@ -271,6 +266,19 @@ impl ResolvedTags {
         }
 
         self.all.last().cloned()
+    }
+}
+
+#[cfg(test)]
+mod test_support {
+    use super::{CommandTag, PostgresAdapter};
+
+    impl PostgresAdapter {
+        pub(in crate::adapters::postgres) fn extract_command_tag(
+            stdout: &str,
+        ) -> Option<CommandTag> {
+            Self::parse_command_tag(stdout).ok()
+        }
     }
 }
 

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -57,13 +57,6 @@ impl FileQueryHistoryStore {
         Self { base_dir: None }
     }
 
-    #[cfg(test)]
-    fn with_base_dir(base_dir: PathBuf) -> Self {
-        Self {
-            base_dir: Some(base_dir),
-        }
-    }
-
     fn resolve_history_dir(&self, project_name: &str) -> Result<PathBuf, QueryHistoryError> {
         if let Some(base) = &self.base_dir {
             Ok(base.join("history"))
@@ -129,6 +122,14 @@ mod tests {
     use crate::domain::connection::ConnectionId;
     use crate::domain::query_history::QueryResultStatus;
     use tempfile::TempDir;
+
+    impl FileQueryHistoryStore {
+        fn with_base_dir(base_dir: PathBuf) -> Self {
+            Self {
+                base_dir: Some(base_dir),
+            }
+        }
+    }
 
     fn make_entry(query: &str) -> QueryHistoryEntry {
         QueryHistoryEntry::new(

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2064,7 +2064,7 @@ mod query_execution {
         AccessMode, DbOperationError, QueryExecutor, UnsupportedOperationKind,
     };
     use sabiql_domain::{QueryValue, RefreshScope};
-    use sabiql_infra::adapters::mysql::{
+    use sabiql_infra::adapters::mysql::test_support::{
         execute_mysql_adhoc_with_read_only_session_for_test,
         execute_mysql_adhoc_with_timeout_for_test,
     };
@@ -3400,7 +3400,7 @@ mod csv_export {
     use super::shared::MYSQL_EMPTY_TABLE;
     use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
     use sabiql_app::ports::outbound::DbOperationError;
-    use sabiql_infra::adapters::mysql::export_mysql_csv_to_path_for_test;
+    use sabiql_infra::adapters::mysql::test_support::export_mysql_csv_to_path_for_test;
     use tempfile::tempdir;
 
     const MYSQL_CSV_TEST_DECODED_LIMIT_BYTES: usize = 16 * 1024 * 1024;

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -1,8 +1,9 @@
 use sabiql_app::ports::outbound::{DbOperationError, DsnBuilder};
 use sabiql_domain::connection::{ConnectionProfile, MySqlConnectionConfig, MySqlSslMode};
+use sabiql_infra::adapters::mysql::MySqlAdapter;
+use sabiql_infra::adapters::mysql::test_support::run_mysql_cli_query_for_test;
 #[cfg(unix)]
-use sabiql_infra::adapters::mysql::run_mysql_cli_script_for_test;
-use sabiql_infra::adapters::mysql::{MySqlAdapter, run_mysql_cli_query_for_test};
+use sabiql_infra::adapters::mysql::test_support::run_mysql_cli_script_for_test;
 
 pub const MYSQL_FIXTURE_TABLE: &str = "mysql_cli_fixture";
 

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -17,9 +17,10 @@ use sabiql_app::model::shared::ui_state::{HELP_MODAL_HEIGHT_PERCENT, HELP_MODAL_
 use sabiql_app::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use sabiql_app::update::browse::result::dispatch_result;
 use sabiql_domain::{Column, ConnectionId, QueryResult};
+use sabiql_ui::theme::test_support::TEST_CONTRAST_THEME;
 use sabiql_ui::theme::{
     ComponentTokens, DEFAULT_THEME, EditorTokens, LIGHT_THEME, ModalTokens, SemanticTokens,
-    SurfaceTokens, TEST_CONTRAST_THEME, ThemePalette,
+    SurfaceTokens, ThemePalette,
 };
 
 fn has_cell(buffer: &Buffer, predicate: impl Fn(&Cell) -> bool) -> bool {

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -55,20 +55,6 @@ impl MainLayout {
         )
     }
 
-    // `render_with_theme` exists only as a test seam for injected palettes.
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn render_with_theme(
-        frame: &mut Frame,
-        state: &AppState,
-        time_ms: Option<u128>,
-        services: &AppServices,
-        now: Instant,
-        theme: &ThemePalette,
-    ) -> RenderOutput {
-        Self::render_impl(frame, state, time_ms, services, now, theme)
-    }
-
     fn render_impl(
         frame: &mut Frame,
         state: &AppState,
@@ -245,6 +231,25 @@ impl MainLayout {
                     pane_height: result_area.height,
                 },
             }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use super::{AppServices, AppState, Frame, Instant, MainLayout, RenderOutput, ThemePalette};
+
+    impl MainLayout {
+        #[doc(hidden)]
+        pub fn render_with_theme(
+            frame: &mut Frame,
+            state: &AppState,
+            time_ms: Option<u128>,
+            services: &AppServices,
+            now: Instant,
+            theme: &ThemePalette,
+        ) -> RenderOutput {
+            Self::render_impl(frame, state, time_ms, services, now, theme)
         }
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -339,79 +339,87 @@ pub const LIGHT_THEME: ThemePalette = ThemePalette {
 };
 
 #[cfg(any(test, feature = "test-support"))]
-#[doc(hidden)]
-pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
-    semantic: SemanticTokens {
-        surface: SurfaceTokens {
-            focus_border: Color::Rgb(0x2f, 0xc4, 0xb2),
-            unfocus_border: Color::Rgb(0x5d, 0x62, 0x74),
-            highlight_border: Color::Rgb(0xff, 0xc8, 0x57),
+pub mod test_support {
+    use super::{
+        Color, ComponentTokens, CursorTokens, EditorTokens, FeedbackTokens, ModalTokens,
+        NavigationTokens, SemanticTokens, StatusTokens, SurfaceTokens, SyntaxTokens, TableTokens,
+        TextTokens, ThemePalette,
+    };
+
+    #[doc(hidden)]
+    pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
+        semantic: SemanticTokens {
+            surface: SurfaceTokens {
+                focus_border: Color::Rgb(0x2f, 0xc4, 0xb2),
+                unfocus_border: Color::Rgb(0x5d, 0x62, 0x74),
+                highlight_border: Color::Rgb(0xff, 0xc8, 0x57),
+            },
+            text: TextTokens {
+                primary: Color::Rgb(0xf6, 0xf0, 0xe8),
+                secondary: Color::Rgb(0xc9, 0xd6, 0xdf),
+                muted: Color::Rgb(0x92, 0xb3, 0xc2),
+                dim: Color::Rgb(0x6a, 0x85, 0x95),
+                accent: Color::Rgb(0xff, 0xc8, 0x57),
+                placeholder: Color::Rgb(0x92, 0xb3, 0xc2),
+            },
+            status: StatusTokens {
+                success: Color::Rgb(0x7b, 0xe0, 0x73),
+                error: Color::Rgb(0xff, 0x7a, 0x59),
+                warning: Color::Rgb(0xff, 0xc8, 0x57),
+                pending: Color::Rgb(0xff, 0x9f, 0x1c),
+                medium_risk: Color::Rgb(0xff, 0x9f, 0x1c),
+            },
+            cursor: CursorTokens {
+                fg: Color::Rgb(0xff, 0xf4, 0xe0),
+                bg: Color::Rgb(0xff, 0xf4, 0xe0),
+                text_fg: Color::Rgb(0x0d, 0x11, 0x18),
+            },
         },
-        text: TextTokens {
-            primary: Color::Rgb(0xf6, 0xf0, 0xe8),
-            secondary: Color::Rgb(0xc9, 0xd6, 0xdf),
-            muted: Color::Rgb(0x92, 0xb3, 0xc2),
-            dim: Color::Rgb(0x6a, 0x85, 0x95),
-            accent: Color::Rgb(0xff, 0xc8, 0x57),
-            placeholder: Color::Rgb(0x92, 0xb3, 0xc2),
+        component: ComponentTokens {
+            modal: ModalTokens {
+                title: Color::Rgb(0xf6, 0xf0, 0xe8),
+                hint: Color::Rgb(0x7b, 0xe0, 0x73),
+                border: Color::Rgb(0xd8, 0x2a, 0x1f),
+                border_highlight: Color::Rgb(0xff, 0xe0, 0x66),
+            },
+            navigation: NavigationTokens {
+                key_chip_bg: Color::Rgb(0x1a, 0x45, 0x5e),
+                key_chip_fg: Color::Rgb(0xff, 0xe0, 0x66),
+                section_header: Color::Rgb(0x2f, 0xc4, 0xb2),
+                scrollbar_active: Color::Rgb(0x2f, 0xc4, 0xb2),
+                scrollbar_inactive: Color::Rgb(0x5d, 0x62, 0x74),
+                tab_active: Color::Rgb(0x2f, 0xc4, 0xb2),
+                tab_inactive: Color::Rgb(0x92, 0xb3, 0xc2),
+                active_indicator: Color::Rgb(0x2f, 0xc4, 0xb2),
+            },
+            editor: EditorTokens {
+                current_line_bg: Color::Rgb(0x1d, 0x2d, 0x3f),
+                completion_selected_bg: Color::Rgb(0x2d, 0x5d, 0x46),
+            },
+            table: TableTokens {
+                result_row_active_bg: Color::Rgb(0x2b, 0x32, 0x54),
+                result_cell_active_bg: Color::Rgb(0x3a, 0x44, 0x6e),
+                cell_edit_fg: Color::Rgb(0xff, 0xe0, 0x66),
+                staged_delete_bg: Color::Rgb(0x4a, 0x1f, 0x1f),
+                staged_delete_fg: Color::Rgb(0xff, 0x7a, 0x59),
+                striped_row_bg: Color::Rgb(0x1d, 0x21, 0x2b),
+            },
+            feedback: FeedbackTokens {
+                yank_flash_bg: Color::Rgb(0xff, 0xc8, 0x57),
+                yank_flash_fg: Color::Rgb(0x14, 0x17, 0x21),
+                note_text: Color::Rgb(0x92, 0xb3, 0xc2),
+            },
+            syntax: SyntaxTokens {
+                sql_keyword: Color::Rgb(0x7d, 0xc4, 0xff),
+                sql_string: Color::Rgb(0x9b, 0xf0, 0x8f),
+                sql_number: Color::Rgb(0xff, 0xb8, 0x6b),
+                sql_comment: Color::Rgb(0x7c, 0x8a, 0xa5),
+                sql_operator: Color::Rgb(0x5e, 0xe0, 0xd5),
+                sql_text: Color::Rgb(0xf6, 0xf0, 0xe8),
+            },
         },
-        status: StatusTokens {
-            success: Color::Rgb(0x7b, 0xe0, 0x73),
-            error: Color::Rgb(0xff, 0x7a, 0x59),
-            warning: Color::Rgb(0xff, 0xc8, 0x57),
-            pending: Color::Rgb(0xff, 0x9f, 0x1c),
-            medium_risk: Color::Rgb(0xff, 0x9f, 0x1c),
-        },
-        cursor: CursorTokens {
-            fg: Color::Rgb(0xff, 0xf4, 0xe0),
-            bg: Color::Rgb(0xff, 0xf4, 0xe0),
-            text_fg: Color::Rgb(0x0d, 0x11, 0x18),
-        },
-    },
-    component: ComponentTokens {
-        modal: ModalTokens {
-            title: Color::Rgb(0xf6, 0xf0, 0xe8),
-            hint: Color::Rgb(0x7b, 0xe0, 0x73),
-            border: Color::Rgb(0xd8, 0x2a, 0x1f),
-            border_highlight: Color::Rgb(0xff, 0xe0, 0x66),
-        },
-        navigation: NavigationTokens {
-            key_chip_bg: Color::Rgb(0x1a, 0x45, 0x5e),
-            key_chip_fg: Color::Rgb(0xff, 0xe0, 0x66),
-            section_header: Color::Rgb(0x2f, 0xc4, 0xb2),
-            scrollbar_active: Color::Rgb(0x2f, 0xc4, 0xb2),
-            scrollbar_inactive: Color::Rgb(0x5d, 0x62, 0x74),
-            tab_active: Color::Rgb(0x2f, 0xc4, 0xb2),
-            tab_inactive: Color::Rgb(0x92, 0xb3, 0xc2),
-            active_indicator: Color::Rgb(0x2f, 0xc4, 0xb2),
-        },
-        editor: EditorTokens {
-            current_line_bg: Color::Rgb(0x1d, 0x2d, 0x3f),
-            completion_selected_bg: Color::Rgb(0x2d, 0x5d, 0x46),
-        },
-        table: TableTokens {
-            result_row_active_bg: Color::Rgb(0x2b, 0x32, 0x54),
-            result_cell_active_bg: Color::Rgb(0x3a, 0x44, 0x6e),
-            cell_edit_fg: Color::Rgb(0xff, 0xe0, 0x66),
-            staged_delete_bg: Color::Rgb(0x4a, 0x1f, 0x1f),
-            staged_delete_fg: Color::Rgb(0xff, 0x7a, 0x59),
-            striped_row_bg: Color::Rgb(0x1d, 0x21, 0x2b),
-        },
-        feedback: FeedbackTokens {
-            yank_flash_bg: Color::Rgb(0xff, 0xc8, 0x57),
-            yank_flash_fg: Color::Rgb(0x14, 0x17, 0x21),
-            note_text: Color::Rgb(0x92, 0xb3, 0xc2),
-        },
-        syntax: SyntaxTokens {
-            sql_keyword: Color::Rgb(0x7d, 0xc4, 0xff),
-            sql_string: Color::Rgb(0x9b, 0xf0, 0x8f),
-            sql_number: Color::Rgb(0xff, 0xb8, 0x6b),
-            sql_comment: Color::Rgb(0x7c, 0x8a, 0xa5),
-            sql_operator: Color::Rgb(0x5e, 0xe0, 0xd5),
-            sql_text: Color::Rgb(0xf6, 0xf0, 0xe8),
-        },
-    },
-};
+    };
+}
 
 pub fn palette_for(theme_id: ThemeId) -> &'static ThemePalette {
     match theme_id {


### PR DESCRIPTION
## Problem

Test-only helpers and test-support APIs were interleaved with production implementations, making the production scope harder to audit.

## Background

The test structure rules require test-only items to live in their consuming test module, a shared test-support module, or a dedicated feature-gated test-support module when cross-crate tests need them.

## Approach

Move helpers and test-only implementations into the smallest valid test scope, retain `test-support` only for existing cross-crate callers, and update those callers to the dedicated test-support modules without changing production behavior.
