### PR TITLE
refactor: remove unused pagination row estimate

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -16,7 +16,6 @@ pub enum VisibleResultKind {
 #[derive(Debug, Clone, Default)]
 pub struct PaginationState {
     current_page: usize,
-    total_rows_estimate: Option<i64>,
     reached_end: bool,
     schema: String,
     table: String,
@@ -25,10 +24,6 @@ pub struct PaginationState {
 impl PaginationState {
     pub fn current_page(&self) -> usize {
         self.current_page
-    }
-
-    pub fn total_rows_estimate(&self) -> Option<i64> {
-        self.total_rows_estimate
     }
 
     pub fn reached_end(&self) -> bool {
@@ -73,13 +68,6 @@ impl PaginationState {
         self.current_page.saturating_sub(1)
     }
 
-    pub fn total_pages_estimate(&self) -> Option<usize> {
-        self.total_rows_estimate.map(|total| {
-            let total = total.max(0) as usize;
-            total.div_ceil(PREVIEW_PAGE_SIZE).max(1)
-        })
-    }
-
     pub fn can_next(&self) -> bool {
         !self.reached_end
     }
@@ -90,7 +78,6 @@ impl PaginationState {
 
     pub fn reset(&mut self) {
         self.current_page = 0;
-        self.total_rows_estimate = None;
         self.reached_end = false;
         self.schema.clear();
         self.table.clear();
@@ -102,26 +89,12 @@ impl PaginationState {
         self.table = table.to_string();
     }
 
-    pub fn reset_for_table_with_estimate(
-        &mut self,
-        schema: &str,
-        table: &str,
-        estimate: Option<i64>,
-    ) {
-        self.reset_for_table(schema, table);
-        self.total_rows_estimate = estimate;
-    }
-
     pub fn clear_reached_end(&mut self) {
         self.reached_end = false;
     }
 
     pub fn mark_reached_end(&mut self) {
         self.reached_end = true;
-    }
-
-    pub fn set_total_rows_estimate(&mut self, estimate: Option<i64>) {
-        self.total_rows_estimate = estimate;
     }
 
     // Use when navigation changes only the page index and must preserve the
@@ -539,53 +512,6 @@ mod tests {
         }
 
         #[test]
-        fn total_pages_estimate_rounds_up() {
-            let p = PaginationState {
-                total_rows_estimate: Some(1001),
-                ..Default::default()
-            };
-
-            assert_eq!(p.total_pages_estimate(), Some(3));
-        }
-
-        #[test]
-        fn total_pages_estimate_exact_division() {
-            let p = PaginationState {
-                total_rows_estimate: Some(1000),
-                ..Default::default()
-            };
-
-            assert_eq!(p.total_pages_estimate(), Some(2));
-        }
-
-        #[test]
-        fn total_pages_estimate_none_when_unknown() {
-            let p = PaginationState::default();
-
-            assert_eq!(p.total_pages_estimate(), None);
-        }
-
-        #[test]
-        fn total_pages_estimate_clamps_zero_to_one() {
-            let p = PaginationState {
-                total_rows_estimate: Some(0),
-                ..Default::default()
-            };
-
-            assert_eq!(p.total_pages_estimate(), Some(1));
-        }
-
-        #[test]
-        fn total_pages_estimate_clamps_negative_to_one() {
-            let p = PaginationState {
-                total_rows_estimate: Some(-1),
-                ..Default::default()
-            };
-
-            assert_eq!(p.total_pages_estimate(), Some(1));
-        }
-
-        #[test]
         fn can_next_false_when_reached_end() {
             let p = PaginationState {
                 reached_end: true,
@@ -596,7 +522,7 @@ mod tests {
         }
 
         #[test]
-        fn can_next_true_when_estimate_unknown() {
+        fn can_next_true_before_end_of_data() {
             let p = PaginationState::default();
 
             assert!(p.can_next());
@@ -623,7 +549,6 @@ mod tests {
         fn reset_clears_state() {
             let mut p = PaginationState {
                 current_page: 5,
-                total_rows_estimate: Some(10000),
                 reached_end: true,
                 schema: "public".to_string(),
                 table: "users".to_string(),
@@ -632,26 +557,23 @@ mod tests {
             p.reset();
 
             assert_eq!(p.current_page, 0);
-            assert_eq!(p.total_rows_estimate, None);
             assert!(!p.reached_end);
             assert!(p.schema.is_empty());
             assert!(p.table.is_empty());
         }
 
         #[test]
-        fn reset_for_table_with_estimate_sets_target_and_resets_page_state() {
+        fn reset_for_table_sets_target_and_resets_page_state() {
             let mut p = PaginationState {
                 current_page: 5,
-                total_rows_estimate: Some(1),
                 reached_end: true,
                 schema: "old".to_string(),
                 table: "old".to_string(),
             };
 
-            p.reset_for_table_with_estimate("public", "users", Some(1200));
+            p.reset_for_table("public", "users");
 
             assert_eq!(p.current_page(), 0);
-            assert_eq!(p.total_rows_estimate(), Some(1200));
             assert!(!p.reached_end());
             assert_eq!(p.schema(), "public");
             assert_eq!(p.table(), "users");

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -983,13 +983,11 @@ mod tests {
             let mut session = BrowseSession::default();
             let mut query = QueryExecution::default();
             query.pagination.reset_for_table("old", "old");
-            query.pagination.set_total_rows_estimate(Some(10000));
             query.pagination.set_page_result(5, true);
 
             let _ = session.select_table("public", "users", &mut query);
 
             assert_eq!(query.pagination.current_page(), 0);
-            assert_eq!(query.pagination.total_rows_estimate(), None);
             assert!(!query.pagination.reached_end());
             assert_eq!(query.pagination.schema(), "public");
             assert_eq!(query.pagination.table(), "users");
@@ -1523,9 +1521,7 @@ mod tests {
             let _ = session.set_table_detail(make_table_detail(), session.selection_generation());
 
             let result = make_query_result();
-            query
-                .pagination
-                .reset_for_table_with_estimate("public", "users", Some(1200));
+            query.pagination.reset_for_table("public", "users");
             query.pagination.set_page_result(2, false);
 
             let cache = session.to_cache(
@@ -1551,7 +1547,6 @@ mod tests {
             assert_eq!(query.pagination.schema(), "public");
             assert_eq!(query.pagination.table(), "users");
             assert_eq!(query.pagination.current_page(), 2);
-            assert_eq!(query.pagination.total_rows_estimate(), Some(1200));
             assert!(!query.pagination.reached_end());
             assert!(!query.is_running());
             assert!(!query.is_current_run(stale_run_id));
@@ -1647,7 +1642,6 @@ mod tests {
             let stale_run_id = query.begin_running(std::time::Instant::now());
             query.set_current_result(make_query_result());
             query.pagination.reset_for_table("public", "users");
-            query.pagination.set_total_rows_estimate(Some(1000));
             query.pagination.set_page_result(3, true);
             session.reset(&mut query);
 
@@ -1745,7 +1739,6 @@ mod tests {
             assert_eq!(query.pagination.current_page(), 0);
             assert!(query.pagination.schema().is_empty());
             assert!(query.pagination.table().is_empty());
-            assert!(query.pagination.total_rows_estimate().is_none());
             assert!(!query.pagination.reached_end());
         }
     }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -232,23 +232,7 @@ pub fn reduce_execution(
                 return DispatchResult::handled();
             }
 
-            let row_estimate = state
-                .session
-                .table_detail()
-                .and_then(|d| d.row_count_estimate)
-                .or_else(|| {
-                    state.tables().iter().find_map(|t| {
-                        if t.schema == *schema && t.name == *table {
-                            t.row_count_estimate
-                        } else {
-                            None
-                        }
-                    })
-                });
-            state
-                .query
-                .pagination
-                .reset_for_table_with_estimate(schema, table, row_estimate);
+            state.query.pagination.reset_for_table(schema, table);
 
             // Keep the generation captured at selection time, not the current
             // one: the selection may have been cleared between dispatch and
@@ -768,11 +752,10 @@ mod tests {
         #[test]
         fn resets_pagination() {
             let mut state = create_test_state();
-            state.query.pagination.reset_for_table_with_estimate(
-                "old_schema",
-                "old_table",
-                Some(10000),
-            );
+            state
+                .query
+                .pagination
+                .reset_for_table("old_schema", "old_table");
             state.query.pagination.set_page_result(5, true);
             let now = Instant::now();
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -472,10 +472,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state
-                .query
-                .pagination
-                .reset_for_table_with_estimate("public", "users", Some(1500));
+            state.query.pagination.reset_for_table("public", "users");
             let now = Instant::now();
 
             let effects = dispatch_query(
@@ -583,10 +580,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state
-                .query
-                .pagination
-                .reset_for_table_with_estimate("public", "users", Some(1500));
+            state.query.pagination.reset_for_table("public", "users");
             state.result_interaction.activate_cell(3, 1);
             state.result_interaction.stage_row(3);
 
@@ -687,10 +681,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state
-                .query
-                .pagination
-                .reset_for_table_with_estimate("public", "users", Some(1500));
+            state.query.pagination.reset_for_table("public", "users");
             state.query.pagination.set_page_result(2, false);
             let now = Instant::now();
 
@@ -775,7 +766,6 @@ mod tests {
             let mut state = export_test_state();
             state.query.set_current_result(preview_result(10));
             state.query.pagination.reset_for_table("public", "users");
-            state.query.pagination.set_total_rows_estimate(Some(100));
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1049,7 +1049,7 @@ mod tests {
 
         fn valid_mysql_cache(dsn: &str, database: &str) -> ConnectionCache {
             let mut pagination = PaginationState::default();
-            pagination.reset_for_table_with_estimate("app", "users", Some(1200));
+            pagination.reset_for_table("app", "users");
             pagination.set_page_result(2, false);
             ConnectionCache {
                 connection_dsn: Some(dsn.to_string()),
@@ -1141,7 +1141,6 @@ mod tests {
             assert_eq!(state.query.pagination.schema(), "app");
             assert_eq!(state.query.pagination.table(), "users");
             assert_eq!(state.query.pagination.current_page(), 2);
-            assert_eq!(state.query.pagination.total_rows_estimate(), Some(1200));
             assert_eq!(state.ui.explorer_selected(), 42);
             assert_eq!(state.ui.inspector_tab(), InspectorTab::ForeignKeys);
 
@@ -1339,7 +1338,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let target_id = ConnectionId::new();
             let mut pagination = PaginationState::default();
-            pagination.reset_for_table_with_estimate("main", "items", Some(900));
+            pagination.reset_for_table("main", "items");
             pagination.set_page_result(1, true);
             state.ui.set_explorer_selected_raw(7);
             state.connection_caches.save(
@@ -1399,10 +1398,7 @@ mod tests {
             let _ = state
                 .session
                 .select_table("public", "users", &mut state.query);
-            state
-                .query
-                .pagination
-                .reset_for_table_with_estimate("public", "users", Some(1500));
+            state.query.pagination.reset_for_table("public", "users");
             state.query.pagination.set_page_result(2, false);
             state
                 .query
@@ -1415,7 +1411,7 @@ mod tests {
                 )));
 
             let mut pagination_b = PaginationState::default();
-            pagination_b.reset_for_table_with_estimate("main", "orders", Some(2600));
+            pagination_b.reset_for_table("main", "orders");
             pagination_b.set_page_result(5, false);
             state.connection_caches.save(
                 &connection_b,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -3215,7 +3215,6 @@ mod tests {
 
             assert_eq!(state.query.pagination.schema(), "public");
             assert_eq!(state.query.pagination.table(), "users");
-            assert_eq!(state.query.pagination.total_rows_estimate(), Some(1200));
             assert_eq!(state.query.pagination.current_page(), 0);
             assert!(!state.query.pagination.reached_end());
         }


### PR DESCRIPTION
## Problem
`PaginationState` stores table row estimates, but production pagination and UI never read the value.

## Background
Preview setup copied estimates from table metadata into derived pagination state and exposed estimate-only APIs without a current consumer.

## Approach
Remove the unused estimate state, APIs, and preview lookup while keeping `reset_for_table` for the existing page-state reset. Preserve domain and Inspector row estimates, page navigation, and cache/session behavior.