### PR TITLE
refactor(mysql): own metadata option files in sessions

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -636,17 +636,14 @@ mod tests {
         }
 
         #[test]
-        fn option_file_is_removed_when_mysql_process_start_fails() {
+        fn metadata_session_owns_option_file_when_mysql_process_start_fails() {
             let target = parse_mysql_dsn("mysql://user:secret@localhost:3306").unwrap();
-            let (result, path) = {
-                let option_file = MySqlOptionFile::create(&target).unwrap();
-                let path = option_file.path.clone();
-                let result = MySqlProcess::spawn_with_program(
-                    OsStr::new("__sabiql_missing_mysql_binary__"),
-                    &path,
-                );
-                (result, path)
-            };
+            let option_file = MySqlOptionFile::create(&target).unwrap();
+            let path = option_file.path.clone();
+            let result = MySqlMetadataSession::spawn_with_metadata_program(
+                OsStr::new("__sabiql_missing_mysql_binary__"),
+                option_file,
+            );
 
             assert!(result.is_err());
             assert!(!path.exists());
@@ -1313,16 +1310,22 @@ done
     }
 
     mod metadata_session {
+        use crate::adapters::mysql::option_file::MySqlOptionFile;
+
         use super::*;
 
         #[tokio::test]
         async fn reuses_one_process_for_ordered_resultsets() {
-            let (_directory, program, option_file) = fake_mysql_multi();
+            let (_directory, program, option_file_path) = fake_mysql_multi();
+            let option_file = MySqlOptionFile {
+                path: option_file_path.clone(),
+            };
             let mut session = MySqlMetadataSession::spawn_with_metadata_program(
                 OsStr::new(&program),
-                &option_file,
+                option_file,
             )
             .expect("spawn fake mysql");
+            assert!(option_file_path.exists());
 
             session
                 .prepare_read_only()
@@ -1346,8 +1349,10 @@ done
             assert_eq!(empty_result.columns, ["known_column"]);
             assert!(empty_result.values.is_empty());
             session.finish().await.expect("finish fake mysql");
+            drop(session);
+            assert!(!option_file_path.exists());
 
-            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            let log = fs::read_to_string(format!("{}.log", option_file_path.display())).unwrap();
             assert_eq!(
                 log.lines()
                     .filter(|line| line.starts_with("process="))

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
+use super::super::super::option_file::MySqlOptionFile;
 use super::super::args::{mysql_metadata_session_args, mysql_query_args};
 use super::super::probe::validate_lower_case_table_names;
 use super::super::xml::{MySqlResultSet, parse_mysql_preview_xml, parse_mysql_xml};
@@ -15,6 +16,7 @@ use super::{
 
 pub(in crate::adapters::mysql) struct MySqlMetadataSession {
     process: MySqlProcess,
+    _option_file: MySqlOptionFile,
 }
 
 const MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN: &str = "__sabiql_preview_completion";
@@ -22,22 +24,30 @@ const MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN: &str = "__sabiql_preview_completio
 impl MySqlMetadataSession {
     pub(in crate::adapters::mysql) fn spawn_with_program(
         program: &OsStr,
-        option_file: &std::path::Path,
+        option_file: MySqlOptionFile,
     ) -> Result<Self, DbOperationError> {
-        MySqlProcess::spawn_with_preview_program(program, mysql_query_args(option_file))
-            .map(|process| Self { process })
+        let args = mysql_query_args(&option_file.path);
+        Self::from_process(
+            MySqlProcess::spawn_with_preview_program(program, args),
+            option_file,
+        )
     }
 
     pub(in crate::adapters::mysql) fn spawn_with_metadata_program(
         program: &OsStr,
-        option_file: &std::path::Path,
+        option_file: MySqlOptionFile,
     ) -> Result<Self, DbOperationError> {
-        Self::spawn_with_args(program, mysql_metadata_session_args(option_file))
+        let args = mysql_metadata_session_args(&option_file.path);
+        Self::from_process(MySqlProcess::spawn_with_args(program, args), option_file)
     }
 
-    fn spawn_with_args(program: &OsStr, args: Vec<String>) -> Result<Self, DbOperationError> {
-        Ok(Self {
-            process: MySqlProcess::spawn_with_args(program, args)?,
+    fn from_process(
+        process: Result<MySqlProcess, DbOperationError>,
+        option_file: MySqlOptionFile,
+    ) -> Result<Self, DbOperationError> {
+        process.map(|process| Self {
+            process,
+            _option_file: option_file,
         })
     }
 

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -194,8 +194,7 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
     timeout: Duration,
 ) -> Result<(u8, Vec<MySqlResultSet>), DbOperationError> {
     let option_file = MySqlOptionFile::create(target)?;
-    let mut session =
-        MySqlMetadataSession::spawn_with_metadata_program(program, &option_file.path)?;
+    let mut session = MySqlMetadataSession::spawn_with_metadata_program(program, option_file)?;
     let result = tokio::time::timeout(timeout, async {
         session.prepare_read_only().await?;
         let lower_case_table_names = session.probe().await?;
@@ -211,9 +210,7 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
         Ok((lower_case_table_names, results))
     })
     .await;
-    let result = session.resolve_timed_result(result).await;
-    drop(option_file);
-    result
+    session.resolve_timed_result(result).await
 }
 
 pub(super) fn selected_database(target: &MySqlDsn) -> Result<&str, DbOperationError> {

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -468,6 +468,7 @@ done
         (directory, program, log_path)
     }
 
+    #[cfg(unix)]
     fn assert_option_file_removed(log_path: &std::path::Path) {
         let log = fs::read_to_string(log_path).expect("fake MySQL transcript");
         assert!(log.contains("option-exists=yes"), "{log}");

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -71,15 +71,13 @@ async fn execute_preview_with_program(
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let database = selected_database(&target)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut session = MySqlMetadataSession::spawn_with_program(program, &option_file.path)?;
+    let mut session = MySqlMetadataSession::spawn_with_program(program, option_file)?;
     let result = tokio::time::timeout(
         timeout,
         execute_preview_with_session(&mut session, database, schema, table, limit, offset),
     )
     .await;
-    let result = session.resolve_timed_result(result).await;
-    drop(option_file);
-    result
+    session.resolve_timed_result(result).await
 }
 
 async fn execute_preview_with_session(
@@ -423,6 +421,7 @@ log='{log}'
 printf 'argv=%s\n' "$*" >> "$log"
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 printf 'process=%s option=%s\n' "$$" "$option" >> "$log"
+if [ -e "$option" ]; then printf 'option-exists=yes\n' >> "$log"; else printf 'option-exists=no\n' >> "$log"; fi
 eof=$(printf '\004')
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
@@ -467,6 +466,22 @@ done
         permissions.set_mode(0o755);
         fs::set_permissions(&program, permissions).expect("fake MySQL permissions");
         (directory, program, log_path)
+    }
+
+    fn assert_option_file_removed(log_path: &std::path::Path) {
+        let log = fs::read_to_string(log_path).expect("fake MySQL transcript");
+        assert!(log.contains("option-exists=yes"), "{log}");
+        let option = log
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix("process=")
+                    .and_then(|line| line.split_once(" option=").map(|(_, path)| path))
+            })
+            .expect("option file path");
+        assert!(
+            !std::path::Path::new(option).exists(),
+            "option file remains"
+        );
     }
 
     fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
@@ -546,7 +561,7 @@ done
             "SELECT `payload` FROM `sabiql_test`.`items` ORDER BY `id` LIMIT 2 OFFSET 1"
         );
 
-        let log = fs::read_to_string(log_path).expect("fake MySQL transcript");
+        let log = fs::read_to_string(&log_path).expect("fake MySQL transcript");
         assert_eq!(
             log.lines()
                 .filter(|line| line.starts_with("process="))
@@ -570,6 +585,7 @@ done
         .collect::<Vec<_>>();
         assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
         assert!(!log.contains("INFORMATION_SCHEMA.STATISTICS"), "{log}");
+        assert_option_file_removed(&log_path);
     }
 
     #[cfg(unix)]
@@ -591,15 +607,16 @@ done
             result,
             Err(DbOperationError::MetadataParseFailed(_))
         ));
-        let log = fs::read_to_string(log_path).expect("fake MySQL transcript");
+        let log = fs::read_to_string(&log_path).expect("fake MySQL transcript");
         assert!(log.contains("INFORMATION_SCHEMA.COLUMNS"));
         assert!(!log.contains("LIMIT 2 OFFSET 1"), "{log}");
+        assert_option_file_removed(&log_path);
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn delayed_error_between_preview_and_completion_frames_is_classified() {
-        let (_directory, program, _log_path) = fake_preview_mysql(false, true);
+        let (_directory, program, log_path) = fake_preview_mysql(false, true);
         let result = execute_preview_with_program(
             "mysql://preview:secret@localhost:3306/sabiql_test",
             "sabiql_test",
@@ -616,6 +633,7 @@ done
             Err(DbOperationError::ObjectMissing(details))
                 if details.contains("delayed preview error")
         ));
+        assert_option_file_removed(&log_path);
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -135,16 +135,13 @@ async fn fetch_table_detail_in_session_with_program(
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let database = selected_database(&target)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut session =
-        MySqlMetadataSession::spawn_with_metadata_program(program, &option_file.path)?;
+    let mut session = MySqlMetadataSession::spawn_with_metadata_program(program, option_file)?;
     let result = tokio::time::timeout(
         timeout,
         fetch_table_detail_with_session(&mut session, database, schema, table),
     )
     .await;
-    let result = session.resolve_timed_result(result).await;
-    drop(option_file);
-    result
+    session.resolve_timed_result(result).await
 }
 
 async fn fetch_table_detail_with_session(
@@ -492,6 +489,7 @@ mod session_tests {
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 transcript=$(dirname "$0")/transcript.log
 printf 'option=%s\nprocess=%s\n' "$option" "$$" >> "$transcript"
+if [ -e "$option" ]; then printf 'option-exists=yes\n' >> "$transcript"; else printf 'option-exists=no\n' >> "$transcript"; fi
 mode=$(basename "$0" | sed 's/^mysql-//')
 trap 'printf "exit=%s\n" "$?" >> "$transcript"' EXIT
 if [ "$mode" = "probe-failure" ] || [ "$mode" = "timeout" ]; then
@@ -594,6 +592,7 @@ done
 
     fn assert_option_file_removed(transcript: &std::path::Path) {
         let transcript_text = std::fs::read_to_string(transcript).unwrap();
+        assert!(transcript_text.contains("option-exists=yes"));
         let option = transcript_text
             .lines()
             .find_map(|line| line.strip_prefix("option="))


### PR DESCRIPTION
## Problem
Metadata callers passed only the option-file path to `MySqlMetadataSession`, so each caller had to keep the credential file alive and remove it manually.

## Background
The session process can outlive the query operation during normal completion, probe failure, timeout, or task cancellation.

## Approach
The session now owns the `MySqlOptionFile` after building its spawn arguments. Its field order keeps the option file alive until the process has been dropped, while callers continue to parse DSNs and create option files.
