### PR TITLE
refactor(mysql): centralize session mode probe

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -16,6 +16,7 @@ use super::probe::validate_sql_mode;
 use super::xml::MySqlResultSet;
 
 pub(super) const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
+pub(super) const MYSQL_SESSION_SQL_MODE_COLUMN: &str = "__sabiql_sql_mode";
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum MySqlMetadataFallbackKind {
@@ -377,7 +378,7 @@ pub(super) fn validate_mysql_session(
     result: &MySqlResultSet,
     marker: &str,
 ) -> Result<(), DbOperationError> {
-    if result.columns != [MYSQL_SESSION_MARKER_COLUMN, "__sabiql_sql_mode"]
+    if result.columns != [MYSQL_SESSION_MARKER_COLUMN, MYSQL_SESSION_SQL_MODE_COLUMN]
         || result.values.len() != 1
         || result.values[0].len() != 2
         || result.values[0][0].as_str() != Some(marker)

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -22,7 +22,8 @@ use super::error::{
 #[cfg(not(unix))]
 use super::pipe::read_one_mysql_resultset_from_pipes;
 use super::policy::{
-    MYSQL_SESSION_MARKER_COLUMN, query_failed_after_change, validate_mysql_session,
+    MYSQL_SESSION_MARKER_COLUMN, MYSQL_SESSION_SQL_MODE_COLUMN, query_failed_after_change,
+    validate_mysql_session,
 };
 #[cfg(unix)]
 use super::pty::{
@@ -48,6 +49,12 @@ pub(in crate::adapters::mysql) const MYSQL_QUERY_TIMEOUT: Duration = Duration::f
 const MYSQL_PTY_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const MYSQL_SESSION_SETTINGS: &str = "SET SESSION autocommit=1, completion_type=NO_CHAIN";
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
+
+fn mysql_session_probe_query(marker: &str) -> String {
+    format!(
+        "SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}, @@SESSION.sql_mode AS {MYSQL_SESSION_SQL_MODE_COLUMN}"
+    )
+}
 
 pub(in crate::adapters::mysql) struct MySqlProcess {
     pub(super) child: Child,
@@ -352,13 +359,7 @@ pub(super) async fn configure_mysql_session(
     if access_mode.is_read_only() {
         write_mysql_statement(process, MYSQL_READ_ONLY_STATEMENT).await?;
     }
-    write_mysql_statement(
-        process,
-        &format!(
-            "SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}, @@SESSION.sql_mode AS __sabiql_sql_mode"
-        ),
-    )
-    .await?;
+    write_mysql_statement(process, &mysql_session_probe_query(&marker)).await?;
     loop {
         let result = read_one_mysql_resultset(process).await?;
         let result = parse_mysql_xml(&result)?;

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -15,9 +15,7 @@ use super::super::error::{
     classify_mysql_query_failure, has_mysql_cli_error, is_mysql_batch_diagnostic,
     map_mysql_cli_spawn_error,
 };
-use super::super::policy::{
-    MYSQL_SESSION_MARKER_COLUMN, MySqlMetadataFallbackKind, mysql_metadata_select_query,
-};
+use super::super::policy::{MySqlMetadataFallbackKind, mysql_metadata_select_query};
 use super::super::probe::{run_mysql_command_with_timeout, validate_sql_mode};
 use super::super::sanitize_mysql_command_environment;
 use super::{
@@ -280,9 +278,7 @@ async fn run_mysql_metadata_query_with_read_only_session_process(
         .write_statement(super::MYSQL_READ_ONLY_STATEMENT)
         .await?;
     process
-        .write_statement(&format!(
-            "SELECT '{session_marker}' AS {MYSQL_SESSION_MARKER_COLUMN}, @@SESSION.sql_mode AS __sabiql_sql_mode"
-        ))
+        .write_statement(&super::mysql_session_probe_query(&session_marker))
         .await?;
     let session_output = process.read_until_marker(&session_marker).await?;
     validate_metadata_session_probe(&session_output, &session_marker)?;


### PR DESCRIPTION
## Problem

MySQL session bootstrap and metadata fallback maintained separate copies of the same sql_mode probe statement and result alias.

## Approach

Centralize the session probe SQL and alias while preserving result-column order and each session lifecycle.
