### PR TITLE
refactor(postgres): reuse row predicate for updates

### DIFF
--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -75,11 +75,7 @@ impl SqlDialect for PostgresAdapter {
         new_value: &QueryValue,
         pk_pairs: &[(String, QueryValue)],
     ) -> String {
-        let where_clause = pk_pairs
-            .iter()
-            .map(|(col, val)| equality_predicate(col, val))
-            .collect::<Vec<_>>()
-            .join(" AND ");
+        let where_clause = row_predicate(pk_pairs);
 
         format!(
             "UPDATE {}.{}\nSET {} = {}\nWHERE {};",


### PR DESCRIPTION
## Problem

PostgreSQL UPDATE rebuilt the same primary-key predicate logic already used by other write operations.

## Approach

Reuse the existing PostgreSQL row predicate so NULL handling, quoting, and composite-key order remain defined in one place.
