### PR TITLE
refactor: remove dead ER preparation APIs

### DIFF
--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -137,12 +137,6 @@ impl ErPreparationState {
         self.pending_tables.extend(tables.iter().cloned());
     }
 
-    pub fn retry_failed(&mut self) {
-        for (table, _) in self.failed_tables.drain() {
-            self.pending_tables.insert(table);
-        }
-    }
-
     pub fn mark_idle(&mut self) {
         self.status = ErStatus::Idle;
     }
@@ -183,13 +177,6 @@ impl ErPreparationState {
         run_id
     }
 
-    pub fn begin_full_prefetch(&mut self, total: usize) {
-        self.clear_table_tracking();
-        self.total_tables = total;
-        self.seed_tables.clear();
-        self.fk_expanded = true;
-    }
-
     pub fn set_targets(&mut self, tables: Vec<String>) {
         self.target_tables = tables;
     }
@@ -214,12 +201,6 @@ impl ErPreparationState {
     pub fn invalidate_refresh_signatures(&mut self, total_tables: usize) {
         self.last_signatures.clear();
         self.total_tables = total_tables;
-    }
-
-    fn clear_table_tracking(&mut self) {
-        self.pending_tables.clear();
-        self.fetching_tables.clear();
-        self.failed_tables.clear();
     }
 
     // Re-queueing a table starts a fresh attempt and clears any prior failure
@@ -424,23 +405,6 @@ mod tests {
             assert_eq!(state.seed_tables, tables);
             assert!(state.pending_tables.contains("public.users"));
             assert!(state.pending_tables.contains("public.orders"));
-        }
-    }
-
-    mod retry_failed {
-        use super::*;
-
-        #[test]
-        fn moves_failed_to_pending() {
-            let mut state = ErPreparationState::default();
-            state
-                .failed_tables
-                .insert("public.users".to_string(), "error".to_string());
-
-            state.retry_failed();
-
-            assert!(state.failed_tables.is_empty());
-            assert!(state.pending_tables.contains("public.users"));
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -3046,11 +3046,10 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
-            state.er_preparation.begin_full_prefetch(1);
-            state.er_preparation.mark_fk_expanded();
             state
                 .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .begin_all_prefetch(["public.users".to_string()]);
+            state.er_preparation.mark_fk_expanded();
             let now = Instant::now();
 
             let effects = reduce(
@@ -3078,14 +3077,13 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
-            state.er_preparation.begin_full_prefetch(2);
+            state
+                .er_preparation
+                .begin_all_prefetch(["public.posts".to_string(), "public.users".to_string()]);
             state.er_preparation.mark_fk_expanded();
             state
                 .er_preparation
                 .on_table_failed("public.posts", "timeout".to_string());
-            state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -7,7 +7,12 @@ fn er_waiting_progress() {
     let mut terminal = create_test_terminal();
 
     let _ = state.er_preparation.start_waiting_run();
-    state.er_preparation.begin_full_prefetch(3);
+    state.er_preparation.begin_all_prefetch([
+        "public.users".to_string(),
+        "public.comments".to_string(),
+        "public.posts".to_string(),
+    ]);
+    state.er_preparation.on_table_cached("public.users");
     state
         .er_preparation
         .queue_pending_table("public.comments".to_string());


### PR DESCRIPTION
## Problem

ER preparation state retained unused legacy setup and retry operations alongside the production workflow.

## Approach

Remove the dead operations and exercise fixtures through the same preparation APIs used by production.
