### PR TITLE
refactor: remove unused selection API

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -246,11 +246,6 @@ impl BrowseSession {
         self.table_detail_run.is_current(run_id)
     }
 
-    pub fn is_current_table_selection(&self, schema: &str, table: &str, generation: u64) -> bool {
-        generation == self.selection_generation
-            && self.selected_table_key.as_deref() == Some(&format!("{schema}.{table}"))
-    }
-
     pub fn mark_table_detail_failed(&mut self, generation: u64, error: String) -> bool {
         if generation == self.selection_generation && self.selected_table_key.is_some() {
             self.table_detail_state = TableDetailState::Error(error);


### PR DESCRIPTION
## Problem

The browse session still exposed a selection predicate with no production callers after generation-based stale-result guards became authoritative.

## Approach

Remove the remaining obsolete selection API while preserving table matching, pagination, and stale completion behavior.

## Screenshots

N/A
