### PR TITLE
refactor(infra): simplify CSV cleanup guard state

### DIFF
--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -63,27 +63,23 @@ fn temporary_export_path(final_path: &Path) -> PathBuf {
 }
 
 struct RemoveOnDropGuard {
-    path: PathBuf,
-    cleanup: bool,
+    path: Option<PathBuf>,
 }
 
 impl RemoveOnDropGuard {
     fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            cleanup: true,
-        }
+        Self { path: Some(path) }
     }
 
     fn disarm(&mut self) {
-        self.cleanup = false;
+        self.path = None;
     }
 }
 
 impl Drop for RemoveOnDropGuard {
     fn drop(&mut self) {
-        if self.cleanup {
-            let _ = std::fs::remove_file(&self.path);
+        if let Some(path) = &self.path {
+            let _ = std::fs::remove_file(path);
         }
     }
 }


### PR DESCRIPTION
## Problem

The CSV cleanup guard represented its armed state with both a path and a boolean, allowing the same lifecycle fact to drift across two fields.

## Approach

Represent the guarded path as an option so successful publication disarms cleanup by consuming the only owned state.
