### PR TITLE
refactor(ui): move command tag success text to status

### DIFF
--- a/src/domain/command_tag.rs
+++ b/src/domain/command_tag.rs
@@ -68,32 +68,6 @@ impl CommandTag {
             _ => None,
         }
     }
-
-    pub fn display_message(&self) -> String {
-        match self {
-            Self::Select(n) => row_count_label(*n, "selected"),
-            Self::Insert(n) => row_count_label(*n, "inserted"),
-            Self::Affected(n) => row_count_label(*n, "affected"),
-            Self::Update(n) => row_count_label(*n, "updated"),
-            Self::Delete(n) => row_count_label(*n, "deleted"),
-            Self::Create(obj) => format!("{} created", obj.to_lowercase()),
-            Self::Drop(obj) => format!("{} dropped", obj.to_lowercase()),
-            Self::Alter(obj) => format!("{} altered", obj.to_lowercase()),
-            Self::Truncate => "table truncated".to_string(),
-            Self::Begin => "transaction started".to_string(),
-            Self::Commit => "committed".to_string(),
-            Self::Rollback => "rolled back".to_string(),
-            Self::Other(tag) => tag.to_lowercase(),
-        }
-    }
-}
-
-fn row_count_label(n: u64, verb: &str) -> String {
-    if n == 1 {
-        format!("1 row {verb}")
-    } else {
-        format!("{n} rows {verb}")
-    }
 }
 
 #[cfg(test)]
@@ -121,57 +95,6 @@ mod tests {
         assert_eq!(CommandTag::Begin.affected_rows(), None);
         assert_eq!(CommandTag::Commit.affected_rows(), None);
         assert_eq!(CommandTag::Rollback.affected_rows(), None);
-    }
-
-    #[test]
-    fn display_message_singular_row() {
-        assert_eq!(CommandTag::Insert(1).display_message(), "1 row inserted");
-        assert_eq!(CommandTag::Affected(1).display_message(), "1 row affected");
-        assert_eq!(CommandTag::Delete(1).display_message(), "1 row deleted");
-    }
-
-    #[test]
-    fn display_message_plural_rows() {
-        assert_eq!(CommandTag::Select(5).display_message(), "5 rows selected");
-        assert_eq!(CommandTag::Update(10).display_message(), "10 rows updated");
-    }
-
-    #[test]
-    fn display_message_zero_rows() {
-        assert_eq!(CommandTag::Delete(0).display_message(), "0 rows deleted");
-        assert_eq!(CommandTag::Affected(0).display_message(), "0 rows affected");
-    }
-
-    #[test]
-    fn display_message_ddl() {
-        assert_eq!(
-            CommandTag::Create("TABLE".to_string()).display_message(),
-            "table created"
-        );
-        assert_eq!(
-            CommandTag::Drop("INDEX".to_string()).display_message(),
-            "index dropped"
-        );
-        assert_eq!(
-            CommandTag::Alter("TABLE".to_string()).display_message(),
-            "table altered"
-        );
-    }
-
-    #[test]
-    fn display_message_tcl() {
-        assert_eq!(CommandTag::Truncate.display_message(), "table truncated");
-        assert_eq!(CommandTag::Begin.display_message(), "transaction started");
-        assert_eq!(CommandTag::Commit.display_message(), "committed");
-        assert_eq!(CommandTag::Rollback.display_message(), "rolled back");
-    }
-
-    #[test]
-    fn display_message_other() {
-        assert_eq!(
-            CommandTag::Other("VACUUM".to_string()).display_message(),
-            "vacuum"
-        );
     }
 
     #[test]

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -11,7 +11,7 @@ use crate::app::model::sql_editor::modal::{
 };
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::policy::write::write_guardrails::AdhocRiskDecision;
-use crate::domain::DatabaseDiagnostic;
+use crate::domain::{CommandTag, DatabaseDiagnostic};
 use crate::primitives::atoms::{spinner_char, text_cursor_spans};
 use crate::primitives::utils::text_utils::{truncate_to_width_with, wrapped_line_count};
 use crate::theme::ThemePalette;
