### PR TITLE
refactor: remove JSON detail viewport forwarder

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -258,10 +258,6 @@ impl AppState {
         )
     }
 
-    pub fn json_detail_editor_visible_rows(&self) -> usize {
-        self.ui.json_detail_editor_visible_rows()
-    }
-
     pub fn row_detail_content_visible_rows(&self) -> usize {
         self.ui.row_detail_content_visible_rows
     }

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -360,7 +360,7 @@ fn update_editor_scroll(state: &mut AppState) {
 }
 
 fn effective_visible_rows(state: &AppState) -> usize {
-    match state.json_detail_editor_visible_rows() {
+    match state.ui.json_detail_editor_visible_rows() {
         0 => DEFAULT_JSON_DETAIL_EDITOR_VISIBLE_ROWS,
         rows => rows,
     }


### PR DESCRIPTION
## Problem
`AppState::json_detail_editor_visible_rows` only forwards to `UiState`, so the JSON detail reducer reads its viewport through an unnecessary application facade.

## Background
The viewport value is owned by `UiState`; the single production caller obscures that ownership.

## Approach
Read the viewport directly from `state.ui` and remove the unused `AppState` forwarding method. Layout assignment, default fallback, and JSON detail behavior remain unchanged.