### PR TITLE
refactor(app): remove infallible handler results

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 
 use crate::cmd::cache::TtlCache;
@@ -25,7 +24,7 @@ pub async fn run(
     table_detail_tasks: &TableDetailTaskRegistry,
     metadata_tasks: &Arc<MetadataTaskRegistry>,
     completion_engine: &RefCell<CompletionEngine>,
-) -> Result<()> {
+) {
     match effect {
         Effect::FetchMetadata { dsn, run_id } => {
             fetch_metadata(
@@ -37,11 +36,10 @@ pub async fn run(
                 dsn,
                 run_id,
             )
-            .await
+            .await;
         }
         Effect::FetchEffectiveUser { dsn, run_id } => {
             fetch_effective_user(action_tx, metadata_provider, metadata_tasks, dsn, run_id);
-            Ok(())
         }
         Effect::FetchTableDetail {
             dsn,
@@ -60,7 +58,6 @@ pub async fn run(
                 run_id,
                 table_detail_tasks,
             );
-            Ok(())
         }
         Effect::PrefetchTableDetail {
             dsn,
@@ -78,14 +75,13 @@ pub async fn run(
                 schema,
                 table,
             )
-            .await
+            .await;
         }
         Effect::ProcessPrefetchQueue { run_id } => {
             action_tx
                 .send(Action::ProcessPrefetchQueue { run_id })
                 .await
                 .ok();
-            Ok(())
         }
         Effect::DelayedProcessPrefetchQueue { run_id, delay_secs } => {
             let tx = action_tx.clone();
@@ -93,11 +89,9 @@ pub async fn run(
                 tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
                 tx.send(Action::ProcessPrefetchQueue { run_id }).await.ok();
             });
-            Ok(())
         }
         Effect::CacheInvalidate { dsn } => {
             metadata_cache.invalidate(&dsn).await;
-            Ok(())
         }
 
         _ => unreachable!("metadata::run called with non-metadata effect"),
@@ -112,7 +106,7 @@ async fn fetch_metadata(
     metadata_tasks: &Arc<MetadataTaskRegistry>,
     dsn: String,
     run_id: u64,
-) -> Result<()> {
+) {
     if let Some(path) = sqlite_path_from_dsn(&dsn)
         && let Err(error) =
             validate_sqlite_database_path(sqlite_path_validator, path.to_string()).await
@@ -125,7 +119,7 @@ async fn fetch_metadata(
             })
             .await
             .ok();
-        return Ok(());
+        return;
     }
 
     if let Some(cached) = metadata_cache.get(&dsn).await {
@@ -137,7 +131,7 @@ async fn fetch_metadata(
             })
             .await
             .ok();
-        return Ok(());
+        return;
     }
 
     let provider = Arc::clone(metadata_provider);
@@ -168,8 +162,6 @@ async fn fetch_metadata(
             }
         }
     });
-
-    Ok(())
 }
 
 fn fetch_effective_user(
@@ -242,7 +234,7 @@ async fn prefetch_table_detail(
     run_id: u64,
     schema: String,
     table: String,
-) -> Result<()> {
+) {
     let qualified_name = format!("{schema}.{table}");
     let already_cached = completion_engine.borrow().has_cached_table(&qualified_name);
 
@@ -256,7 +248,7 @@ async fn prefetch_table_detail(
             })
             .await
             .ok();
-        return Ok(());
+        return;
     }
 
     let provider = Arc::clone(metadata_provider);
@@ -304,8 +296,6 @@ async fn prefetch_table_detail(
             }
         }
     });
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
@@ -70,11 +69,7 @@ fn save_query_history(
     });
 }
 
