### PR TITLE
refactor: reuse session DSN guard for effective user

### DIFF
--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -96,7 +96,7 @@ pub(super) fn reduce_loading(
             run_id,
             effective_user,
         } => {
-            if state.session.dsn() != Some(dsn.as_str())
+            if !state.session.dsn_matches(dsn)
                 || !state.session.is_current_effective_user_run(*run_id)
             {
                 return DispatchResult::handled();


### PR DESCRIPTION
## Problem

Effective-user completion expressed the session DSN freshness check differently from adjacent metadata paths.

## Approach

Use the session-owned DSN predicate while preserving the independent run-token check.

## Screenshots

N/A
