### PR TITLE
refactor(infra): clarify MySQL table detail ownership

### DIFF
--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -44,7 +44,7 @@ impl MetadataProvider for MySqlAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        table_detail::fetch_table_detail_in_session(dsn, schema, table).await
+        table_detail::fetch_table_detail(dsn, schema, table).await
     }
 
     async fn fetch_table_columns_and_fks(

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -45,19 +45,13 @@ struct MySqlIndexMetadata {
     primary: bool,
 }
 
-pub(super) async fn fetch_table_detail_in_session(
+pub(super) async fn fetch_table_detail(
     dsn: &str,
     schema: &str,
     table: &str,
 ) -> Result<Table, DbOperationError> {
-    fetch_table_detail_in_session_with_program(
-        dsn,
-        schema,
-        table,
-        OsStr::new("mysql"),
-        MYSQL_QUERY_TIMEOUT,
-    )
-    .await
+    fetch_table_detail_with_program(dsn, schema, table, OsStr::new("mysql"), MYSQL_QUERY_TIMEOUT)
+        .await
 }
 
 pub(super) async fn fetch_table_columns_and_fks(
@@ -117,7 +111,7 @@ async fn fetch_table_columns_and_fks_with_program(
     ))
 }
 
-async fn fetch_table_detail_in_session_with_program(
+async fn fetch_table_detail_with_program(
     dsn: &str,
     schema: &str,
     table: &str,
@@ -597,7 +591,7 @@ done
     async fn inspector_detail_orchestration_uses_one_process_for_table_and_view() {
         for (mode, schema, table) in [("table", "app", "items"), ("view", "app", "items_view")] {
             let (_directory, program, transcript) = fake_metadata_cli(mode);
-            let detail = fetch_table_detail_in_session_with_program(
+            let detail = fetch_table_detail_with_program(
                 "mysql://user:password@localhost:3306/app",
                 schema,
                 table,
@@ -687,7 +681,7 @@ done
     #[tokio::test]
     async fn inspector_detail_rejects_a_mismatched_completion_marker() {
         let (_directory, program, transcript) = fake_metadata_cli("completion-marker-failure");
-        let error = fetch_table_detail_in_session_with_program(
+        let error = fetch_table_detail_with_program(
             "mysql://user:password@localhost:3306/app",
             "app",
             "items",
@@ -749,7 +743,7 @@ done
     #[tokio::test]
     async fn inspector_detail_read_only_setup_failure_never_sends_metadata_sql() {
         let (_directory, program, transcript) = fake_metadata_cli("read-only-failure");
-        let result = fetch_table_detail_in_session_with_program(
+        let result = fetch_table_detail_with_program(
             "mysql://user:password@localhost:3306/app",
             "app",
             "items",
@@ -770,7 +764,7 @@ done
     async fn inspector_detail_orchestration_rejects_empty_and_malformed_shapes_without_partial_table()
      {
         let (_directory, program, transcript) = fake_metadata_cli("empty");
-        let error = fetch_table_detail_in_session_with_program(
+        let error = fetch_table_detail_with_program(
             "mysql://user:password@localhost:3306/app",
             "app",
             "items",
@@ -784,7 +778,7 @@ done
         assert_option_file_removed(&transcript);
 
         let (_directory, program, transcript) = fake_metadata_cli("malformed");
-        let error = fetch_table_detail_in_session_with_program(
+        let error = fetch_table_detail_with_program(
             "mysql://user:password@localhost:3306/app",
             "app",
             "items",
@@ -806,7 +800,7 @@ done
         ] {
             let (directory, program, transcript) = fake_metadata_cli(mode);
             let task = tokio::spawn(async move {
-                fetch_table_detail_in_session_with_program(
+                fetch_table_detail_with_program(
                     "mysql://user:password@localhost:3306/app",
                     "app",
                     "items",
@@ -841,7 +835,7 @@ done
     async fn inspector_detail_orchestration_cleans_up_after_cancellation() {
         let (_directory, program, transcript) = fake_metadata_cli("timeout");
         let task = tokio::spawn(async move {
-            fetch_table_detail_in_session_with_program(
+            fetch_table_detail_with_program(
                 "mysql://user:password@localhost:3306/app",
                 "app",
                 "items",


### PR DESCRIPTION
## Summary
- Name the MySQL table-detail wrapper by its public operation rather than its internally created session.
- Distinguish the injected-program helper from the existing-session helper while preserving the metadata query and cleanup lifecycle.

## Tests
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-mdb10-027-target cargo test -p sabiql-infra table_detail --lib`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-mdb10-027-target cargo check -p sabiql --all-features`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-mdb10-027-target cargo clippy -p sabiql-infra --lib --all-features -- -D warnings`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-mdb10-027-target cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR= bash scripts/lint_all.sh`