### PR TITLE
refactor: remove dead RLS status display

### DIFF
--- a/src/domain/rls.rs
+++ b/src/domain/rls.rs
@@ -27,16 +27,6 @@ pub enum RlsCommand {
     Delete,
 }
 
-impl RlsInfo {
-    pub fn status_display(&self) -> &'static str {
-        match (self.enabled, self.force) {
-            (true, true) => "ENABLED (FORCED)",
-            (true, false) => "ENABLED",
-            (false, _) => "DISABLED",
-        }
-    }
-}
-
 impl std::fmt::Display for RlsCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
## Problem
`RlsInfo::status_display` has no production caller, while the Inspector already renders PostgreSQL RLS status from its structured fields.

## Approach
Remove the dead domain formatter and preserve the existing `RlsInfo` model and Inspector presentation path.