### PR TITLE
refactor: align MySQL result set scanner naming

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -406,7 +406,7 @@ pub(super) async fn stream_mysql_resultset_to_csv(
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: super::xml::MySqlResultsetFrameScanner::default(),
+            frame_scanner: super::xml::MySqlResultSetFrameScanner::default(),
             started: false,
         };
         let source = MySqlXmlFieldLimitReader::new(source);

--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -9,7 +9,7 @@ use crate::app::ports::outbound::DbOperationError;
 use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
 use super::process::read_all_bytes;
 use super::xml::{
-    MySqlResultsetFrameScanner,
+    MySqlResultSetFrameScanner,
     take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget,
     trace_mysql_frame,
 };
@@ -148,7 +148,7 @@ pub(super) async fn read_one_mysql_resultset_from_pipes<R, E>(
     child: &mut tokio::process::Child,
     pending: &mut Vec<u8>,
     pending_stderr: &mut Vec<u8>,
-    frame_scanner: &mut MySqlResultsetFrameScanner,
+    frame_scanner: &mut MySqlResultSetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
     preview_byte_budget: bool,
 ) -> Result<Vec<u8>, DbOperationError>
@@ -176,7 +176,7 @@ pub(super) async fn read_one_mysql_resultset_from_pipes_with_diagnostics<R, E>(
     child: &mut tokio::process::Child,
     pending: &mut Vec<u8>,
     pending_stderr: &mut Vec<u8>,
-    frame_scanner: &mut MySqlResultsetFrameScanner,
+    frame_scanner: &mut MySqlResultSetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
     preview_byte_budget: bool,
 ) -> Result<(Vec<u8>, Vec<crate::domain::DatabaseDiagnostic>), DbOperationError>
@@ -374,7 +374,7 @@ mod tests {
             .unwrap();
         drop(stdout_writer);
         drop(stderr_writer);
-        let mut frame_scanner = MySqlResultsetFrameScanner::default();
+        let mut frame_scanner = MySqlResultSetFrameScanner::default();
         let mut child = exited_child();
 
         let result = read_one_mysql_resultset_from_pipes(
@@ -410,7 +410,7 @@ mod tests {
         let mut stderr = child.stderr.take().expect("piped stderr");
         let mut pending = Vec::new();
         let mut pending_stderr = Vec::new();
-        let mut frame_scanner = MySqlResultsetFrameScanner::default();
+        let mut frame_scanner = MySqlResultSetFrameScanner::default();
 
         let result = read_one_mysql_resultset_from_pipes(
             &mut stdout,

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -31,7 +31,7 @@ use super::pty::{
     read_pty_all, read_pty_until_idle,
 };
 use super::sanitize_mysql_command_environment;
-use super::xml::{MySqlResultsetFrameScanner, parse_mysql_xml, trace_mysql_statement};
+use super::xml::{MySqlResultSetFrameScanner, parse_mysql_xml, trace_mysql_statement};
 
 mod session;
 pub(in crate::adapters::mysql) use session::MySqlMetadataSession;
@@ -72,7 +72,7 @@ pub(in crate::adapters::mysql) struct MySqlProcess {
     #[cfg(not(unix))]
     pub(super) pending_stderr: Vec<u8>,
     #[cfg(not(unix))]
-    pub(super) frame_scanner: MySqlResultsetFrameScanner,
+    pub(super) frame_scanner: MySqlResultSetFrameScanner,
 }
 
 impl MySqlProcess {
@@ -156,7 +156,7 @@ impl MySqlProcess {
                 stderr,
                 pending: Vec::new(),
                 pending_stderr: Vec::new(),
-                frame_scanner: MySqlResultsetFrameScanner::default(),
+                frame_scanner: MySqlResultSetFrameScanner::default(),
             })
         }
     }
@@ -198,7 +198,7 @@ impl MySqlProcess {
                 input,
                 output,
                 pending: Vec::new(),
-                frame_scanner: MySqlResultsetFrameScanner::default(),
+                frame_scanner: MySqlResultSetFrameScanner::default(),
             },
         })
     }
