### PR TITLE
refactor(mysql): reuse quoted scanner

### DIFF
--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -164,30 +164,11 @@ pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexE
     let mut statements = Vec::new();
     let mut start = 0;
     let mut index = 0;
-    let mut quote = None;
     let bytes = sql.as_bytes();
     let mut depth = 0usize;
 
     while index < bytes.len() {
         let byte = bytes[index];
-        if let Some(delimiter) = quote {
-            if byte == b'\\' && delimiter != b'`' {
-                index += 2;
-                continue;
-            }
-            if byte == delimiter {
-                if bytes.get(index + 1) == Some(&delimiter) {
-                    index += 2;
-                } else {
-                    quote = None;
-                    index += 1;
-                }
-                continue;
-            }
-            index += 1;
-            continue;
-        }
-
         if is_line_comment_start(bytes, index) {
             index = skip_line_comment(bytes, index);
             continue;
@@ -197,8 +178,7 @@ pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexE
             continue;
         }
         if matches!(byte, b'\'' | b'"' | b'`') {
-            quote = Some(byte);
-            index += 1;
+            index = skip_quoted(bytes, index, byte)?;
             continue;
         }
         match byte {
@@ -217,11 +197,6 @@ pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexE
         index += 1;
     }
 
-    if quote.is_some() {
-        return Err(MySqlLexError(
-            "unterminated MySQL quoted literal".to_string(),
-        ));
-    }
     if depth != 0 {
         return Err(MySqlLexError("unbalanced MySQL parentheses".to_string()));
     }
@@ -437,7 +412,7 @@ fn is_mysql_statement_keyword(word: &str) -> bool {
     )
 }
 
-fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MySqlLexError> {
+pub(super) fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MySqlLexError> {
     let mut cursor = index + 1;
     while cursor < bytes.len() {
         if bytes[cursor] == b'\\' && quote != b'`' {

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -134,24 +134,8 @@ fn has_mysql_read_only_side_effect_function(tokens: &[lexer::Token], index: usiz
 pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MySqlLexError> {
     let bytes = sql.as_bytes();
     let mut index = 0;
-    let mut quote = None;
 
     while index < bytes.len() {
-        if let Some(delimiter) = quote {
-            if bytes[index] == b'\\' && delimiter != b'`' {
-                index = (index + 2).min(bytes.len());
-            } else if bytes[index] == delimiter {
-                if bytes.get(index + 1) == Some(&delimiter) {
-                    index += 2;
-                } else {
-                    quote = None;
-                    index += 1;
-                }
-            } else {
-                index += 1;
-            }
-            continue;
-        }
         if lexer::is_line_comment_start(bytes, index) {
             index = lexer::skip_line_comment(bytes, index);
             continue;
@@ -164,16 +148,12 @@ pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MySqlLexError
             continue;
         }
         if matches!(bytes[index], b'\'' | b'"' | b'`') {
-            quote = Some(bytes[index]);
+            index = lexer::skip_quoted(bytes, index, bytes[index])?;
+            continue;
         }
         index += 1;
     }
 
-    if quote.is_some() {
-        return Err(MySqlLexError(
-            "unterminated MySQL quoted literal".to_string(),
-        ));
-    }
     Ok(false)
 }
 


### PR DESCRIPTION
## Problem

MySQL statement analysis maintained duplicate error-returning scanners for quoted text.

## Approach

Reuse the existing quoted scanner while preserving quote forms, escape handling, offsets, and unterminated-input errors.
