### PR TITLE
refactor(mysql): clarify XML field chunk processing

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -261,7 +261,7 @@ impl<R> MySqlXmlFieldLimitReader<R> {
         }
     }
 
-    fn process(&mut self, bytes: &[u8]) -> usize {
+    fn process_chunk(&mut self, bytes: &[u8]) -> usize {
         for (index, &byte) in bytes.iter().enumerate() {
             if !self.process_byte(byte) {
                 return index;
@@ -301,7 +301,7 @@ where
                 if bytes_read == 0 {
                     return Poll::Ready(Ok(()));
                 }
-                let bytes_allowed = self.process(&chunk[..bytes_read]);
+                let bytes_allowed = self.process_chunk(&chunk[..bytes_read]);
                 if bytes_allowed < bytes_read {
                     self.limit_error_pending = true;
                 }


### PR DESCRIPTION
## Problem
`MySqlXmlFieldLimitReader::process` accepts one read chunk and returns the number of bytes allowed through the field-limit state machine, but its name does not identify that chunk-level responsibility.

## Background
The reader is a MySQL-specific `AsyncRead` wrapper whose `poll_read` caller supplies each bounded read chunk.

## Approach
Rename the internal operation to `process_chunk` so the reader state transition and byte-limit behavior are clear at the call site. Runtime behavior and tests are unchanged.

## Screenshots