-#[allow(
-    clippy::unused_async,
-    reason = "consistent async interface for effect runner dispatch"
-)]
-pub async fn run(
+pub fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
     query_executor: &Arc<dyn QueryExecutor>,
@@ -82,7 +77,7 @@ pub async fn run(
     cached_result_exporter: &Arc<dyn CachedResultExporter>,
     query_tasks: &QueryTaskRegistry,
     state: &AppState,
-) -> Result<()> {
+) {
     match effect {
         Effect::ExecutePreview {
             dsn,
@@ -127,7 +122,6 @@ pub async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         Effect::ExecuteExplain {
@@ -181,7 +175,6 @@ pub async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         Effect::ExecuteAdhoc {
@@ -245,7 +238,6 @@ pub async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         Effect::ExecuteWrite {
@@ -304,7 +296,6 @@ pub async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         Effect::CountRowsForExport {
@@ -329,7 +320,6 @@ pub async fn run(
                 .await
                 .ok();
             });
-            Ok(())
         }
 
         Effect::ExportCsv {
@@ -369,7 +359,6 @@ pub async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         Effect::ExportCsvFromCache {
@@ -406,7 +395,6 @@ pub async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         _ => unreachable!("query::run called with non-query effect"),

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
@@ -90,7 +89,7 @@ pub(crate) async fn run(
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     state: &AppState,
-) -> Result<()> {
+) {
     match effect {
         Effect::SaveAndConnect {
             id,
@@ -113,7 +112,7 @@ pub(crate) async fn run(
                         })
                         .await
                         .ok();
-                    return Ok(());
+                    return;
                 }
             };
             let store = Arc::clone(&connection.connection_store);
@@ -136,7 +135,7 @@ pub(crate) async fn run(
                             })
                             .await
                             .ok();
-                        return Ok(());
+                        return;
                     }
                 };
                 let dsn = connection.dsn_builder.build_dsn(&profile);
@@ -164,7 +163,7 @@ pub(crate) async fn run(
                         None => {}
                     }
                 });
-                return Ok(());
+                return;
             }
 
             let dsn = connection.dsn_builder.build_dsn(&profile);
@@ -221,7 +220,7 @@ pub(crate) async fn run(
                         }
                     })
                     .await;
-                return Ok(());
+                return;
             }
 
             let target = ConnectionTarget::from_profile(&profile, dsn);
@@ -271,7 +270,6 @@ pub(crate) async fn run(
                     }
                 }
             });
-            Ok(())
         }
 
         Effect::ProbeMySqlConnection { target, run_id } => {
@@ -299,7 +297,6 @@ pub(crate) async fn run(
                     };
                 })
                 .await;
-            Ok(())
         }
 
         Effect::LoadConnectionForEdit { id } => {
@@ -321,7 +318,6 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionEditLoadFailed(e)).ok();
                 }
             });
-            Ok(())
         }
 
         Effect::LoadConnections => {
@@ -350,7 +346,6 @@ pub(crate) async fn run(
                 }))
                 .ok();
             });
-            Ok(())
         }
 
         Effect::DeleteConnection { id } => {
@@ -365,7 +360,6 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionDeleteFailed(e)).ok();
                 }
             });
-            Ok(())
         }
 
         Effect::SwitchConnection { connection_index } => {
@@ -378,7 +372,6 @@ pub(crate) async fn run(
                     .await
                     .ok();
             }
-            Ok(())
         }
 
         Effect::SwitchToService { service_index } => {
@@ -397,7 +390,6 @@ pub(crate) async fn run(
                     .await
                     .ok();
             }
-            Ok(())
         }
 
         _ => unreachable!("connection::run called with non-connection effect"),

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -183,7 +183,7 @@ impl EffectRunner {
                     &self.utility.clipboard,
                     &self.utility.folder_opener,
                 )
-                .await?;
+                .await;
                 Ok(vec![])
             }
 
@@ -215,7 +215,7 @@ impl EffectRunner {
                     &self.metadata_cache,
                     state,
                 )
-                .await?;
+                .await;
                 Ok(vec![])
             }
 
@@ -239,7 +239,7 @@ impl EffectRunner {
                     &self.metadata_tasks,
                     completion_engine,
                 )
-                .await?;
+                .await;
                 Ok(vec![])
             }
 
