### PR TITLE
refactor: simplify pending preview consumption

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -120,16 +120,10 @@ pub struct DeleteRefreshTarget {
 
 #[derive(Debug, Clone)]
 pub(crate) struct PendingPreview {
-    result: Arc<QueryResult>,
-    generation: u64,
-    target_page: Option<usize>,
-    highlight: bool,
-}
-
-impl PendingPreview {
-    pub(crate) fn into_parts(self) -> (Arc<QueryResult>, Option<usize>, bool) {
-        (self.result, self.target_page, self.highlight)
-    }
+    pub(crate) result: Arc<QueryResult>,
+    pub(crate) generation: u64,
+    pub(crate) target_page: Option<usize>,
+    pub(crate) highlight: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -4,7 +4,9 @@ use std::time::{Duration, Instant};
 use crate::cmd::effect::Effect;
 use crate::domain::{QueryResult, QuerySource, RefreshScope};
 use crate::model::app_state::AppState;
-use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSelection};
+use crate::model::browse::query_execution::{
+    PREVIEW_PAGE_SIZE, PendingPreview, PostDeleteRowSelection,
+};
 use crate::model::shared::help::HelpOrigin;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
@@ -179,7 +181,12 @@ pub fn reduce_execution(
             let Some(pending) = state.query.take_pending_preview(*generation) else {
                 return DispatchResult::handled();
             };
-            let (result, target_page, highlight) = pending.into_parts();
+            let PendingPreview {
+                result,
+                generation: _,
+                target_page,
+                highlight,
+            } = pending;
             if result.is_error() && !highlight {
                 state.query.clear_delete_refresh_target();
             }


### PR DESCRIPTION
## Problem

Pending preview consumption exposed a position-dependent tuple and silently discarded one field.

## Approach

Destructure the pending preview by field name while preserving generation validation and Inspector-before-Result reveal ordering.
