### PR TITLE
refactor: remove unreachable Inspector empty state

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -482,7 +482,7 @@ mod tests {
         ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource,
         QueryValue, Table, TableKind, TableKindInfo,
     };
-    use crate::model::browse::inspector_view_model::{InspectorEmptyState, InspectorLoadState};
+    use crate::model::browse::inspector_view_model::InspectorLoadState;
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use crate::model::er_state::ErStatus;
@@ -623,10 +623,7 @@ mod tests {
             view_model.load_state(),
             &InspectorLoadState::NoTableSelected
         );
-        assert_eq!(
-            view_model.empty_state(),
-            Some(InspectorEmptyState::NoTableSelected)
-        );
+        assert_eq!(view_model.empty_state(), None);
     }
 
     #[rstest]

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -129,7 +129,6 @@ pub enum InspectorRlsRow {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InspectorEmptyState {
-    NoTableSelected,
     NoColumns,
     NoIndexes,
     NoForeignKeys,
@@ -157,13 +156,11 @@ impl InspectorViewModel {
             TableDetailState::Error(error) => (InspectorLoadState::Error(error.clone()), None),
         };
         let Some(table) = table else {
-            let empty_state = matches!(&load_state, InspectorLoadState::NoTableSelected)
-                .then_some(InspectorEmptyState::NoTableSelected);
             return Self {
                 active_tab,
                 load_state,
                 section: None,
-                empty_state,
+                empty_state: None,
                 unavailable_reason: None,
                 mysql_trigger_details: false,
             };
@@ -416,7 +413,6 @@ impl InspectorSection {
 impl InspectorEmptyState {
     pub fn message(self) -> &'static str {
         match self {
-            Self::NoTableSelected => "(select a table)",
             Self::NoColumns => "No columns",
             Self::NoIndexes => "No indexes",
             Self::NoForeignKeys => "No foreign keys",
@@ -627,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn no_table_exposes_empty_state_without_display_rows() {
+    fn no_table_exposes_load_state_without_display_rows() {
         let model = InspectorViewModel::build_with_detail_state(
             &EngineFeatureProfile::postgres_like(),
             InspectorTab::Info,
@@ -637,10 +633,8 @@ mod tests {
         );
 
         assert_eq!(model.row_count(), 0);
-        assert_eq!(
-            model.empty_state(),
-            Some(InspectorEmptyState::NoTableSelected)
-        );
+        assert_eq!(model.load_state(), &InspectorLoadState::NoTableSelected);
+        assert_eq!(model.empty_state(), None);
         assert_eq!(model.unavailable_reason(), None);
     }
 

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -8,9 +8,8 @@ use ratatui::widgets::{Cell, Paragraph, Row, Table as RatatuiTable, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::inspector_view_model::{
-    InspectorColumnRow, InspectorEmptyState, InspectorForeignKeyRow, InspectorIndexRow,
-    InspectorInfoRow, InspectorLoadState, InspectorRlsRow, InspectorSection, InspectorTriggerRow,
-    InspectorViewModel,
+    InspectorColumnRow, InspectorForeignKeyRow, InspectorIndexRow, InspectorInfoRow,
+    InspectorLoadState, InspectorRlsRow, InspectorSection, InspectorTriggerRow, InspectorViewModel,
 };
 use crate::app::model::shared::engine_feature_profile::InspectorInfoField;
 use crate::app::model::shared::flash_timer::{FlashId, FlashTimerStore};
@@ -142,12 +141,11 @@ impl Inspector {
         }
 
         if let Some(empty_state) = view_model.empty_state() {
-            let style = if matches!(empty_state, InspectorEmptyState::NoTableSelected) {
-                Style::default().fg(theme.semantic.text.placeholder)
-            } else {
-                Style::default().fg(theme.semantic.text.primary)
-            };
-            frame.render_widget(Paragraph::new(empty_state.message()).style(style), inner);
+            frame.render_widget(
+                Paragraph::new(empty_state.message())
+                    .style(Style::default().fg(theme.semantic.text.primary)),
+                inner,
+            );
             return ViewportPlan::default();
         }
 


### PR DESCRIPTION
## Problem

The Inspector represented the no-table-selected state twice even though load-state rendering returned before the empty-state branch.

## Approach

Keep the load state as the sole representation and remove the unreachable duplicate empty-state path.

## Screenshots

N/A