@@ -645,7 +645,7 @@ mod tests {
                 input: TokioFile::from_std(master.try_clone().expect("clone PTY master")),
                 output: TokioFile::from_std(master),
                 pending: Vec::new(),
-                frame_scanner: MySqlResultsetFrameScanner::default(),
+                frame_scanner: MySqlResultSetFrameScanner::default(),
             };
 
             assert!(
@@ -2067,7 +2067,7 @@ mod windows_tests {
             stderr,
             pending: Vec::new(),
             pending_stderr: b"ERROR 1".to_vec(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
         };
         let directory = tempfile::tempdir().expect("temporary directory");
         let path = directory.path().join("export.csv");
@@ -2118,7 +2118,7 @@ mod windows_tests {
             stderr,
             pending: Vec::new(),
             pending_stderr: b"ERROR 1".to_vec(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
         };
 
         let result =
@@ -2157,7 +2157,7 @@ mod windows_tests {
             stderr,
             pending: Vec::new(),
             pending_stderr: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
         };
 
         let result =

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -14,7 +14,7 @@ use super::error::{
     classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error, trace_mysql_error,
 };
 use super::xml::{
-    MySqlResultsetFrameScanner, take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget,
+    MySqlResultSetFrameScanner, take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget,
     trace_mysql_frame,
 };
 
@@ -22,7 +22,7 @@ pub(super) struct MySqlPty {
     pub(super) input: TokioFile,
     pub(super) output: TokioFile,
     pub(super) pending: Vec<u8>,
-    pub(super) frame_scanner: MySqlResultsetFrameScanner,
+    pub(super) frame_scanner: MySqlResultSetFrameScanner,
 }
 
 pub(super) fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
@@ -190,7 +190,7 @@ pub(super) struct MySqlExportPtySource<'a> {
     pub(super) error_output: Vec<u8>,
     pub(super) error_buffer: Vec<u8>,
     pub(super) pending: Vec<u8>,
-    pub(super) frame_scanner: MySqlResultsetFrameScanner,
+    pub(super) frame_scanner: MySqlResultSetFrameScanner,
     pub(super) started: bool,
 }
 
@@ -302,7 +302,7 @@ mod tests {
             input: TokioFile::from_std(input_file.reopen().unwrap()),
             output: TokioFile::from_std(output_file.reopen().unwrap()),
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
         };
         (output_file, pty)
     }
@@ -352,7 +352,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
             started: false,
         };
         let mut result = Vec::new();
@@ -373,7 +373,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
             started: false,
         };
         let mut result = Vec::new();
@@ -392,7 +392,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             input,
             output,
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
         };
         let mut writer = TokioFile::from_std(slave);
         let producer = tokio::spawn(async move {
@@ -409,7 +409,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
             started: false,
         };
         let mut output = vec![0; 1024];
@@ -436,7 +436,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             input,
             output,
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
         };
         let mut writer = TokioFile::from_std(slave);
         let producer = tokio::spawn(async move {
@@ -455,7 +455,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
             started: false,
         };
         let mut output = vec![0; 1024];
@@ -482,7 +482,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MySqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultSetFrameScanner::default(),
             started: false,
         };
         let mut first = vec![b'x'; 4096 - b"<resultse".len()];

