### PR TITLE
refactor(mysql): combine session marker and sql mode probe

### DIFF
--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -2,8 +2,7 @@ use std::io::{self, Write};
 
 use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
 
-use super::probe::{is_mysql_connect_timeout_message, mysql_tls_failure_kind, validate_sql_mode};
-use super::xml::MySqlResultSet;
+use super::probe::{is_mysql_connect_timeout_message, mysql_tls_failure_kind};
 
 pub(super) fn map_mysql_cli_spawn_error(error: io::Error) -> DbOperationError {
     if error.kind() == io::ErrorKind::NotFound {
@@ -48,32 +47,6 @@ pub(super) fn write_mysql_transcript_line(line: &str) {
     let mut stderr = io::stderr();
     let _ = stderr.write_all(line.as_bytes());
     let _ = stderr.write_all(b"\n");
-}
-
-pub(super) fn validate_mode_probe(
-    result: &MySqlResultSet,
-    marker: &str,
-) -> Result<(), DbOperationError> {
-    if result.values.len() != 1 || result.columns != ["__sabiql_probe", "__sabiql_sql_mode"] {
-        return Err(DbOperationError::QueryFailed(
-            "mysql sql_mode probe returned an unexpected result".to_string(),
-        ));
-    }
-    let values = &result.values[0];
-    if values.len() != 2 {
-        return Err(DbOperationError::QueryFailed(
-            "mysql sql_mode probe returned an unexpected result".to_string(),
-        ));
-    }
-    if values[0].as_str() != Some(marker) {
-        return Err(DbOperationError::QueryFailed(
-            "mysql sql_mode probe marker did not match".to_string(),
-        ));
-    }
-    let mode = values[1].as_str().ok_or_else(|| {
-        DbOperationError::QueryFailed("mysql sql_mode probe returned no mode".to_string())
-    })?;
-    validate_sql_mode(mode)
 }
 
 pub(super) fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -365,8 +365,6 @@ pub(super) async fn run_mysql_export_process(
     path: PathBuf,
 ) -> Result<(), DbOperationError> {
     configure_mysql_session(process, AccessMode::ReadOnly).await?;
-    process.probe_sql_mode().await?;
-
     write_mysql_statement(process, query).await?;
     let mut csv_writer = CsvFileWriter::create(path).await?;
     let columns = stream_mysql_resultset_to_csv(process, &mut csv_writer).await?;

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -12,6 +12,7 @@ use crate::domain::{
 };
 
 use super::super::sql;
+use super::probe::validate_sql_mode;
 use super::xml::MySqlResultSet;
 
 pub(super) const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
@@ -372,6 +373,25 @@ pub(super) fn validate_mysql_session_marker(
     Ok(())
 }
 
+pub(super) fn validate_mysql_session(
+    result: &MySqlResultSet,
+    marker: &str,
+) -> Result<(), DbOperationError> {
+    if result.columns != [MYSQL_SESSION_MARKER_COLUMN, "__sabiql_sql_mode"]
+        || result.values.len() != 1
+        || result.values[0].len() != 2
+        || result.values[0][0].as_str() != Some(marker)
+    {
+        return Err(DbOperationError::QueryFailed(
+            "mysql read-only session marker did not match".to_string(),
+        ));
+    }
+    let mode = result.values[0][1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql sql_mode probe returned no mode".to_string())
+    })?;
+    validate_sql_mode(mode)
+}
+
 pub(super) fn query_failed_after_change(
     error: DbOperationError,
     refresh_scope: RefreshScope,
@@ -482,7 +502,6 @@ pub(super) fn mysql_possible_refresh_scope(statements: &[MySqlStatement]) -> Ref
 mod tests {
     use crate::app::ports::outbound::UnsupportedOperationKind;
 
-    use super::super::error::validate_mode_probe;
     use super::*;
 
     #[test]
@@ -565,29 +584,47 @@ mod tests {
     }
 
     #[test]
-    fn mode_probe_requires_marker_and_allowed_mode_before_user_sql() {
-        let probe = MySqlResultSet {
-            columns: vec![
-                "__sabiql_probe".to_string(),
-                "__sabiql_sql_mode".to_string(),
-            ],
-            values: vec![vec![
-                QueryValue::Text("marker".to_string()),
-                QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
-            ]],
-        };
-        assert!(validate_mode_probe(&probe, "marker").is_ok());
+    fn session_bootstrap_requires_marker_and_allowed_mode() {
+        fn make_session(mode: QueryValue, marker: &str) -> MySqlResultSet {
+            MySqlResultSet {
+                columns: vec![
+                    MYSQL_SESSION_MARKER_COLUMN.to_string(),
+                    "__sabiql_sql_mode".to_string(),
+                ],
+                values: vec![vec![QueryValue::Text(marker.to_string()), mode]],
+            }
+        }
 
-        let mut unsupported = probe;
-        unsupported.values[0][1] = QueryValue::Text("ANSI_QUOTES".to_string());
+        let session = make_session(
+            QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
+            "marker",
+        );
+        assert!(validate_mysql_session(&session, "marker").is_ok());
+
+        let unsupported = make_session(QueryValue::Text("ANSI_QUOTES".to_string()), "marker");
         assert!(matches!(
-            validate_mode_probe(&unsupported, "marker"),
+            validate_mysql_session(&unsupported, "marker"),
             Err(DbOperationError::UnsupportedOperationWithKind {
                 kind: UnsupportedOperationKind::SessionMode,
                 ..
             })
         ));
+
+        let missing_mode = make_session(QueryValue::Null, "marker");
+        assert!(matches!(
+            validate_mysql_session(&missing_mode, "marker"),
+            Err(DbOperationError::QueryFailed(details)) if details.contains("no mode")
+        ));
+
+        let mismatched_marker =
+            make_session(QueryValue::Text("STRICT_TRANS_TABLES".to_string()), "other");
+        assert!(matches!(
+            validate_mysql_session(&mismatched_marker, "marker"),
+            Err(DbOperationError::QueryFailed(details))
+                if details == "mysql read-only session marker did not match"
+        ));
     }
+
     #[test]
     fn metadata_only_select_rejects_known_side_effects() {
         for query in [

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -18,12 +18,11 @@ use super::args::{MYSQL_CLIENT_MAX_PACKET_BYTES, mysql_adhoc_args, mysql_query_a
 use super::error::classify_mysql_query_failure;
 use super::error::{
     classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, map_mysql_cli_spawn_error,
-    validate_mode_probe,
 };
 #[cfg(not(unix))]
 use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
 use super::policy::{
-    MYSQL_SESSION_MARKER_COLUMN, query_failed_after_change, validate_mysql_session_marker,
+    MYSQL_SESSION_MARKER_COLUMN, query_failed_after_change, validate_mysql_session,
 };
 #[cfg(unix)]
 use super::pty::{
@@ -83,19 +82,6 @@ impl MySqlProcess {
         option_file: &std::path::Path,
     ) -> Result<Self, DbOperationError> {
         Self::spawn_with_query_args(program, mysql_adhoc_args(option_file))
-    }
-
-    pub(in crate::adapters::mysql::cli) async fn probe_sql_mode(
-        &mut self,
-    ) -> Result<(), DbOperationError> {
-        let probe_marker = Uuid::new_v4().simple().to_string();
-        let probe_query = format!(
-            "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
-        );
-        write_mysql_statement(self, &probe_query).await?;
-        let probe_xml = read_one_mysql_resultset(self).await?;
-        let probe = parse_mysql_xml(&probe_xml)?;
-        validate_mode_probe(&probe, &probe_marker)
     }
 
     pub(in crate::adapters::mysql) fn spawn_with_query_args(
@@ -349,7 +335,9 @@ pub(super) async fn configure_mysql_session(
     }
     write_mysql_statement(
         process,
-        &format!("SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"),
+        &format!(
+            "SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}, @@SESSION.sql_mode AS __sabiql_sql_mode"
+        ),
     )
     .await?;
     loop {
@@ -358,7 +346,7 @@ pub(super) async fn configure_mysql_session(
         if result.columns.is_empty() && result.values.is_empty() {
             continue;
         }
-        return validate_mysql_session_marker(&result, &marker);
+        return validate_mysql_session(&result, &marker);
     }
 }
 
@@ -724,15 +712,15 @@ mod tests {
         fs::write(&option_file, "[client]\n").unwrap();
         let program = directory.path().join("mysql");
         let log_file = PathBuf::from(format!("{}.log", option_file.display()));
-        let probe_response = match mode {
+        let session_response = match mode {
             "missing" => "exit 0".to_string(),
             "invalid" => {
                 "printf '%s\\n' '<resultset><row><field name=\"wrong\">x</field></row></resultset>'"
                     .to_string()
             }
-            "unsupported" => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">ANSI_QUOTES</field></row></resultset>'".to_string(),
+            "unsupported" => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_session_marker\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">ANSI_QUOTES</field></row></resultset>'".to_string(),
             "timeout" => "while :; do :; done".to_string(),
-            _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
+            _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_session_marker\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
         };
         let user_response = if mode == "failure" {
             "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit 1"
@@ -772,13 +760,13 @@ while IFS= read -r line; do
     "SET SESSION TRANSACTION READ ONLY")
       {session_failure}
       ;;
-    *__sabiql_probe*)
-      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
-      {probe_response}
-      ;;
     *__sabiql_session_marker*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      if printf '%s\n' "$line" | grep -q sql_mode; then
+        {session_response}
+      else
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      fi
       ;;
     *)
       {user_response}
@@ -814,13 +802,13 @@ while IFS= read -r line; do
       ;;
     ";"|"SET SESSION autocommit=1, completion_type=NO_CHAIN"|"SET SESSION TRANSACTION READ ONLY"|"SET SESSION TRANSACTION READ WRITE")
       ;;
-    *__sabiql_probe*)
-      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
-      ;;
     *__sabiql_session_marker*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      if printf '%s\n' "$line" | grep -q sql_mode; then
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      else
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      fi
       ;;
     *)
       printf '%s\n' '<resultset><row><field name="value">tree</field></row></resultset>'
@@ -882,11 +870,6 @@ printf 'process=%s\n' "$$" >> "$log"
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
   case "$line" in
-    *__sabiql_probe*)
-      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
-      printf '%s\t%s\n' '__sabiql_probe' '__sabiql_sql_mode'
-      printf '%s\t%s\n' "$marker" 'STRICT_TRANS_TABLES'
-      ;;
     *"SET SESSION autocommit=1, completion_type=NO_CHAIN"*)
       ;;
     *"SET SESSION TRANSACTION READ ONLY"*)
@@ -894,8 +877,8 @@ while IFS= read -r line; do
       ;;
     *__sabiql_session_marker*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
-      printf '%s\n' '__sabiql_session_marker'
-      printf '%s\n' "$marker"
+      printf '%s\t%s\n' '__sabiql_session_marker' '__sabiql_sql_mode'
+      printf '%s\t%s\n' "$marker" 'STRICT_TRANS_TABLES'
       ;;
     *"SHOW DATABASES"*)
       printf '%s\n' 'Database'
@@ -965,11 +948,7 @@ while IFS= read -r line; do
       ;;
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
-      if printf '%s\n' "$line" | grep -q lower_case_table_names; then
-        printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
-      else
-        printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
-      fi
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
       ;;
     "SET SESSION autocommit=1, completion_type=NO_CHAIN"|"SET SESSION TRANSACTION READ ONLY")
       ;;
@@ -977,7 +956,11 @@ while IFS= read -r line; do
       ;;
     *__sabiql_session_marker*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      if printf '%s\n' "$line" | grep -q sql_mode; then
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      else
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      fi
       ;;
       *__sabiql_marker*)
       {marker_response}
@@ -1079,7 +1062,7 @@ done
         }
 
         #[tokio::test]
