### PR TITLE
refactor(mysql): inline metadata process cleanup

### DIFF
--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -168,12 +168,8 @@ impl MySqlMetadataSession {
                 "mysql query exceeded the execution timeout".to_string(),
             )),
         };
-        self.cleanup().await;
-        result
-    }
-
-    async fn cleanup(&mut self) {
         cleanup_mysql_process(&mut self.process).await;
+        result
     }
 }
 


### PR DESCRIPTION
## Problem

MySQL metadata timeout resolution routed process cleanup through a forwarding method with no session-specific behavior.

## Approach

Invoke the existing process cleanup boundary directly at the same resolution point.
