### PR TITLE
refactor(mysql): unify metadata session timeout cleanup

### DIFF
--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -128,7 +128,7 @@ impl MySqlMetadataSession {
         result
     }
 
-    pub(in crate::adapters::mysql) async fn cleanup(&mut self) {
+    async fn cleanup(&mut self) {
         cleanup_mysql_process(&mut self.process).await;
     }
 }

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -113,6 +113,21 @@ impl MySqlMetadataSession {
         Ok(())
     }
 
+    pub(in crate::adapters::mysql) async fn resolve_timed_result<T>(
+        &mut self,
+        result: Result<Result<T, DbOperationError>, tokio::time::error::Elapsed>,
+    ) -> Result<T, DbOperationError> {
+        let result = match result {
+            Ok(Ok(value)) => return Ok(value),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            )),
+        };
+        self.cleanup().await;
+        result
+    }
+
     pub(in crate::adapters::mysql) async fn cleanup(&mut self) {
         cleanup_mysql_process(&mut self.process).await;
     }

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -214,19 +214,7 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
         Ok((lower_case_table_names, results))
     })
     .await;
-    let result = match result {
-        Ok(Ok(results)) => Ok(results),
-        Ok(Err(error)) => {
-            session.cleanup().await;
-            Err(error)
-        }
-        Err(_) => {
-            session.cleanup().await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
-            ))
-        }
-    };
+    let result = session.resolve_timed_result(result).await;
     drop(option_file);
     result
 }

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -81,19 +81,7 @@ async fn execute_preview_with_program(
         execute_preview_with_session(&mut session, database, schema, table, limit, offset),
     )
     .await;
-    let result = match result {
-        Ok(Ok(execution)) => Ok(execution),
-        Ok(Err(error)) => {
-            session.cleanup().await;
-            Err(error)
-        }
-        Err(_) => {
-            session.cleanup().await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
-            ))
-        }
-    };
+    let result = session.resolve_timed_result(result).await;
     drop(option_file);
     result
 }

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -150,19 +150,7 @@ async fn fetch_table_detail_in_session_with_program(
         fetch_table_detail_with_session(&mut session, database, schema, table),
     )
     .await;
-    let result = match result {
-        Ok(Ok(table)) => Ok(table),
-        Ok(Err(error)) => {
-            session.cleanup().await;
-            Err(error)
-        }
-        Err(_) => {
-            session.cleanup().await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
-            ))
-        }
-    };
+    let result = session.resolve_timed_result(result).await;
     drop(option_file);
     result
 }


### PR DESCRIPTION
## Problem
MySQL metadata catalog, preview, and table-detail sessions duplicate the same timeout-result cleanup logic.

## Background
Each path must clean up only after an operation error or elapsed timeout while preserving the original operation error and the timeout details.

## Approach
Keep each caller's operation future and completion behavior unchanged, and let `MySqlMetadataSession` resolve the completed timeout result. The session-only helper performs cleanup for failures and retains the existing timeout error.

## Screenshots
<!-- Not applicable. -->
