### PR TITLE
refactor(app): remove CTE definition wrapper

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -279,7 +279,7 @@ impl CompletionEngine {
         let cte_names: HashSet<String> = candidate_context
             .ctes
             .iter()
-            .map(|cte| cte.name.to_lowercase())
+            .map(|cte| cte.to_lowercase())
             .collect();
         PreparedCompletion {
             tokens,
@@ -1250,9 +1250,9 @@ impl CompletionEngine {
 
         // Add CTE names first (higher priority)
         for cte in &sql_context.ctes {
-            if prefix.is_empty() || cte.name.to_lowercase().starts_with(&prefix_lower) {
+            if prefix.is_empty() || cte.to_lowercase().starts_with(&prefix_lower) {
                 candidates.push(CompletionCandidate {
-                    text: cte.name.clone(),
+                    text: cte.clone(),
                     kind: CompletionKind::Table,
                     score: 110, // CTEs slightly above prefix-matched tables
                 });
@@ -3015,7 +3015,6 @@ mod tests {
 
     mod cte_or_table_context {
         use super::*;
-        use crate::policy::sql::lexer::CteDefinition;
 
         #[test]
         fn from_clause_with_cte_returns_cte_or_table() {
@@ -3024,9 +3023,7 @@ mod tests {
             let tokens = SqlLexer::default().tokenize(sql, sql.len());
             let sql_context = SqlContext {
                 tables: vec![],
-                ctes: vec![CteDefinition {
-                    name: "active_users".to_string(),
-                }],
+                ctes: vec!["active_users".to_string()],
                 target_table: None,
             };
 
@@ -3041,9 +3038,7 @@ mod tests {
             let e = engine();
             let sql_context = SqlContext {
                 tables: vec![],
-                ctes: vec![CteDefinition {
-                    name: "active_users".to_string(),
-                }],
+                ctes: vec!["active_users".to_string()],
                 target_table: None,
             };
 
@@ -3068,14 +3063,7 @@ mod tests {
             let e = engine();
             let sql_context = SqlContext {
                 tables: vec![],
-                ctes: vec![
-                    CteDefinition {
-                        name: "active_users".to_string(),
-                    },
-                    CteDefinition {
-                        name: "banned_users".to_string(),
-                    },
-                ],
+                ctes: vec!["active_users".to_string(), "banned_users".to_string()],
                 target_table: None,
             };
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -29,15 +29,10 @@ pub struct TableReference {
     pub alias: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CteDefinition {
-    pub name: String,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct SqlContext {
     pub tables: Vec<TableReference>,
-    pub ctes: Vec<CteDefinition>,
+    pub ctes: Vec<String>,
     // Target table for UPDATE/DELETE/INSERT statements (for column priority boost)
     pub target_table: Option<TableReference>,
 }
@@ -1148,7 +1143,7 @@ impl SqlLexer {
         )
     }
 
-    pub fn extract_cte_definitions(&self, tokens: &[Token]) -> Vec<CteDefinition> {
+    pub fn extract_cte_definitions(&self, tokens: &[Token]) -> Vec<String> {
         let mut ctes = Vec::new();
         let mut i = 0;
 
@@ -1190,7 +1185,7 @@ impl SqlLexer {
                     {
                         // Don't treat SELECT as a CTE name
                         if name != "SELECT" {
-                            ctes.push(CteDefinition { name: name.clone() });
+                            ctes.push(name.clone());
                         }
                         i += 1;
 
@@ -2106,7 +2101,7 @@ mod tests {
             let ctes = l.extract_cte_definitions(&tokens);
 
             assert_eq!(ctes.len(), 1);
-            assert_eq!(ctes[0].name, "active_users");
+            assert_eq!(ctes[0], "active_users");
         }
 
         #[test]
@@ -2118,7 +2113,7 @@ mod tests {
             let ctes = l.extract_cte_definitions(&tokens);
 
             assert_eq!(ctes.len(), 1);
-            assert_eq!(ctes[0].name, "tree");
+            assert_eq!(ctes[0], "tree");
         }
 
         #[test]
@@ -2130,8 +2125,8 @@ mod tests {
             let ctes = l.extract_cte_definitions(&tokens);
 
             assert_eq!(ctes.len(), 2);
-            assert_eq!(ctes[0].name, "cte1");
-            assert_eq!(ctes[1].name, "cte2");
+            assert_eq!(ctes[0], "cte1");
+            assert_eq!(ctes[1], "cte2");
         }
 
         #[test]
@@ -2171,11 +2166,7 @@ mod tests {
                 let context = lexer.build_context(&tokens, cursor_pos);
 
                 assert_eq!(
-                    context
-                        .ctes
-                        .iter()
-                        .map(|cte| cte.name.as_str())
-                        .collect::<Vec<_>>(),
+                    context.ctes.iter().map(String::as_str).collect::<Vec<_>>(),
                     vec!["current_cte"]
                 );
                 assert_eq!(


### PR DESCRIPTION
## Problem

SQL completion carried CTE names through a dedicated wrapper that added no meaning beyond the string itself.

## Approach

Represent CTE names directly while preserving extraction, statement scoping, case handling, and prepared completion behavior.
