### PR TITLE
refactor(postgres): remove unused SSL mode parser

### DIFF
--- a/src/domain/connection/ssl_mode.rs
+++ b/src/domain/connection/ssl_mode.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -42,22 +41,6 @@ impl fmt::Display for SslMode {
     }
 }
 
-impl FromStr for SslMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "disable" => Ok(Self::Disable),
-            "allow" => Ok(Self::Allow),
-            "prefer" => Ok(Self::Prefer),
-            "require" => Ok(Self::Require),
-            "verify-ca" => Ok(Self::VerifyCa),
-            "verify-full" => Ok(Self::VerifyFull),
-            _ => Err(format!("Unknown SSL mode: {s}")),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,35 +51,13 @@ mod tests {
     }
 
     #[test]
-    fn from_str_parses_all_variants() {
-        assert_eq!(SslMode::from_str("disable").unwrap(), SslMode::Disable);
-        assert_eq!(SslMode::from_str("allow").unwrap(), SslMode::Allow);
-        assert_eq!(SslMode::from_str("prefer").unwrap(), SslMode::Prefer);
-        assert_eq!(SslMode::from_str("require").unwrap(), SslMode::Require);
-        assert_eq!(SslMode::from_str("verify-ca").unwrap(), SslMode::VerifyCa);
-        assert_eq!(
-            SslMode::from_str("verify-full").unwrap(),
-            SslMode::VerifyFull
-        );
-    }
+    fn display_matches_wire_values() {
+        let values = SslMode::all_variants()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
 
-    #[test]
-    fn from_str_is_case_insensitive() {
-        assert_eq!(SslMode::from_str("PREFER").unwrap(), SslMode::Prefer);
-        assert_eq!(SslMode::from_str("Verify-CA").unwrap(), SslMode::VerifyCa);
-    }
-
-    #[test]
-    fn from_str_returns_error_for_unknown() {
-        assert!(SslMode::from_str("unknown").is_err());
-    }
-
-    #[test]
-    fn display_matches_parse() {
-        for variant in SslMode::all_variants() {
-            let s = variant.to_string();
-            let parsed = SslMode::from_str(&s).unwrap();
-            assert_eq!(*variant, parsed);
-        }
+        assert_eq!(values, "disable,allow,prefer,require,verify-ca,verify-full");
     }
 }


### PR DESCRIPTION
## Problem

PostgreSQL SSL mode retained a string parser that production code no longer calls.

## Approach

Remove the unused parser and its parser-only tests while keeping profile serialization and connection behavior unchanged.