### PR TITLE
refactor(app): remove dead connection error action

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -7,7 +7,6 @@ use crate::domain::connection::{
 use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::json_detail::JsonDetailMode;
-use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
@@ -444,7 +443,6 @@ pub enum Action {
     },
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
-    ShowConnectionError(ConnectionErrorInfo),
     CloseConnectionError,
     ToggleConnectionErrorDetails,
     CopyConnectionError,

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -14,11 +14,6 @@ pub(super) fn reduce_connection_error(
     now: Instant,
 ) -> DispatchResult {
     match action {
-        Action::ShowConnectionError(info) => {
-            state.connection_error.set_error(info.clone());
-            state.modal.replace_mode(InputMode::ConnectionError);
-            DispatchResult::handled()
-        }
         Action::CloseConnectionError => {
             if state.session.pending_mysql_connection_probe().is_some() {
                 state.session.clear_mysql_connection_probe();


### PR DESCRIPTION
## Problem

An unsent connection-error action made a fourth error entry path appear reachable.

## Approach

Remove the dead action boundary while preserving the three direct state transitions used by metadata, save-and-connect, and profile switching.