### PR TITLE
refactor(app): centralize char-to-byte index conversion

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -2,9 +2,9 @@ use std::collections::HashSet;
 
 use crate::cmd::cache::BoundedLruCache;
 use crate::domain::{DatabaseMetadata, DatabaseType, Table, TableSummary};
+use crate::model::shared::text_input::char_to_byte_index;
 use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 use crate::policy::sql::lexer::{SqlContext, SqlLexer, TableReference, Token, TokenKind};
-use crate::update::helpers::char_to_byte_index;
 
 const COMPLETION_MAX_CANDIDATES: usize = 30;
 const TABLE_CACHE_CAPACITY: usize = 500;

--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -1,9 +1,9 @@
 use crate::model::shared::cursor::CursorMove;
 
 use super::text_input::{
-    TextInputEditing, TextInputLike, TextInputState, TextKillDirection, next_word_start,
-    previous_word_start, readline_forward_word_end, readline_previous_whitespace_boundary,
-    readline_previous_word_start,
+    TextInputEditing, TextInputLike, TextInputState, TextKillDirection, char_to_byte_index,
+    next_word_start, previous_word_start, readline_forward_word_end,
+    readline_previous_whitespace_boundary, readline_previous_word_start,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -256,7 +256,7 @@ impl MultiLineInputState {
     }
 
     pub fn char_to_byte_index(&self, char_idx: usize) -> usize {
-        char_to_byte_index_impl(self.content(), char_idx)
+        char_to_byte_index(self.content(), char_idx)
     }
 
     fn rebuild_derived(&mut self) {
@@ -396,12 +396,6 @@ fn find_cursor_position(line_spans: &[LineSpan], cursor: usize) -> (usize, usize
         .saturating_sub(1);
     let span = line_spans.get(row).copied().unwrap_or_default();
     (row, cursor.saturating_sub(span.start).min(span.len))
-}
-
-fn char_to_byte_index_impl(s: &str, char_idx: usize) -> usize {
-    s.char_indices()
-        .nth(char_idx)
-        .map_or(s.len(), |(byte_idx, _)| byte_idx)
 }
 
 #[cfg(test)]

--- a/src/app/model/shared/text_input.rs
+++ b/src/app/model/shared/text_input.rs
@@ -265,7 +265,7 @@ impl TextInputEditing for TextInputState {
     }
 }
 
-fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
+pub(crate) fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
     s.char_indices()
         .nth(char_idx)
         .map_or(s.len(), |(byte_idx, _)| byte_idx)

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -307,12 +307,6 @@ pub fn deletion_refresh_target_bulk(
     }
 }
 
-pub fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
-    s.char_indices()
-        .nth(char_idx)
-        .map_or(s.len(), |(byte_idx, _)| byte_idx)
-}
-
 pub fn find_text_matches(content: &str, query: &str) -> Vec<usize> {
     if query.is_empty() {
         return Vec::new();

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -21,6 +21,6 @@ pub use connection::dispatch_connection;
 pub use dispatch_result::DispatchResult;
 pub use er::dispatch_er;
 pub use explain::dispatch_explain;
-pub use helpers::{char_to_byte_index, validate_all, validate_field};
+pub use helpers::{validate_all, validate_field};
 pub use modal::dispatch_modal;
 pub use sql_editor::dispatch_sql_modal;


### PR DESCRIPTION
## Problem
UTF-8 character-to-byte index conversion was implemented separately in the update helpers and both text input state modules.

## Background
Keeping the conversion in multiple locations makes Unicode boundary behavior harder to audit.

## Approach
Use the shared text input utility as the single implementation, while preserving the existing multiline editor wrapper and all cursor semantics.