### PR TITLE
refactor(app): move column display policy

### DIFF
--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -5,6 +5,7 @@ use crate::domain::{
 use crate::model::browse::session::TableDetailState;
 use crate::model::shared::engine_feature_profile::{EngineFeatureProfile, InspectorInfoField};
 use crate::model::shared::inspector_tab::InspectorTab;
+use crate::policy::column::column_read_only_reason;
 use crate::policy::table_kind::{inspector_flags_label, inspector_kind_label};
 use crate::ports::outbound::DdlGenerator;
 
@@ -187,7 +188,7 @@ impl InspectorViewModel {
                 let show_read_only = table
                     .columns
                     .iter()
-                    .any(|column| column.read_only_reason().is_some());
+                    .any(|column| column_read_only_reason(column).is_some());
                 let rows: Vec<InspectorColumnRow> = table
                     .columns
                     .iter()
@@ -196,7 +197,7 @@ impl InspectorViewModel {
                         data_type: column.data_type.clone(),
                         nullable: column.is_nullable(),
                         primary_key: column.is_primary_key(),
-                        read_only_reason: column.read_only_reason().map(ToString::to_string),
+                        read_only_reason: column_read_only_reason(column).map(ToString::to_string),
                         default: column.default.clone(),
                         comment: column.comment.clone(),
                         character_set_name: column.character_set_name.clone(),

--- a/src/app/policy/column.rs
+++ b/src/app/policy/column.rs
@@ -1,0 +1,76 @@
+use crate::domain::{Column, ColumnGenerationKind};
+
+pub const fn column_generation_kind_label(kind: ColumnGenerationKind) -> &'static str {
+    match kind {
+        ColumnGenerationKind::Virtual => "VIRTUAL",
+        ColumnGenerationKind::Stored => "STORED",
+    }
+}
+
+pub const fn column_read_only_reason(column: &Column) -> Option<&'static str> {
+    if column.is_generated() {
+        Some("generated")
+    } else if column.is_hidden() {
+        Some("hidden")
+    } else if column.is_read_only() {
+        Some("read-only")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::{Column, ColumnAttributes, ColumnGenerationKind};
+    use rstest::rstest;
+
+    use super::{column_generation_kind_label, column_read_only_reason};
+
+    #[rstest]
+    #[case(ColumnGenerationKind::Virtual, "VIRTUAL")]
+    #[case(ColumnGenerationKind::Stored, "STORED")]
+    fn generation_kind_label_describes_storage_mode(
+        #[case] kind: ColumnGenerationKind,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(column_generation_kind_label(kind), expected);
+    }
+
+    #[rstest]
+    #[case(true, false, false, Some("read-only"))]
+    #[case(true, true, false, Some("hidden"))]
+    #[case(true, false, true, Some("generated"))]
+    #[case(true, true, true, Some("generated"))]
+    #[case(false, false, false, None)]
+    fn column_flags_report_read_only_reason(
+        #[case] read_only: bool,
+        #[case] hidden: bool,
+        #[case] generated: bool,
+        #[case] expected: Option<&str>,
+    ) {
+        let mut attributes = ColumnAttributes::from_parts(true, false, false);
+        if read_only {
+            attributes = attributes | ColumnAttributes::READ_ONLY;
+        }
+        if hidden {
+            attributes = attributes | ColumnAttributes::HIDDEN;
+        }
+        if generated {
+            attributes = attributes | ColumnAttributes::GENERATED;
+        }
+        let column = Column {
+            name: "col".to_string(),
+            data_type: "text".to_string(),
+            default: None,
+            attributes,
+            comment: None,
+            ordinal_position: 1,
+            character_set_name: None,
+            collation_name: None,
+            generation_expression: None,
+            generation_kind: None,
+        };
+
+        assert_eq!(column_read_only_reason(&column), expected);
+    }
+}

--- a/src/app/policy/mod.rs
+++ b/src/app/policy/mod.rs
@@ -1,3 +1,4 @@
+pub mod column;
 pub mod feature_policy;
 pub mod json;
 pub(crate) mod password_masking;

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -10,6 +10,7 @@ use crate::domain::connection::{
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
+use crate::policy::column::column_read_only_reason;
 use crate::policy::write::inline_cell_edit::InlineCellEditError;
 use crate::policy::write::write_guardrails::{
     PreviewWriteability, StableRowIdentity, TargetSummary, WriteOperation, WritePreview,
@@ -198,7 +199,7 @@ pub fn ensure_column_writable(
             .find(|column| column.name == column_name)
     }) && column.is_read_only()
     {
-        let reason = column.read_only_reason().unwrap_or("read-only");
+        let reason = column_read_only_reason(column).unwrap_or("read-only");
         return Err(EditGuardrailError::ReadOnlyColumn(format!(
             "{column_name} ({reason})"
         )));

--- a/src/domain/column.rs
+++ b/src/domain/column.rs
@@ -18,15 +18,6 @@ pub enum ColumnGenerationKind {
     Stored,
 }
 
-impl ColumnGenerationKind {
-    pub const fn label(self) -> &'static str {
-        match self {
-            Self::Virtual => "VIRTUAL",
-            Self::Stored => "STORED",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ColumnAttributes(u8);
 
@@ -94,18 +85,6 @@ impl Column {
     pub const fn is_generated(&self) -> bool {
         self.attributes.contains(ColumnAttributes::GENERATED)
     }
-
-    pub const fn read_only_reason(&self) -> Option<&'static str> {
-        if self.is_generated() {
-            Some("generated")
-        } else if self.is_hidden() {
-            Some("hidden")
-        } else if self.is_read_only() {
-            Some("read-only")
-        } else {
-            None
-        }
-    }
 }
 
 #[cfg(test)]
@@ -151,44 +130,6 @@ mod tests {
             let attributes = ColumnAttributes::NULLABLE | ColumnAttributes::PRIMARY_KEY;
 
             assert_eq!(attributes, ColumnAttributes::from_parts(true, true, false));
-        }
-
-        #[rstest]
-        #[case(true, false, false, Some("read-only"))]
-        #[case(true, true, false, Some("hidden"))]
-        #[case(true, false, true, Some("generated"))]
-        #[case(true, true, true, Some("generated"))]
-        #[case(false, false, false, None)]
-        fn metadata_flags_report_read_only_reason(
-            #[case] read_only: bool,
-            #[case] hidden: bool,
-            #[case] generated: bool,
-            #[case] expected: Option<&str>,
-        ) {
-            let mut attributes = ColumnAttributes::from_parts(true, false, false);
-            if read_only {
-                attributes = attributes | ColumnAttributes::READ_ONLY;
-            }
-            if hidden {
-                attributes = attributes | ColumnAttributes::HIDDEN;
-            }
-            if generated {
-                attributes = attributes | ColumnAttributes::GENERATED;
-            }
-            let column = Column {
-                name: "col".to_string(),
-                data_type: "text".to_string(),
-                default: None,
-                attributes,
-                comment: None,
-                ordinal_position: 1,
-                character_set_name: None,
-                collation_name: None,
-                generation_expression: None,
-                generation_kind: None,
-            };
-
-            assert_eq!(column.read_only_reason(), expected);
         }
     }
 }

--- a/src/infra/adapters/sqlite/metadata/table_detail_tests.rs
+++ b/src/infra/adapters/sqlite/metadata/table_detail_tests.rs
@@ -1,3 +1,4 @@
+use crate::app::policy::column::column_read_only_reason;
 use crate::app::ports::outbound::{DbOperationError, DdlGenerator, MetadataProvider};
 use crate::domain::{
     DatabaseType, FkAction, IndexType, TableKind, TriggerEvent, TriggerTiming, UNRESOLVED_FK_COLUMN,
@@ -401,7 +402,7 @@ mod table_detail {
             .unwrap();
         assert!(generated.is_read_only());
         assert!(generated.is_generated());
-        assert_eq!(generated.read_only_reason(), Some("generated"));
+        assert_eq!(column_read_only_reason(generated), Some("generated"));
 
         let fts = adapter
             .fetch_table_detail(&dsn, "main", "notes_fts")
@@ -414,7 +415,7 @@ mod table_detail {
             .unwrap();
         assert!(hidden.is_read_only());
         assert!(hidden.is_hidden());
-        assert_eq!(hidden.read_only_reason(), Some("hidden"));
+        assert_eq!(column_read_only_reason(hidden), Some("hidden"));
     }
 
     #[tokio::test]

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -19,6 +19,7 @@ use crate::app::model::shared::viewport::{
     ColumnWidthConfig, MAX_COL_WIDTH, SelectionContext, ViewportPlan, select_viewport_columns,
     widths_fingerprint,
 };
+use crate::app::policy::column::column_generation_kind_label;
 use crate::app::services::AppServices;
 use crate::domain::DatabaseType;
 use crate::primitives::atoms::{apply_yank_flash, panel_block};
@@ -850,8 +851,10 @@ fn column_row_cells(row: &InspectorColumnRow, options: ColumnDisplayOptions) -> 
 
 fn generation_display(row: &InspectorColumnRow) -> String {
     match (row.generation_kind, row.generation_expression.as_deref()) {
-        (Some(kind), Some(expression)) => format!("{}: {expression}", kind.label()),
-        (Some(kind), None) => kind.label().to_string(),
+        (Some(kind), Some(expression)) => {
+            format!("{}: {expression}", column_generation_kind_label(kind))
+        }
+        (Some(kind), None) => column_generation_kind_label(kind).to_string(),
         (None, Some(expression)) => expression.to_string(),
         (None, None) => String::new(),
     }


### PR DESCRIPTION
## Problem
Column presentation wording for generated, hidden, and read-only columns is owned by the domain layer.

## Background
The flags and generation kinds remain domain data, while their display wording is presentation policy.

## Approach
Move the two formatters into the app policy layer and route Inspector, write guard, UI generation rendering, and SQLite metadata tests through them while preserving precedence and messages.