### PR TITLE
refactor(mysql): name byte reader explicitly

### DIFF
--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -7,7 +7,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use crate::app::ports::outbound::DbOperationError;
 
 use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
-use super::process::read_all;
+use super::process::read_all_bytes;
 use super::xml::{
     MySqlResultsetFrameScanner,
     take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget,
@@ -261,7 +261,7 @@ async fn finish_mysql_pipe_after_stdout_eof<E>(
 where
     E: AsyncRead + Unpin,
 {
-    let (stderr, status) = tokio::join!(read_all(stderr), child.wait());
+    let (stderr, status) = tokio::join!(read_all_bytes(stderr), child.wait());
     let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     status.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
     pending_stderr.extend_from_slice(&stderr);

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -222,7 +222,7 @@ pub(super) async fn stop_mysql_process(
     Ok((status, true))
 }
 
-pub(super) async fn read_all<R>(reader: &mut R) -> std::io::Result<Vec<u8>>
+pub(super) async fn read_all_bytes<R>(reader: &mut R) -> std::io::Result<Vec<u8>>
 where
     R: AsyncRead + Unpin,
 {
@@ -240,7 +240,8 @@ where
     O: AsyncRead + Unpin,
     E: AsyncRead + Unpin,
 {
-    let (stdout, stderr, status) = tokio::join!(read_all(stdout), read_all(stderr), child.wait());
+    let (stdout, stderr, status) =
+        tokio::join!(read_all_bytes(stdout), read_all_bytes(stderr), child.wait());
     let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     let status = status.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
@@ -406,7 +407,10 @@ pub(super) async fn cleanup_mysql_process(process: &mut MySqlProcess) {
     #[cfg(not(unix))]
     {
         drop(process.stdin.take());
-        let _ = tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+        let _ = tokio::join!(
+            read_all_bytes(&mut process.stdout),
+            read_all_bytes(&mut process.stderr)
+        );
     }
     let _ = process.child.wait().await;
 }


### PR DESCRIPTION
## Problem

The MySQL CLI helper is named `read_all` although it preserves raw bytes.

## Background

The generic name makes the transport boundary less explicit.

## Approach

Rename the helper and its process/pipe callers to `read_all_bytes` without changing PTY/pipe draining, error classification, or lifecycle behavior.