### PR TITLE
refactor(sql): share lexical helpers

### DIFF
--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -1,3 +1,8 @@
+use crate::domain::sql_lex::{
+    advance_single_quote, skip_block_comment, skip_double_quoted_identifier, skip_line_comment,
+    skip_sqlite_quoted_identifier,
+};
+
 // - `Unsupported`: a recognizable SQL command that this classifier does not yet classify
 //   (e.g. GRANT, COPY, DO, MERGE). Risk cannot be assessed, so execution requires user
 //   acknowledgment (see policy::write::sql_risk).
@@ -386,98 +391,6 @@ pub fn extract_target_name(sql: &str, kind: &StatementKind) -> Option<String> {
     }
 }
 
-pub(crate) fn skip_line_comment(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
-    if ch != '-' || !next_char_is(chars, i, '-') {
-        return None;
-    }
-    let mut cursor = i;
-    while cursor < chars.len() && chars[cursor].1 != '\n' {
-        cursor += 1;
-    }
-    Some(cursor)
-}
-
-pub(crate) fn skip_block_comment(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
-    if ch != '/' || !next_char_is(chars, i, '*') {
-        return None;
-    }
-    let mut cursor = i + 2;
-    while cursor + 1 < chars.len() && !(chars[cursor].1 == '*' && chars[cursor + 1].1 == '/') {
-        cursor += 1;
-    }
-    Some(cursor + 2)
-}
-
-pub(crate) fn advance_single_quote(
-    chars: &[(usize, char)],
-    i: usize,
-    ch: char,
-    in_string: &mut bool,
-) -> Option<usize> {
-    if ch != '\'' {
-        return None;
-    }
-    if *in_string {
-        if next_char_is(chars, i, '\'') {
-            return Some(i + 2);
-        }
-        *in_string = false;
-    } else {
-        *in_string = true;
-    }
-    Some(i + 1)
-}
-
-pub(crate) fn skip_double_quoted_identifier(
-    chars: &[(usize, char)],
-    i: usize,
-    ch: char,
-) -> Option<usize> {
-    if ch != '"' {
-        return None;
-    }
-    let mut cursor = i + 1;
-    while cursor < chars.len() {
-        if chars[cursor].1 == '"' {
-            if next_char_is(chars, cursor, '"') {
-                cursor += 2;
-            } else {
-                cursor += 1;
-                break;
-            }
-        } else {
-            cursor += 1;
-        }
-    }
-    Some(cursor)
-}
-
-pub(crate) fn skip_sqlite_quoted_identifier(
-    chars: &[(usize, char)],
-    i: usize,
-    ch: char,
-) -> Option<usize> {
-    let close = match ch {
-        '`' => '`',
-        '[' => ']',
-        _ => return None,
-    };
-    let mut cursor = i + 1;
-    while cursor < chars.len() {
-        if chars[cursor].1 == close {
-            if close == '`' && next_char_is(chars, cursor, close) {
-                cursor += 2;
-            } else {
-                cursor += 1;
-                break;
-            }
-        } else {
-            cursor += 1;
-        }
-    }
-    Some(cursor)
-}
-
 fn skip_quoted_identifier(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
     skip_double_quoted_identifier(chars, i, ch)
         .or_else(|| skip_sqlite_quoted_identifier(chars, i, ch))
@@ -525,10 +438,6 @@ pub(crate) fn update_parentheses_depth(ch: char, depth: &mut i32) {
     } else if ch == ')' {
         *depth -= 1;
     }
-}
-
-pub(crate) fn next_char_is(chars: &[(usize, char)], i: usize, expected: char) -> bool {
-    i + 1 < chars.len() && chars[i + 1].1 == expected
 }
 
 fn is_word_start(chars: &[(usize, char)], i: usize) -> bool {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -7,6 +7,10 @@ use crate::domain::{
         has_mysql_read_only_side_effect, split_mysql_statements,
         statement_contains_unsupported_mysql_control,
     },
+    sql_lex::{
+        advance_single_quote, skip_block_comment, skip_double_quoted_identifier, skip_line_comment,
+        skip_sqlite_quoted_identifier,
+    },
     sqlite_sql::{
         SqliteStatementClassification, SqliteTransactionPolicy, parse_sqlite_pragma,
         split_sqlite_statements, sqlite_statement_classification,
@@ -14,10 +18,8 @@ use crate::domain::{
     },
 };
 use crate::policy::sql::statement_classifier::{
-    StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
-    extract_target_name, first_keyword, skip_block_comment, skip_dollar_quoted_string,
-    skip_double_quoted_identifier, skip_line_comment, skip_sqlite_quoted_identifier,
-    statement_after_leading_ctes,
+    StatementKind, classify, collect_top_level_tokens, drop_subtype, extract_target_name,
+    first_keyword, skip_dollar_quoted_string, statement_after_leading_ctes,
 };
 
 // Why the statement cannot be confirmed via typed target name.

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -14,6 +14,7 @@ pub mod query_history;
 pub mod query_result;
 pub mod rls;
 pub mod schema;
+pub mod sql_lex;
 pub mod sqlite_diagnostics;
 pub mod sqlite_sql;
 pub mod table;

--- a/src/domain/sql_lex.rs
+++ b/src/domain/sql_lex.rs
@@ -1,0 +1,87 @@
+pub fn skip_line_comment(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
+    if ch != '-' || !next_char_is(chars, i, '-') {
+        return None;
+    }
+    let mut cursor = i;
+    while cursor < chars.len() && chars[cursor].1 != '\n' {
+        cursor += 1;
+    }
+    Some(cursor)
+}
+
+pub fn skip_block_comment(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
+    if ch != '/' || !next_char_is(chars, i, '*') {
+        return None;
+    }
+    let mut cursor = i + 2;
+    while cursor + 1 < chars.len() && !(chars[cursor].1 == '*' && chars[cursor + 1].1 == '/') {
+        cursor += 1;
+    }
+    Some(cursor + 2)
+}
+
+pub fn advance_single_quote(
+    chars: &[(usize, char)],
+    i: usize,
+    ch: char,
+    in_string: &mut bool,
+) -> Option<usize> {
+    if ch != '\'' {
+        return None;
+    }
+    if *in_string {
+        if next_char_is(chars, i, '\'') {
+            return Some(i + 2);
+        }
+        *in_string = false;
+    } else {
+        *in_string = true;
+    }
+    Some(i + 1)
+}
+
+pub fn skip_double_quoted_identifier(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
+    if ch != '"' {
+        return None;
+    }
+    let mut cursor = i + 1;
+    while cursor < chars.len() {
+        if chars[cursor].1 == '"' {
+            if next_char_is(chars, cursor, '"') {
+                cursor += 2;
+            } else {
+                cursor += 1;
+                break;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    Some(cursor)
+}
+
+pub fn skip_sqlite_quoted_identifier(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
+    let close = match ch {
+        '`' => '`',
+        '[' => ']',
+        _ => return None,
+    };
+    let mut cursor = i + 1;
+    while cursor < chars.len() {
+        if chars[cursor].1 == close {
+            if close == '`' && next_char_is(chars, cursor, close) {
+                cursor += 2;
+            } else {
+                cursor += 1;
+                break;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    Some(cursor)
+}
+
+fn next_char_is(chars: &[(usize, char)], i: usize, expected: char) -> bool {
+    i + 1 < chars.len() && chars[i + 1].1 == expected
+}

--- a/src/domain/sqlite_sql/splitter.rs
+++ b/src/domain/sqlite_sql/splitter.rs
@@ -1,3 +1,8 @@
+use crate::sql_lex::{
+    advance_single_quote, skip_block_comment, skip_double_quoted_identifier, skip_line_comment,
+    skip_sqlite_quoted_identifier,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqliteStatementSplitError {
     UnclosedCreateTriggerBody,
@@ -242,94 +247,6 @@ fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
         }
     }
     false
-}
-
-fn skip_line_comment(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
-    if ch != '-' || !next_char_is(chars, i, '-') {
-        return None;
-    }
-    let mut cursor = i;
-    while cursor < chars.len() && chars[cursor].1 != '\n' {
-        cursor += 1;
-    }
-    Some(cursor)
-}
-
-fn skip_block_comment(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
-    if ch != '/' || !next_char_is(chars, i, '*') {
-        return None;
-    }
-    let mut cursor = i + 2;
-    while cursor + 1 < chars.len() && !(chars[cursor].1 == '*' && chars[cursor + 1].1 == '/') {
-        cursor += 1;
-    }
-    Some(cursor + 2)
-}
-
-fn advance_single_quote(
-    chars: &[(usize, char)],
-    i: usize,
-    ch: char,
-    in_string: &mut bool,
-) -> Option<usize> {
-    if ch != '\'' {
-        return None;
-    }
-    if *in_string {
-        if next_char_is(chars, i, '\'') {
-            return Some(i + 2);
-        }
-        *in_string = false;
-    } else {
-        *in_string = true;
-    }
-    Some(i + 1)
-}
-
-fn skip_double_quoted_identifier(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
-    if ch != '"' {
-        return None;
-    }
-    let mut cursor = i + 1;
-    while cursor < chars.len() {
-        if chars[cursor].1 == '"' {
-            if next_char_is(chars, cursor, '"') {
-                cursor += 2;
-            } else {
-                cursor += 1;
-                break;
-            }
-        } else {
-            cursor += 1;
-        }
-    }
-    Some(cursor)
-}
-
-fn skip_sqlite_quoted_identifier(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
-    let close = match ch {
-        '`' => '`',
-        '[' => ']',
-        _ => return None,
-    };
-    let mut cursor = i + 1;
-    while cursor < chars.len() {
-        if chars[cursor].1 == close {
-            if close == '`' && next_char_is(chars, cursor, close) {
-                cursor += 2;
-            } else {
-                cursor += 1;
-                break;
-            }
-        } else {
-            cursor += 1;
-        }
-    }
-    Some(cursor)
-}
-
-fn next_char_is(chars: &[(usize, char)], i: usize, expected: char) -> bool {
-    i + 1 < chars.len() && chars[i + 1].1 == expected
 }
 
 pub(super) fn top_level_keywords(sql: &str) -> Vec<String> {


### PR DESCRIPTION
## Problem

SQLite statement splitting and application SQL classification maintained separate copies of the same lexical rules.

## Approach

Share neutral domain-level SQL lexer helpers across both consumers while preserving database-specific parsing boundaries.
