### PR TITLE
refactor(app): remove test-only connection error APIs

### DIFF
--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -100,10 +100,6 @@ impl ConnectionErrorState {
         self.scroll_offset = 0;
     }
 
-    pub fn expand_details(&mut self) {
-        self.details_expanded = true;
-    }
-
     pub fn clear(&mut self) {
         self.error_info = None;
         self.details_expanded = false;
@@ -136,14 +132,6 @@ impl ConnectionErrorState {
     pub fn is_copied_visible_at(&self, now: Instant) -> bool {
         self.copied_feedback_expires
             .is_some_and(|expires| now < expires)
-    }
-
-    pub fn clear_expired_feedback_at(&mut self, now: Instant) {
-        if let Some(expires) = self.copied_feedback_expires
-            && expires <= now
-        {
-            self.copied_feedback_expires = None;
-        }
     }
 
     pub fn clear_copied_feedback(&mut self) {
@@ -186,7 +174,7 @@ mod tests {
         #[test]
         fn stores_info_and_resets_ui() {
             let mut state = ConnectionErrorState::default();
-            state.expand_details();
+            state.toggle_details();
             scroll_to(&mut state, 5);
 
             state.set_error(sample_error());
@@ -215,7 +203,7 @@ mod tests {
         fn collapses_details_and_resets_scroll_without_clearing_error() {
             let mut state = ConnectionErrorState::default();
             state.set_error(sample_error());
-            state.expand_details();
+            state.toggle_details();
             scroll_to(&mut state, 4);
 
             state.reset_view();
@@ -233,7 +221,7 @@ mod tests {
         fn resets_all_fields() {
             let mut state = ConnectionErrorState::default();
             state.set_error(sample_error());
-            state.expand_details();
+            state.toggle_details();
             scroll_to(&mut state, 3);
 
             state.clear();
@@ -261,7 +249,7 @@ mod tests {
         #[test]
         fn resets_scroll_on_collapse() {
             let mut state = ConnectionErrorState::default();
-            state.expand_details();
+            state.toggle_details();
             scroll_to(&mut state, 5);
 
             state.toggle_details();
@@ -334,28 +322,6 @@ mod tests {
             state.mark_copied_at(t);
 
             assert!(!state.is_copied_visible_at(t + Duration::from_secs(4)));
-        }
-
-        #[test]
-        fn clear_expired_removes_when_expired() {
-            let mut state = ConnectionErrorState::default();
-            let t = now();
-            state.mark_copied_at(t);
-
-            state.clear_expired_feedback_at(t + Duration::from_secs(4));
-
-            assert!(!state.is_copied_visible_at(t));
-        }
-
-        #[test]
-        fn clear_expired_keeps_when_not_expired() {
-            let mut state = ConnectionErrorState::default();
-            let t = now();
-            state.mark_copied_at(t);
-
-            state.clear_expired_feedback_at(t + Duration::from_secs(1));
-
-            assert!(state.is_copied_visible_at(t));
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1403,7 +1403,7 @@ mod tests {
         #[test]
         fn close_keeps_error_info_for_reopen() {
             let mut state = state_with_error();
-            state.connection_error.expand_details();
+            state.connection_error.toggle_details();
             state.connection_error.scroll_down(usize::MAX);
             let now = Instant::now();
 

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -522,7 +522,7 @@ fn connection_error_expanded() {
         ConnectionErrorKind::Timeout,
         "psql: error: connection to server at \"192.168.1.100\", port 5432 failed: timeout expired",
     ));
-    state.connection_error.expand_details();
+    state.connection_error.toggle_details();
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -539,7 +539,7 @@ fn connection_error_expanded_with_tabs() {
         ConnectionErrorKind::Unknown,
         "psql: error: connection to server at \"localhost\" (127.0.0.1), port 5433 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?",
     ));
-    state.connection_error.expand_details();
+    state.connection_error.toggle_details();
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -563,7 +563,7 @@ fn connection_error_expanded_long_details_capped() {
             ConnectionErrorKind::Unknown,
             &long_details,
         ));
-    state.connection_error.expand_details();
+    state.connection_error.toggle_details();
 
     let output = render_to_string(&mut terminal, &mut state);
 


### PR DESCRIPTION
## Problem

Connection error state exposed production methods used only by tests, which obscured the actual UI state transitions.

## Approach

Remove the dead APIs and update tests to exercise the remaining state transitions through the existing toggle behavior.