### PR TITLE
refactor(mysql): simplify probe command lifecycle

### DIFF
--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -1,9 +1,20 @@
 use std::io::{self, Write};
 
-use crate::app::ports::outbound::DbOperationError;
+use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
 
 use super::probe::{is_mysql_connect_timeout_message, mysql_tls_failure_kind, validate_sql_mode};
 use super::xml::MySqlResultSet;
+
+pub(super) fn map_mysql_cli_spawn_error(error: io::Error) -> DbOperationError {
+    if error.kind() == io::ErrorKind::NotFound {
+        DbOperationError::CommandNotFound {
+            command: DatabaseCli::MySql,
+            details: error.to_string(),
+        }
+    } else {
+        DbOperationError::ConnectionFailed(error.to_string())
+    }
+}
 
 pub(super) fn has_mysql_cli_error(output: &[u8]) -> bool {
     output
@@ -157,7 +168,7 @@ fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
     digits[..end].parse().ok()
 }
 
-fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
+pub(super) fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
     let text = String::from_utf8_lossy(stderr).trim().to_string();
     if text.is_empty() {
         fallback.to_string()

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsStr;
-use std::io;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -9,16 +8,19 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::app::ports::outbound::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
+    ConnectionFailureKind, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
     MySqlConnectionProbeResult, UnsupportedOperationKind,
 };
 
 use super::args::mysql_connection_args;
+use super::error::{clean_mysql_stderr, map_mysql_cli_spawn_error};
 use super::sanitize_mysql_command_environment;
 
 const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
 const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('version', VERSION(), 'sql_mode', @@SESSION.sql_mode, 'lower_case_table_names', @@lower_case_table_names)";
 const MYSQL_VERSION_ARGS: [&str; 3] = ["--no-defaults", "--no-login-paths", "--version"];
