### PR TITLE
refactor: pass connection target through reset

### DIFF
--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -1,5 +1,5 @@
 use crate::cmd::effect::Effect;
-use crate::domain::connection::{ConnectionId, DatabaseType};
+use crate::domain::connection::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
 use crate::model::shared::inspector_tab::InspectorTab;
@@ -27,22 +27,19 @@ fn reconcile_connection_state(state: &mut AppState, inspector_tab: InspectorTab)
     state.sql_modal.set_active_tab(sql_modal_tab);
 }
 
-pub(super) fn reset_for_new_connection(
-    state: &mut AppState,
-    id: &ConnectionId,
-    dsn: &str,
-    name: &str,
-    database_type: DatabaseType,
-    database: Option<&str>,
-) {
+pub(super) fn reset_for_new_connection(state: &mut AppState, target: &ConnectionTarget) {
     let inspector_tab = state.ui.inspector_tab();
     let sql_modal_tab = state.sql_modal.active_tab();
     reset_active_connection_state_inner(state);
     state.ui.set_inspector_tab(inspector_tab);
     state.sql_modal.set_active_tab(sql_modal_tab);
-    state
-        .session
-        .activate_connection_with_target(id, name, database_type, dsn, database);
+    state.session.activate_connection_with_target(
+        &target.id,
+        &target.name,
+        target.database_type,
+        &target.dsn,
+        target.database.as_deref(),
+    );
     reconcile_connection_state(state, inspector_tab);
 }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -81,7 +81,7 @@ pub fn reduce_connection_lifecycle(
                 DispatchResult::handled_with(termination_effects(&state.query, effects))
             } else {
                 // No cache: reset and fetch metadata
-                reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
+                reset_for_new_connection(state, target);
                 let run_id = state.session.begin_connecting(dsn);
                 DispatchResult::handled_with(termination_effects(
                     &state.query,
@@ -135,7 +135,7 @@ pub fn reduce_connection_lifecycle(
             }
 
             state.connection_caches.remove(id);
-            reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
+            reset_for_new_connection(state, target);
             state
                 .session
                 .set_mysql_lower_case_table_names(*lower_case_table_names);

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -255,15 +255,14 @@ pub fn reduce_connection_setup(
             let ConnectionTarget {
                 id,
                 dsn,
-                name,
                 database_type,
-                database,
+                ..
             } = target;
             state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
             state.connection_caches.remove(id);
 
-            reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
+            reset_for_new_connection(state, target);
             if let Some(lower_case_table_names) = mysql_lower_case_table_names {
                 state
                     .session


### PR DESCRIPTION
## Problem

Connection reset code decomposed an existing connection identity aggregate into parallel arguments at every caller.

## Approach

Pass the connection target directly while preserving reset order, tab restoration, activation, and reconciliation.

## Screenshots

N/A
