### PR TITLE
refactor(query-history): name detached spawns

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -45,7 +45,7 @@ fn utc_now_iso8601() -> String {
     format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
 }
 
-fn save_query_history(
+fn spawn_query_history_append(
     query_history_store: &Arc<dyn QueryHistoryStore>,
     project_name: &str,
     scope: &QueryHistoryScope,
@@ -198,7 +198,7 @@ pub fn run(
                                 .command_tag
                                 .as_ref()
                                 .and_then(CommandTag::affected_rows);
-                            save_query_history(
+                            spawn_query_history_append(
                                 &history_store,
                                 &project,
                                 scope,
@@ -218,7 +218,7 @@ pub fn run(
                     }
                     Err(e) => {
                         if let Some(scope) = &history_scope {
-                            save_query_history(
+                            spawn_query_history_append(
                                 &history_store,
                                 &project,
                                 scope,
@@ -257,7 +257,7 @@ pub fn run(
                 match executor.execute_write(&dsn, &query, access_mode).await {
                     Ok(result) => {
                         if let Some(scope) = &history_scope {
-                            save_query_history(
+                            spawn_query_history_append(
                                 &history_store,
                                 &project,
                                 scope,
@@ -277,7 +277,7 @@ pub fn run(
                     }
                     Err(e) => {
                         if let Some(scope) = &history_scope {
-                            save_query_history(
+                            spawn_query_history_append(
                                 &history_store,
                                 &project,
                                 scope,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -19,7 +19,7 @@ use crate::cmd::metadata_task::MetadataTaskRegistry;
 use crate::cmd::query_task::{QueryTaskRegistry, TableDetailTaskRegistry};
 use crate::cmd::settings as cmd_settings;
 use crate::cmd::sql_editor::completion as cmd_completion;
-use crate::cmd::sql_editor::query_history as cmd_query_history;
+use crate::cmd::sql_editor::query_history::spawn_query_history_load;
 use crate::cmd::sqlite_diagnostics;
 use crate::cmd::utility as cmd_utility;
 use crate::domain::DatabaseMetadata;
@@ -287,7 +287,7 @@ impl EffectRunner {
             }
 
             e @ Effect::LoadQueryHistory { .. } => {
-                cmd_query_history::run(e, &self.action_tx, &self.query.query_history_store);
+                spawn_query_history_load(e, &self.action_tx, &self.query.query_history_store);
                 Ok(vec![])
             }
 

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -6,7 +6,7 @@ use crate::cmd::effect::Effect;
 use crate::ports::outbound::QueryHistoryStore;
 use crate::update::action::Action;
 
-pub fn run(
+pub fn spawn_query_history_load(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
     query_history_store: &Arc<dyn QueryHistoryStore>,
@@ -32,6 +32,6 @@ pub fn run(
                 }
             });
         }
-        _ => unreachable!("query_history::run called with non-query-history effect"),
+        _ => unreachable!("spawn_query_history_load called with non-query-history effect"),
     }
 }


### PR DESCRIPTION
## Problem
Detached query-history append and load operations were exposed through generic names, obscuring their asynchronous behavior.

## Background
The operations intentionally remain fire-and-forget and preserve their existing scope and timestamp handling.

## Approach
Name both command entry points after the detached spawn they perform while preserving the existing task ownership and action flow.