### PR TITLE
refactor(app): align inspector load state naming

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -684,7 +684,7 @@ mod tests {
         let services = AppServices::stub();
         let view_model = state.inspector_view_model(services.ddl_generator.as_ref());
 
-        assert_eq!(view_model.load_state(), &InspectorLoadState::Success);
+        assert_eq!(view_model.load_state(), &InspectorLoadState::Loaded);
         assert!(view_model.section().is_some());
     }
 

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -24,7 +24,7 @@ pub struct InspectorViewModel {
 pub enum InspectorLoadState {
     NoTableSelected,
     Loading,
-    Success,
+    Loaded,
     Error(String),
 }
 
@@ -152,7 +152,7 @@ impl InspectorViewModel {
         let (load_state, table) = match table_detail_state {
             TableDetailState::NotSelected => (InspectorLoadState::NoTableSelected, None),
             TableDetailState::Loading => (InspectorLoadState::Loading, None),
-            TableDetailState::Loaded(table) => (InspectorLoadState::Success, Some(table.as_ref())),
+            TableDetailState::Loaded(table) => (InspectorLoadState::Loaded, Some(table.as_ref())),
             TableDetailState::Error(error) => (InspectorLoadState::Error(error.clone()), None),
         };
         let Some(table) = table else {

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -137,7 +137,7 @@ impl Inspector {
                 );
                 return ViewportPlan::default();
             }
-            InspectorLoadState::Success => {}
+            InspectorLoadState::Loaded => {}
         }
 
         if let Some(empty_state) = view_model.empty_state() {


### PR DESCRIPTION
## Problem
InspectorLoadState uses Success while the upstream TableDetailState uses Loaded, making the load lifecycle vocabulary inconsistent.

## Background
The inspector is the shared presentation model for PostgreSQL, MySQL, and SQLite, so the mismatch is visible across all database paths.

## Approach
Rename the inspector load-state variant and its references to Loaded while preserving state transitions, section handling, and rendering behavior.