### PR TITLE
refactor: remove unused shared UI accessors

### DIFF
--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -141,10 +141,6 @@ impl ExplainContext {
         self.compare_viewport_height = Some(height);
     }
 
-    pub fn scroll_confirm_to(&mut self, offset: usize) {
-        self.confirm_scroll_offset = offset;
-    }
-
     pub fn scroll_plan_to(&mut self, offset: usize) {
         self.scroll_offset = offset;
     }

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -68,14 +68,6 @@ impl ConfirmDialogState {
         self.preview_scroll
     }
 
-    pub fn preview_viewport_height(&self) -> Option<u16> {
-        self.preview_viewport_height
-    }
-
-    pub fn preview_content_height(&self) -> Option<u16> {
-        self.preview_content_height
-    }
-
     pub fn apply_preview_metrics(
         &mut self,
         viewport_height: Option<u16>,

--- a/src/app/model/shared/picker.rs
+++ b/src/app/model/shared/picker.rs
@@ -26,14 +26,6 @@ impl PickerState {
         self.scroll_offset
     }
 
-    pub fn pane_height(&self) -> u16 {
-        self.pane_height
-    }
-
-    pub fn filter_visible_width(&self) -> usize {
-        self.filter_visible_width
-    }
-
     pub fn set_pane_height(&mut self, height: u16) {
         self.pane_height = height;
     }

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -301,16 +301,8 @@ impl UiState {
         self.connection_list_scroll_offset
     }
 
-    pub fn connection_list_pane_height(&self) -> u16 {
-        self.connection_list_pane_height
-    }
-
     pub fn set_connection_list_pane_height(&mut self, height: u16) {
         self.connection_list_pane_height = height;
-    }
-
-    pub fn set_connection_list_scroll_offset(&mut self, offset: usize) {
-        self.connection_list_scroll_offset = offset;
     }
 
     pub fn table_picker(&self) -> &PickerState {
@@ -395,10 +387,6 @@ impl UiState {
         self.inspector_pane_height = height;
     }
 
-    pub fn explorer_pane_height(&self) -> u16 {
-        self.explorer_pane_height
-    }
-
     pub fn set_explorer_pane_height(&mut self, height: u16) {
         self.explorer_pane_height = height;
     }
@@ -417,10 +405,6 @@ impl UiState {
 
     pub fn set_result_widths_cache(&mut self, cache: ColumnWidthsCache) {
         self.result_widths_cache = cache;
-    }
-
-    pub fn result_pane_height(&self) -> u16 {
-        self.result_pane_height
     }
 
     pub fn set_result_pane_height(&mut self, height: u16) {
@@ -443,20 +427,8 @@ impl UiState {
         &mut self.help
     }
 
-    pub fn help_scroll_offset(&self) -> usize {
-        self.help.scroll_offset()
-    }
-
-    pub fn set_help_scroll_offset(&mut self, offset: usize) {
-        self.help.set_scroll_offset(offset);
-    }
-
     pub fn terminal_height(&self) -> u16 {
         self.terminal_height
-    }
-
-    pub fn terminal_width(&self) -> u16 {
-        self.terminal_width
     }
 
     pub fn set_terminal_height(&mut self, height: u16) {
@@ -465,11 +437,6 @@ impl UiState {
 
     pub fn set_terminal_width(&mut self, width: u16) {
         self.terminal_width = width;
-    }
-
-    pub fn set_terminal_size(&mut self, width: u16, height: u16) {
-        self.terminal_width = width;
-        self.terminal_height = height;
     }
 
     pub fn key_sequence(&self) -> KeySequenceState {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -202,6 +202,7 @@ mod tests {
     use super::*;
     use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::browse::session::TableDetailState;
+    use crate::model::shared::ui_state::UiState;
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::ConnectionStoreError;
     use crate::update::action::ModalKind;
@@ -255,9 +256,20 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.terminal_width(), 100);
             assert_eq!(state.ui.terminal_height(), 50);
             let document = HelpDocument::from_state(&state);
+            let expected_layout = {
+                let mut expected = UiState::new();
+                expected.set_terminal_width(100);
+                expected.set_terminal_height(50);
+                expected.help_viewport_layout(document.line_count(), document.content_width())
+            };
+            assert_eq!(
+                state
+                    .ui
+                    .help_viewport_layout(document.line_count(), document.content_width()),
+                expected_layout
+            );
             assert_eq!(
                 state.ui.help().scroll_offset(),
                 state


### PR DESCRIPTION
## Problem

Shared UI state exposed several accessors that had no production callers and made ownership surfaces appear broader than they are.

## Approach

Remove only the unused accessors while preserving their underlying fields and all actively used layout and scrolling operations.
