### PR TITLE
refactor(sql): share bulk delete row grouping

### DIFF
--- a/src/infra/adapters/bulk_delete.rs
+++ b/src/infra/adapters/bulk_delete.rs
@@ -1,0 +1,26 @@
+use crate::domain::QueryValue;
+
+pub(super) fn rows_predicate(
+    pk_pairs_per_row: &[Vec<(String, QueryValue)>],
+    equality_predicate: impl Fn(&str, &QueryValue) -> String,
+) -> String {
+    let predicates = pk_pairs_per_row
+        .iter()
+        .map(|pairs| {
+            pairs
+                .iter()
+                .map(|(column, value)| equality_predicate(column, value))
+                .collect::<Vec<_>>()
+                .join(" AND ")
+        })
+        .collect::<Vec<_>>();
+    if predicates.len() == 1 {
+        predicates[0].clone()
+    } else {
+        predicates
+            .into_iter()
+            .map(|predicate| format!("({predicate})"))
+            .collect::<Vec<_>>()
+            .join(" OR ")
+    }
+}

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -1,4 +1,5 @@
 mod app_config_file;
+mod bulk_delete;
 
 pub mod cached_result_exporter;
 pub mod clipboard;

--- a/src/infra/adapters/mysql/sql/grid_write.rs
+++ b/src/infra/adapters/mysql/sql/grid_write.rs
@@ -1,5 +1,7 @@
 use crate::domain::QueryValue;
 
+use crate::adapters::bulk_delete::rows_predicate;
+
 use super::literal::{equality_predicate, quote_identifier, sql_literal};
 
 pub(super) fn build_update_sql(
@@ -35,25 +37,7 @@ pub(super) fn build_bulk_delete_sql(
         "pk_pairs_per_row must not be empty"
     );
 
-    let predicates = pk_pairs_per_row
-        .iter()
-        .map(|pairs| {
-            pairs
-                .iter()
-                .map(|(column, value)| equality_predicate(column, value))
-                .collect::<Vec<_>>()
-                .join(" AND ")
-        })
-        .collect::<Vec<_>>();
-    let where_clause = if predicates.len() == 1 {
-        predicates[0].clone()
-    } else {
-        predicates
-            .into_iter()
-            .map(|predicate| format!("({predicate})"))
-            .collect::<Vec<_>>()
-            .join(" OR ")
-    };
+    let where_clause = rows_predicate(pk_pairs_per_row, equality_predicate);
 
     format!(
         "DELETE FROM {}.{}\nWHERE {};",

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -3,6 +3,8 @@ use std::fmt::Write as _;
 use crate::app::ports::outbound::SqlDialect;
 use crate::domain::{DatabaseType, QueryValue};
 
+use crate::adapters::bulk_delete::rows_predicate;
+
 use super::super::PostgresAdapter;
 use super::{quote_ident, quote_literal};
 
@@ -35,22 +37,6 @@ fn row_predicate(pk_pairs: &[(String, QueryValue)]) -> String {
         .map(|(col, val)| equality_predicate(col, val))
         .collect::<Vec<_>>()
         .join(" AND ")
-}
-
-fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
-    let predicates = pk_pairs_per_row
-        .iter()
-        .map(|pairs| row_predicate(pairs))
-        .collect::<Vec<_>>();
-    if predicates.len() == 1 {
-        predicates[0].clone()
-    } else {
-        predicates
-            .into_iter()
-            .map(|predicate| format!("({predicate})"))
-            .collect::<Vec<_>>()
-            .join(" OR ")
-    }
 }
 
 impl SqlDialect for PostgresAdapter {
@@ -99,7 +85,7 @@ impl SqlDialect for PostgresAdapter {
             "pk_pairs_per_row must not be empty"
         );
 
-        let where_clause = rows_predicate(pk_pairs_per_row);
+        let where_clause = rows_predicate(pk_pairs_per_row, equality_predicate);
 
         format!(
             "DELETE FROM {}.{}\nWHERE {};",

--- a/src/infra/adapters/sqlite/sql/dialect.rs
+++ b/src/infra/adapters/sqlite/sql/dialect.rs
@@ -1,8 +1,10 @@
 use crate::app::ports::outbound::SqlDialect;
 use crate::domain::{DatabaseType, QueryValue, sqlite_sql::build_sqlite_explain_query_plan_sql};
 
+use crate::adapters::bulk_delete::rows_predicate;
+
 use super::super::SqliteAdapter;
-use super::literal::{equality_predicate, quote_ident, rows_predicate, sql_literal};
+use super::literal::{equality_predicate, quote_ident, sql_literal};
 
 impl SqlDialect for SqliteAdapter {
     fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
@@ -53,7 +55,7 @@ impl SqlDialect for SqliteAdapter {
             "pk_pairs_per_row must not be empty"
         );
 
-        let where_clause = rows_predicate(pk_pairs_per_row);
+        let where_clause = rows_predicate(pk_pairs_per_row, equality_predicate);
 
         format!(
             "DELETE FROM {}\nWHERE {};",

--- a/src/infra/adapters/sqlite/sql/literal.rs
+++ b/src/infra/adapters/sqlite/sql/literal.rs
@@ -34,22 +34,6 @@ pub(super) fn equality_predicate(column: &str, value: &QueryValue) -> String {
     }
 }
 
-pub(super) fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
-    let predicates = pk_pairs_per_row
-        .iter()
-        .map(|pairs| row_predicate(pairs))
-        .collect::<Vec<_>>();
-    if predicates.len() == 1 {
-        predicates[0].clone()
-    } else {
-        predicates
-            .into_iter()
-            .map(|predicate| format!("({predicate})"))
-            .collect::<Vec<_>>()
-            .join(" OR ")
-    }
-}
-
 pub(super) fn encode_preview_column_expr(column: &str) -> String {
     let ident = quote_ident(column);
     format!(
@@ -72,14 +56,6 @@ fn text_sql_literal(value: &str) -> String {
     } else {
         quote_literal(value)
     }
-}
-
-fn row_predicate(pk_pairs: &[(String, QueryValue)]) -> String {
-    pk_pairs
-        .iter()
-        .map(|(col, val)| equality_predicate(col, val))
-        .collect::<Vec<_>>()
-        .join(" AND ")
 }
 
 fn encode_bytes_as_sql_hex(bytes: &[u8]) -> String {


### PR DESCRIPTION
## Problem

PostgreSQL, SQLite, and MySQL bulk deletion duplicated the same row-grouping structure around database-specific predicates.

## Approach

Share only the row-level AND and row-set OR grouping while preserving each dialect's predicate and literal semantics.
