### PR TITLE
refactor(domain): unify database diagnostics

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -435,7 +435,7 @@ mod tests {
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
     use crate::cmd::test_fixtures;
-    use crate::domain::{WriteDiagnostic, WriteDiagnosticLevel, WriteExecutionResult};
+    use crate::domain::{DatabaseDiagnostic, DiagnosticLevel, WriteExecutionResult};
     use crate::model::app_state::AppState;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
@@ -895,8 +895,8 @@ mod tests {
                     Ok(WriteExecutionResult {
                         affected_rows: 1,
                         execution_time_ms: 0,
-                        diagnostics: vec![WriteDiagnostic {
-                            level: WriteDiagnosticLevel::Warning,
+                        diagnostics: vec![DatabaseDiagnostic {
+                            level: DiagnosticLevel::Warning,
                             code: 1265,
                             message: "Data truncated".to_string(),
                         }],
@@ -922,8 +922,8 @@ mod tests {
                     ..
                 } => assert_eq!(
                     diagnostics,
-                    vec![WriteDiagnostic {
-                        level: WriteDiagnosticLevel::Warning,
+                    vec![DatabaseDiagnostic {
+                        level: DiagnosticLevel::Warning,
                         code: 1265,
                         message: "Data truncated".to_string(),
                     }]

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
-use crate::domain::{CommandTag, MySqlDiagnostic};
+use crate::domain::{CommandTag, DatabaseDiagnostic};
 use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::multi_line_input::MultiLineInputState;
 use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -47,7 +47,7 @@ pub struct AdhocSuccessSnapshot {
     pub command_tag: Option<CommandTag>,
     pub row_count: usize,
     pub execution_time_ms: u64,
-    pub mysql_diagnostics: Vec<MySqlDiagnostic>,
+    pub mysql_diagnostics: Vec<DatabaseDiagnostic>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -23,7 +23,8 @@ use std::collections::HashMap;
 
 use crate::domain::SqliteDiagnosticsSnapshot;
 use crate::domain::{
-    DatabaseMetadata, DiagnosticField, QueryResult, Table, TableSignatureSnapshot, WriteDiagnostic,
+    DatabaseDiagnostic, DatabaseMetadata, DiagnosticField, QueryResult, Table,
+    TableSignatureSnapshot,
 };
 
 #[derive(Clone, thiserror::Error)]
@@ -632,7 +633,7 @@ pub enum Action {
         dsn: String,
         run_id: u64,
         affected_rows: usize,
-        diagnostics: Vec<WriteDiagnostic>,
+        diagnostics: Vec<DatabaseDiagnostic>,
     },
     ExecuteWriteFailed {
         dsn: String,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::{RefreshScope, WriteDiagnostic};
+use crate::domain::{DatabaseDiagnostic, RefreshScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::confirm_dialog::ConfirmIntent;
@@ -379,14 +379,14 @@ pub fn reduce_write(
     }
 }
 
-fn write_message_with_diagnostics(message: String, diagnostics: &[WriteDiagnostic]) -> String {
+fn write_message_with_diagnostics(message: String, diagnostics: &[DatabaseDiagnostic]) -> String {
     if diagnostics.is_empty() {
         return message;
     }
 
     let details = diagnostics
         .iter()
-        .map(WriteDiagnostic::display_message)
+        .map(DatabaseDiagnostic::display_message)
         .collect::<Vec<_>>()
         .join("; ");
     format!("{message}; {details}")
@@ -449,7 +449,7 @@ mod tests {
 
     use crate::domain::connection::ConnectionId;
     use crate::domain::{
-        ColumnAttributes, DatabaseType, QueryResult, QuerySource, QueryValue, WriteDiagnosticLevel,
+        ColumnAttributes, DatabaseType, DiagnosticLevel, QueryResult, QuerySource, QueryValue,
     };
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection,
@@ -470,7 +470,7 @@ mod tests {
     fn write_succeeded_action_with_diagnostics(
         state: &mut AppState,
         affected_rows: usize,
-        diagnostics: Vec<WriteDiagnostic>,
+        diagnostics: Vec<DatabaseDiagnostic>,
     ) -> Action {
         let dsn = state
             .session
@@ -1418,8 +1418,8 @@ mod tests {
             let action = write_succeeded_action_with_diagnostics(
                 &mut state,
                 1,
-                vec![WriteDiagnostic {
-                    level: WriteDiagnosticLevel::Warning,
+                vec![DatabaseDiagnostic {
+                    level: DiagnosticLevel::Warning,
                     code: 1265,
                     message: "Data truncated".to_string(),
                 }],

--- a/src/domain/diagnostic.rs
+++ b/src/domain/diagnostic.rs
@@ -1,17 +1,17 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MySqlDiagnosticLevel {
+pub enum DiagnosticLevel {
     Warning,
     Note,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MySqlDiagnostic {
-    pub level: MySqlDiagnosticLevel,
+pub struct DatabaseDiagnostic {
+    pub level: DiagnosticLevel,
     pub code: u32,
     pub message: String,
 }
 
-impl MySqlDiagnostic {
+impl DatabaseDiagnostic {
     #[must_use]
     pub fn display_message(&self) -> String {
         format!(
@@ -23,7 +23,7 @@ impl MySqlDiagnostic {
     }
 }
 
-impl MySqlDiagnosticLevel {
+impl DiagnosticLevel {
     #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -40,8 +40,8 @@ mod tests {
     #[test]
     fn formats_level_code_and_message_for_statuses() {
         assert_eq!(
-            MySqlDiagnostic {
-                level: MySqlDiagnosticLevel::Warning,
+            DatabaseDiagnostic {
+                level: DiagnosticLevel::Warning,
                 code: 1265,
                 message: "Data truncated".to_string(),
             }

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -3,12 +3,12 @@
 pub mod column;
 pub mod command_tag;
 pub mod connection;
+pub mod diagnostic;
 pub mod er;
 pub mod explain_plan;
 pub mod foreign_key;
 pub mod index;
 pub mod metadata;
-pub mod mysql_diagnostics;
 pub mod mysql_sql;
 pub mod query_history;
 pub mod query_result;
@@ -23,6 +23,7 @@ pub mod write_result;
 
 pub use column::{Column, ColumnAttributes, ColumnGenerationKind};
 pub use command_tag::CommandTag;
+pub use diagnostic::{DatabaseDiagnostic, DiagnosticLevel};
 pub use er::ErTableInfo;
 pub use explain_plan::{
     mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
@@ -31,7 +32,6 @@ pub use explain_plan::{
 pub use foreign_key::{FkAction, ForeignKey, UNRESOLVED_FK_COLUMN};
 pub use index::{Index, IndexAttributes, IndexType};
 pub use metadata::{DatabaseMetadata, MetadataState};
-pub use mysql_diagnostics::{MySqlDiagnostic, MySqlDiagnosticLevel};
 pub use query_result::{ExplicitRowIdentity, QueryResult, QuerySource, QueryValue, RefreshScope};
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
@@ -41,7 +41,7 @@ pub use table::{
 };
 pub use table_kind::{TableKind, TableKindInfo};
 pub use trigger::{Trigger, TriggerCreationContext, TriggerEvent, TriggerTiming};
-pub use write_result::{WriteDiagnostic, WriteDiagnosticLevel, WriteExecutionResult};
+pub use write_result::WriteExecutionResult;
 
 pub use connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use super::{CommandTag, MySqlDiagnostic};
+use super::{CommandTag, DatabaseDiagnostic};
 
 const BLOB_PREVIEW_BYTES: usize = 8;
 
@@ -268,7 +268,7 @@ pub struct QueryResult {
     pub error: Option<String>,
     pub command_tag: Option<CommandTag>,
     pub refresh_scope: RefreshScope,
-    pub mysql_diagnostics: Vec<MySqlDiagnostic>,
+    pub mysql_diagnostics: Vec<DatabaseDiagnostic>,
     rows: Vec<Vec<String>>,
     values: Vec<Vec<QueryValue>>,
     explicit_row_identity: Option<ExplicitRowIdentity>,
@@ -371,7 +371,7 @@ impl QueryResult {
     }
 
     #[must_use]
-    pub fn with_mysql_diagnostics(mut self, diagnostics: Vec<MySqlDiagnostic>) -> Self {
+    pub fn with_mysql_diagnostics(mut self, diagnostics: Vec<DatabaseDiagnostic>) -> Self {
         self.mysql_diagnostics = diagnostics;
         self
     }
@@ -605,7 +605,7 @@ mod tests {
 
     mod builder {
         use super::*;
-        use crate::MySqlDiagnosticLevel;
+        use crate::DiagnosticLevel;
 
         #[test]
         fn with_command_tag_sets_tag() {
@@ -625,8 +625,8 @@ mod tests {
                 0,
                 QuerySource::Adhoc,
             )
-            .with_mysql_diagnostics(vec![MySqlDiagnostic {
-                level: MySqlDiagnosticLevel::Warning,
+            .with_mysql_diagnostics(vec![DatabaseDiagnostic {
+                level: DiagnosticLevel::Warning,
                 code: 1062,
                 message: "duplicate".to_string(),
             }]);

--- a/src/domain/write_result.rs
+++ b/src/domain/write_result.rs
@@ -1,41 +1,6 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WriteDiagnosticLevel {
-    Warning,
-    Note,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WriteDiagnostic {
-    pub level: WriteDiagnosticLevel,
-    pub code: u32,
-    pub message: String,
-}
-
-impl WriteDiagnostic {
-    #[must_use]
-    pub fn display_message(&self) -> String {
-        format!(
-            "{} (Code {}): {}",
-            self.level.as_str(),
-            self.code,
-            self.message
-        )
-    }
-}
-
-impl WriteDiagnosticLevel {
-    #[must_use]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Warning => "Warning",
-            Self::Note => "Note",
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteExecutionResult {
     pub affected_rows: usize,
     pub execution_time_ms: u64,
-    pub diagnostics: Vec<WriteDiagnostic>,
+    pub diagnostics: Vec<super::DatabaseDiagnostic>,
 }

--- a/src/infra/adapters/mysql/cli/diagnostics.rs
+++ b/src/infra/adapters/mysql/cli/diagnostics.rs
@@ -1,24 +1,24 @@
-use crate::domain::{MySqlDiagnostic, MySqlDiagnosticLevel};
+use crate::domain::{DatabaseDiagnostic, DiagnosticLevel};
 
-pub(super) fn parse_mysql_cli_diagnostics(output: &[u8]) -> Vec<MySqlDiagnostic> {
+pub(super) fn parse_mysql_cli_diagnostics(output: &[u8]) -> Vec<DatabaseDiagnostic> {
     output
         .split(|byte| matches!(byte, b'\n' | b'\r'))
         .filter_map(parse_mysql_cli_diagnostic_line)
         .collect()
 }
 
-fn parse_mysql_cli_diagnostic_line(line: &[u8]) -> Option<MySqlDiagnostic> {
+fn parse_mysql_cli_diagnostic_line(line: &[u8]) -> Option<DatabaseDiagnostic> {
     let line = String::from_utf8_lossy(line);
     let line = line.trim();
     let (level, rest) = if let Some(rest) = line.strip_prefix("Warning (Code ") {
-        (MySqlDiagnosticLevel::Warning, rest)
+        (DiagnosticLevel::Warning, rest)
     } else if let Some(rest) = line.strip_prefix("Note (Code ") {
-        (MySqlDiagnosticLevel::Note, rest)
+        (DiagnosticLevel::Note, rest)
     } else {
         return None;
     };
     let (code, message) = rest.split_once("): ")?;
-    Some(MySqlDiagnostic {
+    Some(DatabaseDiagnostic {
         level,
         code: code.parse().ok()?,
         message: message.to_string(),
@@ -38,13 +38,13 @@ mod tests {
         assert_eq!(
             diagnostics,
             vec![
-                MySqlDiagnostic {
-                    level: MySqlDiagnosticLevel::Warning,
+                DatabaseDiagnostic {
+                    level: DiagnosticLevel::Warning,
                     code: 1062,
                     message: "Duplicate entry '1'".to_string(),
                 },
-                MySqlDiagnostic {
-                    level: MySqlDiagnosticLevel::Note,
+                DatabaseDiagnostic {
+                    level: DiagnosticLevel::Note,
                     code: 1050,
                     message: "Table exists".to_string(),
                 },

--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -179,7 +179,7 @@ pub(super) async fn read_one_mysql_resultset_from_pipes_with_diagnostics<R, E>(
     frame_scanner: &mut MySqlResultsetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
     preview_byte_budget: bool,
-) -> Result<(Vec<u8>, Vec<crate::domain::MySqlDiagnostic>), DbOperationError>
+) -> Result<(Vec<u8>, Vec<crate::domain::DatabaseDiagnostic>), DbOperationError>
 where
     R: AsyncRead + Unpin,
     E: AsyncRead + Unpin,

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{
-    CommandTag, MySqlDiagnostic, QueryValue, RefreshScope,
+    CommandTag, DatabaseDiagnostic, QueryValue, RefreshScope,
     mysql_sql::{
         MySqlStatement, MySqlStatementKind, classify_mysql_multi_statement,
         classify_mysql_multi_statement_with_lower_case_table_names,
@@ -30,7 +30,7 @@ pub(in crate::adapters::mysql) struct MySqlExecutionResult {
     pub(in crate::adapters::mysql) result_set: Option<MySqlResultSet>,
     pub(in crate::adapters::mysql) command_tag: Option<CommandTag>,
     pub(in crate::adapters::mysql) refresh_scope: RefreshScope,
-    pub(in crate::adapters::mysql) diagnostics: Vec<MySqlDiagnostic>,
+    pub(in crate::adapters::mysql) diagnostics: Vec<DatabaseDiagnostic>,
 }
 
 pub(in crate::adapters::mysql) fn validate_mysql_multi_query(

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -11,7 +11,7 @@ use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
 use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
-use crate::domain::{MySqlDiagnostic, RefreshScope};
+use crate::domain::{DatabaseDiagnostic, RefreshScope};
 
 use super::args::{MYSQL_CLIENT_MAX_PACKET_BYTES, mysql_adhoc_args, mysql_query_args};
 #[cfg(not(unix))]
@@ -469,7 +469,7 @@ pub(super) async fn read_one_mysql_resultset(
 
 pub(super) async fn read_one_mysql_resultset_with_diagnostics(
     process: &mut MySqlProcess,
-) -> Result<(Vec<u8>, Vec<MySqlDiagnostic>), DbOperationError> {
+) -> Result<(Vec<u8>, Vec<DatabaseDiagnostic>), DbOperationError> {
     #[cfg(unix)]
     {
         return read_one_pty_resultset_with_diagnostics(
@@ -626,7 +626,7 @@ mod tests {
     use crate::adapters::csv_export::export_to_path;
     use crate::domain::mysql_sql::{classify_mysql_statement, split_mysql_statements};
     use crate::domain::{
-        CommandTag, MySqlDiagnostic, MySqlDiagnosticLevel, QueryValue, RefreshScope,
+        CommandTag, DatabaseDiagnostic, DiagnosticLevel, QueryValue, RefreshScope,
     };
 
     mod cleanup {
@@ -1074,8 +1074,8 @@ done
             );
             assert_eq!(
                 result.diagnostics,
-                vec![MySqlDiagnostic {
-                    level: MySqlDiagnosticLevel::Warning,
+                vec![DatabaseDiagnostic {
+                    level: DiagnosticLevel::Warning,
                     code: 1265,
                     message: "truncated".to_string(),
                 }]
@@ -1769,13 +1769,13 @@ done
             assert_eq!(
                 result.diagnostics,
                 vec![
-                    MySqlDiagnostic {
-                        level: MySqlDiagnosticLevel::Warning,
+                    DatabaseDiagnostic {
+                        level: DiagnosticLevel::Warning,
                         code: 1062,
                         message: "duplicate ignored".to_string(),
                     },
-                    MySqlDiagnostic {
-                        level: MySqlDiagnosticLevel::Note,
+                    DatabaseDiagnostic {
+                        level: DiagnosticLevel::Note,
                         code: 1050,
                         message: "table already exists".to_string(),
                     },

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{
-    MySqlDiagnostic, RefreshScope,
+    DatabaseDiagnostic, RefreshScope,
     mysql_sql::{
         MySqlStatement, MySqlStatementKind, has_top_level_user_variable_into_clause,
         mysql_statement_is_data_modifying, mysql_statement_is_schema_modifying,
@@ -71,7 +71,7 @@ pub(super) async fn run_mysql_adhoc_with_program_and_statements(
 struct MySqlStatementExecution {
     result_set: Option<MySqlResultSet>,
     refresh_scope: RefreshScope,
-    diagnostics: Vec<MySqlDiagnostic>,
+    diagnostics: Vec<DatabaseDiagnostic>,
 }
 
 pub(super) async fn fill_mysql_empty_result_columns(
@@ -81,7 +81,7 @@ pub(super) async fn fill_mysql_empty_result_columns(
     query: &str,
     kind: &MySqlStatementKind,
     access_mode: AccessMode,
-    diagnostics: &mut Vec<MySqlDiagnostic>,
+    diagnostics: &mut Vec<DatabaseDiagnostic>,
 ) -> Result<MySqlResultSet, DbOperationError> {
     if !result.columns.is_empty() || !result.values.is_empty() {
         return Ok(result);
@@ -182,7 +182,7 @@ async fn fill_mysql_last_result_columns(
     last_result_statement: Option<&MySqlStatement>,
     access_mode: AccessMode,
     refresh_scope: RefreshScope,
-    diagnostics: &mut Vec<MySqlDiagnostic>,
+    diagnostics: &mut Vec<DatabaseDiagnostic>,
 ) -> Result<(), DbOperationError> {
     let Some(result) = last_result_set.take() else {
         return Ok(());

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -8,7 +8,7 @@ use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
-use crate::domain::{MySqlDiagnostic, QueryValue};
+use crate::domain::{DatabaseDiagnostic, QueryValue};
 
 use super::super::args::mysql_metadata_args;
 use super::super::error::{
@@ -45,7 +45,7 @@ pub(super) async fn mysql_metadata_columns_with_diagnostics(
     query: &str,
     kind: MySqlMetadataFallbackKind,
     access_mode: AccessMode,
-) -> Result<(Vec<String>, Vec<MySqlDiagnostic>), DbOperationError> {
+) -> Result<(Vec<String>, Vec<DatabaseDiagnostic>), DbOperationError> {
     let query = match kind {
         MySqlMetadataFallbackKind::Select | MySqlMetadataFallbackKind::Table => {
             return mysql_metadata_select_columns_with_diagnostics(process, query).await;
@@ -63,7 +63,7 @@ pub(super) async fn mysql_metadata_columns_with_diagnostics(
 async fn mysql_metadata_select_columns_with_diagnostics(
     process: &mut MySqlProcess,
     query: &str,
-) -> Result<(Vec<String>, Vec<MySqlDiagnostic>), DbOperationError> {
+) -> Result<(Vec<String>, Vec<DatabaseDiagnostic>), DbOperationError> {
     let suffix = Uuid::new_v4().simple().to_string();
     let source_alias = format!("__sabiql_metadata_source_{suffix}");
     let marker_alias = format!("__sabiql_metadata_marker_{suffix}");

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -8,7 +8,7 @@ use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
 use crate::app::ports::outbound::DbOperationError;
-use crate::domain::MySqlDiagnostic;
+use crate::domain::DatabaseDiagnostic;
 
 use super::error::{
     classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, trace_mysql_error,
@@ -82,7 +82,7 @@ pub(super) async fn read_one_pty_resultset_with_diagnostics(
     pty: &mut MySqlPty,
     client_packet_limit_bytes: Option<usize>,
     preview_byte_budget: bool,
-) -> Result<(Vec<u8>, Vec<MySqlDiagnostic>), DbOperationError> {
+) -> Result<(Vec<u8>, Vec<DatabaseDiagnostic>), DbOperationError> {
     let mut chunk = [0; 4096];
     loop {
         if let Some(frame) = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(

--- a/src/infra/adapters/mysql/cli/xml.rs
+++ b/src/infra/adapters/mysql/cli/xml.rs
@@ -3,7 +3,7 @@ use quick_xml::escape::unescape;
 use quick_xml::events::{BytesRef, Event};
 
 use crate::app::ports::outbound::DbOperationError;
-use crate::domain::{MySqlDiagnostic, QueryValue};
+use crate::domain::{DatabaseDiagnostic, QueryValue};
 
 use super::diagnostics::parse_mysql_cli_diagnostics;
 use super::error::{
@@ -20,7 +20,7 @@ const MYSQL_RESULTSET_START: &[u8] = b"<resultset";
 
 const MYSQL_RESULTSET_END: &[u8] = b"</resultset>";
 
-type MySqlResultsetFrameWithDiagnostics = (Vec<u8>, Vec<MySqlDiagnostic>);
+type MySqlResultsetFrameWithDiagnostics = (Vec<u8>, Vec<DatabaseDiagnostic>);
 
 pub(super) const MYSQL_PREVIEW_MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MYSQL_PREVIEW_MAX_FIELD_BYTES: usize = 4 * 1024 * 1024;
@@ -78,7 +78,7 @@ impl MySqlResultsetFrameScanner {
         &mut self,
         buffer: &mut Vec<u8>,
         (start, end): (usize, usize),
-    ) -> (Vec<u8>, Vec<MySqlDiagnostic>) {
+    ) -> (Vec<u8>, Vec<DatabaseDiagnostic>) {
         let frame = buffer[start..end].to_vec();
         let diagnostics = parse_mysql_cli_diagnostics(&buffer[..start]);
         buffer.drain(..end);
@@ -453,7 +453,7 @@ pub(super) fn parse_mysql_field(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::MySqlDiagnosticLevel;
+    use crate::domain::DiagnosticLevel;
 
     impl MySqlResultsetFrameScanner {
         fn take(&mut self, buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
@@ -661,13 +661,13 @@ mod tests {
         assert_eq!(
             diagnostics,
             vec![
-                MySqlDiagnostic {
-                    level: MySqlDiagnosticLevel::Warning,
+                DatabaseDiagnostic {
+                    level: DiagnosticLevel::Warning,
                     code: 1062,
                     message: "duplicate".to_string(),
                 },
-                MySqlDiagnostic {
-                    level: MySqlDiagnosticLevel::Note,
+                DatabaseDiagnostic {
+                    level: DiagnosticLevel::Note,
                     code: 1050,
                     message: "exists".to_string(),
                 },
@@ -695,8 +695,8 @@ mod tests {
         assert_eq!(frame, b"<resultset></resultset>");
         assert_eq!(
             diagnostics,
-            vec![MySqlDiagnostic {
-                level: MySqlDiagnosticLevel::Warning,
+            vec![DatabaseDiagnostic {
+                level: DiagnosticLevel::Warning,
                 code: 1265,
                 message: "truncated".to_string(),
             }]

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -3,8 +3,7 @@ use std::time::Instant;
 use crate::adapters::csv_export::export_to_downloads;
 use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use crate::domain::{
-    MySqlDiagnostic, MySqlDiagnosticLevel, QueryResult, QuerySource, WriteDiagnostic,
-    WriteDiagnosticLevel, WriteExecutionResult, mysql_sql::mysql_tree_explain_query_kind,
+    QueryResult, QuerySource, WriteExecutionResult, mysql_sql::mysql_tree_explain_query_kind,
 };
 use async_trait::async_trait;
 
@@ -184,11 +183,7 @@ impl QueryExecutor for MySqlAdapter {
         Ok(WriteExecutionResult {
             affected_rows,
             execution_time_ms: start.elapsed().as_millis() as u64,
-            diagnostics: execution
-                .diagnostics
-                .into_iter()
-                .map(write_diagnostic_from_mysql)
-                .collect(),
+            diagnostics: execution.diagnostics,
         })
     }
 
@@ -214,17 +209,6 @@ impl QueryExecutor for MySqlAdapter {
             export_mysql_csv_to_file(target, &query, path).await
         })
         .await
-    }
-}
-
-fn write_diagnostic_from_mysql(diagnostic: MySqlDiagnostic) -> WriteDiagnostic {
-    WriteDiagnostic {
-        level: match diagnostic.level {
-            MySqlDiagnosticLevel::Warning => WriteDiagnosticLevel::Warning,
-            MySqlDiagnosticLevel::Note => WriteDiagnosticLevel::Note,
-        },
-        code: diagnostic.code,
-        message: diagnostic.message,
     }
 }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2086,12 +2086,12 @@ mod query_execution {
                 || result.columns != ["2"]
                 || result.values() != [[QueryValue::Text("2".to_string())]]
                 || !result.mysql_diagnostics.iter().any(|diagnostic| {
-                    diagnostic.level == sabiql_domain::MySqlDiagnosticLevel::Warning
+                    diagnostic.level == sabiql_domain::DiagnosticLevel::Warning
                         && diagnostic.code == 1062
                         && diagnostic.message.contains("Duplicate entry")
                 })
                 || !result.mysql_diagnostics.iter().any(|diagnostic| {
-                    diagnostic.level == sabiql_domain::MySqlDiagnosticLevel::Note
+                    diagnostic.level == sabiql_domain::DiagnosticLevel::Note
                         && diagnostic.code == 1050
                         && diagnostic.message.contains("already exists")
                 })
@@ -2122,7 +2122,7 @@ mod query_execution {
                     || result.values().is_empty()
                     || result.columns != ["EXPLAIN"]
                     || !result.mysql_diagnostics.iter().any(|diagnostic| {
-                        diagnostic.level == sabiql_domain::MySqlDiagnosticLevel::Warning
+                        diagnostic.level == sabiql_domain::DiagnosticLevel::Warning
                             && diagnostic.code == 1292
                             && diagnostic
                                 .message

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -7,7 +7,7 @@ use sabiql_app::model::shared::settings::KeymapPreset;
 use sabiql_app::model::sql_editor::modal::SqlModalStatus;
 use sabiql_app::policy::write::sql_risk::AcknowledgeReason;
 use sabiql_domain::query_history::{QueryHistoryEntry, QueryResultStatus};
-use sabiql_domain::{ConnectionId, MySqlDiagnostic, MySqlDiagnosticLevel, QueryResult};
+use sabiql_domain::{ConnectionId, DatabaseDiagnostic, DiagnosticLevel, QueryResult};
 
 #[test]
 fn sql_modal_with_completion() {
@@ -341,13 +341,13 @@ fn sql_modal_success_with_mysql_diagnostics() {
         row_count: 1,
         execution_time_ms: 15,
         mysql_diagnostics: vec![
-            MySqlDiagnostic {
-                level: MySqlDiagnosticLevel::Warning,
+            DatabaseDiagnostic {
+                level: DiagnosticLevel::Warning,
                 code: 1062,
                 message: "Duplicate entry '1' for key 'users.PRIMARY'".to_string(),
             },
-            MySqlDiagnostic {
-                level: MySqlDiagnosticLevel::Note,
+            DatabaseDiagnostic {
+                level: DiagnosticLevel::Note,
                 code: 1050,
                 message: "Table 'users' already exists".to_string(),
             },
@@ -362,8 +362,8 @@ fn sql_modal_success_with_mysql_diagnostics() {
             QuerySource::Adhoc,
         )
         .with_command_tag(CommandTag::Insert(1))
-        .with_mysql_diagnostics(vec![MySqlDiagnostic {
-            level: MySqlDiagnosticLevel::Warning,
+        .with_mysql_diagnostics(vec![DatabaseDiagnostic {
+            level: DiagnosticLevel::Warning,
             code: 1062,
             message: "Duplicate entry '1' for key 'users.PRIMARY'".to_string(),
         }]),

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -11,7 +11,7 @@ use crate::app::model::sql_editor::modal::{
 };
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::policy::write::write_guardrails::AdhocRiskDecision;
-use crate::domain::MySqlDiagnostic;
+use crate::domain::DatabaseDiagnostic;
 use crate::primitives::atoms::{spinner_char, text_cursor_spans};
 use crate::primitives::utils::text_utils::{truncate_to_width_with, wrapped_line_count};
 use crate::theme::ThemePalette;
@@ -310,7 +310,7 @@ fn render_success_status_with_diagnostics(
     );
 }
 
-fn diagnostic_status_line(diagnostic: &MySqlDiagnostic) -> String {
+fn diagnostic_status_line(diagnostic: &DatabaseDiagnostic) -> String {
     format!("⚠ {}", diagnostic.display_message())
 }
 
@@ -324,7 +324,7 @@ fn error_status_message(error: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::MySqlDiagnosticLevel;
+    use crate::domain::DiagnosticLevel;
 
     #[test]
     fn diagnostics_height_only_applies_to_success_status() {
@@ -333,8 +333,8 @@ mod tests {
             command_tag: None,
             row_count: 1,
             execution_time_ms: 15,
-            mysql_diagnostics: vec![MySqlDiagnostic {
-                level: MySqlDiagnosticLevel::Warning,
+            mysql_diagnostics: vec![DatabaseDiagnostic {
+                level: DiagnosticLevel::Warning,
                 code: 1265,
                 message: "truncated".to_string(),
             }],


### PR DESCRIPTION
## Problem
Read and write execution paths carried structurally identical diagnostic DTOs, so the same level, code, message, and display behavior had to be maintained twice.

## Background
The duplication also required a field-by-field conversion at the MySQL write boundary.

## Approach
Use a narrow `DatabaseDiagnostic`/`DiagnosticLevel` domain DTO directly from both read and write results. MySQL parsing and transport remain adapter-local, and PostgreSQL/SQLite capabilities are unchanged.

## Accounting
Production DTO/conversion scope: types 4 -> 2, duplicate fields 6 -> 3, functions 5 -> 2, match arms 6 -> 2, lines 78 -> 34. The conversion helper references went from 2 to 0. Across `src/**/*.rs` including tests, concrete DTO identifier references went from 110 to 0; shared DTO identifier references are 92.

## Validation
- `cargo fmt --all -- --check`
- Focused domain, app, infra parser/XML, and UI tests
- `cargo check --workspace --all-targets`
- Targeted Clippy with `--all-targets --all-features -D warnings`
- `CARGO_TARGET_DIR= bash scripts/lint_all.sh`