### PR TITLE
refactor(app): encode query completion context

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -6,16 +6,16 @@ use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
 use crate::cmd::query_task::QueryTaskRegistry;
+use crate::domain::DatabaseType;
 use crate::domain::command_tag::CommandTag;
 use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
-use crate::domain::{DatabaseType, QuerySource};
 use crate::domain::{
     mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
     sqlite_explain_query_plan_text_from_result,
 };
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
-use crate::update::action::Action;
+use crate::update::action::{Action, QueryCompletionContext, QueryFailureContext};
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
     // Algorithm from https://howardhinnant.github.io/date_algorithms.html
@@ -111,8 +111,10 @@ pub async fn run(
                             dsn,
                             run_id,
                             result: Arc::new(result),
-                            generation,
-                            target_page: Some(target_page),
+                            context: QueryCompletionContext::Preview {
+                                generation,
+                                target_page,
+                            },
                         })
                         .await
                         .ok();
@@ -122,8 +124,7 @@ pub async fn run(
                             dsn,
                             run_id,
                             error: e,
-                            generation,
-                            source: QuerySource::Preview,
+                            context: QueryFailureContext::Preview { generation },
                         })
                         .await
                         .ok();
@@ -223,8 +224,7 @@ pub async fn run(
                             dsn,
                             run_id,
                             result: Arc::new(result),
-                            generation: 0,
-                            target_page: None,
+                            context: QueryCompletionContext::Adhoc,
                         })
                         .await
                         .ok();
@@ -245,8 +245,7 @@ pub async fn run(
                             dsn,
                             run_id,
                             error: e,
-                            generation: 0,
-                            source: QuerySource::Adhoc,
+                            context: QueryFailureContext::Adhoc,
                         })
                         .await
                         .ok();
