### PR TITLE
fix(app): cancel active tasks before MySQL try-connect probe

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -568,6 +568,7 @@ mod tests {
         use crate::domain::connection::{ConnectionId, DatabaseType};
         use crate::domain::{QueryResult, Table, WriteExecutionResult};
         use crate::model::connection::cache::ConnectionCache;
+        use crate::model::connection::state::ConnectionState;
         use crate::ports::outbound::{AccessMode, DbOperationError};
         use crate::update::action::ConnectionTarget;
         use crate::update::reducer::reduce;
@@ -639,6 +640,30 @@ mod tests {
                 _file_name: &str,
             ) -> Result<PathBuf, DbOperationError> {
                 unreachable!("test only starts a preview")
+            }
+        }
+
+        struct ProbeThatObservesQueryDrop {
+            query_dropped: Arc<AtomicBool>,
+            started: Mutex<Option<oneshot::Sender<bool>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl MySqlConnectionProbe for ProbeThatObservesQueryDrop {
+            async fn probe(
+                &self,
+                _dsn: &str,
+            ) -> Result<MySqlConnectionProbeResult, DbOperationError> {
+                self.started
+                    .lock()
+                    .expect("probe started signal lock poisoned")
+                    .take()
+                    .expect("probe should start once")
+                    .send(self.query_dropped.load(Ordering::SeqCst))
+                    .ok();
+                Ok(MySqlConnectionProbeResult {
+                    lower_case_table_names: 0,
+                })
             }
         }
 
@@ -777,6 +802,105 @@ mod tests {
             .await
             .expect("context termination should drop the pending query task");
             assert!(!state.query.is_current_run(run_id));
+        }
+
+        #[tokio::test]
+        async fn try_connect_cancels_pending_query_before_mysql_probe() {
+            let (query_started_tx, query_started_rx) = oneshot::channel();
+            let query_dropped = Arc::new(AtomicBool::new(false));
+            let executor = PendingQueryExecutor {
+                started: Mutex::new(Some(query_started_tx)),
+                dropped: Arc::clone(&query_dropped),
+            };
+            let (probe_started_tx, probe_started_rx) = oneshot::channel();
+            let probe = ProbeThatObservesQueryDrop {
+                query_dropped: Arc::clone(&query_dropped),
+                started: Mutex::new(Some(probe_started_tx)),
+            };
+            let (action_tx, _action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn_and_probe(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(executor),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+                Arc::new(test_fixtures::NoopDsnBuilder),
+                Arc::new(probe),
+            );
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql-test");
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/app",
+                Some("app"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::NotConnected);
+            let run_id = state.query.begin_running(Instant::now());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::ExecutePreview {
+                        dsn: "mysql://user@localhost:3306/app".to_string(),
+                        schema: "app".to_string(),
+                        table: "users".to_string(),
+                        generation: 1,
+                        run_id,
+                        limit: 100,
+                        offset: 0,
+                        target_page: 0,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            query_started_rx.await.expect("pending query should start");
+
+            let effects = reduce(
+                &mut state,
+                Action::TryConnect,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::CancelActiveTasks,
+                    Effect::ProbeMySqlConnection { .. }
+                ]
+            ));
+
+            runner
+                .run(
+                    effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                probe_started_rx
+                    .await
+                    .expect("probe should start after cancellation")
+            );
+            timeout(Duration::from_secs(1), async {
+                while !query_dropped.load(Ordering::SeqCst) {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("cancelled query task should be dropped");
         }
 
         #[tokio::test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -228,7 +228,10 @@ pub(super) fn try_connect(state: &mut AppState, now: std::time::Instant) -> Vec<
                 clear_query_confirmation(state);
                 state.query.reset_for_context_change();
                 state.session.mark_connecting();
-                return vec![Effect::ProbeMySqlConnection { target, run_id }];
+                return termination_effects(
+                    &state.query,
+                    vec![Effect::ProbeMySqlConnection { target, run_id }],
+                );
             }
             let run_id = state.session.begin_connecting(&dsn);
             vec![Effect::FetchMetadata { dsn, run_id }]
@@ -1563,6 +1566,36 @@ mod tests {
                 state.session.connection_state(),
                 ConnectionState::Connecting
             );
+        }
+
+        #[test]
+        fn mysql_try_connect_cancels_active_query_before_probe() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql-test");
+            let dsn = "mysql://user@localhost:3306/app";
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                dsn,
+                Some("app"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::NotConnected);
+            let query_run_id = state.query.begin_running(std::time::Instant::now());
+
+            let effects = reduce(&mut state, &Action::TryConnect).unwrap();
+
+            assert!(!state.query.is_running());
+            assert!(!state.query.is_current_run(query_run_id));
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(effects[0], Effect::CancelActiveTasks));
+            let Effect::ProbeMySqlConnection { target, .. } = &effects[1] else {
+                panic!("expected MySQL probe after task cancellation, got {effects:?}");
+            };
+            assert_eq!(target.id, id);
+            assert_eq!(target.dsn, dsn);
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- route MySQL TryConnect through termination_effects so active runtime tasks are cancelled before probing
- add reducer and runner coverage for active query invalidation and cancellation order

## Tests
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-cr-06-target cargo test -p sabiql-app update::connection::lifecycle::tests
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-cr-06-target cargo test -p sabiql-app cmd::runner::tests::query_context_termination
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-cr-06-target cargo test -p sabiql-app cmd::runner::tests::mysql_connection_probe_lifecycle
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-cr-06-target cargo check -p sabiql-app
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-cr-06-target cargo clippy -p sabiql-app --all-targets --no-deps -- -D warnings
- cargo fmt --all -- --check
- RUSTC_WRAPPER= CARGO_TARGET_DIR= bash scripts/lint_all.sh