@@ -259,7 +259,7 @@ fn success_status_message(snapshot: &AdhocSuccessSnapshot) -> String {
     let time_secs = snapshot.execution_time_ms as f64 / 1000.0;
 
     if let Some(tag) = snapshot.command_tag.as_ref() {
-        format!("\u{2713} {} ({:.2}s)", tag.display_message(), time_secs)
+        format!("\u{2713} {} ({:.2}s)", command_tag_message(tag), time_secs)
     } else {
         let rows_label = if snapshot.row_count == 1 {
             "row"
@@ -270,6 +270,32 @@ fn success_status_message(snapshot: &AdhocSuccessSnapshot) -> String {
             "\u{2713} {} {} ({:.2}s)",
             snapshot.row_count, rows_label, time_secs
         )
+    }
+}
+
+fn command_tag_message(tag: &CommandTag) -> String {
+    match tag {
+        CommandTag::Select(n) => row_count_label(*n, "selected"),
+        CommandTag::Insert(n) => row_count_label(*n, "inserted"),
+        CommandTag::Affected(n) => row_count_label(*n, "affected"),
+        CommandTag::Update(n) => row_count_label(*n, "updated"),
+        CommandTag::Delete(n) => row_count_label(*n, "deleted"),
+        CommandTag::Create(obj) => format!("{} created", obj.to_lowercase()),
+        CommandTag::Drop(obj) => format!("{} dropped", obj.to_lowercase()),
+        CommandTag::Alter(obj) => format!("{} altered", obj.to_lowercase()),
+        CommandTag::Truncate => "table truncated".to_string(),
+        CommandTag::Begin => "transaction started".to_string(),
+        CommandTag::Commit => "committed".to_string(),
+        CommandTag::Rollback => "rolled back".to_string(),
+        CommandTag::Other(tag) => tag.to_lowercase(),
+    }
+}
+
+fn row_count_label(n: u64, verb: &str) -> String {
+    if n == 1 {
+        format!("1 row {verb}")
+    } else {
+        format!("{n} rows {verb}")
     }
 }
 
@@ -325,6 +351,81 @@ fn error_status_message(error: &str) -> String {
 mod tests {
     use super::*;
     use crate::domain::DiagnosticLevel;
+
+    #[test]
+    fn command_tag_message_singular_row() {
+        assert_eq!(
+            command_tag_message(&CommandTag::Insert(1)),
+            "1 row inserted"
+        );
+        assert_eq!(
+            command_tag_message(&CommandTag::Affected(1)),
+            "1 row affected"
+        );
+        assert_eq!(command_tag_message(&CommandTag::Delete(1)), "1 row deleted");
+    }
+
+    #[test]
+    fn command_tag_message_plural_rows() {
+        assert_eq!(
+            command_tag_message(&CommandTag::Select(5)),
+            "5 rows selected"
+        );
+        assert_eq!(
+            command_tag_message(&CommandTag::Update(10)),
+            "10 rows updated"
+        );
+    }
+
+    #[test]
+    fn command_tag_message_zero_rows() {
+        assert_eq!(
+            command_tag_message(&CommandTag::Delete(0)),
+            "0 rows deleted"
+        );
+        assert_eq!(
+            command_tag_message(&CommandTag::Affected(0)),
+            "0 rows affected"
+        );
+    }
+
+    #[test]
+    fn command_tag_message_ddl() {
+        assert_eq!(
+            command_tag_message(&CommandTag::Create("TABLE".to_string())),
+            "table created"
+        );
+        assert_eq!(
+            command_tag_message(&CommandTag::Drop("INDEX".to_string())),
+            "index dropped"
+        );
+        assert_eq!(
+            command_tag_message(&CommandTag::Alter("TABLE".to_string())),
+            "table altered"
+        );
+    }
+
+    #[test]
+    fn command_tag_message_tcl() {
+        assert_eq!(
+            command_tag_message(&CommandTag::Truncate),
+            "table truncated"
+        );
+        assert_eq!(
+            command_tag_message(&CommandTag::Begin),
+            "transaction started"
+        );
+        assert_eq!(command_tag_message(&CommandTag::Commit), "committed");
+        assert_eq!(command_tag_message(&CommandTag::Rollback), "rolled back");
+    }
+
+    #[test]
+    fn command_tag_message_other() {
+        assert_eq!(
+            command_tag_message(&CommandTag::Other("VACUUM".to_string())),
+            "vacuum"
+        );
+    }
 
     #[test]
     fn diagnostics_height_only_applies_to_success_status() {


### PR DESCRIPTION
## Problem
CommandTag combines database result semantics with SQL modal success copy, placing UI wording in the domain layer.

## Background
CommandTag semantics such as affected rows and refresh scope remain domain concerns, while the success message has a single SQL modal status consumer.

## Approach
Keep classification and refresh behavior in the domain and move only success-message formatting, including row pluralization, into the status UI. Existing success text and snapshot output remain unchanged.