### PR TITLE
refactor(mysql): centralize server error code parsing

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -2,6 +2,7 @@ use crate::policy::password_masking::mask_password;
 use crate::ports::outbound::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
     SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind, is_mysql_connect_timeout_message,
+    mysql_server_error_code,
 };
 use sabiql_domain::connection::MySqlSslMode;
 use url::Url;
@@ -188,15 +189,6 @@ impl ConnectionErrorKind {
             Self::HostUnreachable | Self::ConnectionLost | Self::Timeout | Self::ConnectionRefused
         )
     }
-}
-
-fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
-    let start = lowercase_details.find("error ")? + "error ".len();
-    let digits = &lowercase_details[start..];
-    let end = digits
-        .find(|character: char| !character.is_ascii_digit())
-        .unwrap_or(digits.len());
-    digits[..end].parse().ok()
 }
 
 fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -9,6 +9,15 @@ pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED"
 pub const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str = "SQLITE_SAFE_MODE_REQUIRED";
 pub const MYSQL_CONNECT_TIMEOUT_ERRNOS: &[&str] = &["(60)", "(110)", "(10060)"];
 
+pub fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
+    let start = lowercase_details.find("error ")? + "error ".len();
+    let digits = &lowercase_details[start..];
+    let end = digits
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(digits.len());
+    digits[..end].parse().ok()
+}
+
 pub fn is_mysql_connect_timeout_message(value: &str) -> bool {
     let lowercase = value.to_ascii_lowercase();
     lowercase.contains("can't connect to mysql server")

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -33,7 +33,7 @@ pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
     SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
-    is_mysql_connect_timeout_message,
+    is_mysql_connect_timeout_message, mysql_server_error_code,
 };
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 
 use crate::app::ports::outbound::{
-    DatabaseCli, DbOperationError, is_mysql_connect_timeout_message,
+    DatabaseCli, DbOperationError, is_mysql_connect_timeout_message, mysql_server_error_code,
 };
 
 use super::probe::mysql_tls_failure_kind;
@@ -131,16 +131,6 @@ fn classify_mysql_server_error(
         3024 => error(DbOperationError::Timeout),
         _ => return None,
     })
-}
-
-fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
-    let marker = "error ";
-    let start = lowercase_details.find(marker)? + marker.len();
-    let digits = &lowercase_details[start..];
-    let end = digits
-        .find(|character: char| !character.is_ascii_digit())
-        .unwrap_or(digits.len());
-    digits[..end].parse().ok()
 }
 
 pub(super) fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {


### PR DESCRIPTION
## Problem

The application and MySQL adapter duplicated the same lexical parser for numeric server error codes.

## Approach

Share only the MySQL-specific numeric extraction while leaving error classification policy in each existing layer unchanged.