### PR TITLE
refactor(app): inline MySQL probe cancellation

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -113,15 +113,11 @@ impl EffectRunner {
         self.metadata_tasks.cancel().await;
     }
 
-    async fn cancel_mysql_connection_probe(&self) {
-        self.mysql_connection_probe_task.cancel().await;
-    }
-
     async fn cancel_active_tasks(&self) {
         self.query_tasks.cancel();
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
-        self.cancel_mysql_connection_probe().await;
+        self.mysql_connection_probe_task.cancel().await;
     }
 
     pub async fn run<T: Renderer>(


### PR DESCRIPTION
## Problem

The runner hid a single MySQL probe cancellation behind a one-caller forwarding method.

## Approach

Call the probe task owner directly at the existing shutdown point while preserving cancellation order and await behavior.
