### PR TITLE
refactor: centralize MySQL connect-timeout classification

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,7 +1,7 @@
 use crate::policy::password_masking::mask_password;
 use crate::ports::outbound::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
-    SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
+    SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind, is_mysql_connect_timeout_message,
 };
 use sabiql_domain::connection::MySqlSslMode;
 use url::Url;
@@ -83,7 +83,7 @@ impl ConnectionErrorKind {
             return Self::DatabaseNotFound;
         }
 
-        if is_mysql_connect_timeout_message(&stderr_lower)
+        if is_mysql_connect_timeout_message(stderr)
             || stderr_lower.contains("timeout expired")
             || stderr_lower.contains("timed out")
             || stderr_lower.contains("connection timed out")
@@ -188,13 +188,6 @@ impl ConnectionErrorKind {
             Self::HostUnreachable | Self::ConnectionLost | Self::Timeout | Self::ConnectionRefused
         )
     }
-}
-
-fn is_mysql_connect_timeout_message(value: &str) -> bool {
-    value.contains("can't connect to mysql server")
-        && MYSQL_CONNECT_TIMEOUT_ERRNOS
-            .iter()
-            .any(|errno| value.contains(errno))
 }
 
 fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -9,6 +9,14 @@ pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED"
 pub const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str = "SQLITE_SAFE_MODE_REQUIRED";
 pub const MYSQL_CONNECT_TIMEOUT_ERRNOS: &[&str] = &["(60)", "(110)", "(10060)"];
 
+pub fn is_mysql_connect_timeout_message(value: &str) -> bool {
+    let lowercase = value.to_ascii_lowercase();
+    lowercase.contains("can't connect to mysql server")
+        && MYSQL_CONNECT_TIMEOUT_ERRNOS
+            .iter()
+            .any(|errno| lowercase.contains(errno))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatabaseCli {
     Psql,
@@ -308,6 +316,18 @@ impl From<csv::Error> for DbOperationError {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn mysql_connect_timeout_classifier_preserves_errno_and_case_rules() {
+        for errno in MYSQL_CONNECT_TIMEOUT_ERRNOS {
+            assert!(is_mysql_connect_timeout_message(&format!(
+                "Can't connect to MySQL server (host) {errno}"
+            )));
+        }
+        assert!(!is_mysql_connect_timeout_message(
+            "Can't connect to MySQL server (host) (111)"
+        ));
+    }
 
     mod summaries_and_hints {
         use super::*;

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -33,6 +33,7 @@ pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
     SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
+    is_mysql_connect_timeout_message,
 };
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -1,8 +1,10 @@
 use std::io::{self, Write};
 
-use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
+use crate::app::ports::outbound::{
+    DatabaseCli, DbOperationError, is_mysql_connect_timeout_message,
+};
 
-use super::probe::{is_mysql_connect_timeout_message, mysql_tls_failure_kind};
+use super::probe::mysql_tls_failure_kind;
 
 pub(super) fn map_mysql_cli_spawn_error(error: io::Error) -> DbOperationError {
     if error.kind() == io::ErrorKind::NotFound {

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -8,8 +8,8 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::app::ports::outbound::{
-    ConnectionFailureKind, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
-    MySqlConnectionProbeResult, UnsupportedOperationKind,
+    ConnectionFailureKind, DbOperationError, MySqlConnectionProbeResult, UnsupportedOperationKind,
+    is_mysql_connect_timeout_message,
 };
 
 use super::args::mysql_connection_args;
@@ -256,14 +256,6 @@ pub(super) fn mysql_tls_failure_kind(lowercase_details: &str) -> Option<Connecti
     }
 
     None
-}
-
-pub(super) fn is_mysql_connect_timeout_message(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-    lower.contains("can't connect to mysql server")
-        && MYSQL_CONNECT_TIMEOUT_ERRNOS
-            .iter()
-            .any(|errno| lower.contains(errno))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
MySQL connect-timeout detection is duplicated in the application and adapter layers, so errno and case-handling rules can drift.

## Background
The same MySQL connection error taxonomy is consumed by the probe and connection-error classifier.

## Approach
Keep the classifier in the existing shared database-operation error utility and have both layers call it. Preserve the existing timeout/refusal split, generic timeout fallbacks, timeout durations, and user-facing taxonomy.