### PR TITLE
refactor(app): centralize post-change refresh scope

### DIFF
--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -119,6 +119,13 @@ pub enum DbOperationError {
 }
 
 impl DbOperationError {
+    pub fn post_change_refresh_scope(&self) -> Option<RefreshScope> {
+        match self {
+            Self::QueryFailedAfterChange { refresh_scope, .. } => Some(*refresh_scope),
+            _ => None,
+        }
+    }
+
     pub fn summary(&self) -> &'static str {
         match self {
             Self::ConnectionFailed(_) => "Connection failed",
@@ -327,6 +334,22 @@ mod tests {
         assert!(!is_mysql_connect_timeout_message(
             "Can't connect to MySQL server (host) (111)"
         ));
+    }
+
+    mod post_change_refresh_scope {
+        use super::*;
+
+        #[test]
+        fn wrapped_none_is_distinct_from_an_unwrapped_error() {
+            let source = DbOperationError::QueryFailed("failed".to_string());
+            let error = DbOperationError::QueryFailedAfterChange {
+                source: Arc::new(source.clone()),
+                refresh_scope: RefreshScope::None,
+            };
+
+            assert_eq!(source.post_change_refresh_scope(), None);
+            assert_eq!(error.post_change_refresh_scope(), Some(RefreshScope::None));
+        }
     }
 
     mod summaries_and_hints {

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -161,10 +161,9 @@ pub fn reduce_execution(
                     state.sql_modal.finish_adhoc_error(user_message);
                 }
             }
-            let refresh_scope = match error {
-                DbOperationError::QueryFailedAfterChange { refresh_scope, .. } => *refresh_scope,
-                _ => RefreshScope::None,
-            };
+            let refresh_scope = error
+                .post_change_refresh_scope()
+                .unwrap_or(RefreshScope::None);
             let effects = if is_preview {
                 vec![]
             } else {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -16,7 +16,7 @@ use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
 use crate::policy::write::write_update::escape_preview_value;
-use crate::ports::outbound::{AccessMode, DbOperationError};
+use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::browse::query::{
@@ -354,10 +354,9 @@ pub fn reduce_write(
             }
 
             state.query.mark_idle();
-            let refresh_scope = match error {
-                DbOperationError::QueryFailedAfterChange { refresh_scope, .. } => *refresh_scope,
-                _ => RefreshScope::None,
-            };
+            let refresh_scope = error
+                .post_change_refresh_scope()
+                .unwrap_or(RefreshScope::None);
             let operation = state.result_interaction.complete_write_failure();
             state.query.clear_delete_refresh_target();
             state.messages.set_error_at(error.user_message(), now);

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -397,9 +397,7 @@ pub(super) fn query_failed_after_change(
     error: DbOperationError,
     refresh_scope: RefreshScope,
 ) -> DbOperationError {
-    if refresh_scope == RefreshScope::None
-        || matches!(&error, DbOperationError::QueryFailedAfterChange { .. })
-    {
+    if refresh_scope == RefreshScope::None || error.post_change_refresh_scope().is_some() {
         error
     } else {
         DbOperationError::QueryFailedAfterChange {
@@ -734,6 +732,18 @@ mod tests {
             error,
             DbOperationError::ForeignKeyViolation(details) if details == "foreign key failed"
         ));
+    }
+
+    #[test]
+    fn change_failure_is_not_wrapped_again() {
+        let error = DbOperationError::QueryFailedAfterChange {
+            source: Arc::new(DbOperationError::QueryFailed("failed".to_string())),
+            refresh_scope: RefreshScope::Data,
+        };
+
+        let error = query_failed_after_change(error, RefreshScope::Metadata);
+
+        assert_eq!(error.post_change_refresh_scope(), Some(RefreshScope::Data));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Post-change refresh scope was recovered through repeated direct matches on the same error variant.

## Approach

Expose one read-only accessor and reuse it at wrapper and reducer boundaries without changing producers or refresh behavior.