-        async fn sends_user_sql_only_after_a_valid_mode_probe() {
+        async fn sends_user_sql_only_after_a_valid_session_configuration() {
             let (_directory, program, log_file) = fake_mysql("success");
             let option_file = log_file.with_extension("cnf");
             fs::write(&option_file, "[client]\n").unwrap();
@@ -1099,7 +1082,7 @@ done
             let positions = [
                 MYSQL_SESSION_SETTINGS,
                 MYSQL_SESSION_MARKER_COLUMN,
-                "__sabiql_probe",
+                "__sabiql_sql_mode",
                 "SELECT 123",
             ]
             .into_iter()
@@ -1221,11 +1204,11 @@ done
                 .find(MYSQL_READ_ONLY_STATEMENT)
                 .expect("read-only session statement");
             let settings_index = log.find(MYSQL_SESSION_SETTINGS).expect("session settings");
-            let probe_index = log.find("__sabiql_probe").expect("mode probe");
+            let mode_index = log.find("__sabiql_sql_mode").expect("sql_mode validation");
             let user_index = log.find("SELECT 2").expect("user statement");
             assert!(settings_index < session_index, "{log}");
-            assert!(session_index < probe_index, "{log}");
-            assert!(probe_index < user_index, "{log}");
+            assert!(session_index < mode_index, "{log}");
+            assert!(mode_index < user_index, "{log}");
             assert!(session_index < user_index, "{log}");
             assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
         }
@@ -1377,6 +1360,7 @@ done
                 MYSQL_SESSION_SETTINGS,
                 MYSQL_READ_ONLY_STATEMENT,
                 MYSQL_SESSION_MARKER_COLUMN,
+                "__sabiql_sql_mode",
                 "__sabiql_probe",
                 "SELECT TABLES",
                 "SELECT COLUMNS",
@@ -1413,7 +1397,7 @@ done
                 MYSQL_SESSION_SETTINGS,
                 MYSQL_READ_ONLY_STATEMENT,
                 MYSQL_SESSION_MARKER_COLUMN,
-                "__sabiql_probe",
+                "__sabiql_sql_mode",
                 "SHOW DATABASES",
             ]
             .into_iter()

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -233,8 +233,6 @@ async fn run_mysql_adhoc_process(
     expected_columns: Option<&[&str]>,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     configure_mysql_session(process, access_mode).await?;
-    process.probe_sql_mode().await?;
-
     let mut last_result_set = None;
     let mut last_result_statement = None;
     let mut refresh_scope = RefreshScope::None;

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -298,19 +298,11 @@ async fn run_mysql_metadata_query_with_read_only_session_process(
         .await?;
     process
         .write_statement(&format!(
-            "SELECT '{session_marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"
+            "SELECT '{session_marker}' AS {MYSQL_SESSION_MARKER_COLUMN}, @@SESSION.sql_mode AS __sabiql_sql_mode"
         ))
         .await?;
     let session_output = process.read_until_marker(&session_marker).await?;
-    validate_metadata_session_marker(&session_output, &session_marker)?;
-
-    let probe_marker = Uuid::new_v4().simple().to_string();
-    let probe_query = format!(
-        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
-    );
-    process.write_statement(&probe_query).await?;
-    let probe_output = process.read_until_marker(&probe_marker).await?;
-    validate_metadata_mode_probe(&probe_output, &probe_marker)?;
+    validate_metadata_session_probe(&session_output, &session_marker)?;
 
     process.write_statement(query).await?;
     let mut stdin = process
@@ -332,10 +324,10 @@ async fn run_mysql_metadata_query_with_read_only_session_process(
     parse_mysql_metadata_header(&stdout, query)
 }
 
-fn validate_metadata_mode_probe(output: &[u8], marker: &str) -> Result<(), DbOperationError> {
+fn validate_metadata_session_probe(output: &[u8], marker: &str) -> Result<(), DbOperationError> {
     let fields = parse_metadata_marker_fields(output, marker).ok_or_else(|| {
         DbOperationError::QueryFailed(
-            "MySQL metadata fallback returned an invalid mode probe".to_string(),
+            "MySQL metadata fallback returned an invalid read-only session marker".to_string(),
         )
     })?;
     let sql_mode = fields.get(1).ok_or_else(|| {
@@ -346,16 +338,6 @@ fn validate_metadata_mode_probe(output: &[u8], marker: &str) -> Result<(), DbOpe
     let sql_mode = String::from_utf8(sql_mode.to_vec())
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     validate_sql_mode(&sql_mode)
-}
-
-fn validate_metadata_session_marker(output: &[u8], marker: &str) -> Result<(), DbOperationError> {
-    if parse_metadata_marker_fields(output, marker).is_some() {
-        Ok(())
-    } else {
-        Err(DbOperationError::QueryFailed(
-            "MySQL metadata fallback returned an invalid read-only session marker".to_string(),
-        ))
-    }
 }
 
 fn parse_metadata_marker_fields<'a>(output: &'a [u8], marker: &str) -> Option<Vec<&'a [u8]>> {
@@ -434,20 +416,26 @@ mod tests {
 
     #[test]
     fn preserves_marker_and_header_validation_boundaries() {
-        assert!(validate_metadata_session_marker(b"\r\nmarker\r\n", "marker").is_ok());
+        assert!(
+            validate_metadata_session_probe(b"\r\nmarker\tSTRICT_TRANS_TABLES\r\n", "marker")
+                .is_ok()
+        );
         assert!(matches!(
-            validate_metadata_session_marker(b"marker-prefix\n", "marker"),
+            validate_metadata_session_probe(b"marker-prefix\n", "marker"),
             Err(DbOperationError::QueryFailed(details))
                 if details == "MySQL metadata fallback returned an invalid read-only session marker"
         ));
         assert!(matches!(
-            validate_metadata_mode_probe(b"marker\n", "marker"),
+            validate_metadata_session_probe(b"marker\n", "marker"),
             Err(DbOperationError::QueryFailed(details))
                 if details == "MySQL metadata fallback returned an incomplete mode probe"
         ));
-        assert!(validate_metadata_mode_probe(b"marker\t\xff\n", "marker").is_err());
+        assert!(validate_metadata_session_probe(b"marker\t\xff\n", "marker").is_err());
         assert!(
-            validate_metadata_mode_probe(b"marker\tSTRICT_TRANS_TABLES,ANSI_QUOTES\n", "marker",)
+            validate_metadata_session_probe(
+                b"marker\tSTRICT_TRANS_TABLES,ANSI_QUOTES\n",
+                "marker",
+            )
                 .is_err()
         );
         assert_eq!(

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
 use super::super::args::{mysql_metadata_session_args, mysql_query_args};
-use super::super::probe::{validate_lower_case_table_names, validate_sql_mode};
+use super::super::probe::validate_lower_case_table_names;
 use super::super::xml::{MySqlResultSet, parse_mysql_preview_xml, parse_mysql_xml};
 use super::{
     MySqlProcess, cleanup_mysql_process, configure_mysql_session, finish_mysql_session,
@@ -44,7 +44,7 @@ impl MySqlMetadataSession {
     pub(in crate::adapters::mysql) async fn probe(&mut self) -> Result<u8, DbOperationError> {
         let marker = Uuid::new_v4().simple().to_string();
         let query = format!(
-            "SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode, @@lower_case_table_names AS __sabiql_lower_case_table_names"
+            "SELECT '{marker}' AS __sabiql_probe, @@lower_case_table_names AS __sabiql_lower_case_table_names"
         );
         let result = self.execute(&query).await?;
         validate_metadata_probe(&result, &marker)
@@ -135,28 +135,19 @@ impl MySqlMetadataSession {
 
 fn validate_metadata_probe(result: &MySqlResultSet, marker: &str) -> Result<u8, DbOperationError> {
     if result.values.len() != 1
-        || result.columns
-            != [
-                "__sabiql_probe",
-                "__sabiql_sql_mode",
-                "__sabiql_lower_case_table_names",
-            ]
+        || result.columns != ["__sabiql_probe", "__sabiql_lower_case_table_names"]
     {
         return Err(DbOperationError::QueryFailed(
             "mysql metadata probe returned an unexpected result".to_string(),
         ));
     }
     let values = &result.values[0];
-    if values.len() != 3 || values[0].as_str() != Some(marker) {
+    if values.len() != 2 || values[0].as_str() != Some(marker) {
         return Err(DbOperationError::QueryFailed(
             "mysql metadata probe returned an unexpected result".to_string(),
         ));
     }
-    let sql_mode = values[1].as_str().ok_or_else(|| {
-        DbOperationError::QueryFailed("mysql metadata probe returned no mode".to_string())
-    })?;
-    validate_sql_mode(sql_mode)?;
-    let lower_case_table_names = values[2]
+    let lower_case_table_names = values[1]
         .as_str()
         .ok_or_else(|| {
             DbOperationError::QueryFailed(

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -37,8 +37,6 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
     access_mode: AccessMode,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     configure_mysql_session(process, access_mode).await?;
-    process.probe_sql_mode().await?;
-
     write_mysql_statement(process, query).await?;
     let (stdout, mut diagnostics) = read_one_mysql_resultset_with_diagnostics(process).await?;
     let result_set = parse_mysql_xml(&stdout)?;
@@ -78,8 +76,6 @@ pub(super) mod test_support {
         access_mode: AccessMode,
     ) -> Result<MySqlResultSet, DbOperationError> {
         configure_mysql_session(process, access_mode).await?;
-        process.probe_sql_mode().await?;
-
         write_mysql_statement(process, query).await?;
 
         #[cfg(unix)]

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -431,12 +431,12 @@ while IFS= read -r line; do
     ";") ;;
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)'.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
       ;;
     *"SET SESSION TRANSACTION READ ONLY"*) ;;
     *__sabiql_session_marker*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_session_marker.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
       ;;
     *INFORMATION_SCHEMA.COLUMNS*)
       {columns_result}
@@ -558,6 +558,8 @@ done
         let positions = [
             "SET SESSION autocommit=1, completion_type=NO_CHAIN",
             "SET SESSION TRANSACTION READ ONLY",
+            "__sabiql_session_marker",
+            "__sabiql_sql_mode",
             "__sabiql_probe",
             "INFORMATION_SCHEMA.COLUMNS",
             "LIMIT 2 OFFSET 1",

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -713,13 +713,13 @@ while IFS= read -r line; do
     case "$line" in
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_probe.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
       ;;
     *"SET SESSION TRANSACTION READ ONLY")
       ;;
     *__sabiql_session_marker*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_session_marker.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
       ;;
     *COLUMNS*)
       printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">items</field><field name="COLUMN_NAME">id</field><field name="COLUMN_TYPE">int</field><field name="IS_NULLABLE">NO</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA"></field><field name="COLUMN_COMMENT" xsi:nil="true"/><field name="ORDINAL_POSITION">1</field><field name="PRIMARY_KEY_POSITION">1</field></row></resultset>'

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -507,7 +507,7 @@ while IFS= read -r line; do
       printf '%s\n' '<resultset><row><field name="wrong">x</field></row></resultset>'
     else
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)'.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
     fi
     continue
   fi
@@ -520,7 +520,7 @@ while IFS= read -r line; do
         exit 1
       fi
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_session_marker.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
       ;;
     *TABLES*)
       if [ "$mode" = "empty" ]; then
@@ -659,6 +659,7 @@ done
                     "SET SESSION autocommit=1, completion_type=NO_CHAIN",
                     "SET SESSION TRANSACTION READ ONLY",
                     "__sabiql_session_marker",
+                    "__sabiql_sql_mode",
                     "__sabiql_probe",
                     "INFORMATION_SCHEMA.TABLES",
                     "INFORMATION_SCHEMA.COLUMNS",
@@ -672,6 +673,7 @@ done
                     "SET SESSION autocommit=1, completion_type=NO_CHAIN",
                     "SET SESSION TRANSACTION READ ONLY",
                     "__sabiql_session_marker",
+                    "__sabiql_sql_mode",
                     "__sabiql_probe",
                     "INFORMATION_SCHEMA.TABLES",
                     "INFORMATION_SCHEMA.COLUMNS",


### PR DESCRIPTION
## Problem

MySQL session bootstrap validated the session marker and `sql_mode` in separate result frames, so each production caller had to preserve the follow-up probe ordering.

## Background

The same split was duplicated across query, export, and metadata fallback paths while metadata sessions also revalidated `sql_mode` before reading `lower_case_table_names`.

## Approach

The bootstrap frame now returns and validates the session marker with `@@SESSION.sql_mode`. Query and export callers no longer issue a second mode probe; metadata-specific probes retain only `lower_case_table_names`, and the tab transport keeps its own boundary reader.
