### PR TITLE
refactor: centralize connection retry display predicate

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -355,6 +355,14 @@ impl AppState {
         self.ui.toggle_focus()
     }
 
+    pub fn can_retry_connection_error(&self) -> bool {
+        !self.connection_error.is_save_and_connect_failure()
+            && (self.session.has_pending_connection_switch()
+                || !self.session.can_reenter_connection_setup()
+                || (self.session.active_database_type() == Some(DatabaseType::MySQL)
+                    && self.connection_error.can_retry()))
+    }
+
     pub fn can_request_csv_export(&self) -> bool {
         let Some(result) = self.query.visible_result() else {
             return false;
@@ -476,6 +484,7 @@ mod tests {
     };
     use crate::model::browse::inspector_view_model::{InspectorEmptyState, InspectorLoadState};
     use crate::model::browse::row_detail::RowDetailState;
+    use crate::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
     use crate::model::shared::render_output::{
@@ -521,6 +530,81 @@ mod tests {
             schema: "public".to_string(),
             name: "users".to_string(),
             ..test_support::table::minimal("", "")
+        }
+    }
+
+    mod connection_error_retry {
+        use super::*;
+
+        fn active_connection_state(database_type: DatabaseType, dsn: &str) -> AppState {
+            let mut state = make_state();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                database_type,
+                dsn,
+            );
+            state
+        }
+
+        fn retryable_error() -> ConnectionErrorInfo {
+            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Timeout, "connection timed out")
+        }
+
+        #[test]
+        fn allows_retry_for_active_mysql_retryable_error() {
+            let mut state = active_connection_state(
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
+            );
+            state.connection_error.set_error(retryable_error());
+
+            assert!(state.can_retry_connection_error());
+        }
+
+        #[test]
+        fn hides_retry_for_non_mysql_retryable_error() {
+            let mut state =
+                active_connection_state(DatabaseType::PostgreSQL, "postgres://localhost/app");
+            state.connection_error.set_error(retryable_error());
+
+            assert!(!state.can_retry_connection_error());
+        }
+
+        #[test]
+        fn hides_retry_for_save_and_connect_failure() {
+            let mut state = active_connection_state(
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
+            );
+            state
+                .connection_error
+                .set_save_and_connect_error(retryable_error(), DatabaseType::MySQL);
+
+            assert!(!state.can_retry_connection_error());
+        }
+
+        #[test]
+        fn keeps_retry_for_pending_connection_switch() {
+            let mut state = active_connection_state(
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/old?ssl-mode=PREFERRED",
+            );
+            let target_id = ConnectionId::from_string("mysql-new");
+            let _ = state.session.begin_mysql_connection_probe(
+                &target_id,
+                "mysql-new",
+                "mysql://user@localhost:3306/new?ssl-mode=PREFERRED",
+                Some("new"),
+            );
+            state
+                .connection_error
+                .set_error(ConnectionErrorInfo::with_kind(
+                    ConnectionErrorKind::Unknown,
+                    "connection failed",
+                ));
+
+            assert!(state.can_retry_connection_error());
         }
     }
 

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -170,13 +170,12 @@ pub(super) fn reduce_connection_error(
 mod tests {
     use super::*;
     use crate::domain::{ConnectionId, DatabaseType};
-    use crate::model::connection::error::ConnectionErrorInfo;
+    use crate::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use crate::model::connection::state::ConnectionState;
     use crate::update::test_fixtures;
 
     mod scroll_down {
         use super::*;
-        use crate::model::connection::error::ConnectionErrorKind;
 
         fn scroll_down_action() -> Action {
             Action::Scroll {
@@ -288,6 +287,33 @@ mod tests {
                 .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
         );
         assert!(state.session.connection_state().is_connecting());
+    }
+
+    #[test]
+    fn retry_mysql_ignores_non_retryable_error() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_target(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
+            Some("app"),
+        );
+        state
+            .connection_error
+            .set_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::Unknown,
+                "connection failed",
+            ));
+        state.session.set_connection_state(ConnectionState::Failed);
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        let effects = reduce_connection_error(&mut state, &Action::RetryConnection, Instant::now())
+            .into_effects()
+            .expect("retry action handled");
+
+        assert!(effects.is_empty());
+        assert_eq!(state.input_mode(), InputMode::ConnectionError);
     }
 
     #[test]

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -465,6 +465,40 @@ fn render_service_error_without_service_file_hint(save_and_connect: bool) -> Str
 }
 
 #[test]
