### PR TITLE
refactor(mysql): reuse explain analyze query

### DIFF
--- a/src/infra/adapters/mysql/sql/explain.rs
+++ b/src/infra/adapters/mysql/sql/explain.rs
@@ -8,8 +8,9 @@ pub(super) fn build_explain_sql(query: &str) -> Option<String> {
 }
 
 pub(super) fn build_explain_analyze_sql(query: &str) -> Option<String> {
-    mysql_tree_explain_query_kind(&format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))?;
-    Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))
+    let explain = format!("EXPLAIN ANALYZE FORMAT=TREE {query}");
+    mysql_tree_explain_query_kind(&explain)?;
+    Some(explain)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

MySQL EXPLAIN ANALYZE generation formatted the same query text twice across validation and return paths.

## Approach

Construct the statement once, validate it by reference, and return the same value without changing SQL or fallback behavior.
