### PR TITLE
refactor: derive MySQL metadata row widths from result columns

### DIFF
--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -414,7 +414,7 @@ pub(super) fn parse_foreign_key_metadata(
         .values
         .iter()
         .map(|row| {
-            if row.len() != 10 {
+            if row.len() != FOREIGN_KEY_RESULT_COLUMNS.len() {
                 return Err(metadata_shape_error("foreign key row"));
             }
             Ok(MySqlForeignKeyMetadata {
@@ -518,7 +518,7 @@ pub(super) fn parse_unique_column_metadata(
         .values
         .iter()
         .map(|row| {
-            if row.len() != 1 {
+            if row.len() != UNIQUE_COLUMN_RESULT_COLUMNS.len() {
                 return Err(metadata_shape_error("single-column UNIQUE row"));
             }
             Ok(required_text(&row[0], "COLUMN_NAME")?.to_string())

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -77,7 +77,7 @@ fn parse_signature_column_metadata(
         .values
         .iter()
         .map(|row| {
-            if row.len() != 10 {
+            if row.len() != SIGNATURE_COLUMNS_RESULT_COLUMNS.len() {
                 return Err(metadata_shape_error("signature COLUMNS row"));
             }
             Ok(MySqlSignatureColumnMetadata {
@@ -342,7 +342,7 @@ fn parse_signature_unique_column_metadata(
     expect_columns(result, SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS)?;
     let mut unique_columns_by_table = HashMap::new();
     for row in &result.values {
-        if row.len() != 2 {
+        if row.len() != SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS.len() {
             return Err(metadata_shape_error("signature UNIQUE row"));
         }
         unique_columns_by_table

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -266,7 +266,7 @@ fn parse_trigger_metadata(result: &MySqlResultSet) -> Result<Vec<Trigger>, DbOpe
         .values
         .iter()
         .map(|row| {
-            if row.len() != 11 {
+            if row.len() != TRIGGER_RESULT_COLUMNS.len() {
                 return Err(metadata_shape_error("TRIGGERS row"));
             }
             let timing = required_text(&row[2], "ACTION_TIMING")?
@@ -331,7 +331,7 @@ fn parse_index_metadata(
         .values
         .iter()
         .map(|row| {
-            if row.len() != 10 {
+            if row.len() != INDEX_RESULT_COLUMNS.len() {
                 return Err(metadata_shape_error("STATISTICS row"));
             }
             let column_name = optional_text(&row[4], "COLUMN_NAME")?;


### PR DESCRIPTION
## Problem

MySQL metadata parsers duplicate result row widths as numeric literals while validating against named result columns, allowing query shape changes to drift from row validation.

## Background

The parsers already validate result headers against the corresponding `RESULT_COLUMNS` definitions, but row validation repeats those widths separately.

## Approach

Use each parser's existing `RESULT_COLUMNS` slice length for row-width validation while preserving parsing order, indexes, and errors.

## Screenshots

Not applicable.
