### PR TITLE
refactor(app): remove dead connection error API

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -219,17 +219,6 @@ pub struct ConnectionErrorInfo {
 }
 
 impl ConnectionErrorInfo {
-    pub fn new(raw_stderr: impl Into<String>) -> Self {
-        let raw_details = raw_stderr.into();
-        let kind = ConnectionErrorKind::classify(&raw_details);
-        let masked_details = mask_password(&raw_details);
-
-        Self {
-            kind,
-            masked_details,
-        }
-    }
-
     pub fn with_kind(kind: ConnectionErrorKind, raw_stderr: impl Into<String>) -> Self {
         let raw_details = raw_stderr.into();
         let masked_details = mask_password(&raw_details);
@@ -321,25 +310,8 @@ impl ConnectionErrorInfo {
         Self::with_kind(kind, raw_details)
     }
 
-    pub fn summary(&self) -> &'static str {
-        self.kind.summary()
-    }
-
-    pub fn hint(&self) -> &'static str {
-        self.kind.hint()
-    }
-
     pub fn masked_details(&self) -> &str {
         &self.masked_details
-    }
-
-    pub fn user_message(&self) -> String {
-        let details = self.masked_details.trim();
-        if details.is_empty() {
-            format!("{}. {}.", self.summary(), self.hint())
-        } else {
-            format!("{}: {}. {}.", self.summary(), details, self.hint())
-        }
     }
 
     pub const fn is_retryable(&self) -> bool {
@@ -528,12 +500,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn new_auto_classifies() {
-            let info = ConnectionErrorInfo::new("psql: command not found");
-            assert_eq!(info.kind, ConnectionErrorKind::CliNotFound);
-        }
-
-        #[test]
         fn with_kind_uses_provided_kind() {
             let info = ConnectionErrorInfo::with_kind(ConnectionErrorKind::Timeout, "error");
             assert_eq!(info.kind, ConnectionErrorKind::Timeout);
@@ -592,7 +558,7 @@ mod tests {
                 ));
 
             assert_eq!(info.kind, ConnectionErrorKind::PermissionDenied);
-            assert_eq!(info.hint(), "Check the connected user's privileges");
+            assert_eq!(info.kind.hint(), "Check the connected user's privileges");
         }
 
         #[test]
@@ -603,7 +569,7 @@ mod tests {
                 ));
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteFileNotFound);
-            assert_eq!(info.summary(), "SQLite database file not found");
+            assert_eq!(info.kind.summary(), "SQLite database file not found");
         }
 
         #[test]
@@ -615,8 +581,8 @@ mod tests {
                 });
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteCliNotFound);
-            assert_eq!(info.summary(), "sqlite3 not found");
-            assert_eq!(info.hint(), "Install sqlite3 and add it to PATH");
+            assert_eq!(info.kind.summary(), "sqlite3 not found");
+            assert_eq!(info.kind.hint(), "Install sqlite3 and add it to PATH");
         }
 
         #[rstest]
@@ -637,7 +603,7 @@ mod tests {
                 });
 
             assert_eq!(info.kind, expected_kind);
-            assert_eq!(info.summary(), expected_summary);
+            assert_eq!(info.kind.summary(), expected_summary);
         }
 
         #[rstest]
@@ -664,12 +630,8 @@ mod tests {
                 },
             );
 
-            assert_eq!(info.summary(), expected_kind.summary());
-            assert_eq!(info.hint(), expected_kind.hint());
-            assert_eq!(
-                info.user_message(),
-                format!("{}: provider details. {}.", info.summary(), info.hint())
-            );
+            assert_eq!(info.kind.summary(), expected_kind.summary());
+            assert_eq!(info.kind.hint(), expected_kind.hint());
             assert!(!info.is_retryable());
             assert_eq!(info.kind, expected_kind);
         }
@@ -703,12 +665,8 @@ mod tests {
             );
 
             assert_eq!(info.kind, expected_kind);
-            assert_eq!(info.summary(), expected_kind.summary());
-            assert_eq!(info.hint(), expected_kind.hint());
-            assert_eq!(
-                info.user_message(),
-                format!("{}: tls details. {}.", info.summary(), info.hint())
-            );
+            assert_eq!(info.kind.summary(), expected_kind.summary());
+            assert_eq!(info.kind.hint(), expected_kind.hint());
             assert!(!info.is_retryable());
         }
 
@@ -721,7 +679,6 @@ mod tests {
 
             assert_eq!(info.kind, ConnectionErrorKind::Unknown);
             assert!(!info.masked_details().contains("secret"));
-            assert!(!info.user_message().contains("secret"));
             assert!(!info.is_retryable());
         }
 
@@ -770,7 +727,7 @@ mod tests {
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
-            assert_eq!(info.summary(), "SQLite 3.41.1 or later required");
+            assert_eq!(info.kind.summary(), "SQLite 3.41.1 or later required");
         }
 
         #[test]
@@ -782,18 +739,8 @@ mod tests {
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
-            assert_eq!(info.summary(), "SQLite 3.41.1 or later required");
-            assert_eq!(info.hint(), "Upgrade sqlite3 to use SQLite safely");
-        }
-
-        #[test]
-        fn delegates_summary_and_hint() {
-            let info = ConnectionErrorInfo::new("psql: command not found");
-            assert_eq!(info.summary(), "Database CLI not found");
-            assert_eq!(
-                info.hint(),
-                "Install the database CLI (e.g. psql) and add it to PATH"
-            );
+            assert_eq!(info.kind.summary(), "SQLite 3.41.1 or later required");
+            assert_eq!(info.kind.hint(), "Upgrade sqlite3 to use SQLite safely");
         }
     }
 
