### PR TITLE
refactor: return table metadata as a slice

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -270,7 +270,7 @@ impl AppState {
         self.ui.row_detail_content_visible_columns
     }
 
-    pub fn tables(&self) -> Vec<&TableSummary> {
+    pub fn tables(&self) -> &[TableSummary] {
         self.session.tables()
     }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -818,11 +818,10 @@ impl BrowseSession {
         self.is_reloading
     }
 
-    pub fn tables(&self) -> Vec<&TableSummary> {
+    pub fn tables(&self) -> &[TableSummary] {
         self.metadata
             .as_ref()
-            .map(|m| m.table_summaries.iter().collect())
-            .unwrap_or_default()
+            .map_or(&[], |metadata| metadata.table_summaries.as_slice())
     }
 
     pub fn is_service_connection(&self) -> bool {

--- a/src/app/update/browse/navigation/explorer.rs
+++ b/src/app/update/browse/navigation/explorer.rs
@@ -679,7 +679,7 @@ mod tests {
         ) {
             let mut state = state_with_named_tables(names, content_width);
             let expected = explorer_table_label_width(
-                state.tables()[0],
+                &state.tables()[0],
                 state.session.active_database_type_or_default(),
             )
             .saturating_sub(content_width);
@@ -705,7 +705,7 @@ mod tests {
             let mut state = state_with_named_tables(&["abcdefghij"], 4);
             state.ui.set_explorer_horizontal_offset(
                 explorer_table_label_width(
-                    state.tables()[0],
+                    &state.tables()[0],
                     state.session.active_database_type_or_default(),
                 )
                 .saturating_sub(state.ui.explorer_content_width()),
@@ -727,7 +727,7 @@ mod tests {
             assert_eq!(
                 state.ui.explorer_horizontal_offset(),
                 explorer_table_label_width(
-                    state.tables()[0],
+                    &state.tables()[0],
                     state.session.active_database_type_or_default(),
                 )
                 .saturating_sub(state.ui.explorer_content_width())
@@ -739,7 +739,7 @@ mod tests {
             let mut state = state_with_named_tables(&["abcdefghij"], 4);
             state.ui.set_explorer_horizontal_offset(
                 explorer_table_label_width(
-                    state.tables()[0],
+                    &state.tables()[0],
                     state.session.active_database_type_or_default(),
                 )
                 .saturating_sub(state.ui.explorer_content_width()),
@@ -759,7 +759,7 @@ mod tests {
             assert_eq!(
                 state.ui.explorer_horizontal_offset(),
                 explorer_table_label_width(
-                    state.tables()[0],
+                    &state.tables()[0],
                     state.session.active_database_type_or_default(),
                 )
                 .saturating_sub(state.ui.explorer_content_width())
@@ -785,7 +785,7 @@ mod tests {
             })));
 
             let expected = explorer_table_label_width(
-                state.tables()[0],
+                &state.tables()[0],
                 state.session.active_database_type_or_default(),
             )
             .saturating_sub(10);
@@ -805,7 +805,7 @@ mod tests {
             assert_eq!(state.ui.explorer_horizontal_offset(), expected);
             assert_eq!(
                 explorer_table_label(
-                    state.tables()[0],
+                    &state.tables()[0],
                     state.session.active_database_type_or_default(),
                 ),
                 "main.settings [table+no-rowid]"

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::text_input::{TextInputEditing, TextInputState};
@@ -93,8 +94,11 @@ pub(super) fn reduce_er_picker(
             DispatchResult::handled()
         }
         Action::ErSelectAll => {
-            let all_tables: Vec<String> =
-                state.tables().iter().map(|t| t.qualified_name()).collect();
+            let all_tables: Vec<String> = state
+                .tables()
+                .iter()
+                .map(TableSummary::qualified_name)
+                .collect();
             if state.ui.er_selected_tables().len() == all_tables.len() {
                 state.ui.clear_er_selected_tables();
             } else {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -116,11 +116,7 @@ fn reduce_inner(
                 if state.ui.focused_pane() != FocusedPane::Explorer {
                     return vec![];
                 }
-                let table = state
-                    .tables()
-                    .get(state.ui.explorer_selected())
-                    .copied()
-                    .cloned();
+                let table = state.tables().get(state.ui.explorer_selected()).cloned();
                 if let Some(table) = table {
                     return select_table(state, &table, now);
                 }

--- a/src/ui/features/browse/explorer.rs
+++ b/src/ui/features/browse/explorer.rs
@@ -42,7 +42,7 @@ impl Explorer {
         let table_names: Vec<String> = if has_cached_data {
             state
                 .tables()
-                .into_iter()
+                .iter()
                 .map(|summary| {
                     explorer_table_label(summary, state.session.active_database_type_or_default())
                 })


### PR DESCRIPTION
## Problem

Read-only table consumers allocated a new vector of references every time they accessed session metadata.

## Approach

Expose the owned table summaries as a borrowed slice while preserving order, empty-state behavior, and selection semantics.
