### PR TITLE
refactor: remove dead CSV export action

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -660,13 +660,6 @@ pub enum Action {
         export_query: String,
         file_name: String,
     },
-    ExecuteCsvExport {
-        dsn: String,
-        run_id: u64,
-        export_query: String,
-        file_name: String,
-        row_count: Option<usize>,
-    },
     CsvExportSucceeded {
         dsn: String,
         run_id: u64,

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -278,29 +278,6 @@ pub fn reduce_pagination(
             )
         }
 
-        Action::ExecuteCsvExport {
-            dsn,
-            run_id,
-            export_query,
-            file_name,
-            row_count,
-        } => {
-            if reject_pending_mysql_connection_probe(state, now) {
-                return DispatchResult::handled();
-            }
-            if state.is_stale_query_run(dsn, *run_id) {
-                return DispatchResult::handled();
-            }
-
-            DispatchResult::handled_with(vec![Effect::ExportCsv {
-                dsn: dsn.clone(),
-                run_id: *run_id,
-                query: export_query.clone(),
-                file_name: file_name.clone(),
-                row_count: *row_count,
-            }])
-        }
-
         Action::CsvExportSucceeded {
             dsn,
             run_id,


### PR DESCRIPTION
## Problem
`ExecuteCsvExport` is a production-dead Action with no production constructor.

## Background
CSV confirmation flows already emit the active export effects directly.

## Approach
Remove the unreachable Action variant and reducer arm while preserving the existing CSV request, count, cache, and export effect paths.