+fn connection_error_save_failure_hides_retry_in_modal_and_footer() {
+    let output = render_service_error_without_service_file_hint(true);
+
+    assert!(output.contains("Actions:  e  Re-enter"));
+    assert!(output.contains("e:Edit"));
+    assert!(!output.contains("Retry"));
+}
+
+#[test]
+fn non_mysql_retryable_error_hides_retry_in_modal_and_footer() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+    state.session.activate_connection_with_dsn(
+        &sabiql_domain::ConnectionId::from_string("postgres-test"),
+        "postgres",
+        DatabaseType::PostgreSQL,
+        "postgres://localhost:5432/app",
+    );
+    state.modal.set_mode(InputMode::ConnectionError);
+    state
+        .connection_error
+        .set_error(ConnectionErrorInfo::with_kind(
+            ConnectionErrorKind::Timeout,
+            "connection timed out",
+        ));
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    assert!(output.contains("Actions:  e  Re-enter"));
+    assert!(output.contains("e:Edit"));
+    assert!(!output.contains("Retry"));
+}
+
+#[test]
 fn connection_error_omits_service_file_hint_for_mysql_save() {
     let output = render_service_error_without_service_file_hint(true);
 

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use ratatui::prelude::*;
 use ratatui::widgets::{Paragraph, Wrap};
 
-use crate::domain::DatabaseType;
 use crate::theme::ThemePalette;
 
 use crate::app::model::app_state::AppState;
@@ -169,21 +168,12 @@ impl ConnectionError {
         theme: &ThemePalette,
     ) {
         let error_state = &state.connection_error;
-        let can_retry = state
-            .session
-            .active_database_type()
-            .is_some_and(|database_type| database_type == DatabaseType::MySQL)
-            && error_state.can_retry();
         let mut spans = vec![Span::styled(
             "Actions: ",
             Style::default().fg(theme.semantic.text.muted),
         )];
 
-        if !error_state.is_save_and_connect_failure()
-            && (state.session.has_pending_connection_switch()
-                || !state.session.can_reenter_connection_setup()
-                || can_retry)
-        {
+        if state.can_retry_connection_error() {
             spans.push(key_chip("r", theme));
             spans.push(Span::raw(" Retry  "));
         } else {

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -22,7 +22,6 @@ use crate::app::update::input::keybindings::{
     overlay, query_history, query_history_picker, read_only, result_active, settings, sql_modal,
     sql_modal_confirming, sqlite_diagnostics, table_picker, table_picker as table_picker_key,
 };
-use crate::domain::DatabaseType;
 use crate::features::settings::hints::settings_hints;
 use crate::primitives::atoms::key_text;
 use crate::primitives::atoms::spinner_char;
@@ -295,15 +294,7 @@ impl Footer {
                 hints
             }
             InputMode::ConnectionError => {
-                let can_retry = state
-                    .session
-                    .active_database_type()
-                    .is_some_and(|database_type| database_type == DatabaseType::MySQL)
-                    && state.connection_error.can_retry();
-                let first = if state.session.has_pending_connection_switch()
-                    || !state.session.can_reenter_connection_setup()
-                    || can_retry
-                {
+                let first = if state.can_retry_connection_error() {
                     connection_error::RETRY.as_hint()
                 } else {
                     connection_error::EDIT.as_hint()
@@ -461,6 +452,7 @@ mod tests {
     use super::Footer;
     use crate::app::domain::{ConnectionId, DatabaseType};
     use crate::app::model::app_state::AppState;
+    use crate::app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use crate::app::model::connection::setup::ConnectionField;
     use crate::app::model::shared::focused_pane::FocusedPane;
     use crate::app::model::shared::input_mode::InputMode;
@@ -468,7 +460,8 @@ mod tests {
     use crate::app::model::shared::ui_state::FocusMode;
     use crate::app::model::sql_editor::modal::SqlModalStatus;
     use crate::app::update::input::keybindings::{
-        connection_setup, global, help, json_detail, json_edit, result_active, row_detail,
+        connection_error, connection_setup, global, help, json_detail, json_edit, result_active,
+        row_detail,
     };
     use rstest::rstest;
 
@@ -710,5 +703,25 @@ mod tests {
         assert!(hints.contains(&connection_setup::ENTER_DROPDOWN.as_hint()));
         assert!(hints.contains(&connection_setup::SAVE.as_hint()));
         assert!(!hints.contains(&("Enter", "Connect")));
+    }
+
+    #[test]
+    fn connection_error_footer_hides_retry_for_save_and_connect_failure() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
+        );
+        state.connection_error.set_save_and_connect_error(
+            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Timeout, "connection timed out"),
+            DatabaseType::MySQL,
+        );
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        let hints = Footer::get_context_hints(&state);
+
+        assert_eq!(hints[0], connection_error::EDIT.as_hint());
     }
 }


### PR DESCRIPTION
## Problem
The connection error modal excluded save-and-connect failures from Retry, but the footer could still advertise an action that the reducer rejects.

## Background
Both surfaces independently reconstructed the connection retry display policy, allowing their conditions to diverge.

## Approach
Centralize the product predicate while preserving pending-switch handling, the MySQL retryability gate, non-MySQL behavior, and the reducer safety check.