### PR TITLE
refactor(app): derive prefetch state from async run

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1215,7 +1215,7 @@ mod tests {
             let state = make_state();
 
             assert!(!state.sql_modal.has_pending_prefetch());
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
         }
 
         #[test]
@@ -1297,7 +1297,7 @@ mod tests {
 
             dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert!(!state.sql_modal.has_pending_prefetch());
             assert_eq!(state.sql_modal.prefetch_in_flight_count(), 0);
             assert!(state.sql_modal.failed_prefetch("public.failed").is_none());

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -89,7 +89,6 @@ pub struct SqlModalContext {
     prefetch_queue: VecDeque<String>,
     prefetching_tables: HashSet<String>,
     failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
-    pub(crate) prefetch_started: bool,
     prefetch_tracks_er: bool,
     pub(crate) prefetch_run: AsyncRun,
     active_tab: SqlModalTab,
@@ -107,7 +106,6 @@ impl SqlModalContext {
     // ── Prefetch lifecycle ──────────────────────────────────────────
 
     pub fn reset_prefetch(&mut self) {
-        self.prefetch_started = false;
         self.prefetch_queue.clear();
         self.prefetching_tables.clear();
         self.failed_prefetch_tables.clear();
@@ -121,7 +119,6 @@ impl SqlModalContext {
             // Responses from the replaced completion run are stale and will be discarded.
             self.prefetching_tables.clear();
         }
-        self.prefetch_started = true;
         self.prefetch_tracks_er = true;
         self.prefetch_queue.clear();
         self.failed_prefetch_tables.clear();
@@ -130,7 +127,6 @@ impl SqlModalContext {
 
     #[must_use]
     pub fn begin_completion_prefetch(&mut self) -> u64 {
-        self.prefetch_started = true;
         self.prefetch_tracks_er = false;
         self.prefetch_queue.clear();
         self.failed_prefetch_tables.clear();
@@ -142,14 +138,9 @@ impl SqlModalContext {
     }
 
     pub fn invalidate_prefetch(&mut self) {
-        self.prefetch_started = false;
         self.prefetch_tracks_er = false;
         self.prefetching_tables.clear();
         self.prefetch_run.clear_active();
-    }
-
-    pub fn is_prefetch_started(&self) -> bool {
-        self.prefetch_started
     }
 
     pub fn has_pending_prefetch(&self) -> bool {
@@ -502,7 +493,7 @@ mod tests {
             assert_eq!(ctx.editor.cursor(), 0);
             assert_eq!(ctx.status, SqlModalStatus::Normal);
             assert!(!ctx.completion.visible);
-            assert!(!ctx.is_prefetch_started());
+            assert!(ctx.active_prefetch_run_id().is_none());
         }
 
         #[test]
@@ -545,7 +536,7 @@ mod tests {
 
             ctx.reset_prefetch();
 
-            assert!(!ctx.is_prefetch_started());
+            assert!(ctx.active_prefetch_run_id().is_none());
             assert!(!ctx.has_pending_prefetch());
             assert_eq!(ctx.prefetch_in_flight_count(), 0);
             assert!(ctx.failed_prefetch("public.failed").is_none());

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -1165,7 +1165,7 @@ mod tests {
             )
             .expect("completion prefetch should be handled");
 
-            assert!(state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_some());
             assert!(!state.sql_modal.prefetch_tracks_er());
             assert!(state.sql_modal.is_prefetch_queued("public.users"));
             assert!(state.sql_modal.is_prefetch_queued("public.orders"));

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -96,7 +96,8 @@ pub(super) fn reduce_prefetch(
 ) -> DispatchResult {
     match action {
         Action::StartPrefetchAll => {
-            if (!state.sql_modal.is_prefetch_started() || !state.sql_modal.prefetch_tracks_er())
+            if (state.sql_modal.active_prefetch_run_id().is_none()
+                || !state.sql_modal.prefetch_tracks_er())
                 && let Some(metadata) = state.session.metadata()
             {
                 let run_id = state.sql_modal.begin_prefetch();
@@ -126,7 +127,9 @@ pub(super) fn reduce_prefetch(
         }
 
         Action::StartPrefetchScoped { tables } => {
-            if state.sql_modal.is_prefetch_started() && state.sql_modal.prefetch_tracks_er() {
+            if state.sql_modal.active_prefetch_run_id().is_some()
+                && state.sql_modal.prefetch_tracks_er()
+            {
                 DispatchResult::handled()
             } else {
                 let run_id = state.sql_modal.begin_prefetch();

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1657,7 +1657,7 @@ mod tests {
 
             dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert!(!state.sql_modal.has_pending_prefetch());
             assert!(state.session.table_detail().is_none());
         }
@@ -1779,7 +1779,7 @@ mod tests {
             let effects =
                 dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert!(
                 effects
                     .iter()

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -2463,7 +2463,7 @@ mod tests {
             let action = create_postgres_switch_action(&target_id, "cached_db");
             reduce(&mut state, &action);
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert!(!state.sql_modal.has_pending_prefetch());
         }
 
@@ -2479,7 +2479,7 @@ mod tests {
             let action = create_postgres_switch_action(&new_id, "fresh_db");
             reduce(&mut state, &action);
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert!(!state.sql_modal.has_pending_prefetch());
         }
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -117,7 +117,7 @@ mod tests {
         }
 
         #[test]
-        fn prefetch_started_true_still_resets_and_emits_smart_refresh() {
+        fn active_prefetch_run_still_resets_and_emits_smart_refresh() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             state.session.set_metadata(Some(make_metadata(0)));
@@ -126,7 +126,7 @@ mod tests {
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1760,13 +1760,13 @@ mod tests {
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
 
         #[test]
-        fn prefetch_started_true_emits_smart_refresh() {
+        fn active_prefetch_run_emits_smart_refresh() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
@@ -1777,7 +1777,7 @@ mod tests {
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -1105,7 +1105,7 @@ mod tests {
             .expect("SQL modal open should be handled");
 
             assert!(effects.is_empty());
-            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
         }
 
         #[test]


### PR DESCRIPTION
## Problem

SQL modal prefetch lifecycle duplicated the active-run state in a separate boolean, allowing two state sources to drift.

## Background

Completion and ER prefetch already use the same monotonic run tracker for stale-result rejection and cancellation.

## Approach

Use the active prefetch run as the single source of truth for whether prefetch has started, while preserving the existing ER mode, queue, run ID, stale-result, and cancellation behavior.