### PR TITLE
refactor(mysql): share pipe finish phase

### DIFF
--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -7,6 +7,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use crate::app::ports::outbound::DbOperationError;
 
 use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
+use super::process::read_all;
 use super::xml::{
     MySqlResultsetFrameScanner,
     take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget,
@@ -139,15 +140,6 @@ where
         }
         result
     }
-}
-
-pub(super) async fn read_all<R>(reader: &mut R) -> io::Result<Vec<u8>>
-where
-    R: AsyncRead + Unpin,
-{
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).await?;
-    Ok(output)
 }
 
 pub(super) async fn read_one_mysql_resultset_from_pipes<R, E>(

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 #[cfg(unix)]
 use tokio::fs::File as TokioFile;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 #[cfg(not(unix))]
 use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
@@ -20,7 +20,7 @@ use super::error::{
     classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, map_mysql_cli_spawn_error,
 };
 #[cfg(not(unix))]
-use super::pipe::{read_all, read_one_mysql_resultset_from_pipes};
+use super::pipe::read_one_mysql_resultset_from_pipes;
 use super::policy::{
     MYSQL_SESSION_MARKER_COLUMN, query_failed_after_change, validate_mysql_session,
 };
@@ -216,6 +216,31 @@ pub(super) async fn stop_mysql_process(
     Ok((status, true))
 }
 
+pub(super) async fn read_all<R>(reader: &mut R) -> std::io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+async fn finish_mysql_pipe<O, E>(
+    stdout: &mut O,
+    stderr: &mut E,
+    child: &mut Child,
+) -> Result<(ExitStatus, Vec<u8>, Vec<u8>), DbOperationError>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    let (stdout, stderr, status) = tokio::join!(read_all(stdout), read_all(stderr), child.wait());
+    let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    let status = status.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    Ok((status, stdout, stderr))
+}
+
 pub(super) struct MySqlSessionResult {
     pub(super) status: ExitStatus,
     pub(super) forcibly_stopped: bool,
@@ -271,14 +296,8 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
 
     #[cfg(not(unix))]
     let (stdout, error_bytes, status) = {
-        let (stdout, stderr, status) = tokio::join!(
-            read_all(&mut process.stdout),
-            read_all(&mut process.stderr),
-            process.child.wait()
-        );
-        let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        let status = status.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+        let (status, stdout, stderr) =
+            finish_mysql_pipe(&mut process.stdout, &mut process.stderr, &mut process.child).await?;
         let mut error_bytes = std::mem::take(&mut process.pending_stderr);
         error_bytes.extend_from_slice(&stderr);
         (stdout, error_bytes, status)

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -1,8 +1,8 @@
 use std::ffi::OsStr;
-use std::process::{ExitStatus, Stdio};
+use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
 use uuid::Uuid;
@@ -21,8 +21,8 @@ use super::super::policy::{
 use super::super::probe::{run_mysql_command_with_timeout, validate_sql_mode};
 use super::super::sanitize_mysql_command_environment;
 use super::{
-    MYSQL_QUERY_TIMEOUT, MySqlProcess, read_one_mysql_resultset_with_diagnostics,
-    write_mysql_statement,
+    MYSQL_QUERY_TIMEOUT, MySqlProcess, finish_mysql_pipe,
+    read_one_mysql_resultset_with_diagnostics, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn mysql_metadata_columns(
@@ -221,27 +221,10 @@ impl MySqlMetadataProcess {
     }
 }
 
-async fn finish_mysql_metadata_process(
-    process: &mut MySqlMetadataProcess,
-) -> Result<(ExitStatus, Vec<u8>, Vec<u8>), DbOperationError> {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let (stdout_result, stderr_result, status_result) = tokio::join!(
-        process.stdout.read_to_end(&mut stdout),
-        process.stderr.read_to_end(&mut stderr),
-        process.child.wait(),
-    );
-    stdout_result.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    stderr_result.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    let status =
-        status_result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-    Ok((status, stdout, stderr))
-}
-
 async fn cleanup_mysql_metadata_process(process: &mut MySqlMetadataProcess) {
     drop(process.stdin.take());
     let _ = process.child.kill().await;
-    let _ = finish_mysql_metadata_process(process).await;
+    let _ = finish_mysql_pipe(&mut process.stdout, &mut process.stderr, &mut process.child).await;
 }
 
 async fn run_mysql_metadata_query_with_read_only_session(
@@ -314,7 +297,8 @@ async fn run_mysql_metadata_query_with_read_only_session_process(
         .await
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
     drop(stdin);
-    let (status, stdout, stderr) = finish_mysql_metadata_process(process).await?;
+    let (status, stdout, stderr) =
+        finish_mysql_pipe(&mut process.stdout, &mut process.stderr, &mut process.child).await?;
     if has_mysql_cli_error(&stderr) {
         return Err(classify_mysql_query_failure(&stderr));
     }


### PR DESCRIPTION
## Problem
The non-Unix query and plain-text metadata process finish paths duplicate the pipe drain and child wait phase.

## Background
Both paths must drain stdout and stderr while reaping the child, but their caller-specific stdin shutdown, pending stderr handling, and exit validation must remain distinct.

## Approach
Share the pipe finish phase in the parent process module with a helper that concurrently drains both readers and waits for the child while preserving the existing I/O error classifications. Keep pending stderr merging and metadata exit validation in their respective callers.
