### PR TITLE
refactor: name prefetched table details

### DIFF
--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -270,11 +270,11 @@ async fn handle_smart_refresh_cache_and_diff(
 
     let TableSignatureSnapshot {
         signatures,
-        table_details,
+        prefetched_table_details,
     } = Arc::unwrap_or_clone(signature_snapshot);
     {
         let mut engine = completion_engine.borrow_mut();
-        for detail in table_details {
+        for detail in prefetched_table_details {
             engine.cache_table_detail(detail.qualified_name(), detail);
         }
     }
@@ -435,7 +435,7 @@ mod tests {
                     name: "items".to_string(),
                     signature: "signature".to_string(),
                 }],
-                table_details: vec![table],
+                prefetched_table_details: vec![table],
             }),
         )
         .await

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -518,7 +518,7 @@ mod tests {
                 new_metadata: make_metadata(1),
                 signature_snapshot: Arc::new(TableSignatureSnapshot {
                     signatures: Vec::new(),
-                    table_details: Vec::new(),
+                    prefetched_table_details: Vec::new(),
                 }),
             })
         }

--- a/src/domain/table.rs
+++ b/src/domain/table.rs
@@ -78,7 +78,7 @@ impl TableSignature {
 #[derive(Debug, Clone)]
 pub struct TableSignatureSnapshot {
     pub signatures: Vec<TableSignature>,
-    pub table_details: Vec<Table>,
+    pub prefetched_table_details: Vec<Table>,
 }
 
 impl TableSummary {

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -145,7 +145,7 @@ fn table_signatures_from_metadata(
     }
 
     let mut signatures = Vec::with_capacity(tables.len());
-    let mut table_details = Vec::with_capacity(tables.len());
+    let mut prefetched_table_details = Vec::with_capacity(tables.len());
     for table in tables {
         let key = (table.schema.clone(), table.name.clone());
         let mut columns = columns_by_table.remove(&key).ok_or_else(|| {
@@ -197,11 +197,11 @@ fn table_signatures_from_metadata(
             name: table.name.clone(),
             signature: table_signature(&detail),
         });
-        table_details.push(detail);
+        prefetched_table_details.push(detail);
     }
     Ok(TableSignatureSnapshot {
         signatures,
-        table_details,
+        prefetched_table_details,
     })
 }
 
@@ -633,7 +633,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(signatures.signatures.len(), 2);
-        assert_eq!(signatures.table_details.len(), 2);
+        assert_eq!(signatures.prefetched_table_details.len(), 2);
         assert_eq!(signatures.signatures[0].qualified_name(), "App.child");
         assert!(signatures.signatures[0].signature.contains("id"));
         assert!(
@@ -641,7 +641,7 @@ mod tests {
                 .signature
                 .contains("fk_child_parent")
         );
-        let child = &signatures.table_details[0];
+        let child = &signatures.prefetched_table_details[0];
         assert_eq!(child.columns.len(), 2);
         assert!(child.columns[1].is_unique());
         assert_eq!(child.foreign_keys.len(), 1);
@@ -782,9 +782,9 @@ done
         });
 
         assert_eq!(snapshot.signatures.len(), 1);
-        assert_eq!(snapshot.table_details.len(), 1);
+        assert_eq!(snapshot.prefetched_table_details.len(), 1);
         assert_eq!(
-            snapshot.table_details[0]
+            snapshot.prefetched_table_details[0]
                 .storage_attributes
                 .engine
                 .as_deref(),

--- a/src/infra/adapters/postgres/metadata.rs
+++ b/src/infra/adapters/postgres/metadata.rs
@@ -54,7 +54,7 @@ impl MetadataProvider for PostgresAdapter {
             .await?;
         Ok(TableSignatureSnapshot {
             signatures: Self::parse_table_signatures(&json)?,
-            table_details: Vec::new(),
+            prefetched_table_details: Vec::new(),
         })
     }
 

--- a/src/infra/adapters/sqlite/metadata/mod.rs
+++ b/src/infra/adapters/sqlite/metadata/mod.rs
@@ -77,7 +77,7 @@ impl MetadataProvider for SqliteAdapter {
             .collect::<Result<Vec<_>, DbOperationError>>()?;
         Ok(TableSignatureSnapshot {
             signatures,
-            table_details: Vec::new(),
+            prefetched_table_details: Vec::new(),
         })
     }
 }


### PR DESCRIPTION
## Problem
`TableSignatureSnapshot.table_details` stores prefetched table details only for MySQL, while PostgreSQL and SQLite provide an empty vector.

## Background
The field name does not identify the cache-seeding role of the MySQL-only data.

## Approach
Rename the snapshot field and its local/fixture references to `prefetched_table_details`, preserving the metadata contents, empty-vector behavior, and ER cache flow.