### PR TITLE
refactor: remove redundant adhoc status accessors

### DIFF
--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -274,20 +274,6 @@ impl SqlModalContext {
         &self.status
     }
 
-    pub fn last_adhoc_error(&self) -> Option<&str> {
-        match &self.status {
-            SqlModalStatus::Error(error) => Some(error),
-            _ => None,
-        }
-    }
-
-    pub fn last_adhoc_success(&self) -> Option<&AdhocSuccessSnapshot> {
-        match &self.status {
-            SqlModalStatus::Success(snapshot) => Some(snapshot),
-            _ => None,
-        }
-    }
-
     pub fn active_tab(&self) -> SqlModalTab {
         self.active_tab
     }
@@ -770,26 +756,20 @@ mod tests {
             };
             ctx.finish_adhoc_success(snapshot.clone());
             assert!(matches!(
-                &ctx.status,
+                ctx.status(),
                 SqlModalStatus::Success(payload) if payload == &snapshot
             ));
-            assert!(ctx.last_adhoc_success().is_some());
-            assert!(ctx.last_adhoc_error().is_none());
 
             ctx.finish_adhoc_error("syntax error".to_string());
 
             assert!(matches!(
-                &ctx.status,
+                ctx.status(),
                 SqlModalStatus::Error(error) if error == "syntax error"
             ));
-            assert!(ctx.last_adhoc_success().is_none());
-            assert_eq!(ctx.last_adhoc_error(), Some("syntax error"));
 
             ctx.enter_normal();
 
-            assert_eq!(ctx.status, SqlModalStatus::Normal);
-            assert!(ctx.last_adhoc_success().is_none());
-            assert!(ctx.last_adhoc_error().is_none());
+            assert_eq!(ctx.status(), &SqlModalStatus::Normal);
         }
     }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1314,6 +1314,7 @@ mod tests {
     mod query_failed {
         use super::*;
         use crate::model::shared::ui_state::ResultNavMode;
+        use crate::model::sql_editor::modal::SqlModalStatus;
 
         #[test]
         fn resets_result_selection_and_offsets() {
@@ -1476,12 +1477,10 @@ mod tests {
                 effect,
                 Effect::ExecutePreview { table, .. } if table == "users"
             )));
-            assert!(
-                state
-                    .sql_modal
-                    .last_adhoc_error()
-                    .is_some_and(|message| message.contains("later statement failed"))
-            );
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(message) if message.contains("later statement failed")
+            ));
         }
 
         #[test]
@@ -1560,10 +1559,10 @@ mod tests {
 
             dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
-            assert_eq!(
-                state.sql_modal.last_adhoc_error(),
-                Some("previous adhoc error")
-            );
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(message) if message == "previous adhoc error"
+            ));
             let result = state.query.current_result().expect("result");
             assert_eq!(result.source, QuerySource::Preview);
             assert!(result.is_error());
@@ -1881,19 +1880,19 @@ mod tests {
 
             dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
-            let saved_tag = state
-                .sql_modal
-                .last_adhoc_success()
-                .and_then(|s| s.command_tag.clone());
+            let saved_tag = match state.sql_modal.status() {
+                SqlModalStatus::Success(snapshot) => snapshot.command_tag.clone(),
+                _ => panic!("expected adhoc success status"),
+            };
             assert!(matches!(saved_tag, Some(CommandTag::Alter(_))));
 
             let action = query_completed_action(&mut state, preview_result(5), 0, Some(0));
             dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
-            let tag_after = state
-                .sql_modal
-                .last_adhoc_success()
-                .and_then(|s| s.command_tag.clone());
+            let tag_after = match state.sql_modal.status() {
+                SqlModalStatus::Success(snapshot) => snapshot.command_tag.clone(),
+                _ => panic!("expected adhoc success status after preview"),
+            };
             assert!(matches!(tag_after, Some(CommandTag::Alter(_))));
         }
     }

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -412,11 +412,10 @@ mod tests {
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
-            assert_eq!(
-                state.sql_modal.last_adhoc_error(),
-                Some("No active connection")
-            );
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(error) if error == "No active connection"
+            ));
             assert!(effects.is_handled_and(Vec::is_empty));
         }
 
@@ -521,11 +520,10 @@ mod tests {
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalConfirmExecute, Instant::now());
 
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
-            assert_eq!(
-                state.sql_modal.last_adhoc_error(),
-                Some("No active connection")
-            );
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(error) if error == "No active connection"
+            ));
             assert!(effects.is_handled_and(Vec::is_empty));
         }
 
@@ -732,11 +730,11 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(effects.is_empty());
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
-            assert_eq!(
-                state.sql_modal.last_adhoc_error(),
-                Some("Read-only mode: write operations are disabled")
-            );
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(error)
+                    if error == "Read-only mode: write operations are disabled"
+            ));
         }
 
         #[test]
@@ -753,7 +751,10 @@ mod tests {
                 execution_time_ms: 10,
                 mysql_diagnostics: Vec::new(),
             });
-            assert!(state.sql_modal.last_adhoc_success().is_some());
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Success(_)
+            ));
 
             // Now submit a write query in read-only mode
             state
@@ -764,9 +765,11 @@ mod tests {
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
-            assert!(state.sql_modal.last_adhoc_success().is_none());
-            assert!(state.sql_modal.last_adhoc_error().is_some());
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(error)
+                    if error == "Read-only mode: write operations are disabled"
+            ));
         }
 
         #[test]
@@ -820,11 +823,11 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(effects.is_empty());
-            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error(_)));
-            assert_eq!(
-                state.sql_modal.last_adhoc_error(),
-                Some("Read-only mode: write operations are disabled")
-            );
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::Error(error)
+                    if error == "Read-only mode: write operations are disabled"
+            ));
         }
     }
 


### PR DESCRIPTION
## Problem
`last_adhoc_error` and `last_adhoc_success` duplicate `SqlModalStatus` inspection and imply history semantics despite exposing only the current status payload.

## Background
The modal status is the source of truth for the current adhoc success or error state.

## Approach
Remove the redundant accessors and make tests match the existing `status()` variants directly, preserving status transitions and payloads.