+const MYSQL_SUPPORTED_MAJOR: u32 = 8;
+const MYSQL_SUPPORTED_MINOR: u32 = 4;
 
 #[derive(Debug, Deserialize)]
 struct MySqlProbeResponse {
@@ -59,13 +61,7 @@ async fn run_mysql_version_command(
 
     match timeout(MYSQL_PROBE_TIMEOUT, command.output()).await {
         Ok(Ok(output)) => Ok(output),
-        Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => {
-            Err(DbOperationError::CommandNotFound {
-                command: DatabaseCli::MySql,
-                details: error.to_string(),
-            })
-        }
-        Ok(Err(error)) => Err(DbOperationError::ConnectionFailed(error.to_string())),
+        Ok(Err(error)) => Err(map_mysql_cli_spawn_error(error)),
         Err(_) => Err(DbOperationError::Timeout(
             "mysql probe exceeded the connection timeout".to_string(),
         )),
@@ -73,11 +69,19 @@ async fn run_mysql_version_command(
 }
 
 pub(in crate::adapters::mysql) async fn probe_mysql_server(
-    option_file: &PathBuf,
+    option_file: &Path,
 ) -> Result<MySqlConnectionProbeResult, DbOperationError> {
-    let output = run_mysql_command(mysql_probe_args(option_file), Some(option_file)).await?;
+    let output = run_mysql_command_with_timeout(
+        mysql_probe_args(option_file),
+        MYSQL_PROBE_TIMEOUT,
+        "mysql probe exceeded the connection timeout",
+    )
+    .await?;
     if !output.status.success() {
-        return Err(classify_mysql_probe_failure(clean_stderr(&output.stderr)));
+        return Err(classify_mysql_probe_failure(clean_mysql_stderr(
+            &output.stderr,
+            "mysql probe failed",
+        )));
     }
 
     let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
@@ -108,17 +112,16 @@ fn contains_unsupported_mysql_product(value: &str) -> bool {
 
 fn is_oracle_mysql_cli_84_version(value: &str) -> bool {
     let lower = value.to_ascii_lowercase();
-    lower.contains("mysql")
-        && !contains_unsupported_mysql_product(value)
-        && version_major_minor(value) == Some((8, 4))
+    lower.contains("mysql") && is_oracle_mysql_84_version(value)
 }
 
-fn is_oracle_mysql_server_84_version(value: &str) -> bool {
-    !contains_unsupported_mysql_product(value) && version_major_minor(value) == Some((8, 4))
+fn is_oracle_mysql_84_version(value: &str) -> bool {
+    !contains_unsupported_mysql_product(value)
+        && version_major_minor(value) == Some((MYSQL_SUPPORTED_MAJOR, MYSQL_SUPPORTED_MINOR))
 }
 
 fn validate_server_version(version: &str) -> Result<(), DbOperationError> {
-    if is_oracle_mysql_server_84_version(version) {
+    if is_oracle_mysql_84_version(version) {
         Ok(())
     } else {
         Err(DbOperationError::UnsupportedOperationWithKind {
@@ -163,26 +166,8 @@ fn mysql_probe_args(option_file: &std::path::Path) -> Vec<String> {
     args
 }
 
-pub(super) async fn run_mysql_command<I, S>(
-    args: I,
-    option_file: Option<&PathBuf>,
-) -> Result<std::process::Output, DbOperationError>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    run_mysql_command_with_timeout(
-        args,
-        option_file,
-        MYSQL_PROBE_TIMEOUT,
-        "mysql probe exceeded the connection timeout",
-    )
-    .await
-}
-
 pub(super) async fn run_mysql_command_with_timeout<I, S>(
     args: I,
-    option_file: Option<&PathBuf>,
     command_timeout: Duration,
     timeout_message: &str,
 ) -> Result<std::process::Output, DbOperationError>
@@ -193,29 +178,11 @@ where
     let mut command = Command::new("mysql");
     command.args(args).stdin(Stdio::null()).kill_on_drop(true);
     sanitize_mysql_command_environment(&mut command);
-    if option_file.is_some() {
-        command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    }
 
     match timeout(command_timeout, command.output()).await {
         Ok(Ok(output)) => Ok(output),
-        Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => {
-            Err(DbOperationError::CommandNotFound {
-                command: DatabaseCli::MySql,
-                details: error.to_string(),
-            })
-        }
-        Ok(Err(error)) => Err(DbOperationError::ConnectionFailed(error.to_string())),
+        Ok(Err(error)) => Err(map_mysql_cli_spawn_error(error)),
         Err(_) => Err(DbOperationError::Timeout(timeout_message.to_string())),
-    }
-}
-
-fn clean_stderr(stderr: &[u8]) -> String {
-    let text = String::from_utf8_lossy(stderr).trim().to_string();
-    if text.is_empty() {
-        "mysql probe failed".to_string()
-    } else {
-        text
     }
 }
 
@@ -315,9 +282,9 @@ mod probe_tests {
         assert!(!is_oracle_mysql_cli_84_version(
             "mysql  Ver 8.4.3-3 for Linux (Percona Server)"
         ));
-        assert!(is_oracle_mysql_server_84_version("8.4.3"));
-        assert!(!is_oracle_mysql_server_84_version("8.4.3-TiDB"));
-        assert!(!is_oracle_mysql_server_84_version("8.4.3-Percona"));
+        assert!(is_oracle_mysql_84_version("8.4.3"));
+        assert!(!is_oracle_mysql_84_version("8.4.3-TiDB"));
+        assert!(!is_oracle_mysql_84_version("8.4.3-Percona"));
         assert!(matches!(
             validate_server_version("8.0.36"),
             Err(DbOperationError::UnsupportedOperationWithKind {
@@ -492,8 +459,9 @@ mod probe_tests {
     mod version_command {
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
-        use std::path::Path;
+        use std::path::PathBuf;
 
+        use crate::app::ports::outbound::DatabaseCli;
         use tempfile::TempDir;
 
         use super::*;

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsStr;
-use std::io;
 use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
@@ -11,14 +10,15 @@ use tokio::process::{Child, Command};
 use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
 use uuid::Uuid;
 
-use crate::app::ports::outbound::{AccessMode, DatabaseCli, DbOperationError};
+use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{MySqlDiagnostic, RefreshScope};
 
 use super::args::{MYSQL_CLIENT_MAX_PACKET_BYTES, mysql_adhoc_args, mysql_query_args};
 #[cfg(not(unix))]
 use super::error::classify_mysql_query_failure;
 use super::error::{
-    classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, validate_mode_probe,
+    classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, map_mysql_cli_spawn_error,
+    validate_mode_probe,
 };
 #[cfg(not(unix))]
 use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
@@ -49,17 +49,6 @@ pub(in crate::adapters::mysql) const MYSQL_QUERY_TIMEOUT: Duration = Duration::f
 const MYSQL_PTY_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const MYSQL_SESSION_SETTINGS: &str = "SET SESSION autocommit=1, completion_type=NO_CHAIN";
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
-
-fn map_mysql_cli_spawn_error(error: io::Error) -> DbOperationError {
-    if error.kind() == io::ErrorKind::NotFound {
-        DbOperationError::CommandNotFound {
-            command: DatabaseCli::MySql,
-            details: error.to_string(),
-        }
-    } else {
-        DbOperationError::ConnectionFailed(error.to_string())
-    }
-}
 
 pub(in crate::adapters::mysql) struct MySqlProcess {
     pub(super) child: Child,
@@ -507,8 +496,11 @@ fn mysql_statement_input(query: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod process_tests {
+    use std::io;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
+
+    use crate::app::ports::outbound::DatabaseCli;
 
     use super::*;
 

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -13,6 +13,7 @@ use crate::domain::{MySqlDiagnostic, QueryValue};
 use super::super::args::mysql_metadata_args;
 use super::super::error::{
     classify_mysql_query_failure, has_mysql_cli_error, is_mysql_batch_diagnostic,
+    map_mysql_cli_spawn_error,
 };
 use super::super::policy::{
     MYSQL_SESSION_MARKER_COLUMN, MySqlMetadataFallbackKind, mysql_metadata_select_query,
@@ -125,10 +126,8 @@ pub(super) async fn mysql_metadata_columns_external_with_program(
 
     let mut args = mysql_metadata_args(option_file);
     args.push(format!("--execute={query}"));
-    let option_file = option_file.to_path_buf();
     let output = run_mysql_command_with_timeout(
         args,
-        Some(&option_file),
         MYSQL_QUERY_TIMEOUT,
         "mysql query exceeded the execution timeout",
     )
@@ -156,7 +155,7 @@ impl MySqlMetadataProcess {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         sanitize_mysql_command_environment(&mut command);
-        let mut child = command.spawn().map_err(super::map_mysql_cli_spawn_error)?;
+        let mut child = command.spawn().map_err(map_mysql_cli_spawn_error)?;
         let stdin = child.stdin.take().ok_or_else(|| {
             DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
         })?;

--- a/src/infra/adapters/mysql/connection.rs
+++ b/src/infra/adapters/mysql/connection.rs
@@ -12,17 +12,11 @@ use super::option_file::MySqlOptionFile;
 impl MySqlConnectionProbe for MySqlAdapter {
     async fn probe(&self, dsn: &str) -> Result<MySqlConnectionProbeResult, DbOperationError> {
         let target = parse_and_validate_mysql_dsn(dsn)?;
-        self.check_cli_version().await?;
+        check_mysql_cli_version().await?;
 
         let option_file = MySqlOptionFile::create(&target)?;
         let result = super::cli::probe_mysql_server(&option_file.path).await;
         drop(option_file);
         result
-    }
-}
-
-impl MySqlAdapter {
-    async fn check_cli_version(&self) -> Result<(), DbOperationError> {
-        check_mysql_cli_version().await
     }
 }


### PR DESCRIPTION
## Problem
MySQL probe setup retains optional arguments, forwarding wrappers, and duplicated error and version logic that no longer represent distinct choices.

## Background
The probe and metadata paths now have fixed capture, timeout, and version-policy behavior, so the extra indirection increases maintenance cost without preserving a meaningful boundary.

## Approach
Keep version and query command runners separate while removing the unused option-file state, thin forwarding functions, and duplicated stderr, version, and spawn-error handling. Preserve the existing version exclusions, timeout messages, output parsing, and metadata process behavior.

## Screenshots
<!-- Screenshots/GIF. Optional -->
