### PR TITLE
refactor(app): name enabled action dispatcher

### DIFF
--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -36,7 +36,7 @@ pub fn reduce(
     // Mark dirty for all state-changing actions (except None and Render)
     let should_mark_dirty = !matches!(action, Action::None | Action::Render);
 
-    let effects = reduce_inner(state, action, now, services);
+    let effects = dispatch_enabled_action(state, action, now, services);
 
     if should_mark_dirty {
         state.mark_dirty();
@@ -45,7 +45,7 @@ pub fn reduce(
     effects
 }
 
-fn reduce_inner(
+fn dispatch_enabled_action(
     state: &mut AppState,
     action: Action,
     now: Instant,


### PR DESCRIPTION
## Problem
`reduce_inner` does not communicate that it is the reducer body reached only after feature-policy validation, which makes the dispatch boundary harder to read.

## Background
The outer reducer applies feature gating and dirty-state handling, while this function dispatches enabled actions to feature reducers and handles remaining actions.

## Approach
Rename the reducer body to `dispatch_enabled_action` while preserving dispatch order, passthrough behavior, and dirty marking.