### PR TITLE
refactor: consolidate MySQL query failure wrapping

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -388,20 +388,6 @@ pub(super) fn query_failed_after_change(
     }
 }
 
-pub(super) fn query_failed_after_mysql_statement(
-    error: DbOperationError,
-    possible_refresh_scope: RefreshScope,
-) -> DbOperationError {
-    let refresh_scope = match &error {
-        DbOperationError::QueryFailedAfterChange {
-            refresh_scope: existing_scope,
-            ..
-        } => *existing_scope,
-        _ => possible_refresh_scope,
-    };
-    query_failed_after_change(error, refresh_scope)
-}
-
 pub(super) fn is_mysql_row_count_marker(result: &MySqlResultSet, marker: &str) -> bool {
     result.columns == ["__sabiql_marker", "affected_rows"]
         && result.values.len() == 1

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -23,7 +23,7 @@ use super::error::{
 #[cfg(not(unix))]
 use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
 use super::policy::{
-    MYSQL_SESSION_MARKER_COLUMN, query_failed_after_mysql_statement, validate_mysql_session_marker,
+    MYSQL_SESSION_MARKER_COLUMN, query_failed_after_change, validate_mysql_session_marker,
 };
 #[cfg(unix)]
 use super::pty::{
@@ -433,14 +433,11 @@ where
         Ok(Ok(value)) => Ok(value),
         Ok(Err(error)) => {
             cleanup_mysql_process(process).await;
-            Err(query_failed_after_mysql_statement(
-                error,
-                possible_refresh_scope,
-            ))
+            Err(query_failed_after_change(error, possible_refresh_scope))
         }
         Err(_) => {
             cleanup_mysql_process(process).await;
-            Err(query_failed_after_mysql_statement(
+            Err(query_failed_after_change(
                 DbOperationError::Timeout("mysql query exceeded the execution timeout".to_string()),
                 possible_refresh_scope,
             ))

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -17,7 +17,7 @@ use crate::domain::{
 use super::super::policy::{
     MySqlExecutionResult, mysql_command_tag, mysql_metadata_fallback_has_unsupported_session_state,
     mysql_possible_refresh_scope, mysql_refresh_scope, mysql_row_count_marker,
-    query_failed_after_change, query_failed_after_mysql_statement,
+    query_failed_after_change,
 };
 use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns_with_diagnostics;
@@ -142,10 +142,7 @@ async fn run_mysql_statement(
     let (xml, diagnostics) = match read_one_mysql_resultset_with_diagnostics(process).await {
         Ok(result) => result,
         Err(error) => {
-            return Err(query_failed_after_mysql_statement(
-                error,
-                possible_refresh_scope,
-            ));
+            return Err(query_failed_after_change(error, possible_refresh_scope));
         }
     };
     let result = match super::parse_mysql_xml(&xml) {
@@ -302,7 +299,7 @@ async fn run_mysql_adhoc_process(
         match read_one_mysql_resultset_with_diagnostics(process).await {
             Ok(result) => result,
             Err(error) => {
-                return Err(query_failed_after_mysql_statement(error, refresh_scope));
+                return Err(query_failed_after_change(error, refresh_scope));
             }
         };
     diagnostics.extend(marker_diagnostics);


### PR DESCRIPTION
## Problem
MySQL query failures use two refresh-wrapping entry points even though both preserve an existing `QueryFailedAfterChange` and otherwise apply the supplied refresh scope.

## Background
The phase-specific wrapper duplicates the shared error-wrapping policy and obscures that callers already know the executed or possible scope.

## Approach
Use `query_failed_after_change` for every affected caller and remove the redundant wrapper. Keep executed-scope and timeout possible-scope calculation at the callers.
