### PR TITLE
refactor(ui): remove connection error render wrapper

### DIFF
--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -15,10 +15,6 @@ pub struct ConnectionError;
 
 impl ConnectionError {
     pub fn render(frame: &mut Frame, state: &AppState, now: Instant, theme: &ThemePalette) {
-        Self::render_at(frame, state, now, theme);
-    }
-
-    pub fn render_at(frame: &mut Frame, state: &AppState, now: Instant, theme: &ThemePalette) {
         let error_state = &state.connection_error;
         let Some(error_info) = error_state.error_info() else {
             return;


### PR DESCRIPTION
## Problem
The connection error UI exposes a render entry point that only forwards to a second implementation, making the rendering boundary appear duplicated.

## Background
The layout already supplies the render timestamp and is the only production caller.

## Approach
Use the existing render entry point as the sole implementation while preserving the timestamp, layout, and all connection-error presentation behavior.

## Screenshots
Not applicable; this is a behavior-preserving cleanup.