### PR TITLE
refactor(mysql): inline metadata diagnostics discard

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -18,10 +18,10 @@ use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli
 #[cfg(not(unix))]
 use super::pipe::MySqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
+use super::process::metadata::mysql_metadata_columns_with_diagnostics;
 use super::process::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
-    mysql_metadata_columns, run_mysql_process_with_timeout, validate_mysql_session_exit,
-    write_mysql_statement,
+    run_mysql_process_with_timeout, validate_mysql_session_exit, write_mysql_statement,
 };
 #[cfg(unix)]
 use super::pty::MySqlExportPtySource;
@@ -376,14 +376,15 @@ pub(super) async fn run_mysql_export_process(
                 "MySQL empty CSV result has no supported metadata fallback".to_string(),
             )
         })?;
-        let columns = mysql_metadata_columns(
+        let columns = mysql_metadata_columns_with_diagnostics(
             process,
             option_file,
             query,
             fallback_kind,
             AccessMode::ReadOnly,
         )
-        .await?;
+        .await?
+        .0;
         csv_writer.write_record(columns.iter()).await?;
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -41,8 +41,7 @@ mod single;
 #[cfg(feature = "test-support")]
 pub(in crate::adapters::mysql) mod test_support;
 pub(in crate::adapters::mysql) use single::run_mysql_single_statement;
-mod metadata;
-pub(super) use metadata::mysql_metadata_columns;
+pub(super) mod metadata;
 
 pub(in crate::adapters::mysql) const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
 #[cfg(unix)]

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -23,21 +23,7 @@ use super::{
     read_one_mysql_resultset_with_diagnostics, write_mysql_statement,
 };
 
-pub(in crate::adapters::mysql) async fn mysql_metadata_columns(
-    process: &mut MySqlProcess,
-    option_file: &std::path::Path,
-    query: &str,
-    kind: MySqlMetadataFallbackKind,
-    access_mode: AccessMode,
-) -> Result<Vec<String>, DbOperationError> {
-    Ok(
-        mysql_metadata_columns_with_diagnostics(process, option_file, query, kind, access_mode)
-            .await?
-            .0,
-    )
-}
-
-pub(super) async fn mysql_metadata_columns_with_diagnostics(
+pub(in crate::adapters::mysql::cli) async fn mysql_metadata_columns_with_diagnostics(
     process: &mut MySqlProcess,
     option_file: &std::path::Path,
     query: &str,


### PR DESCRIPTION
## Problem

A private metadata wrapper existed only to discard diagnostics before returning the parsed result.

## Approach

Return the parsed result and diagnostics from the existing operation boundary, then discard diagnostics at the two callers that intentionally do not use them.