### PR TITLE
refactor(app): flatten ER display errors

### DIFF
--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -13,8 +13,7 @@ use crate::domain::{DatabaseMetadata, ErTableInfo, TableSignatureSnapshot};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{ConfigWriter, ErDiagramExporter, ErLogWriter, MetadataProvider};
 use crate::update::action::{
-    Action, ErDiagramError, ErDiagramFailure, ErLogError, SmartErRefreshError,
-    SmartErRefreshFetched, SmartErRefreshResult,
+    Action, SmartErRefreshError, SmartErRefreshFetched, SmartErRefreshResult,
 };
 
 struct GenerateErDiagramRequest {
@@ -114,10 +113,10 @@ async fn handle_generate_diagram(
     let all_tables = collect_cached_er_tables(completion_engine);
     if all_tables.is_empty() {
         action_tx
-            .send(Action::ErDiagramFailed(ErDiagramFailure {
+            .send(Action::ErDiagramFailed {
                 run_id,
-                error: ErDiagramError::NoData("No table data loaded yet".to_string()),
-            }))
+                error: "No table data loaded yet".to_string(),
+            })
             .await
             .ok();
         return Ok(());
@@ -133,12 +132,10 @@ async fn handle_generate_diagram(
 
     if tables.is_empty() {
         action_tx
-            .send(Action::ErDiagramFailed(ErDiagramFailure {
+            .send(Action::ErDiagramFailed {
                 run_id,
-                error: ErDiagramError::NoData(
-                    "Selected tables not found in cached data".to_string(),
-                ),
-            }))
+                error: "Selected tables not found in cached data".to_string(),
+            })
             .await
             .ok();
         return Ok(());
@@ -191,14 +188,14 @@ async fn handle_write_failure_log(
             let tx = action_tx.clone();
             tokio::task::spawn_blocking(move || {
                 if let Err(e) = writer.write_er_failure_log(failed_tables, cache_dir) {
-                    tx.blocking_send(Action::ErLogWriteFailed(ErLogError::Io(e.to_string())))
+                    tx.blocking_send(Action::ErLogWriteFailed(e.to_string()))
                         .ok();
                 }
             });
         }
         Err(e) => {
             action_tx
-                .send(Action::ErLogWriteFailed(ErLogError::Config(e.to_string())))
+                .send(Action::ErLogWriteFailed(e.to_string()))
                 .await
                 .ok();
         }

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 
 use crate::domain::ErTableInfo;
 use crate::ports::outbound::ErDiagramExporter;
-use crate::update::action::{Action, ErDiagramError, ErDiagramFailure, ErDiagramInfo};
+use crate::update::action::{Action, ErDiagramInfo};
 
 pub fn spawn_er_diagram_task(
     exporter: Arc<dyn ErDiagramExporter>,
@@ -37,18 +37,18 @@ pub fn spawn_er_diagram_task(
             }
             Ok(Err(e)) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(ErDiagramFailure {
+                    .send(Action::ErDiagramFailed {
                         run_id,
-                        error: ErDiagramError::ExportFailed(e.to_string()),
-                    }))
+                        error: e.to_string(),
+                    })
                     .await;
             }
             Err(e) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(ErDiagramFailure {
+                    .send(Action::ErDiagramFailed {
                         run_id,
-                        error: ErDiagramError::TaskPanicked(e.to_string()),
-                    }))
+                        error: format!("Task panicked: {e}"),
+                    })
                     .await;
             }
         }
@@ -170,9 +170,9 @@ mod tests {
 
             let action = receive_action(&mut rx).await;
             match action {
-                Action::ErDiagramFailed(e) => {
-                    assert!(e.to_string().contains("export failed"));
-                    assert_eq!(e.run_id, 7);
+                Action::ErDiagramFailed { run_id, error } => {
+                    assert!(error.contains("export failed"));
+                    assert_eq!(run_id, 7);
                 }
                 _ => panic!("expected ErDiagramFailed, got {action:?}"),
             }
@@ -197,9 +197,9 @@ mod tests {
 
             let action = receive_action(&mut rx).await;
             match action {
-                Action::ErDiagramFailed(e) => {
-                    assert!(e.to_string().contains("Task panicked"));
-                    assert_eq!(e.run_id, 11);
+                Action::ErDiagramFailed { run_id, error } => {
+                    assert!(error.contains("Task panicked"));
+                    assert_eq!(run_id, 11);
                 }
                 _ => panic!("expected ErDiagramFailed, got {action:?}"),
             }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -57,31 +57,6 @@ impl fmt::Debug for ConnectionSaveError {
     }
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum ErDiagramError {
-    #[error("{0}")]
-    NoData(String),
-    #[error("{0}")]
-    ExportFailed(String),
-    #[error("Task panicked: {0}")]
-    TaskPanicked(String),
-}
-
-#[derive(Debug, Clone, thiserror::Error)]
-#[error("{error}")]
-pub struct ErDiagramFailure {
-    pub run_id: u64,
-    pub error: ErDiagramError,
-}
-
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum ErLogError {
-    #[error("{0}")]
-    Io(String),
-    #[error("{0}")]
-    Config(String),
-}
-
 pub use crate::model::shared::cursor::CursorMove;
 
 // ---------------------------------------------------------------------------
@@ -742,8 +717,11 @@ pub enum Action {
     SmartErRefreshCompleted(SmartErRefreshResult),
     SmartErRefreshFailed(SmartErRefreshError),
     ErDiagramOpened(ErDiagramInfo),
-    ErDiagramFailed(ErDiagramFailure),
-    ErLogWriteFailed(ErLogError),
+    ErDiagramFailed {
+        run_id: u64,
+        error: String,
+    },
+    ErLogWriteFailed(String),
 }
 
 impl Action {
@@ -773,7 +751,7 @@ impl Action {
             | Self::SmartErRefreshCompleted(_)
             | Self::SmartErRefreshFailed(_)
             | Self::ErDiagramOpened(_)
-            | Self::ErDiagramFailed(_)
+            | Self::ErDiagramFailed { .. }
             | Self::ErLogWriteFailed(_)
             | Self::TextInput {
                 target: InputTarget::ErFilter,

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -32,16 +32,16 @@ pub(super) fn reduce_diagram_lifecycle(
             );
             DispatchResult::handled()
         }
-        Action::ErDiagramFailed(failure) => {
-            if !state.er_preparation.is_current_run(failure.run_id) {
+        Action::ErDiagramFailed { run_id, error } => {
+            if !state.er_preparation.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             state.er_preparation.mark_idle();
-            state.messages.set_error_at(failure.error.to_string(), now);
+            state.messages.set_error_at(error.clone(), now);
             DispatchResult::handled()
         }
         Action::ErLogWriteFailed(error) => {
-            state.messages.set_error_at(error.to_string(), now);
+            state.messages.set_error_at(error.clone(), now);
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -29,8 +29,7 @@ mod tests {
     use crate::model::app_state::AppState;
     use crate::model::er_state::ErStatus;
     use crate::update::action::{
-        ErDiagramError, ErDiagramFailure, ErDiagramInfo, SmartErRefreshError,
-        SmartErRefreshFetched, SmartErRefreshResult,
+        ErDiagramInfo, SmartErRefreshError, SmartErRefreshFetched, SmartErRefreshResult,
     };
     use std::sync::Arc;
 
@@ -653,10 +652,10 @@ mod tests {
 
             let effects = reduce_er(
                 &mut state,
-                &Action::ErDiagramFailed(ErDiagramFailure {
+                &Action::ErDiagramFailed {
                     run_id,
-                    error: ErDiagramError::ExportFailed("stale failure".to_string()),
-                }),
+                    error: "stale failure".to_string(),
+                },
                 Instant::now(),
             )
             .unwrap();


### PR DESCRIPTION
## Problem

ER display-only error wrappers were converted immediately to strings and never inspected by variant.

## Approach

Carry the existing display text directly in Actions while preserving run guards, footer text, export errors, and smart-refresh errors.