### PR TITLE
refactor: centralize registry DDL and dialect selection

### DIFF
--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -61,6 +61,22 @@ impl DbAdapterRegistry {
             DatabaseType::MySQL => Ok(self.mysql.as_ref()),
         }
     }
+
+    fn ddl_generator(&self, database_type: DatabaseType) -> &dyn DdlGenerator {
+        match database_type {
+            DatabaseType::PostgreSQL => self.postgres.as_ref(),
+            DatabaseType::SQLite => self.sqlite.as_ref(),
+            DatabaseType::MySQL => self.mysql.as_ref(),
+        }
+    }
+
+    fn sql_dialect(&self, database_type: DatabaseType) -> &dyn SqlDialect {
+        match database_type {
+            DatabaseType::PostgreSQL => self.postgres.as_ref(),
+            DatabaseType::SQLite => self.sqlite.as_ref(),
+            DatabaseType::MySQL => self.mysql.as_ref(),
+        }
+    }
 }
 
 fn is_postgres_conninfo_dsn(dsn: &str) -> bool {
@@ -186,21 +202,15 @@ impl QueryExecutor for DbAdapterRegistry {
 
 impl DdlGenerator for DbAdapterRegistry {
     fn generate_ddl(&self, database_type: DatabaseType, table: &Table) -> String {
-        match database_type {
-            DatabaseType::PostgreSQL => self.postgres.generate_ddl(database_type, table),
-            DatabaseType::SQLite => self.sqlite.generate_ddl(database_type, table),
-            DatabaseType::MySQL => self.mysql.generate_ddl(database_type, table),
-        }
+        self.ddl_generator(database_type)
+            .generate_ddl(database_type, table)
     }
 }
 
 impl SqlDialect for DbAdapterRegistry {
     fn build_explain_sql(&self, database_type: DatabaseType, query: &str) -> Option<String> {
-        match database_type {
-            DatabaseType::PostgreSQL => self.postgres.build_explain_sql(database_type, query),
-            DatabaseType::SQLite => self.sqlite.build_explain_sql(database_type, query),
-            DatabaseType::MySQL => self.mysql.build_explain_sql(database_type, query),
-        }
+        self.sql_dialect(database_type)
+            .build_explain_sql(database_type, query)
     }
 
     fn build_explain_analyze_sql(
@@ -208,13 +218,8 @@ impl SqlDialect for DbAdapterRegistry {
         database_type: DatabaseType,
         query: &str,
     ) -> Option<String> {
-        match database_type {
-            DatabaseType::PostgreSQL => self
-                .postgres
-                .build_explain_analyze_sql(database_type, query),
-            DatabaseType::SQLite => self.sqlite.build_explain_analyze_sql(database_type, query),
-            DatabaseType::MySQL => self.mysql.build_explain_analyze_sql(database_type, query),
-        }
+        self.sql_dialect(database_type)
+            .build_explain_analyze_sql(database_type, query)
     }
 
     fn build_update_sql(
@@ -226,32 +231,14 @@ impl SqlDialect for DbAdapterRegistry {
         new_value: &QueryValue,
         pk_pairs: &[(String, QueryValue)],
     ) -> String {
-        match database_type {
-            DatabaseType::PostgreSQL => self.postgres.build_update_sql(
-                database_type,
-                schema,
-                table,
-                column,
-                new_value,
-                pk_pairs,
-            ),
-            DatabaseType::SQLite => self.sqlite.build_update_sql(
-                database_type,
-                schema,
-                table,
-                column,
-                new_value,
-                pk_pairs,
-            ),
-            DatabaseType::MySQL => self.mysql.build_update_sql(
-                database_type,
-                schema,
-                table,
-                column,
-                new_value,
-                pk_pairs,
-            ),
-        }
+        self.sql_dialect(database_type).build_update_sql(
+            database_type,
+            schema,
+            table,
+            column,
+            new_value,
+            pk_pairs,
+        )
     }
 
     fn build_bulk_delete_sql(
@@ -261,20 +248,12 @@ impl SqlDialect for DbAdapterRegistry {
         table: &str,
         pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
-        match database_type {
-            DatabaseType::PostgreSQL => {
-                self.postgres
-                    .build_bulk_delete_sql(database_type, schema, table, pk_pairs_per_row)
-            }
-            DatabaseType::SQLite => {
-                self.sqlite
-                    .build_bulk_delete_sql(database_type, schema, table, pk_pairs_per_row)
-            }
-            DatabaseType::MySQL => {
-                self.mysql
-                    .build_bulk_delete_sql(database_type, schema, table, pk_pairs_per_row)
-            }
-        }
+        self.sql_dialect(database_type).build_bulk_delete_sql(
+            database_type,
+            schema,
+            table,
+            pk_pairs_per_row,
+        )
     }
 }
 

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -441,6 +441,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn mysql_registry_dispatches_ddl_and_dialect_to_mysql_adapter() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+        let source_ddl = "CREATE TABLE `users` (`id` INT)".to_string();
+        let mut table = make_table();
+        table.source_ddl = Some(source_ddl.clone());
+
+        assert_eq!(
+            registry.generate_ddl(DatabaseType::MySQL, &table),
+            source_ddl
+        );
+        assert_eq!(
+            registry.build_explain_sql(DatabaseType::MySQL, "SELECT 1"),
+            Some("EXPLAIN FORMAT=TREE SELECT 1".to_string())
+        );
+        assert_eq!(
+            registry.build_explain_analyze_sql(DatabaseType::MySQL, "SELECT 1"),
+            Some("EXPLAIN ANALYZE FORMAT=TREE SELECT 1".to_string())
+        );
+    }
+
     #[tokio::test]
     async fn mysql_dsn_requires_a_selected_database_for_metadata() {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));


### PR DESCRIPTION
## Problem
DbAdapterRegistry repeated the same three-database dispatch across the synchronous DDL and SQL dialect ports.

## Background
The registry already centralizes the corresponding metadata and query executor selection while preserving database-specific adapter behavior.

## Approach
Use one private selector per synchronous port and keep DatabaseType in each port call so adapter-owned SQL differences and existing registry behavior remain unchanged.