### PR TITLE
refactor(app): name ER prefetch actions

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1266,7 +1266,7 @@ mod tests {
         fn prepare_state_for_reload() -> AppState {
             let mut state = make_state();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .queue_table_prefetch("public.users".to_string());

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -364,7 +364,7 @@ mod tests {
         }
     }
 
-    mod begin_prefetch {
+    mod begin_er_prefetch {
         use super::*;
 
         #[test]

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -114,7 +114,7 @@ impl SqlModalContext {
     }
 
     #[must_use]
-    pub fn begin_prefetch(&mut self) -> u64 {
+    pub fn begin_er_prefetch(&mut self) -> u64 {
         if self.prefetch_run.active_id().is_some() && !self.prefetch_tracks_er {
             // Responses from the replaced completion run are stale and will be discarded.
             self.prefetching_tables.clear();
@@ -508,7 +508,7 @@ mod tests {
         #[test]
         fn reset_clears_all_state() {
             let mut ctx = SqlModalContext::default();
-            let _ = ctx.begin_prefetch();
+            let _ = ctx.begin_er_prefetch();
             ctx.queue_table_prefetch("public.users".to_string());
             ctx.start_table_prefetch("public.posts".to_string());
             ctx.fail_table_prefetch(

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -510,8 +510,8 @@ pub enum Action {
         schema: String,
         table: String,
     },
-    StartPrefetchAll,
-    StartPrefetchScoped {
+    StartErPrefetchAll,
+    StartErPrefetchScoped {
         tables: Vec<String>,
     },
     StartCompletionPrefetch {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -200,8 +200,8 @@ mod tests {
         #[test]
         fn stale_prefetch_run_does_not_advance_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let old_run_id = state.sql_modal.begin_prefetch();
-            let _ = state.sql_modal.begin_prefetch();
+            let old_run_id = state.sql_modal.begin_er_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .queue_table_prefetch("public.users".to_string());
@@ -341,7 +341,7 @@ mod tests {
         #[test]
         fn backoff_table_requeued_at_tail_with_process_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             let queued = "public.orders".to_string();
             state.sql_modal.queue_table_prefetch(queued.clone());
@@ -381,7 +381,7 @@ mod tests {
         #[test]
         fn backoff_uses_injected_now() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             let failed_at = Instant::now();
             let now = failed_at.checked_add(Duration::from_secs(1)).unwrap();
@@ -416,7 +416,7 @@ mod tests {
         #[test]
         fn process_queue_does_not_reprocess_requeued_backoff_table() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.fail_table_prefetch(
                 qualified.clone(),
@@ -449,7 +449,7 @@ mod tests {
         #[test]
         fn no_dsn_requeues_without_marking_in_flight() {
             let mut state = AppState::new("test".to_string());
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             state.er_preparation.queue_pending_table(qualified.clone());
 
@@ -474,7 +474,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_gives_up_and_calls_on_table_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             state.er_preparation.queue_pending_table(qualified.clone());
             state.sql_modal.fail_table_prefetch(
@@ -509,7 +509,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
@@ -546,7 +546,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
@@ -586,7 +586,7 @@ mod tests {
         #[test]
         fn expired_backoff_proceeds_normally() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             // Failed 10 seconds ago with retry_count=1 (backoff = 2s, already expired)
             state.sql_modal.fail_table_prefetch(
@@ -625,7 +625,7 @@ mod tests {
         #[test]
         fn increments_retry_count() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.fail_table_prefetch(
                 qualified.clone(),
@@ -664,7 +664,7 @@ mod tests {
         #[test]
         fn first_failure_sets_retry_count_1() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.start_table_prefetch(qualified.clone());
 
@@ -688,7 +688,7 @@ mod tests {
         #[test]
         fn failure_requeues_table_for_retry_with_delayed_process() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.start_table_prefetch(qualified.clone());
             state.er_preparation.start_fetching(&qualified);
@@ -730,7 +730,7 @@ mod tests {
         #[test]
         fn failure_continues_existing_queue_before_retry_delay() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             let failed = "public.users".to_string();
             let queued = "public.posts".to_string();
             state.sql_modal.start_table_prefetch(failed.clone());
@@ -765,7 +765,7 @@ mod tests {
         #[test]
         fn transient_failure_then_success_clears_er_failure_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
@@ -957,9 +957,10 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(530)));
 
-            let effects = dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now())
-                .into_effects()
-                .expect("reducer should handle action");
+            let effects =
+                dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(
                 effects
@@ -973,9 +974,10 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(50)));
 
-            let effects = dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now())
-                .into_effects()
-                .expect("reducer should handle action");
+            let effects =
+                dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(
                 effects
@@ -989,9 +991,10 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(10_001)));
 
-            let effects = dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now())
-                .into_effects()
-                .expect("reducer should handle action");
+            let effects =
+                dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(
                 effects
@@ -1005,7 +1008,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(10)));
 
-            dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now());
+            dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now());
 
             assert!(state.er_preparation.fk_expanded());
         }
@@ -1014,7 +1017,7 @@ mod tests {
         fn process_queue_starts_prefetch_effects_without_action_redispatch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(2)));
-            dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now());
+            dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now());
             let run_id = state
                 .sql_modal
                 .active_prefetch_run_id()
@@ -1059,14 +1062,14 @@ mod tests {
         #[test]
         fn second_call_while_running_is_ignored() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .er_preparation
                 .queue_pending_table("public.users".to_string());
 
             let effects = dispatch_metadata(
                 &mut state,
-                &Action::StartPrefetchScoped {
+                &Action::StartErPrefetchScoped {
                     tables: vec!["public.posts".to_string()],
                 },
                 Instant::now(),
@@ -1090,7 +1093,7 @@ mod tests {
 
             let effects = dispatch_metadata(
                 &mut state,
-                &Action::StartPrefetchScoped {
+                &Action::StartErPrefetchScoped {
                     tables: tables.clone(),
                 },
                 Instant::now(),
@@ -1134,7 +1137,7 @@ mod tests {
 
             let effects = dispatch_metadata(
                 &mut state,
-                &Action::StartPrefetchScoped { tables },
+                &Action::StartErPrefetchScoped { tables },
                 Instant::now(),
             )
             .into_effects()
@@ -1227,7 +1230,7 @@ mod tests {
 
             let effects = dispatch_metadata(
                 &mut state,
-                &Action::StartPrefetchScoped {
+                &Action::StartErPrefetchScoped {
                     tables: vec!["public.orders".to_string()],
                 },
                 Instant::now(),
@@ -1262,7 +1265,7 @@ mod tests {
         #[test]
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_unexpanded();
             // pending and fetching are empty → is_complete() = true
@@ -1294,8 +1297,8 @@ mod tests {
         #[test]
         fn stale_expand_does_not_start_neighbor_extraction() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let stale_run_id = state.sql_modal.begin_prefetch();
-            let current_run_id = state.sql_modal.begin_prefetch();
+            let stale_run_id = state.sql_modal.begin_er_prefetch();
+            let current_run_id = state.sql_modal.begin_er_prefetch();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1321,7 +1324,7 @@ mod tests {
         #[test]
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
@@ -1345,7 +1348,7 @@ mod tests {
         #[test]
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
@@ -1404,8 +1407,8 @@ mod tests {
         #[test]
         fn stale_neighbors_from_previous_run_do_not_mutate_current_run() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let stale_run_id = state.sql_modal.begin_prefetch();
-            let current_run_id = state.sql_modal.begin_prefetch();
+            let stale_run_id = state.sql_modal.begin_er_prefetch();
+            let current_run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
@@ -1430,7 +1433,7 @@ mod tests {
         #[test]
         fn duplicate_neighbors_are_not_requeued() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation
@@ -1473,7 +1476,7 @@ mod tests {
         fn phase2_table_retry_limit_triggers_completion() {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -937,7 +937,7 @@ mod tests {
         }
     }
 
-    mod start_prefetch_all {
+    mod start_er_prefetch_all {
         use super::*;
         use crate::domain::{DatabaseMetadata, TableSummary};
 
@@ -1044,7 +1044,7 @@ mod tests {
         }
     }
 
-    mod start_prefetch_scoped {
+    mod start_er_prefetch_scoped {
         use super::*;
         use crate::domain::{DatabaseMetadata, TableSummary};
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -95,12 +95,12 @@ pub(super) fn reduce_prefetch(
     now: Instant,
 ) -> DispatchResult {
     match action {
-        Action::StartPrefetchAll => {
+        Action::StartErPrefetchAll => {
             if (state.sql_modal.active_prefetch_run_id().is_none()
                 || !state.sql_modal.prefetch_tracks_er())
                 && let Some(metadata) = state.session.metadata()
             {
-                let run_id = state.sql_modal.begin_prefetch();
+                let run_id = state.sql_modal.begin_er_prefetch();
                 let qualified_names: Vec<String> = metadata
                     .table_summaries
                     .iter()
@@ -126,13 +126,13 @@ pub(super) fn reduce_prefetch(
             }
         }
 
-        Action::StartPrefetchScoped { tables } => {
+        Action::StartErPrefetchScoped { tables } => {
             if state.sql_modal.active_prefetch_run_id().is_some()
                 && state.sql_modal.prefetch_tracks_er()
             {
                 DispatchResult::handled()
             } else {
-                let run_id = state.sql_modal.begin_prefetch();
+                let run_id = state.sql_modal.begin_er_prefetch();
                 state.er_preparation.begin_scoped_prefetch(tables);
 
                 for qualified_name in tables {

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1646,7 +1646,7 @@ mod tests {
         #[test]
         fn ddl_resets_prefetch_state_and_clears_table_detail() {
             let mut state = state_with_table("public", "users");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .queue_table_prefetch("public.users".to_string());

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -2458,7 +2458,7 @@ mod tests {
             state
                 .connection_caches
                 .save(&target_id, ConnectionCache::default());
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .queue_table_prefetch("public.users".to_string());
@@ -2474,7 +2474,7 @@ mod tests {
         fn switch_without_cache_resets_sql_prefetch() {
             let mut state = AppState::new("test".to_string());
             let new_id = ConnectionId::new();
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .queue_table_prefetch("public.users".to_string());

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -118,7 +118,7 @@ mod tests {
         #[test]
         fn active_prefetch_run_still_resets_and_emits_smart_refresh() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
@@ -176,7 +176,7 @@ mod tests {
         #[test]
         fn no_metadata_returns_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -356,7 +356,7 @@ mod tests {
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
+                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchScoped { .. }))
             )));
         }
 
@@ -385,7 +385,7 @@ mod tests {
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
+                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchScoped { .. }))
             )));
         }
 
@@ -443,7 +443,7 @@ mod tests {
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
+                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchScoped { .. }))
             )));
         }
 
@@ -617,7 +617,7 @@ mod tests {
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchAll))
+                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchAll))
             )));
         }
 
@@ -750,7 +750,7 @@ mod tests {
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchAll))
+                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchAll))
             )));
         }
     }

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -70,9 +70,9 @@ pub(super) fn reduce_smart_refresh_completed(
                     format!("Refreshing {} table(s) for ER diagram...", refetch.len()),
                     now,
                 );
-                effects.push(Effect::DispatchActions(vec![Action::StartPrefetchScoped {
-                    tables: refetch,
-                }]));
+                effects.push(Effect::DispatchActions(vec![
+                    Action::StartErPrefetchScoped { tables: refetch },
+                ]));
             }
 
             DispatchResult::handled_with(effects)

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -43,7 +43,7 @@ pub(super) fn reduce_smart_refresh_failed(
             );
             DispatchResult::handled_with(vec![
                 Effect::ClearCompletionEngineCache,
-                Effect::DispatchActions(vec![Action::StartPrefetchAll]),
+                Effect::DispatchActions(vec![Action::StartErPrefetchAll]),
             ])
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1762,7 +1762,7 @@ mod tests {
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .er_preparation
                 .queue_pending_table("public.users".to_string());
@@ -1783,7 +1783,7 @@ mod tests {
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1813,7 +1813,7 @@ mod tests {
         fn no_metadata_returns_error() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1859,7 +1859,7 @@ mod tests {
         fn emits_cache_effect() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .start_table_prefetch("public.users".to_string());
@@ -1890,7 +1890,7 @@ mod tests {
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state
                 .sql_modal
                 .queue_table_prefetch("public.orders".to_string());
@@ -2997,7 +2997,7 @@ mod tests {
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_er_prefetch();
             state
                 .er_preparation
                 .set_targets(vec!["public.users".to_string()]);
@@ -3036,12 +3036,12 @@ mod tests {
             assert!(effects.iter().any(|effect| matches!(
                 effect,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|action| matches!(action, Action::StartPrefetchAll))
+                    if actions.iter().any(|action| matches!(action, Action::StartErPrefetchAll))
             )));
 
             reduce(
                 &mut state,
-                Action::StartPrefetchAll,
+                Action::StartErPrefetchAll,
                 Instant::now(),
                 &AppServices::stub(),
             );
@@ -3055,7 +3055,7 @@ mod tests {
         fn prefetch_complete_dispatches_er_generate() {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation
@@ -3086,7 +3086,7 @@ mod tests {
         fn prefetch_complete_with_failures_does_not_auto_open() {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation


### PR DESCRIPTION
## Problem
ER-only prefetch entry points use generic names that make them appear interchangeable with completion prefetch.

## Background
The ER and completion paths share queue state but retain different ownership and lifecycle semantics.

## Approach
Rename the ER-specific context method and Action variants while preserving queue behavior, feature gating, state transitions, and Action ordering. Update the affected tests to use the explicit vocabulary.