### PR TITLE
refactor: rename SQL modal tab input action

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -537,7 +537,7 @@ pub enum Action {
     SqlModalYank,
     SqlModalYankSuccess,
     SqlModalNewLine,
-    SqlModalTab,
+    SqlModalInsertTab,
     SqlModalSubmit,
     SqlModalClear,
     SqlModalCancelConfirm,

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -380,7 +380,7 @@ fn handle_sql_modal_keys_internal(
             target: InputTarget::SqlModal,
         },
         Key::Enter => Action::SqlModalNewLine,
-        Key::Tab => Action::SqlModalTab,
+        Key::Tab => Action::SqlModalInsertTab,
         Key::Char(c) => Action::TextInput {
             target: InputTarget::SqlModal,
             ch: c,
@@ -466,7 +466,7 @@ mod tests {
     enum Expected {
         SqlModalSubmit,
         SqlModalNewLine,
-        SqlModalTab,
+        SqlModalInsertTab,
         SqlModalBackspace,
         SqlModalDelete,
         SqlModalInput(char),
@@ -498,7 +498,7 @@ mod tests {
         match expected {
             Expected::SqlModalSubmit => assert!(matches!(result, Action::SqlModalSubmit)),
             Expected::SqlModalNewLine => assert!(matches!(result, Action::SqlModalNewLine)),
-            Expected::SqlModalTab => assert!(matches!(result, Action::SqlModalTab)),
+            Expected::SqlModalInsertTab => assert!(matches!(result, Action::SqlModalInsertTab)),
             Expected::SqlModalBackspace => assert!(matches!(
                 result,
                 Action::TextBackspace {
@@ -601,7 +601,7 @@ mod tests {
         // Completion-aware keys: behavior when completion is hidden
         #[rstest]
         #[case(Key::Esc, Expected::SqlModalEnterNormal)]
-        #[case(Key::Tab, Expected::SqlModalTab)]
+        #[case(Key::Tab, Expected::SqlModalInsertTab)]
         #[case(Key::Enter, Expected::SqlModalNewLine)]
         #[case(Key::Up, Expected::SqlModalMoveCursor(CursorMove::Up))]
         #[case(Key::Down, Expected::SqlModalMoveCursor(CursorMove::Down))]

--- a/src/app/update/sql_editor/editing.rs
+++ b/src/app/update/sql_editor/editing.rs
@@ -120,7 +120,7 @@ pub(super) fn reduce_editing(
                 .schedule_completion(now + Duration::from_millis(100));
             DispatchResult::handled()
         }
-        Action::SqlModalTab => {
+        Action::SqlModalInsertTab => {
             state.sql_modal.enter_editing();
             state.sql_modal.editor.insert_tab();
             state


### PR DESCRIPTION
## Problem
`Action::SqlModalTab` shares its name with the display `SqlModalTab` model, making input handling and display-tab selection harder to distinguish.

## Background
The Action represents inserting a tab character into SQL text, while the model enum represents SQL, Plan, and Compare display tabs.

## Approach
Rename the input Action to `SqlModalInsertTab` and keep the display model and key behavior unchanged.