### PR TITLE
refactor: hide metadata shared ownership

### DIFF
--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -50,8 +50,7 @@ pub async fn run(
             let (prep, missing) = {
                 let engine = completion_engine.borrow();
                 let prep = engine.prepare_for_database(content, cursor, database_type);
-                let missing = engine
-                    .missing_tables_prepared(&prep, state.session.metadata().map(AsRef::as_ref));
+                let missing = engine.missing_tables_prepared(&prep, state.session.metadata());
                 (prep, missing)
             };
 
@@ -83,7 +82,7 @@ pub async fn run(
                     content,
                     cursor,
                     &prep,
-                    state.session.metadata().map(AsRef::as_ref),
+                    state.session.metadata(),
                     state.session.table_detail(),
                     &recent_cols,
                     CompletionDatabaseScope {

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -693,8 +693,8 @@ impl BrowseSession {
         &self.metadata_state
     }
 
-    pub fn metadata(&self) -> Option<&Arc<DatabaseMetadata>> {
-        self.metadata.as_ref()
+    pub fn metadata(&self) -> Option<&DatabaseMetadata> {
+        self.metadata.as_deref()
     }
 
     pub fn database_name(&self) -> Option<&str> {


### PR DESCRIPTION
## Problem

Read-only metadata callers had to depend on the session's internal `Arc` ownership and repeat dereference conversions.

## Approach

Expose the borrowed metadata value while preserving shared ownership, cache restoration, and reload behavior inside the session.

## Screenshots

N/A
