### PR TITLE
refactor(sqlite): centralize table kind JSON

### DIFF
--- a/src/infra/adapters/sqlite/sql/metadata.rs
+++ b/src/infra/adapters/sqlite/sql/metadata.rs
@@ -84,18 +84,12 @@ pub(in crate::adapters::sqlite) fn is_table_list_unavailable(error: &str) -> boo
 pub(in crate::adapters::sqlite) fn preview_metadata_query(table: &str) -> String {
     let table = quote_literal(table);
     let columns = metadata_columns_json(&table);
+    let table_kind = table_kind_json(&table);
     format!(
         r"
         SELECT json_object(
             'columns', json({columns}),
-            'table', json((
-                SELECT json_object('type', tl.type, 'wr', tl.wr, 'strict', tl.strict, 'sql', m.sql)
-                FROM pragma_table_list() AS tl
-                LEFT JOIN sqlite_master AS m
-                  ON m.type IN ('table', 'view') AND m.name = tl.name
-                WHERE tl.schema = 'main' AND tl.name = {table} COLLATE NOCASE
-                LIMIT 1
-            ))
+            'table', {table_kind}
         ) AS payload
         "
     )
@@ -137,6 +131,7 @@ pub(in crate::adapters::sqlite) fn table_signatures_query() -> String {
 }
 
 fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: bool) -> String {
+    let table_kind = table_kind_json(table_expr);
     let columns = metadata_columns_json(table_expr);
     let indexes = metadata_indexes_json(table_expr, include_full_detail);
     let foreign_keys = metadata_foreign_keys_json(table_expr);
@@ -158,14 +153,7 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
     };
     format!(
         r#"json_object(
-            'table', json((
-                SELECT json_object('type', tl.type, 'wr', tl.wr, 'strict', tl.strict, 'sql', m.sql)
-                FROM pragma_table_list() AS tl
-                LEFT JOIN sqlite_master AS m
-                  ON m.type IN ('table', 'view') AND m.name = tl.name
-                WHERE tl.schema = 'main' AND tl.name = {table_expr} COLLATE NOCASE
-                LIMIT 1
-            )),
+            'table', {table_kind},
             'columns', json({columns}),
             'indexes', json({indexes}),
             'foreign_keys', json({foreign_keys}),
@@ -185,6 +173,17 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
             {source_ddl}
         )"#,
         referenced_columns = metadata_columns_json("r.name"),
+    )
+}
+
+fn table_kind_json(table_expr: &str) -> String {
+    format!(
+        r"json((
+            SELECT json_object('type', tl.type, 'wr', tl.wr, 'strict', tl.strict, 'sql', m.sql)
+            FROM pragma_table_list() AS tl
+            LEFT JOIN sqlite_master AS m ON m.type IN ('table', 'view') AND m.name = tl.name
+            WHERE tl.schema = 'main' AND tl.name = {table_expr} COLLATE NOCASE LIMIT 1
+        ))"
     )
 }
 


### PR DESCRIPTION
## Problem

SQLite metadata queries duplicated the JSON expression that derives table-kind information.

## Approach

Centralize the table-kind JSON projection while preserving each query's payload, filtering, and ordering behavior.
