### PR TITLE
refactor: reuse SQLite diagnostics capability check

### DIFF
--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -313,11 +313,9 @@ impl Footer {
                 let mut hints = Vec::new();
                 if feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
                     hints.push(sqlite_diagnostics::SCROLL.as_hint());
-                }
-                if feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics)
-                    && state.sqlite_diagnostics.can_run_quick_check()
-                {
-                    hints.push(sqlite_diagnostics::RUN_QUICK_CHECK.as_hint());
+                    if state.sqlite_diagnostics.can_run_quick_check() {
+                        hints.push(sqlite_diagnostics::RUN_QUICK_CHECK.as_hint());
+                    }
                 }
                 hints.extend([
                     sqlite_diagnostics::HELP.as_hint(),


### PR DESCRIPTION
## Problem

SQLite diagnostics footer hints evaluated the same capability twice in adjacent branches.

## Approach

Evaluate the capability once and derive the optional quick-check hint inside the same block, preserving hint order and state-dependent visibility.
