### PR TITLE
refactor: consolidate SQLite config errors

### DIFF
--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -14,16 +14,8 @@ use super::ssl_mode::SslMode;
 pub enum ConnectionProfileError {
     #[error("{0}")]
     Name(#[from] ConnectionNameError),
-    #[error("SQLite database path is required")]
-    EmptySqlitePath,
-    #[error("SQLite database path contains unsupported characters")]
-    InvalidSqlitePath,
-    #[error(
-        "SQLite in-memory databases are not supported because sabiql starts sqlite3 per operation and cannot retain their contents; use a temporary database file"
-    )]
-    UnsupportedSqliteInMemoryDatabase,
-    #[error("SQLite URI filenames are not supported; use a regular file path")]
-    UnsupportedSqliteUriFilename,
+    #[error(transparent)]
+    SqliteConfig(#[from] SqliteConnectionConfigError),
     #[error("PostgreSQL connection field `{0}` is required")]
     MissingPostgresField(&'static str),
     #[error("MySQL connection field `{0}` is required")]
@@ -46,21 +38,6 @@ pub enum ConnectionProfileError {
     MySqlCleartextAuthRequiresTls,
     #[error("{0}")]
     SqlitePath(#[from] SqlitePathError),
-}
-
-impl From<SqliteConnectionConfigError> for ConnectionProfileError {
-    fn from(error: SqliteConnectionConfigError) -> Self {
-        match error {
-            SqliteConnectionConfigError::EmptyPath => Self::EmptySqlitePath,
-            SqliteConnectionConfigError::UnsupportedPath => Self::InvalidSqlitePath,
-            SqliteConnectionConfigError::UnsupportedInMemoryDatabase => {
-                Self::UnsupportedSqliteInMemoryDatabase
-            }
-            SqliteConnectionConfigError::UnsupportedUriFilename => {
-                Self::UnsupportedSqliteUriFilename
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -381,7 +358,9 @@ mod tests {
 
             assert!(matches!(
                 result,
-                Err(ConnectionProfileError::EmptySqlitePath)
+                Err(ConnectionProfileError::SqliteConfig(
+                    SqliteConnectionConfigError::EmptyPath
+                ))
             ));
         }
 
@@ -391,7 +370,9 @@ mod tests {
 
             assert!(matches!(
                 result,
-                Err(ConnectionProfileError::InvalidSqlitePath)
+                Err(ConnectionProfileError::SqliteConfig(
+                    SqliteConnectionConfigError::UnsupportedPath
+                ))
             ));
         }
 
@@ -401,7 +382,9 @@ mod tests {
 
             assert!(matches!(
                 result,
-                Err(ConnectionProfileError::UnsupportedSqliteInMemoryDatabase)
+                Err(ConnectionProfileError::SqliteConfig(
+                    SqliteConnectionConfigError::UnsupportedInMemoryDatabase
+                ))
             ));
         }
 
@@ -411,7 +394,9 @@ mod tests {
 
             assert!(matches!(
                 result,
-                Err(ConnectionProfileError::UnsupportedSqliteUriFilename)
+                Err(ConnectionProfileError::SqliteConfig(
+                    SqliteConnectionConfigError::UnsupportedUriFilename
+                ))
             ));
         }
     }

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionName, ConnectionProfile, ConnectionProfileError,
     DatabaseType, MySqlConnectionConfig, MySqlSslMode, MySqlTransport, PostgresConnectionConfig,
-    SqliteConnectionConfig, SslMode,
+    SqliteConnectionConfig, SqliteConnectionConfigError, SslMode,
 };
 
 pub const CURRENT_VERSION: u32 = 3;
@@ -226,7 +226,7 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
 fn required_sqlite_path(value: Option<&String>) -> Result<String, ConnectionProfileError> {
     value
         .cloned()
-        .ok_or(ConnectionProfileError::EmptySqlitePath)
+        .ok_or_else(|| SqliteConnectionConfigError::EmptyPath.into())
 }
 
 fn required_postgres_field(
@@ -394,7 +394,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::EmptySqlitePath)
+            Err(ConnectionProfileError::SqliteConfig(
+                SqliteConnectionConfigError::EmptyPath
+            ))
         ));
     }
 
@@ -406,7 +408,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::EmptySqlitePath)
+            Err(ConnectionProfileError::SqliteConfig(
+                SqliteConnectionConfigError::EmptyPath
+            ))
         ));
     }
 
@@ -418,7 +422,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::InvalidSqlitePath)
+            Err(ConnectionProfileError::SqliteConfig(
+                SqliteConnectionConfigError::UnsupportedPath
+            ))
         ));
     }
 
@@ -430,7 +436,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::UnsupportedSqliteInMemoryDatabase)
+            Err(ConnectionProfileError::SqliteConfig(
+                SqliteConnectionConfigError::UnsupportedInMemoryDatabase
+            ))
         ));
     }
 
@@ -442,7 +450,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::UnsupportedSqliteUriFilename)
+            Err(ConnectionProfileError::SqliteConfig(
+                SqliteConnectionConfigError::UnsupportedUriFilename
+            ))
         ));
     }
 


### PR DESCRIPTION
## Problem

SQLite connection validation errors were exposed through two parallel taxonomies, requiring their variants and messages to remain synchronized manually.

## Approach

Wrap the canonical SQLite configuration error transparently in the connection profile error while preserving validation behavior and user-facing messages.
