### PR TITLE
refactor(sqlite): reuse quoted record boundaries

### DIFF
--- a/src/infra/adapters/sqlite/sqlite3/parser/output.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/output.rs
@@ -277,11 +277,11 @@ pub(in crate::adapters::sqlite::sqlite3) fn parse_quoted_value(
 }
 
 fn parse_quoted_records(
-    stdout: &str,
+    raw_records: &[SplitSegment],
     source: QuerySource,
 ) -> Result<Vec<QuotedRecord>, DbOperationError> {
-    split_quoted_records(stdout)?
-        .into_iter()
+    raw_records
+        .iter()
         .enumerate()
         .map(|(index, segment)| {
             let decode_preview_transport = source == QuerySource::Preview && index > 0;
@@ -311,7 +311,8 @@ pub(in crate::adapters::sqlite) fn quoted_to_query_result(
         ));
     }
 
-    let mut records = parse_quoted_records(stdout, source)?;
+    let raw_records = split_quoted_records(stdout)?;
+    let mut records = parse_quoted_records(&raw_records, source)?;
     let Some(header) = records.first() else {
         return Ok(QueryResult::success(
             query.to_string(),
@@ -342,7 +343,7 @@ pub(in crate::adapters::sqlite) fn last_sqlite_result_set(
 ) -> Result<Option<String>, DbOperationError> {
     let (stmt_col, marker_col) = sqlite_result_probe_columns(marker);
     let raw_records = split_quoted_records(stdout)?;
-    let records = parse_quoted_records(stdout, QuerySource::Adhoc)?;
+    let records = parse_quoted_records(&raw_records, QuerySource::Adhoc)?;
 
     let mut last_result = None;
     let mut result_start = 0;
@@ -399,7 +400,7 @@ pub(in crate::adapters::sqlite) fn strip_sqlite_probes(
 
     let (stmt_col, changes_col) = sqlite_probe_columns(marker);
     let raw_records = split_quoted_records(stdout)?;
-    let records = parse_quoted_records(stdout, QuerySource::Adhoc)?;
+    let records = parse_quoted_records(&raw_records, QuerySource::Adhoc)?;
 
     let mut changes = HashMap::new();
     let mut kept = Vec::new();


### PR DESCRIPTION
## Problem

SQLite quoted output was split into record boundaries more than once when marker processing also needed the original representation.

## Approach

Share one record-boundary split between raw output reconstruction and typed marker validation while preserving SQLite value decoding and marker semantics.
