### PR TITLE
refactor: unify JSON text presentation outcome

### DIFF
--- a/src/app/policy/preview_cell_text/display.rs
+++ b/src/app/policy/preview_cell_text/display.rs
@@ -12,9 +12,7 @@ pub fn format_for_cell_detail(
 ) -> CellDetailDisplay {
     let should_pretty_print = matches!(
         handling,
-        PreviewCellTextDisplayHandling::SqliteText
-            | PreviewCellTextDisplayHandling::PostgreSqlJson
-            | PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+        PreviewCellTextDisplayHandling::PrettyPrintJsonText
             | PreviewCellTextDisplayHandling::StructuredJson
     );
     if !should_pretty_print {
@@ -51,7 +49,10 @@ mod tests {
         let handling =
             CellPresentationPolicy::new(DatabaseType::PostgreSQL, "json", r#"{"b":2,"a":1}"#)
                 .display_handling();
-        assert_eq!(handling, PreviewCellTextDisplayHandling::PostgreSqlJson);
+        assert_eq!(
+            handling,
+            PreviewCellTextDisplayHandling::PrettyPrintJsonText
+        );
         let formatted = format_for_cell_detail(r#"{"b":2,"a":1}"#, handling);
         assert_eq!(formatted.content, "{\n  \"a\": 1,\n  \"b\": 2\n}");
         assert!(formatted.formatted_json);
@@ -138,7 +139,7 @@ mod tests {
         .display_handling();
         assert_eq!(
             handling,
-            PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+            PreviewCellTextDisplayHandling::PrettyPrintJsonText
         );
         assert_eq!(
             format_for_cell_detail(r#"{"items":["admin","writer"]}"#, handling),

--- a/src/app/policy/preview_cell_text/handling.rs
+++ b/src/app/policy/preview_cell_text/handling.rs
@@ -9,9 +9,7 @@ pub enum PreviewCellTextDiffHandling {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreviewCellTextDisplayHandling {
     RawText,
-    SqliteText,
-    PostgreSqlJsonLikeText,
-    PostgreSqlJson,
+    PrettyPrintJsonText,
     StructuredJson,
 }
 
@@ -31,7 +29,7 @@ impl CellPresentationPolicy {
         };
         let display_handling = match database_type {
             DatabaseType::SQLite if has_sqlite_text_affinity(column_data_type) => {
-                PreviewCellTextDisplayHandling::SqliteText
+                PreviewCellTextDisplayHandling::PrettyPrintJsonText
             }
             DatabaseType::MySQL if column_data_type == "json" => {
                 PreviewCellTextDisplayHandling::StructuredJson
@@ -39,9 +37,9 @@ impl CellPresentationPolicy {
             DatabaseType::SQLite | DatabaseType::MySQL => PreviewCellTextDisplayHandling::RawText,
             DatabaseType::PostgreSQL => match column_data_type {
                 "jsonb" => PreviewCellTextDisplayHandling::StructuredJson,
-                "json" => PreviewCellTextDisplayHandling::PostgreSqlJson,
+                "json" => PreviewCellTextDisplayHandling::PrettyPrintJsonText,
                 _ if looks_like_json_container(value) => {
-                    PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+                    PreviewCellTextDisplayHandling::PrettyPrintJsonText
                 }
                 _ => PreviewCellTextDisplayHandling::RawText,
             },
@@ -156,16 +154,16 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_text_affinity_uses_text_display_handling() {
+    fn sqlite_text_affinity_uses_pretty_print_json_text_handling() {
         assert_eq!(
             CellPresentationPolicy::new(DatabaseType::SQLite, "TEXT", r#"{"items":["admin"]}"#)
                 .display_handling(),
-            PreviewCellTextDisplayHandling::SqliteText
+            PreviewCellTextDisplayHandling::PrettyPrintJsonText
         );
         assert_eq!(
             CellPresentationPolicy::new(DatabaseType::SQLite, "varchar(255)", "42")
                 .display_handling(),
-            PreviewCellTextDisplayHandling::SqliteText
+            PreviewCellTextDisplayHandling::PrettyPrintJsonText
         );
     }
 
@@ -183,11 +181,11 @@ mod tests {
     }
 
     #[test]
-    fn postgresql_text_json_container_uses_json_like_display_handling() {
+    fn postgresql_text_json_container_uses_pretty_print_json_text_handling() {
         assert_eq!(
             CellPresentationPolicy::new(DatabaseType::PostgreSQL, "text", r#"{"items":["admin"]}"#)
                 .display_handling(),
-            PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+            PreviewCellTextDisplayHandling::PrettyPrintJsonText
         );
     }
 }


### PR DESCRIPTION
## Problem

Three database-named presentation outcomes performed the same JSON text formatting, implying downstream behavior differences that did not exist.

## Approach

Represent the shared pretty-print result with one outcome while preserving database, column-type, and value classification.