@@ -655,14 +654,13 @@ mod tests {
         use crate::cmd::test_fixtures;
         use std::time::Instant;
 
-        use crate::domain::QuerySource;
         use crate::model::app_state::AppState;
         use crate::ports::outbound::connection_store::MockConnectionStore;
         use crate::ports::outbound::metadata::MockMetadataProvider;
         use crate::ports::outbound::query_executor::MockQueryExecutor;
         use crate::ports::outbound::{DbOperationError, RenderOutput, RenderResult, Renderer};
         use crate::services::AppServices;
-        use crate::update::action::Action;
+        use crate::update::action::{Action, QueryFailureContext};
 
         struct NoopRenderer;
         impl Renderer for NoopRenderer {
@@ -780,7 +778,7 @@ mod tests {
                 matches!(
                     action,
                     Action::QueryFailed {
-                        source: QuerySource::Preview,
+                        context: QueryFailureContext::Preview { .. },
                         ..
                     }
                 ),

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -23,8 +23,7 @@ use std::collections::HashMap;
 
 use crate::domain::SqliteDiagnosticsSnapshot;
 use crate::domain::{
-    DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table, TableSignatureSnapshot,
-    WriteDiagnostic,
+    DatabaseMetadata, DiagnosticField, QueryResult, Table, TableSignatureSnapshot, WriteDiagnostic,
 };
 
 #[derive(Clone, thiserror::Error)]
@@ -316,6 +315,18 @@ impl fmt::Debug for ConnectionTarget {
 // setup -> DB structure -> SQL -> query results -> result derivatives.
 // Product groups follow the object in the action sentence, not UI/reducer names
 // (e.g., MetadataLoaded -> Database structure, QueryCompleted -> Query results).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryCompletionContext {
+    Adhoc,
+    Preview { generation: u64, target_page: usize },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryFailureContext {
+    Adhoc,
+    Preview { generation: u64 },
+}
+
 #[derive(Debug, Clone)]
 pub enum Action {
     // App shell
@@ -592,15 +603,13 @@ pub enum Action {
         dsn: String,
         run_id: u64,
         result: Arc<QueryResult>,
-        generation: u64,
-        target_page: Option<usize>,
+        context: QueryCompletionContext,
     },
     QueryFailed {
         dsn: String,
         run_id: u64,
         error: DbOperationError,
-        generation: u64,
-        source: QuerySource,
+        context: QueryFailureContext,
     },
     RevealPendingPreview {
         generation: u64,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -10,7 +10,9 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
 use crate::ports::outbound::{AccessMode, DbOperationError};
 use crate::services::AppServices;
-use crate::update::action::{Action, ModalKind, TableTarget};
+use crate::update::action::{
+    Action, ModalKind, QueryCompletionContext, QueryFailureContext, TableTarget,
+};
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
@@ -29,25 +31,32 @@ pub fn reduce_execution(
             dsn,
             run_id,
             result,
-            generation,
-            target_page,
+            context,
         } => {
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
-            if *generation != 0 && *generation != state.session.selection_generation() {
+            if let QueryCompletionContext::Preview { generation, .. } = context
+                && *generation != state.session.selection_generation()
+            {
                 return DispatchResult::handled();
             }
 
-            if *generation != 0
+            if let QueryCompletionContext::Preview {
+                generation,
+                target_page,
+            } = context
                 && result.source == QuerySource::Preview
                 && state.session.selected_table_key().is_some()
                 && !state.session.is_table_detail_terminal(*generation)
             {
                 state.query.mark_idle();
-                state
-                    .query
-                    .defer_preview(Arc::clone(result), *generation, *target_page, true);
+                state.query.defer_preview(
+                    Arc::clone(result),
+                    *generation,
+                    Some(*target_page),
+                    true,
+                );
                 return DispatchResult::handled();
             }
 
@@ -78,7 +87,11 @@ pub fn reduce_execution(
                 // Preview errors arrive as error results and are shown in the
                 // Result pane like any other preview.
                 (QuerySource::Preview, _) => {
-                    apply_preview_result(state, result, *target_page, now, true);
+                    let target_page = match context {
+                        QueryCompletionContext::Adhoc => None,
+                        QueryCompletionContext::Preview { target_page, .. } => Some(*target_page),
+                    };
+                    apply_preview_result(state, result, target_page, now, true);
                 }
             }
 
@@ -88,23 +101,20 @@ pub fn reduce_execution(
             dsn,
             run_id,
             error,
-            generation,
-            source,
+            context,
         } => {
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 
-            if *source == QuerySource::Preview
-                && matches!(error, DbOperationError::PreviewSizeExceeded(_))
-            {
+            let is_preview = matches!(context, QueryFailureContext::Preview { .. });
+            if is_preview && matches!(error, DbOperationError::PreviewSizeExceeded(_)) {
                 state.query.mark_idle();
                 state.messages.set_error_at(error.user_message(), now);
                 return DispatchResult::handled();
             }
 
-            if *source == QuerySource::Preview
-                && *generation != 0
+            if let QueryFailureContext::Preview { generation } = context
                 && *generation == state.session.selection_generation()
                 && state.session.selected_table_key().is_some()
                 && !state.session.is_table_detail_terminal(*generation)
@@ -125,9 +135,13 @@ pub fn reduce_execution(
                 return DispatchResult::handled();
             }
 
-            if *generation == 0 || *generation == state.session.selection_generation() {
+            if !matches!(
+                context,
+                QueryFailureContext::Preview { generation }
+                    if *generation != state.session.selection_generation()
+            ) {
                 state.query.mark_idle();
-                if *source == QuerySource::Preview {
+                if is_preview {
                     state.result_interaction.reset_view();
                     state
                         .query
@@ -150,10 +164,10 @@ pub fn reduce_execution(
                 DbOperationError::QueryFailedAfterChange { refresh_scope, .. } => *refresh_scope,
                 _ => RefreshScope::None,
             };
-            let effects = if *source == QuerySource::Adhoc {
-                refresh_effects_for_scope(state, refresh_scope, now)
-            } else {
+            let effects = if is_preview {
                 vec![]
+            } else {
+                refresh_effects_for_scope(state, refresh_scope, now)
             };
             DispatchResult::handled_with(effects)
         }
@@ -572,8 +586,10 @@ mod tests {
             dsn: state.session.dsn().unwrap_or_default().to_string(),
             run_id,
             error,
-            generation,
-            source,
+            context: match source {
+                QuerySource::Adhoc => QueryFailureContext::Adhoc,
+                QuerySource::Preview => QueryFailureContext::Preview { generation },
+            },
         }
     }
 
@@ -1274,8 +1290,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: old_run_id,
                     result: adhoc_result(),
-                    generation: 0,
-                    target_page: None,
+                    context: QueryCompletionContext::Adhoc,
                 },
                 Instant::now(),
                 &AppServices::stub(),
@@ -1299,8 +1314,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: stale_run_id,
                     result: adhoc_result(),
-                    generation: 0,
-                    target_page: None,
+                    context: QueryCompletionContext::Adhoc,
                 },
                 Instant::now(),
                 &AppServices::stub(),

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -67,7 +67,7 @@ pub(super) mod tests {
         Table, Trigger, TriggerEvent, TriggerTiming,
     };
     use crate::model::app_state::AppState;
-    use crate::update::action::Action;
+    use crate::update::action::{Action, QueryCompletionContext};
     use crate::update::test_fixtures;
 
     pub fn create_test_state() -> AppState {
@@ -91,8 +91,13 @@ pub(super) mod tests {
             dsn: "postgres://localhost/test".to_string(),
             run_id,
             result,
-            generation,
-            target_page,
+            context: match target_page {
+                Some(target_page) => QueryCompletionContext::Preview {
+                    generation,
+                    target_page,
+                },
+                None => QueryCompletionContext::Adhoc,
+            },
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -205,6 +205,7 @@ mod tests {
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::ConnectionStoreError;
     use crate::update::action::ModalKind;
+    use crate::update::action::QueryCompletionContext;
     use crate::update::action::{ConnectionSaveError, ConnectionTarget, SmartErRefreshError};
     use crate::update::action::{InputTarget, SelectMotion};
     use crate::update::test_fixtures;
@@ -3196,8 +3197,10 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     result,
-                    generation: current_gen,
-                    target_page: Some(0),
+                    context: QueryCompletionContext::Preview {
+                        generation: current_gen,
+                        target_page: 0,
+                    },
                 },
                 now,
                 &AppServices::stub(),


### PR DESCRIPTION
## Problem
Query completion actions encoded adhoc and preview freshness with sentinel values (`generation: 0` and `target_page: None`), allowing invalid combinations in the action payloads.

## Background
The action payloads carried the same lifecycle distinction through independent fields even though adhoc completions do not have a selection generation or target page.

## Approach
Represent completion and failure lifecycle data with closed adhoc/preview context enums. Keep `QueryResult.source`, preview freshness and deferred display, adhoc refresh behavior, failure handling, and stale-run rejection unchanged.

## Screenshots
Not applicable.
