### PR TITLE
perf(mysql): shorten Inspector session completion

### DIFF
--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -20,6 +20,7 @@ pub(in crate::adapters::mysql) struct MySqlMetadataSession {
 }
 
 const MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN: &str = "__sabiql_preview_completion";
+const MYSQL_INSPECTOR_COMPLETION_MARKER_COLUMN: &str = "__sabiql_inspector_completion";
 
 impl MySqlMetadataSession {
     pub(in crate::adapters::mysql) fn spawn_with_program(
@@ -89,6 +90,42 @@ impl MySqlMetadataSession {
                 .collect();
         }
         Ok(result)
+    }
+
+    pub(in crate::adapters::mysql) async fn execute_show_create_with_completion_marker(
+        &mut self,
+        query: &str,
+        expected_columns: &[&str],
+    ) -> Result<MySqlResultSet, DbOperationError> {
+        let marker = Uuid::new_v4().simple().to_string();
+        let marker_query =
+            format!("SELECT '{marker}' AS {MYSQL_INSPECTOR_COMPLETION_MARKER_COLUMN}");
+
+        write_mysql_statement(&mut self.process, query).await?;
+        write_mysql_statement(&mut self.process, &marker_query).await?;
+
+        let source_xml = read_one_mysql_resultset(&mut self.process).await?;
+        let mut source_result = parse_mysql_xml(&source_xml)?;
+        if source_result.columns.is_empty() && source_result.values.is_empty() {
+            source_result.columns = expected_columns
+                .iter()
+                .map(|column| (*column).to_string())
+                .collect();
+        }
+        let marker_xml = read_one_mysql_resultset(&mut self.process).await?;
+        let marker_result = parse_mysql_xml(&marker_xml)?;
+        if marker_result.columns != [MYSQL_INSPECTOR_COMPLETION_MARKER_COLUMN]
+            || marker_result.values.len() != 1
+            || marker_result.values[0].len() != 1
+            || marker_result.values[0][0].as_str() != Some(marker.as_str())
+        {
+            return Err(DbOperationError::QueryFailed(
+                "mysql inspector completion marker did not match".to_string(),
+            ));
+        }
+        let result = finish_mysql_session_after_preview_frame(&mut self.process).await?;
+        validate_mysql_session_exit(&result, self.process.client_packet_limit_bytes)?;
+        Ok(source_result)
     }
 
     pub(in crate::adapters::mysql) async fn finish(&mut self) -> Result<(), DbOperationError> {

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -199,14 +199,13 @@ async fn fetch_table_detail_with_session(
     )?;
     let source_ddl = parse_source_ddl(
         &session
-            .execute_with_expected_columns(
+            .execute_show_create_with_completion_marker(
                 &show_create_query(table, table_metadata.kind),
                 show_create_result_columns(table_metadata.kind),
             )
             .await?,
         table_metadata.kind,
     )?;
-    session.finish().await?;
 
     let mut detail = table_from_columns_and_foreign_keys(table_metadata, columns, foreign_keys);
     detail.indexes = indexes;
@@ -508,6 +507,14 @@ while IFS= read -r line; do
     fi
     continue
   fi
+  if printf '%s\n' "$line" | grep -q '__sabiql_inspector_completion'; then
+    marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)'.*/\1/")
+    if [ "$mode" = "completion-marker-failure" ]; then
+      marker=wrong-marker
+    fi
+    printf '%s\n' '<resultset><row><field name="__sabiql_inspector_completion">'"$marker"'</field></row></resultset>'
+    continue
+  fi
   case "$line" in
     *"SET SESSION TRANSACTION READ ONLY")
       ;;
@@ -665,6 +672,7 @@ done
                     "REFERENTIAL_CONSTRAINTS",
                     "INFORMATION_SCHEMA.TRIGGERS",
                     "SHOW CREATE VIEW",
+                    "__sabiql_inspector_completion",
                 ]
             } else {
                 [
@@ -679,6 +687,7 @@ done
                     "REFERENTIAL_CONSTRAINTS",
                     "INFORMATION_SCHEMA.TRIGGERS",
                     "SHOW CREATE TABLE",
+                    "__sabiql_inspector_completion",
                 ]
             };
             let positions = labels
@@ -689,6 +698,26 @@ done
             assert_process_stopped(&transcript);
             assert_option_file_removed(&transcript);
         }
+    }
+
+    #[tokio::test]
+    async fn inspector_detail_rejects_a_mismatched_completion_marker() {
+        let (_directory, program, transcript) = fake_metadata_cli("completion-marker-failure");
+        let error = fetch_table_detail_in_session_with_program(
+            "mysql://user:password@localhost:3306/app",
+            "app",
+            "items",
+            OsStr::new(&program),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, DbOperationError::QueryFailed(details) if details.contains("completion marker"))
+        );
+        assert_process_stopped(&transcript);
+        assert_option_file_removed(&transcript);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
MySQL Inspector waits for the CLI session to become idle after SHOW CREATE, adding a low-RTT delay before the table detail is delivered.

## Background
Oracle MySQL 8.4 measurements on the same local fixture showed the Inspector completion wait was on the critical path, while Result completion was already concurrent and not dominant.

## Approach
Send SHOW CREATE and a unique completion-marker SELECT before reading either result. Read and strictly validate both frames, then drain diagnostics and validate process termination immediately after the marker instead of using the 100 ms idle heuristic. This preserves the existing PTY/pipe, read-only, probe, timeout, cancellation, packet-limit, DDL, stale-guard, and parallel display boundaries. The old SAB-541 / PR #852 JSON aggregation is not reused.

## Screenshots

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-542