@@ -263,8 +263,7 @@ impl EffectRunner {
                     &self.query.cached_result_exporter,
                     &self.query_tasks,
                     state,
-                )
-                .await?;
+                );
                 Ok(vec![])
             }
 
@@ -308,7 +307,7 @@ impl EffectRunner {
             | Effect::ClearCompletionEngineCache
             | Effect::ResizeCompletionCache { .. }
             | Effect::TriggerCompletion) => {
-                cmd_completion::run(e, &self.action_tx, state, completion_engine).await?;
+                cmd_completion::run(e, &self.action_tx, state, completion_engine).await;
                 Ok(vec![])
             }
         }

--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 
-use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 
 use crate::cmd::completion_engine::{CompletionDatabaseScope, CompletionEngine};
@@ -14,7 +13,7 @@ pub async fn run(
     action_tx: &mpsc::Sender<Action>,
     state: &AppState,
     completion_engine: &RefCell<CompletionEngine>,
-) -> Result<()> {
+) {
     match effect {
         Effect::CacheTableInCompletionEngine {
             qualified_name,
@@ -23,22 +22,18 @@ pub async fn run(
             completion_engine
                 .borrow_mut()
                 .cache_table_detail(qualified_name, *table);
-            Ok(())
         }
 
         Effect::EvictTablesFromCompletionCache { tables } => {
             completion_engine.borrow_mut().evict_tables(&tables);
-            Ok(())
         }
 
         Effect::ClearCompletionEngineCache => {
             completion_engine.borrow_mut().clear_table_cache();
-            Ok(())
         }
 
         Effect::ResizeCompletionCache { capacity } => {
             completion_engine.borrow_mut().resize_cache(capacity);
-            Ok(())
         }
 
         Effect::TriggerCompletion => {
@@ -104,7 +99,6 @@ pub async fn run(
                 })
                 .await
                 .ok();
-            Ok(())
         }
 
         _ => unreachable!("completion::run called with non-completion effect"),
@@ -142,8 +136,7 @@ mod tests {
             &state,
             &RefCell::new(CompletionEngine::new()),
         )
-        .await
-        .expect("completion should run");
+        .await;
 
         assert!(matches!(
             action_rx.recv().await,

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
@@ -12,7 +11,7 @@ pub(crate) async fn run(
     action_tx: &mpsc::Sender<Action>,
     clipboard: &Arc<dyn ClipboardWriter>,
     folder_opener: &Arc<dyn FolderOpener>,
-) -> Result<()> {
+) {
     match effect {
         Effect::CopyToClipboard {
             content,
@@ -43,7 +42,6 @@ pub(crate) async fn run(
         }
         _ => unreachable!("utility::run called with non-utility effect"),
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -114,8 +112,7 @@ mod tests {
                 &clipboard,
                 &folder_opener,
             )
-            .await
-            .unwrap();
+            .await;
 
             let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
                 .await
@@ -142,8 +139,7 @@ mod tests {
                 &clipboard,
                 &folder_opener,
             )
-            .await
-            .unwrap();
+            .await;
 
             let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
                 .await
@@ -170,8 +166,7 @@ mod tests {
                 &clipboard,
                 &folder_opener,
             )
-            .await
-            .unwrap();
+            .await;
 
             let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
                 .await
@@ -202,8 +197,7 @@ mod tests {
                 &clipboard,
                 &folder_opener,
             )
-            .await
-            .unwrap();
+            .await;
 
             let opened = opener.opened.lock().unwrap();
             assert_eq!(opened.len(), 1);
@@ -225,8 +219,7 @@ mod tests {
                 &clipboard,
                 &folder_opener,
             )
-            .await
-            .unwrap();
+            .await;
 
             let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
                 .await


### PR DESCRIPTION
## Problem

Several effect handlers returned Result even though every operational failure is converted to an Action and none can return Err.

## Approach

Make only those handlers infallible while preserving task ownership, action routing, channel policy, and the genuinely fallible ER boundary.