### PR TITLE
refactor(mysql): unify metadata snapshot ownership

### DIFF
--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -10,7 +10,7 @@ use crate::domain::{
 
 use super::super::{
     cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
-    dsn::parse_and_validate_mysql_dsn,
+    dsn::MySqlDsn,
     option_file::MySqlOptionFile,
     sql::{
         COLUMN_METADATA_BASE_RESULT_COLUMNS, COLUMN_METADATA_RESULT_COLUMNS,
@@ -83,18 +83,16 @@ impl MySqlTableMetadata {
 
 #[derive(Debug, Clone)]
 pub(super) struct MySqlMetadataSnapshot {
-    pub(super) database: String,
     pub(super) tables: Vec<MySqlTableMetadata>,
-    pub(super) table_summaries: Vec<TableSummary>,
 }
 
 pub(super) async fn fetch_metadata_snapshot(
-    dsn: &str,
+    target: &MySqlDsn,
+    database: &str,
 ) -> Result<MySqlMetadataSnapshot, DbOperationError> {
-    let database = selected_database(dsn)?;
     let (lower_case_table_names, result) =
-        execute_metadata_query(dsn, TABLES_QUERY, TABLES_RESULT_COLUMNS).await?;
-    metadata_snapshot_from_result(&database, None, &result, lower_case_table_names)
+        execute_metadata_query(target, TABLES_QUERY, TABLES_RESULT_COLUMNS).await?;
+    metadata_snapshot_from_result(database, None, &result, lower_case_table_names)
 }
 
 pub(super) fn find_table(
@@ -162,12 +160,12 @@ pub(super) fn parse_preview_columns_for_table(
 }
 
 pub(super) async fn execute_metadata_query(
-    dsn: &str,
+    target: &MySqlDsn,
     query: &str,
     expected_columns: &[&str],
 ) -> Result<(u8, MySqlResultSet), DbOperationError> {
     let (lower_case_table_names, results) =
-        execute_metadata_queries_in_session(dsn, &[(query, expected_columns)]).await?;
+        execute_metadata_queries_in_session(target, &[(query, expected_columns)]).await?;
     let result = results.into_iter().next().ok_or_else(|| {
         DbOperationError::MetadataParseFailed(
             "MySQL metadata query returned no result set".to_string(),
@@ -177,11 +175,11 @@ pub(super) async fn execute_metadata_query(
 }
 
 pub(super) async fn execute_metadata_queries_in_session(
-    dsn: &str,
+    target: &MySqlDsn,
     queries: &[(&str, &[&str])],
 ) -> Result<(u8, Vec<MySqlResultSet>), DbOperationError> {
     execute_metadata_queries_in_session_with_program(
-        dsn,
+        target,
         queries,
         OsStr::new("mysql"),
         MYSQL_QUERY_TIMEOUT,
@@ -190,13 +188,12 @@ pub(super) async fn execute_metadata_queries_in_session(
 }
 
 pub(super) async fn execute_metadata_queries_in_session_with_program(
-    dsn: &str,
+    target: &MySqlDsn,
     queries: &[(&str, &[&str])],
     program: &OsStr,
     timeout: Duration,
 ) -> Result<(u8, Vec<MySqlResultSet>), DbOperationError> {
-    let target = parse_and_validate_mysql_dsn(dsn)?;
-    let option_file = MySqlOptionFile::create(&target)?;
+    let option_file = MySqlOptionFile::create(target)?;
     let mut session =
         MySqlMetadataSession::spawn_with_metadata_program(program, &option_file.path)?;
     let result = tokio::time::timeout(timeout, async {
@@ -219,8 +216,8 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
     result
 }
 
-pub(super) fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
-    parse_and_validate_mysql_dsn(dsn)?.database.ok_or_else(|| {
+pub(super) fn selected_database(target: &MySqlDsn) -> Result<&str, DbOperationError> {
+    target.database.as_deref().ok_or_else(|| {
         DbOperationError::UnsupportedOperation(
             "MySQL metadata requires a selected database".to_string(),
         )
@@ -270,12 +267,7 @@ pub(super) fn metadata_snapshot_from_result(
             "MySQL metadata is limited to the selected database".to_string(),
         ));
     }
-    let table_summaries = tables.iter().cloned().map(table_summary).collect();
-    Ok(MySqlMetadataSnapshot {
-        database: database.to_string(),
-        tables,
-        table_summaries,
-    })
+    Ok(MySqlMetadataSnapshot { tables })
 }
 
 fn parse_table_metadata(
@@ -579,7 +571,7 @@ fn parse_fk_action(value: &QueryValue, field: &str) -> Result<FkAction, DbOperat
     })
 }
 
-fn table_summary(table: MySqlTableMetadata) -> TableSummary {
+pub(super) fn table_summary(table: MySqlTableMetadata) -> TableSummary {
     TableSummary::new(table.schema, table.name, table.row_count_estimate, false).with_kind_info(
         TableKindInfo {
             kind: table.kind,
@@ -771,8 +763,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(snapshot.table_summaries[0].name, "users");
-        assert_eq!(snapshot.table_summaries[0].schema, "app");
+        let summary = table_summary(snapshot.tables[0].clone());
+        assert_eq!(summary.name, "users");
+        assert_eq!(summary.schema, "app");
         assert_eq!(snapshot.tables[0].engine.as_deref(), Some("InnoDB"));
         assert_eq!(snapshot.tables[0].row_format.as_deref(), Some("Dynamic"));
         assert_eq!(
@@ -809,7 +802,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(snapshot.tables[0].schema, "APP");
-            assert_eq!(snapshot.table_summaries[0].schema, "APP");
+            assert_eq!(table_summary(snapshot.tables[0].clone()).schema, "APP");
 
             let unicode_snapshot = metadata_snapshot_from_result(
                 "äpp",
@@ -820,7 +813,10 @@ mod tests {
             .unwrap();
 
             assert_eq!(unicode_snapshot.tables[0].schema, "ÄPP");
-            assert_eq!(unicode_snapshot.table_summaries[0].schema, "ÄPP");
+            assert_eq!(
+                table_summary(unicode_snapshot.tables[0].clone()).schema,
+                "ÄPP"
+            );
         }
     }
 

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -5,6 +5,7 @@ use crate::domain::{DatabaseMetadata, Schema, Table, TableSignatureSnapshot};
 
 use super::adapter::MySqlAdapter;
 use super::cli::MySqlResultSet;
+use super::dsn::parse_and_validate_mysql_dsn;
 use super::sql::{EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS};
 
 mod catalog;
@@ -17,16 +18,23 @@ pub(super) use preview::{convert_preview_values_with_binary_charset, execute_pre
 #[async_trait]
 impl MetadataProvider for MySqlAdapter {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        let snapshot = catalog::fetch_metadata_snapshot(dsn).await?;
-        let mut metadata = DatabaseMetadata::new(snapshot.database.clone());
-        metadata.schemas = vec![Schema::new(snapshot.database)];
-        metadata.table_summaries = snapshot.table_summaries;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
+        let database = catalog::selected_database(&target)?;
+        let snapshot = catalog::fetch_metadata_snapshot(&target, database).await?;
+        let mut metadata = DatabaseMetadata::new(database.to_string());
+        metadata.schemas = vec![Schema::new(database.to_string())];
+        metadata.table_summaries = snapshot
+            .tables
+            .into_iter()
+            .map(catalog::table_summary)
+            .collect();
         Ok(metadata)
     }
 
     async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         let (_, result) = catalog::execute_metadata_query(
-            dsn,
+            &target,
             EFFECTIVE_USER_QUERY,
             EFFECTIVE_USER_RESULT_COLUMNS,
         )

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -18,7 +18,7 @@ use super::super::{
 };
 use super::catalog::{
     MySqlColumnMetadata, column_from_metadata, parse_preview_columns_for_table, primary_key_names,
-    validate_selected_schema_name,
+    selected_database, validate_selected_schema_name,
 };
 
 #[derive(Debug, Clone)]
@@ -69,11 +69,7 @@ async fn execute_preview_with_program(
     timeout: Duration,
 ) -> Result<PreviewExecution, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
-    let database = target.database.as_deref().ok_or_else(|| {
-        DbOperationError::UnsupportedOperation(
-            "MySQL metadata requires a selected database".to_string(),
-        )
-    })?;
+    let database = selected_database(&target)?;
     let option_file = MySqlOptionFile::create(&target)?;
     let mut session = MySqlMetadataSession::spawn_with_program(program, &option_file.path)?;
     let result = tokio::time::timeout(

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -8,6 +8,7 @@ use crate::domain::{
 };
 
 use super::super::cli::{MYSQL_QUERY_TIMEOUT, MySqlResultSet};
+use super::super::dsn::parse_and_validate_mysql_dsn;
 use super::super::sql::{
     FOREIGN_KEY_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS,
     SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
@@ -39,9 +40,10 @@ async fn fetch_table_signatures_with_program(
     program: &OsStr,
     timeout: Duration,
 ) -> Result<TableSignatureSnapshot, DbOperationError> {
-    let database = selected_database(dsn)?;
+    let target = parse_and_validate_mysql_dsn(dsn)?;
+    let database = selected_database(&target)?;
     let (lower_case_table_names, results) = execute_metadata_queries_in_session_with_program(
-        dsn,
+        &target,
         &[
             (TABLES_QUERY, TABLES_RESULT_COLUMNS),
             (SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS),
@@ -56,10 +58,10 @@ async fn fetch_table_signatures_with_program(
     )
     .await?;
     let snapshot =
-        metadata_snapshot_from_result(&database, None, &results[0], lower_case_table_names)?;
+        metadata_snapshot_from_result(database, None, &results[0], lower_case_table_names)?;
     table_signatures_from_metadata(
         &snapshot.tables,
-        &database,
+        database,
         lower_case_table_names,
         parse_signature_column_metadata(&results[1])?,
         parse_foreign_key_metadata(&results[2])?,

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -90,14 +90,15 @@ async fn fetch_table_columns_and_fks_with_program(
     program: &OsStr,
     timeout: Duration,
 ) -> Result<Table, DbOperationError> {
-    let database = selected_database(dsn)?;
+    let target = parse_and_validate_mysql_dsn(dsn)?;
+    let database = selected_database(&target)?;
     let table_query = table_query(schema, table);
     let columns_query = columns_query(schema, table);
     let unique_columns_query = unique_columns_query(schema, table);
     let foreign_keys_query = foreign_keys_query(schema, table);
     let (lower_case_table_names, results) =
         super::catalog::execute_metadata_queries_in_session_with_program(
-            dsn,
+            &target,
             &[
                 (table_query.as_str(), TABLES_RESULT_COLUMNS),
                 (columns_query.as_str(), COLUMN_METADATA_RESULT_COLUMNS),
@@ -108,18 +109,14 @@ async fn fetch_table_columns_and_fks_with_program(
             timeout,
         )
         .await?;
-    let snapshot = metadata_snapshot_from_result(
-        &database,
-        Some(schema),
-        &results[0],
-        lower_case_table_names,
-    )?;
+    let snapshot =
+        metadata_snapshot_from_result(database, Some(schema), &results[0], lower_case_table_names)?;
     let table_metadata = find_table(schema, table, &snapshot.tables, lower_case_table_names)?;
     let mut columns = parse_columns_for_table(&results[1], schema, table)?;
     mark_single_column_unique(&mut columns, &parse_unique_column_metadata(&results[2])?);
     let foreign_keys = foreign_keys_from_metadata(
         parse_foreign_key_metadata(&results[3])?,
-        &database,
+        database,
         lower_case_table_names,
     )?;
     Ok(table_from_columns_and_foreign_keys(
@@ -137,11 +134,7 @@ async fn fetch_table_detail_in_session_with_program(
     timeout: Duration,
 ) -> Result<Table, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
-    let database = target.database.as_deref().ok_or_else(|| {
-        DbOperationError::UnsupportedOperation(
-            "MySQL metadata requires a selected database".to_string(),
-        )
-    })?;
+    let database = selected_database(&target)?;
     let option_file = MySqlOptionFile::create(&target)?;
     let mut session =
         MySqlMetadataSession::spawn_with_metadata_program(program, &option_file.path)?;


### PR DESCRIPTION
## Problem
MySQL catalog snapshots retain both raw table metadata and derived table summaries, even though only the metadata boundary needs the summaries.

## Background
The catalog, preview, table-detail, and signature paths also repeat selected-database validation and reparse an unchanged DSN when they already hold the parsed MySQL target.

## Approach
Keep only validated raw tables in `MySqlMetadataSnapshot`, derive `TableSummary` values once in `fetch_metadata`, and centralize selected-database validation on the parsed target. Pass that target through metadata query helpers while preserving schema validation, ordering, case handling, metadata errors, and signature/detail construction.

## Screenshots
Not applicable.
