### PR TITLE
refactor: encapsulate connection error state

### DIFF
--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -17,10 +17,10 @@ enum ConnectionErrorSource {
 
 #[derive(Debug, Clone, Default)]
 pub struct ConnectionErrorState {
-    pub(crate) error_info: Option<ConnectionErrorInfo>,
-    pub(crate) details_expanded: bool,
-    pub(crate) scroll_offset: usize,
-    pub(crate) copied_feedback_expires: Option<Instant>,
+    error_info: Option<ConnectionErrorInfo>,
+    details_expanded: bool,
+    scroll_offset: usize,
+    copied_feedback_expires: Option<Instant>,
     source: ConnectionErrorSource,
 }
 

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -24,8 +24,7 @@ pub(super) fn reduce_connection_error(
                 state.session.clear_mysql_connection_probe();
                 state.connection_error.clear();
             } else {
-                state.connection_error.details_expanded = false;
-                state.connection_error.scroll_offset = 0;
+                state.connection_error.reset_view();
                 state.connection_error.clear_copied_feedback();
             }
             state.modal.set_mode(InputMode::Normal);
@@ -200,10 +199,10 @@ mod tests {
 
             reduce_connection_error(&mut state, &action, now);
             reduce_connection_error(&mut state, &action, now);
-            assert_eq!(state.connection_error.scroll_offset, 2);
+            assert_eq!(state.connection_error.scroll_offset(), 2);
 
             reduce_connection_error(&mut state, &action, now);
-            assert_eq!(state.connection_error.scroll_offset, 2);
+            assert_eq!(state.connection_error.scroll_offset(), 2);
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -109,7 +109,7 @@ fn reduce_inner(
                     return select_table(state, &table, now);
                 }
             } else if state.modal.active_mode() == InputMode::Normal {
-                if state.connection_error.error_info.is_some() {
+                if state.connection_error.has_error() {
                     state.modal.replace_mode(InputMode::ConnectionError);
                     return vec![];
                 }
@@ -1349,7 +1349,7 @@ mod tests {
                 MetadataState::Error(_)
             ));
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
-            assert!(state.connection_error.error_info.is_some());
+            assert!(state.connection_error.has_error());
             assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
         }
 
@@ -1392,8 +1392,8 @@ mod tests {
         #[test]
         fn close_keeps_error_info_for_reopen() {
             let mut state = state_with_error();
-            state.connection_error.details_expanded = true;
-            state.connection_error.scroll_offset = 5;
+            state.connection_error.expand_details();
+            state.connection_error.scroll_down(usize::MAX);
             let now = Instant::now();
 
             reduce(
@@ -1404,11 +1404,11 @@ mod tests {
             );
 
             // error_info is kept so Enter can re-open modal
-            assert!(state.connection_error.error_info.is_some());
+            assert!(state.connection_error.has_error());
             assert_eq!(state.input_mode(), InputMode::Normal);
             // UI state is reset
-            assert!(!state.connection_error.details_expanded);
-            assert_eq!(state.connection_error.scroll_offset, 0);
+            assert!(!state.connection_error.details_expanded());
+            assert_eq!(state.connection_error.scroll_offset(), 0);
         }
 
         #[test]
@@ -1455,14 +1455,14 @@ mod tests {
                 &AppServices::stub(),
             );
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
-            assert!(state.connection_error.error_info.is_some());
+            assert!(state.connection_error.has_error());
         }
 
         #[test]
         fn toggle_details_flips_expanded_state() {
             let mut state = state_with_error();
             let now = Instant::now();
-            assert!(!state.connection_error.details_expanded);
+            assert!(!state.connection_error.details_expanded());
 
             reduce(
                 &mut state,
@@ -1470,7 +1470,7 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(state.connection_error.details_expanded);
+            assert!(state.connection_error.details_expanded());
 
             reduce(
                 &mut state,
@@ -1478,7 +1478,7 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(!state.connection_error.details_expanded);
+            assert!(!state.connection_error.details_expanded());
         }
 
         #[test]


### PR DESCRIPTION
## Problem

Connection error reducers bypassed existing aggregate operations and synchronized internal fields directly.

## Approach

Use the existing error-state operations and close direct field access while preserving error content, scrolling, and copy feedback.
