### PR TITLE
refactor(domain): remove unused SQLite profile constructor

### DIFF
--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -137,18 +137,6 @@ impl ConnectionProfile {
         })
     }
 
-    pub fn with_id_sqlite(
-        id: ConnectionId,
-        name: impl Into<String>,
-        path: impl Into<String>,
-    ) -> Result<Self, ConnectionProfileError> {
-        Ok(Self {
-            id,
-            name: ConnectionName::new(name)?,
-            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)?),
-        })
-    }
-
     pub fn with_id_and_config(
         id: ConnectionId,
         name: impl Into<String>,


### PR DESCRIPTION
## Problem
ConnectionProfile exposes a zero-caller SQLite-specific construction path, making the domain API broader than its production and test usage.

## Background
Existing SQLite creation and general ID-preserving configuration paths already cover every current caller while retaining validation behavior.

## Approach
Limit the profile API to the construction paths that are actually used. Keep SQLite profile semantics, validation, and serialization unchanged.