### PR TITLE
refactor: use global binding for CSV export

### DIFF
--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -37,12 +37,6 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
             Key::Char('o') if kb::query_history(keymap_preset).combos.contains(&combo) => {
                 return Action::OpenModal(ModalKind::QueryHistoryPicker);
             }
-            Key::Char('e')
-                if kb::csv_export(keymap_preset).combos.contains(&combo)
-                    && state.can_request_csv_export() =>
-            {
-                return Action::RequestCsvExport;
-            }
             Key::Char('p') if kb::table_picker(keymap_preset).combos.contains(&combo) => {
                 return Action::OpenModal(ModalKind::TablePicker);
             }


### PR DESCRIPTION
## Problem

CSV export had a dedicated normal-input branch in addition to the global key-binding resolver.

## Approach

Use the global binding path as the single owner while preserving preset, availability, and key-sequence behavior.

## Screenshots

N/A
