### PR TITLE
refactor: remove query history forwarding constructor

### DIFF
--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -280,10 +280,11 @@ mod tests {
 
     fn make_entry(query: &str) -> QueryHistoryEntry {
         use crate::domain::query_history::QueryResultStatus;
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             query.to_string(),
             "2026-03-13T12:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Success,
             None,
         )

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -1115,10 +1115,11 @@ mod tests {
         use crate::ports::outbound::query_history::QueryHistoryError;
 
         fn make_entry(query: &str, conn_id: &ConnectionId) -> QueryHistoryEntry {
-            QueryHistoryEntry::new(
+            QueryHistoryEntry::new_with_database(
                 query.to_string(),
                 "2026-03-13T12:00:00Z".to_string(),
                 conn_id.clone(),
+                None,
                 QueryResultStatus::Success,
                 None,
             )

--- a/src/domain/query_history.rs
+++ b/src/domain/query_history.rs
@@ -61,23 +61,6 @@ pub struct QueryHistoryEntry {
 }
 
 impl QueryHistoryEntry {
-    pub fn new(
-        query: String,
-        executed_at: String,
-        connection_id: ConnectionId,
-        result_status: QueryResultStatus,
-        affected_rows: Option<u64>,
-    ) -> Self {
-        Self::new_with_database(
-            query,
-            executed_at,
-            connection_id,
-            None,
-            result_status,
-            affected_rows,
-        )
-    }
-
     pub fn new_with_database(
         query: String,
         executed_at: String,
@@ -103,10 +86,11 @@ mod tests {
 
     #[test]
     fn serde_round_trip() {
-        let entry = QueryHistoryEntry::new(
+        let entry = QueryHistoryEntry::new_with_database(
             "SELECT * FROM users".to_string(),
             "2026-03-13T12:00:00Z".to_string(),
             ConnectionId::from_string("test-uuid"),
+            None,
             QueryResultStatus::Success,
             None,
         );
@@ -119,10 +103,11 @@ mod tests {
 
     #[test]
     fn serde_round_trip_with_affected_rows() {
-        let entry = QueryHistoryEntry::new(
+        let entry = QueryHistoryEntry::new_with_database(
             "UPDATE users SET name = 'x'".to_string(),
             "2026-03-13T12:00:00Z".to_string(),
             ConnectionId::from_string("test-uuid"),
+            None,
             QueryResultStatus::Success,
             Some(5),
         );
@@ -137,10 +122,11 @@ mod tests {
 
     #[test]
     fn serde_json_format() {
-        let entry = QueryHistoryEntry::new(
+        let entry = QueryHistoryEntry::new_with_database(
             "SELECT 1".to_string(),
             "2026-03-13T12:00:00Z".to_string(),
             ConnectionId::from_string("abc-123"),
+            None,
             QueryResultStatus::Success,
             None,
         );

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -132,10 +132,11 @@ mod tests {
     }
 
     fn make_entry(query: &str) -> QueryHistoryEntry {
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             query.to_string(),
             "2026-03-13T12:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Success,
             None,
         )

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -701,24 +701,27 @@ fn query_history_picker_with_entries() {
 
     state.modal.set_mode(InputMode::QueryHistoryPicker);
     state.query_history_picker.replace_entries(&[
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             "SELECT * FROM users WHERE id = 1".to_string(),
             "2026-03-13T10:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Success,
             None,
         ),
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             "INSERT INTO orders (user_id, total) VALUES (1, 100)".to_string(),
             "2026-03-13T11:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Success,
             Some(1),
         ),
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             "SELECT count(*) FROM users".to_string(),
             "2026-03-13T12:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Failed,
             None,
         ),
@@ -748,17 +751,19 @@ fn query_history_picker_filter_mode() {
 
     state.modal.set_mode(InputMode::QueryHistoryPicker);
     state.query_history_picker.replace_entries(&[
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             "SELECT * FROM users".to_string(),
             "2026-03-13T10:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Success,
             None,
         ),
-        QueryHistoryEntry::new(
+        QueryHistoryEntry::new_with_database(
             "SELECT * FROM orders".to_string(),
             "2026-03-13T11:00:00Z".to_string(),
             ConnectionId::from_string("test-conn"),
+            None,
             QueryResultStatus::Success,
             None,
         ),


### PR DESCRIPTION
## Problem

Query history entries exposed two construction paths even though the database-less path had no production callers. This allowed fixtures to bypass an explicit database-scope choice.

## Approach

Use the canonical constructor for every entry and pass `None` explicitly where the fixture represents history without a database. Serialization and database filtering semantics remain unchanged.