--- a/src/infra/adapters/mysql/cli/xml.rs
+++ b/src/infra/adapters/mysql/cli/xml.rs
@@ -26,14 +26,14 @@ pub(super) const MYSQL_PREVIEW_MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MYSQL_PREVIEW_MAX_FIELD_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Default)]
-pub(super) struct MySqlResultsetFrameScanner {
+pub(super) struct MySqlResultSetFrameScanner {
     resultset_start: Option<usize>,
     resultset_end: Option<usize>,
     resultset_start_cursor: usize,
     resultset_end_cursor: usize,
 }
 
-impl MySqlResultsetFrameScanner {
+impl MySqlResultSetFrameScanner {
     pub(super) fn frame_start(&mut self, buffer: &[u8]) -> Option<usize> {
         if self.resultset_start_cursor > buffer.len() {
             self.resultset_start_cursor = 0;
@@ -103,7 +103,7 @@ impl MySqlResultsetFrameScanner {
 
 fn take_resultset_frame(
     buffer: &mut Vec<u8>,
-    scanner: &mut MySqlResultsetFrameScanner,
+    scanner: &mut MySqlResultSetFrameScanner,
     preview_byte_budget: bool,
 ) -> Result<Option<MySqlResultsetFrameWithDiagnostics>, DbOperationError> {
     let bounds = scanner.frame_bounds(buffer);
@@ -124,7 +124,7 @@ fn take_resultset_frame(
 #[cfg(any(unix, test))]
 pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
     buffer: &mut Vec<u8>,
-    scanner: &mut MySqlResultsetFrameScanner,
+    scanner: &mut MySqlResultSetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
     preview_byte_budget: bool,
 ) -> Result<Option<MySqlResultsetFrameWithDiagnostics>, DbOperationError> {
@@ -143,7 +143,7 @@ pub(super) fn take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget
 pub(super) fn take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(
     buffer: &mut Vec<u8>,
     error_output: &[u8],
-    scanner: &mut MySqlResultsetFrameScanner,
+    scanner: &mut MySqlResultSetFrameScanner,
     client_packet_limit_bytes: Option<usize>,
     preview_byte_budget: bool,
 ) -> Result<Option<MySqlResultsetFrameWithDiagnostics>, DbOperationError> {
@@ -455,7 +455,7 @@ mod tests {
     use super::*;
     use crate::domain::DiagnosticLevel;
 
-    impl MySqlResultsetFrameScanner {
+    impl MySqlResultSetFrameScanner {
         fn take(&mut self, buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
             let bounds = self.frame_bounds(buffer)?;
             Some(self.take_bounds(buffer, bounds))
@@ -556,7 +556,7 @@ mod tests {
             b'x',
             MYSQL_PREVIEW_MAX_FRAME_BYTES + 1 - MYSQL_RESULTSET_START.len(),
         ));
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         assert!(
             take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
@@ -605,7 +605,7 @@ mod tests {
     fn frames_one_xml_resultset_and_preserves_following_output() {
         let mut buffer = b"    -> <?xml version=\"1.0\"?>\n<resultset></resultset>\r\n    -> <?xml version=\"1.0\"?>\n<resultset>"
             .to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         assert_eq!(
             scanner.take(&mut buffer),
@@ -623,7 +623,7 @@ mod tests {
     fn frames_resultset_after_mysql_cli_text() {
         let mut buffer =
             b"SELECT 1;\n<?xml version=\"1.0\"?>\nquery text\n<resultset></resultset>".to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         assert_eq!(
             scanner.take(&mut buffer),
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     fn frame_start_does_not_scan_for_the_end_delimiter() {
         let buffer = b"<resultset></resultset>";
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         assert_eq!(scanner.frame_start(buffer), Some(0));
         assert_eq!(scanner.resultset_end, None);
@@ -645,7 +645,7 @@ mod tests {
     fn collects_diagnostics_before_a_resultset_and_preserves_following_marker() {
         let mut buffer = b"Warning (Code 1062): duplicate\nNote (Code 1050): exists\n<resultset></resultset>marker"
             .to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         let (frame, diagnostics) =
             take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
@@ -679,7 +679,7 @@ mod tests {
     #[test]
     fn pipe_frame_collection_keeps_diagnostics_before_the_resultset() {
         let mut buffer = b"Warning (Code 1265): truncated\n<resultset></resultset>".to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         let (frame, diagnostics) =
             take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(
@@ -712,7 +712,7 @@ mod tests {
         expected.extend_from_slice(MYSQL_RESULTSET_END);
 
         let mut buffer = Vec::new();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
         let mut frames = Vec::new();
         for chunk in expected.chunks(4096) {
             buffer.extend_from_slice(chunk);
@@ -735,7 +735,7 @@ mod tests {
         expected.extend_from_slice(MYSQL_RESULTSET_END);
 
         let mut buffer = Vec::new();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
         let mut frames = Vec::new();
         for chunk in expected.chunks(37) {
             buffer.extend_from_slice(chunk);
@@ -755,7 +755,7 @@ mod tests {
         let mut input = first.to_vec();
         input.extend_from_slice(second);
         let mut buffer = Vec::new();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
         let mut frames = Vec::new();
 
         for chunk in input.chunks(11) {
@@ -773,7 +773,7 @@ mod tests {
     fn delimiter_prefix_in_field_text_does_not_end_the_frame() {
         let expected = b"<resultset><row><field name=\"value\">literal </resultset prefix</field></row></resultset>";
         let mut buffer = expected.to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         assert_eq!(scanner.take(&mut buffer), Some(expected.to_vec()));
         assert!(buffer.is_empty());
@@ -784,7 +784,7 @@ mod tests {
         let mut buffer = br#"<resultset><row><field name="message">line 1
 ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
             .to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         let frame = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
             &mut buffer,
@@ -803,7 +803,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
     fn cli_error_before_resultset_frame_is_still_rejected() {
         let mut buffer =
             b"ERROR 1054 (42S22): Unknown column\n<resultset><row></row></resultset>".to_vec();
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         let result = take_mysql_pty_resultset_frame_with_diagnostics_and_preview_budget(
             &mut buffer,
@@ -824,7 +824,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
     fn error_before_resultset_frame_is_not_accepted() {
         let mut buffer = b"<resultset><row></row></resultset>".to_vec();
         let error = b"ERROR 1054 (42S22): Unknown column missing_column\n";
-        let mut scanner = MySqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultSetFrameScanner::default();
 
         assert!(matches!(
             take_mysql_resultset_frame_after_error_check_with_diagnostics_and_preview_budget(


### PR DESCRIPTION
## Problem\nThe MySQL frame scanner type uses Resultset, while the related Rust result type uses ResultSet, making the Rust naming inconsistent.\n\n## Background\nThe lowercase s reflects the MySQL XML element spelling, but the scanner is a Rust type and should follow Rust type naming.\n\n## Approach\nRename the scanner type and its callers to MySqlResultSetFrameScanner while preserving XML tags, delimiters, frame handling, and result shapes.