### PR TITLE
refactor(sqlite): flatten table kind metadata

### DIFF
--- a/src/infra/adapters/sqlite/metadata/catalog.rs
+++ b/src/infra/adapters/sqlite/metadata/catalog.rs
@@ -2,7 +2,7 @@ use crate::domain::{DatabaseMetadata, Schema, TableKindInfo, TableSummary};
 
 use super::{
     super::{schema::MAIN_SCHEMA, sqlite3::metadata::RawTable},
-    kind_info::{table_kind_info_from_legacy_sql, table_kind_info_from_pragma},
+    kind_info::{table_kind_info_from_legacy_sql, table_kind_info_from_raw},
 };
 
 pub(super) fn metadata_from_catalog(path: &str, tables: &[RawTable]) -> DatabaseMetadata {
@@ -19,10 +19,10 @@ pub(super) fn metadata_from_catalog(path: &str, tables: &[RawTable]) -> Database
 }
 
 fn kind_info_for_raw_table(table: &RawTable) -> TableKindInfo {
-    if table.r#type.is_empty() {
-        return table_kind_info_from_legacy_sql(table.sql.as_deref());
+    if table.kind.r#type.is_empty() {
+        return table_kind_info_from_legacy_sql(table.kind.sql.as_deref());
     }
-    table_kind_info_from_pragma(&table.r#type, table.wr, table.strict, table.sql.as_deref())
+    table_kind_info_from_raw(&table.kind)
 }
 
 fn database_name(path: &str) -> String {

--- a/src/infra/adapters/sqlite/metadata/catalog_tests.rs
+++ b/src/infra/adapters/sqlite/metadata/catalog_tests.rs
@@ -9,13 +9,10 @@ use super::kind_info_for_raw_table;
 
 #[test]
 fn legacy_list_row_uses_sql_for_storage() {
-    let table = RawTable {
-        name: "settings".to_string(),
-        sql: Some("CREATE TABLE settings(id INTEGER PRIMARY KEY) WITHOUT ROWID;".to_string()),
-        r#type: String::new(),
-        wr: 0,
-        strict: 0,
-    };
+    let table: RawTable = serde_json::from_str(
+        r#"{"name":"settings","sql":"CREATE TABLE settings(id INTEGER PRIMARY KEY) WITHOUT ROWID;"}"#,
+    )
+    .unwrap();
 
     let kind_info = kind_info_for_raw_table(&table);
 

--- a/src/infra/adapters/sqlite/sqlite3/metadata/raw.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata/raw.rs
@@ -3,13 +3,8 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub(in crate::adapters::sqlite) struct RawTable {
     pub(in crate::adapters::sqlite) name: String,
-    pub(in crate::adapters::sqlite) sql: Option<String>,
-    #[serde(default)]
-    pub(in crate::adapters::sqlite) r#type: String,
-    #[serde(default)]
-    pub(in crate::adapters::sqlite) wr: i64,
-    #[serde(default)]
-    pub(in crate::adapters::sqlite) strict: i64,
+    #[serde(flatten)]
+    pub(in crate::adapters::sqlite) kind: RawTableKindInfo,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -63,7 +58,7 @@ pub(super) struct RawJsonPayload {
     pub(super) payload: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub(in crate::adapters::sqlite) struct RawTableKindInfo {
     #[serde(rename = "type", default)]
     pub(in crate::adapters::sqlite) r#type: String,


### PR DESCRIPTION
## Problem

SQLite raw table metadata duplicated the fields already represented by its table-kind information.

## Approach

Flatten the existing kind structure into the raw payload while preserving JSON compatibility, defaults, and SQL fallback behavior.