@@ -833,7 +780,10 @@ mod tests {
 
         #[test]
         fn info_keeps_only_masked_details() {
-            let info = ConnectionErrorInfo::new("postgres://user:secret@host");
+            let info = ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::Unknown,
+                "postgres://user:secret@host",
+            );
             assert!(!info.masked_details().contains("secret"));
             assert_eq!(info.masked_details(), "postgres://user:****@host");
         }

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -339,7 +339,10 @@ mod tests {
         );
         state
             .connection_error
-            .set_error(ConnectionErrorInfo::new("connection refused"));
+            .set_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::ConnectionRefused,
+                "connection refused",
+            ));
         state.modal.set_mode(InputMode::ConnectionError);
 
         reduce_connection_error(&mut state, &Action::CloseConnectionError, Instant::now());
@@ -371,7 +374,10 @@ mod tests {
             .begin_mysql_connection_probe(&id, "mysql-a", dsn, Some("a"));
         state
             .connection_error
-            .set_error(ConnectionErrorInfo::new("connection refused"));
+            .set_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::ConnectionRefused,
+                "connection refused",
+            ));
         state.modal.set_mode(InputMode::ConnectionError);
 
         assert!(!state.session.has_pending_connection_switch());
@@ -406,7 +412,10 @@ mod tests {
         );
         state
             .connection_error
-            .set_error(ConnectionErrorInfo::new("connection refused"));
+            .set_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::ConnectionRefused,
+                "connection refused",
+            ));
         state.modal.set_mode(InputMode::ConnectionError);
 
         reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -392,7 +392,10 @@ mod tests {
             state.session.set_connection_state(ConnectionState::Failed);
             state
                 .connection_error
-                .set_error(ConnectionErrorInfo::new("connection refused"));
+                .set_error(ConnectionErrorInfo::with_kind(
+                    ConnectionErrorKind::ConnectionRefused,
+                    "connection refused",
+                ));
 
             let retry_effects = reduce_connection_error(
                 &mut state,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -814,7 +814,7 @@ mod tests {
                 let error_info = state.connection_error.error_info().unwrap();
                 assert_eq!(error_info.kind, expected);
                 if expected == ConnectionErrorKind::PermissionDenied {
-                    assert!(!error_info.hint().contains("password"));
+                    assert!(!error_info.kind.hint().contains("password"));
                 }
             }
         }

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -142,7 +142,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
 mod tests {
     use super::*;
     use crate::domain::{ConnectionId, DatabaseType};
-    use crate::model::connection::error::ConnectionErrorInfo;
+    use crate::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use crate::model::shared::key_sequence::KeySequenceState;
     use crate::model::shared::settings::KeymapPreset;
     use crate::model::shared::ui_state::FocusMode;
@@ -499,7 +499,10 @@ mod tests {
                 let mut state = browse_state();
                 state
                     .connection_error
-                    .set_error(ConnectionErrorInfo::new("boom"));
+                    .set_error(ConnectionErrorInfo::with_kind(
+                        ConnectionErrorKind::Unknown,
+                        "boom",
+                    ));
 
                 let result = handle_normal_mode(KeyCombo::alt(Key::Enter), &state);
 
@@ -511,7 +514,10 @@ mod tests {
                 let mut state = browse_state();
                 state
                     .connection_error
-                    .set_error(ConnectionErrorInfo::new("boom"));
+                    .set_error(ConnectionErrorInfo::with_kind(
+                        ConnectionErrorKind::Unknown,
+                        "boom",
+                    ));
 
                 let result = handle_normal_mode(KeyCombo::plain(Key::Enter), &state);
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1108,7 +1108,7 @@ mod tests {
     mod response_handlers {
         use super::*;
         use crate::domain::{DatabaseMetadata, MetadataState, QueryResult, QuerySource};
-        use crate::model::connection::error::ConnectionErrorInfo;
+        use crate::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
         use crate::model::connection::state::ConnectionState;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
@@ -1366,7 +1366,10 @@ mod tests {
             let mut state = create_test_state();
             state
                 .connection_error
-                .set_error(ConnectionErrorInfo::new("error"));
+                .set_error(ConnectionErrorInfo::with_kind(
+                    ConnectionErrorKind::Unknown,
+                    "error",
+                ));
             state.ui.set_focused_pane(FocusedPane::Result); // Any pane works
             let now = Instant::now();
 

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -450,12 +450,12 @@ fn render_service_error_without_service_file_hint(save_and_connect: bool) -> Str
         .set_service_file_path(Some(std::path::PathBuf::from("/etc/pg_service.conf")));
     if save_and_connect {
         state.connection_error.set_save_and_connect_error(
-            ConnectionErrorInfo::new("mysql save failed"),
+            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Unknown, "mysql save failed"),
             DatabaseType::MySQL,
         );
     } else {
         state.connection_error.set_connection_switch_error(
-            ConnectionErrorInfo::new("mysql switch failed"),
+            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Unknown, "mysql switch failed"),
             DatabaseType::MySQL,
         );
     }


### PR DESCRIPTION
## Problem

Connection error state exposed constructor and presentation helpers with no production callers, obscuring the typed conversion boundary used at runtime.

## Approach

Remove the dead API and keep tests on the existing typed fixture and error-kind presentation paths.
