### PR TITLE
refactor: remove unused write execution timing

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -894,7 +894,6 @@ mod tests {
                 .returning(|_, _, _| {
                     Ok(WriteExecutionResult {
                         affected_rows: 1,
-                        execution_time_ms: 0,
                         diagnostics: vec![DatabaseDiagnostic {
                             level: DiagnosticLevel::Warning,
                             code: 1265,

--- a/src/domain/write_result.rs
+++ b/src/domain/write_result.rs
@@ -1,6 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteExecutionResult {
     pub affected_rows: usize,
-    pub execution_time_ms: u64,
     pub diagnostics: Vec<super::DatabaseDiagnostic>,
 }

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -157,11 +157,6 @@ impl QueryExecutor for MySqlAdapter {
         let statements =
             validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
 
-        #[expect(
-            clippy::disallowed_methods,
-            reason = "infra measures mysql execution time at the I/O boundary"
-        )]
-        let start = Instant::now();
         let option_file = MySqlOptionFile::create(&target)?;
         let result = run_mysql_adhoc(&option_file.path, &statements, access_mode).await;
         drop(option_file);
@@ -182,7 +177,6 @@ impl QueryExecutor for MySqlAdapter {
 
         Ok(WriteExecutionResult {
             affected_rows,
-            execution_time_ms: start.elapsed().as_millis() as u64,
             diagnostics: execution.diagnostics,
         })
     }

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -413,15 +413,7 @@ impl PostgresAdapter {
         query: &str,
         read_only: bool,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        #[expect(
-            clippy::disallowed_methods,
-            reason = "infra measures psql execution time at the I/O boundary"
-        )]
-        let start = Instant::now();
-
         let output = self.run_psql(dsn, &[], query, read_only).await?;
-
-        let elapsed = start.elapsed().as_millis() as u64;
 
         if !output.status.success() {
             return Err(classify_query_error(&output.stderr));
@@ -435,7 +427,6 @@ impl PostgresAdapter {
 
         Ok(WriteExecutionResult {
             affected_rows,
-            execution_time_ms: elapsed,
             diagnostics: Vec::new(),
         })
     }

--- a/src/infra/adapters/sqlite/executor.rs
+++ b/src/infra/adapters/sqlite/executor.rs
@@ -122,12 +122,11 @@ impl QueryExecutor for SqliteAdapter {
     ) -> Result<WriteExecutionResult, DbOperationError> {
         let path = Self::path_from_dsn(dsn)?;
         let plan = sqlite_statement_plan(query)?;
-        let (affected_rows, execution_time_ms) = self
+        let affected_rows = self
             .execute_changes_query(path, &plan, access_mode.is_read_only())
             .await?;
         Ok(WriteExecutionResult {
             affected_rows,
-            execution_time_ms,
             diagnostics: Vec::new(),
         })
     }
@@ -218,18 +217,12 @@ impl SqliteAdapter {
         path: &str,
         plan: &SqliteStatementPlan<'_>,
         read_only: bool,
-    ) -> Result<(usize, u64), DbOperationError> {
-        #[expect(
-            clippy::disallowed_methods,
-            reason = "infra measures sqlite3 execution time at the I/O boundary"
-        )]
-        let start = Instant::now();
+    ) -> Result<usize, DbOperationError> {
         let stdout = self
             .cli
             .execute_csv(path, &append_changes_query_for_plan(plan), read_only)
             .await?;
-        let elapsed = start.elapsed().as_millis() as u64;
-        Ok((parse_affected_rows(&stdout)?, elapsed))
+        parse_affected_rows(&stdout)
     }
 }
 


### PR DESCRIPTION
## Problem

Write execution results recorded elapsed time even though the application consumes only affected rows and diagnostics.

## Approach

Remove write-only timing state and its adapter-side measurement while preserving query and explain timing.

## Screenshots

N/A
