### PR TITLE
refactor(ui): remove unreachable MySQL trigger branch

### DIFF
--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -895,13 +895,6 @@ fn foreign_key_row_cells(row: &InspectorForeignKeyRow) -> Vec<String> {
 
 fn trigger_row_cells(row: &InspectorTriggerRow, database_type: DatabaseType) -> Vec<String> {
     let mut cells = Vec::new();
-    if database_type == DatabaseType::MySQL {
-        cells.push(
-            row.action_order
-                .map(|order| order.to_string())
-                .unwrap_or_default(),
-        );
-    }
     cells.extend([
         row.name.clone(),
         row.timing.clone(),


### PR DESCRIPTION
## Problem
The shared trigger-row renderer contains a MySQL action-order branch that cannot execute because MySQL returns to its dedicated detail renderer first.

## Background
The unreachable branch makes the common renderer appear to own MySQL action-order presentation even though that responsibility belongs to the MySQL-specific renderer.

## Approach
Remove only the unreachable MySQL branch. PostgreSQL and SQLite table rendering, MySQL detail rendering, scrolling, and creation-context output remain unchanged.