### PR TITLE
refactor(sqlite): simplify spawn error classifier

### DIFF
--- a/src/infra/adapters/sqlite/sqlite3/error.rs
+++ b/src/infra/adapters/sqlite/sqlite3/error.rs
@@ -1,12 +1,11 @@
 use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
 
 pub(in crate::adapters::sqlite) fn classify_cli_spawn_error(
-    command: DatabaseCli,
     error: std::io::Error,
 ) -> DbOperationError {
     if error.kind() == std::io::ErrorKind::NotFound {
         DbOperationError::CommandNotFound {
-            command,
+            command: DatabaseCli::Sqlite3,
             details: error.to_string(),
         }
     } else {
@@ -177,10 +176,10 @@ mod tests {
 
     #[test]
     fn missing_sqlite_cli_has_command_specific_details() {
-        let error = classify_cli_spawn_error(
-            DatabaseCli::Sqlite3,
-            std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory"),
-        );
+        let error = classify_cli_spawn_error(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file or directory",
+        ));
 
         assert!(matches!(
             error,
@@ -193,10 +192,10 @@ mod tests {
 
     #[test]
     fn non_missing_sqlite_cli_error_is_query_failed() {
-        let error = classify_cli_spawn_error(
-            DatabaseCli::Sqlite3,
-            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied"),
-        );
+        let error = classify_cli_spawn_error(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "permission denied",
+        ));
 
         assert!(matches!(
             error,

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -7,9 +7,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::app::ports::outbound::{
-    DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
-};
+use crate::app::ports::outbound::{DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER};
 
 use super::super::path_validation;
 use super::error::{classify_cli_spawn_error, classify_query_error};
@@ -69,7 +67,7 @@ impl SqliteCli {
             .arg("--version")
             .output()
             .await
-            .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
+            .map_err(classify_cli_spawn_error)?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         let version = SqliteVersion::parse(&stdout).ok_or_else(|| {
             safe_mode_required_error("could not determine the installed sqlite3 version")
@@ -189,7 +187,7 @@ impl SqliteCli {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
+            .map_err(classify_cli_spawn_error)?;
 
         let stdin = child.stdin.take();
         let stdout = child.stdout.take();
@@ -327,7 +325,7 @@ impl SqliteCli {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
+            .map_err(classify_cli_spawn_error)?;
 
         let stdin = child.stdin.take();
         let mut stdout_handle = child.stdout.take();


### PR DESCRIPTION
## Problem

The SQLite spawn classifier accepted a CLI argument even though every caller always supplied sqlite3.

## Approach

Own the fixed CLI identity inside the SQLite classifier while preserving not-found details and other spawn-error mappings.