### PR TITLE
refactor: remove redundant SQLite diagnostics transition

### DIFF
--- a/src/app/model/sqlite/diagnostics.rs
+++ b/src/app/model/sqlite/diagnostics.rs
@@ -150,16 +150,6 @@ impl SqliteDiagnosticsState {
         }
     }
 
-    pub fn set_loaded(&mut self, run_id: u64, snapshot: SqliteDiagnosticsSnapshot) {
-        if self.is_current_run(run_id) || matches!(self.load_state, LoadState::Idle) {
-            self.load_state = LoadState::Loaded {
-                run_id,
-                snapshot: Box::new(snapshot),
-                quick_check_running: false,
-            };
-        }
-    }
-
     pub fn snapshot(&self) -> Option<&SqliteDiagnosticsSnapshot> {
         match &self.load_state {
             LoadState::Loaded { snapshot, .. } => Some(snapshot),
@@ -267,7 +257,7 @@ mod tests {
     fn stale_run_does_not_replace_loaded_snapshot() {
         let mut state = SqliteDiagnosticsState::default();
         let run_id = state.begin_fetch();
-        state.set_loaded(
+        state.set_core_loaded(
             run_id,
             SqliteDiagnosticsSnapshot {
                 sqlite_version: DiagnosticField::ok("3.45.0"),
@@ -275,7 +265,7 @@ mod tests {
             },
         );
 
-        state.set_loaded(
+        state.set_core_loaded(
             run_id + 1,
             SqliteDiagnosticsSnapshot {
                 sqlite_version: DiagnosticField::ok("9.9.9"),

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -1031,7 +1031,7 @@ fn sqlite_diagnostics_overlay_loaded() {
     let mut terminal = create_test_terminal();
 
     let run_id = state.sqlite_diagnostics.begin_fetch();
-    state.sqlite_diagnostics.set_loaded(
+    state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
             db_file: DiagnosticField::ok("/tmp/app.db"),
@@ -1062,7 +1062,7 @@ fn sqlite_diagnostics_overlay_partial_failure() {
     let mut terminal = create_test_terminal();
 
     let run_id = state.sqlite_diagnostics.begin_fetch();
-    state.sqlite_diagnostics.set_loaded(
+    state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
             db_file: DiagnosticField::ok("/tmp/app.db"),
@@ -1154,7 +1154,7 @@ fn sqlite_diagnostics_overlay_wrapped_scroll() {
     let mut terminal = create_test_terminal_sized(50, 24);
 
     let run_id = state.sqlite_diagnostics.begin_fetch();
-    state.sqlite_diagnostics.set_loaded(
+    state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
             db_file: DiagnosticField::ok(


### PR DESCRIPTION
## Problem

SQLite diagnostics fixtures used a second loaded-state transition that bypassed the production fetch lifecycle.

## Approach

Use the production fetch and core-load transition in fixtures and remove the redundant state mutation path.

## Screenshots

N/A
