### PR TITLE
refactor(app): remove query history scope clone

### DIFF
--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -19,21 +19,15 @@ pub fn run(
             let store = Arc::clone(query_history_store);
             let tx = action_tx.clone();
 
-            let scope_for_action = scope.clone();
             tokio::spawn(async move {
                 match store.load(&project_name, &scope).await {
                     Ok(entries) => {
-                        tx.send(Action::QueryHistoryLoaded(
-                            scope_for_action.clone(),
-                            entries,
-                        ))
-                        .await
-                        .ok();
-                    }
-                    Err(e) => {
-                        tx.send(Action::QueryHistoryLoadFailed(scope_for_action, e))
+                        tx.send(Action::QueryHistoryLoaded(scope, entries))
                             .await
                             .ok();
+                    }
+                    Err(e) => {
+                        tx.send(Action::QueryHistoryLoadFailed(scope, e)).await.ok();
                     }
                 }
             });


### PR DESCRIPTION
## Problem

The query-history load task cloned its scope solely to send the same value after the load completed.

## Approach

Borrow the scope for loading, then move the original value into the resulting action without changing history filtering or dispatch order.
