### PR TITLE
refactor(sqlite): share table-not-found error construction

### DIFF
--- a/src/infra/adapters/sqlite/metadata/mod.rs
+++ b/src/infra/adapters/sqlite/metadata/mod.rs
@@ -16,6 +16,10 @@ use super::{SqliteAdapter, schema::MAIN_SCHEMA};
 use catalog::metadata_from_catalog;
 use table_detail::{TableDetailMode, table_from_metadata};
 
+fn sqlite_table_not_found(table: &str) -> DbOperationError {
+    DbOperationError::ObjectMissing(format!("SQLite table not found: {table}"))
+}
+
 #[async_trait]
 impl MetadataProvider for SqliteAdapter {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {

--- a/src/infra/adapters/sqlite/metadata/preview.rs
+++ b/src/infra/adapters/sqlite/metadata/preview.rs
@@ -23,14 +23,10 @@ fn preview_metadata_from_raw(
     metadata: RawPreviewMetadata,
 ) -> Result<(Vec<String>, Vec<String>, TableKindInfo), DbOperationError> {
     let Some(table_kind) = metadata.table.as_ref() else {
-        return Err(DbOperationError::ObjectMissing(format!(
-            "SQLite table not found: {table}"
-        )));
+        return Err(super::sqlite_table_not_found(table));
     };
     if metadata.columns.is_empty() {
-        return Err(DbOperationError::ObjectMissing(format!(
-            "SQLite table not found: {table}"
-        )));
+        return Err(super::sqlite_table_not_found(table));
     }
     let primary_key = extract_primary_key(&metadata.columns);
     let visible_columns = metadata

--- a/src/infra/adapters/sqlite/metadata/table_detail.rs
+++ b/src/infra/adapters/sqlite/metadata/table_detail.rs
@@ -67,9 +67,7 @@ pub(super) fn table_from_metadata(
     metadata: RawTableMetadata,
 ) -> Result<Table, DbOperationError> {
     if metadata.columns.is_empty() || metadata.table.is_none() {
-        return Err(DbOperationError::ObjectMissing(format!(
-            "SQLite table not found: {table}"
-        )));
+        return Err(super::sqlite_table_not_found(table));
     }
     let unique_single_columns = unique_single_columns_from_batch(&metadata.indexes);
     let indexes = if mode.include_indexes() {


### PR DESCRIPTION
## Problem

SQLite metadata paths repeated the same table-not-found error construction.

## Approach

Centralize that local construction while preserving object names, error taxonomy, and lookup behavior.