### PR TITLE
refactor(mysql): combine metadata session setup and probe

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -1341,10 +1341,9 @@ done
             assert!(option_file_path.exists());
 
             session
-                .prepare_read_only()
+                .prepare_read_only_and_probe()
                 .await
-                .expect("read-only session setup");
-            session.probe().await.expect("mode probe");
+                .expect("read-only session setup and metadata probe");
             for query in [
                 "SELECT TABLES",
                 "SELECT COLUMNS",

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -51,19 +51,16 @@ impl MySqlMetadataSession {
         })
     }
 
-    pub(in crate::adapters::mysql) async fn probe(&mut self) -> Result<u8, DbOperationError> {
+    pub(in crate::adapters::mysql) async fn prepare_read_only_and_probe(
+        &mut self,
+    ) -> Result<u8, DbOperationError> {
+        configure_mysql_session(&mut self.process, AccessMode::ReadOnly).await?;
         let marker = Uuid::new_v4().simple().to_string();
         let query = format!(
             "SELECT '{marker}' AS __sabiql_probe, @@lower_case_table_names AS __sabiql_lower_case_table_names"
         );
         let result = self.execute(&query).await?;
         validate_metadata_probe(&result, &marker)
-    }
-
-    pub(in crate::adapters::mysql) async fn prepare_read_only(
-        &mut self,
-    ) -> Result<(), DbOperationError> {
-        configure_mysql_session(&mut self.process, AccessMode::ReadOnly).await
     }
 
     pub(in crate::adapters::mysql) async fn execute(

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -196,8 +196,7 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
     let option_file = MySqlOptionFile::create(target)?;
     let mut session = MySqlMetadataSession::spawn_with_metadata_program(program, option_file)?;
     let result = tokio::time::timeout(timeout, async {
-        session.prepare_read_only().await?;
-        let lower_case_table_names = session.probe().await?;
+        let lower_case_table_names = session.prepare_read_only_and_probe().await?;
         let mut results = Vec::with_capacity(queries.len());
         for (query, expected_columns) in queries {
             results.push(

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -88,8 +88,7 @@ async fn execute_preview_with_session(
     limit: usize,
     offset: usize,
 ) -> Result<PreviewExecution, DbOperationError> {
-    session.prepare_read_only().await?;
-    let lower_case_table_names = session.probe().await?;
+    let lower_case_table_names = session.prepare_read_only_and_probe().await?;
     validate_selected_schema_name(database, schema, lower_case_table_names)?;
 
     let column_result = session

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -150,8 +150,7 @@ async fn fetch_table_detail_with_session(
     schema: &str,
     table: &str,
 ) -> Result<Table, DbOperationError> {
-    session.prepare_read_only().await?;
-    let lower_case_table_names = session.probe().await?;
+    let lower_case_table_names = session.prepare_read_only_and_probe().await?;
     let tables_result = session
         .execute_with_expected_columns(&table_query(schema, table), TABLES_RESULT_COLUMNS)
         .await?;


### PR DESCRIPTION
## Problem
Metadata session callers must perform two mandatory lifecycle steps before issuing metadata SQL, leaving an intermediate state that production code never uses.

## Background
The session bootstrap and metadata probe already have a fixed order and shared error boundary across catalog, preview, and table-detail execution.

## Approach
Make the existing session operation complete both bootstrap steps and return the validated lower-case table-name setting. Callers now receive that setting only after read-only setup and the metadata probe succeed, while metadata query execution and option-file ownership remain unchanged.
