### PR TITLE
refactor(mysql): derive MySQL lexer error

### DIFF
--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 mod classifier;
 mod export;
 mod lexer;
@@ -67,14 +65,9 @@ impl MySqlStatement {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{0}")]
 pub struct MySqlLexError(pub String);
-
-impl fmt::Display for MySqlLexError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
 
 pub fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexError> {
     lexer::split_mysql_statements(sql)


### PR DESCRIPTION
## Problem

MySQL lexer errors manually forwarded Display to their inner message without implementing the standard Error boundary.

## Approach

Derive the error implementation while preserving the newtype, signatures, and display text.
