### PR TITLE
refactor(app): move SQLite diagnostic presentation

### DIFF
--- a/src/app/model/sqlite/diagnostics.rs
+++ b/src/app/model/sqlite/diagnostics.rs
@@ -216,6 +216,15 @@ pub fn display_rows(snapshot: &SqliteDiagnosticsSnapshot) -> Vec<DiagnosticDispl
     .collect()
 }
 
+pub fn display_field(field: &DiagnosticField) -> String {
+    match field {
+        DiagnosticField::Ok(value) => value.clone(),
+        DiagnosticField::Err(error) => format!("(failed: {error})"),
+        DiagnosticField::Pending => String::new(),
+        DiagnosticField::Unavailable => "(unavailable)".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,6 +239,18 @@ mod tests {
         assert_eq!(first, 1);
         assert_eq!(second, 2);
         assert!(state.is_loading());
+    }
+
+    #[test]
+    fn display_field_formats_each_state() {
+        for (field, expected) in [
+            (DiagnosticField::ok("value"), "value"),
+            (DiagnosticField::err("timeout"), "(failed: timeout)"),
+            (DiagnosticField::Pending, ""),
+            (DiagnosticField::Unavailable, "(unavailable)"),
+        ] {
+            assert_eq!(display_field(&field), expected);
+        }
     }
 
     #[test]

--- a/src/domain/sqlite_diagnostics.rs
+++ b/src/domain/sqlite_diagnostics.rs
@@ -30,15 +30,6 @@ impl DiagnosticField {
         }
     }
 
-    pub fn display(&self) -> String {
-        match self {
-            Self::Ok(value) => value.clone(),
-            Self::Err(error) => format!("(failed: {error})"),
-            Self::Pending => String::new(),
-            Self::Unavailable => "(unavailable)".to_string(),
-        }
-    }
-
     pub fn is_ok(&self) -> bool {
         matches!(self, Self::Ok(_))
     }
@@ -93,14 +84,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn diagnostic_field_display_formats_error() {
-        let field = DiagnosticField::err("timeout");
-
-        assert_eq!(field.display(), "(failed: timeout)");
-        assert!(!field.is_ok());
-    }
-
-    #[test]
     fn diagnostic_field_rejects_invalid_public_construction() {
         let field = DiagnosticField::ok("value");
 
@@ -117,7 +100,6 @@ mod tests {
         assert!(!field.is_err());
         assert!(field.ok_value().is_none());
         assert!(field.err_message().is_none());
-        assert_eq!(field.display(), "");
     }
 
     #[test]

--- a/src/ui/features/overlays/sqlite_diagnostics.rs
+++ b/src/ui/features/overlays/sqlite_diagnostics.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::sqlite::diagnostics::{DiagnosticFieldKind, display_rows};
+use crate::app::model::sqlite::diagnostics::{DiagnosticFieldKind, display_field, display_rows};
 use crate::domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
 use crate::primitives::molecules::{FooterHintBar, render_modal};
 use crate::primitives::utils::text_utils::wrapped_line_count;
@@ -113,7 +113,7 @@ pub fn build_render_lines(
 
     let mut lines = vec![Line::raw("")];
     for row in display_rows(snapshot) {
-        let field_value = row.field.display();
+        let field_value = display_field(row.field);
         let value = if row.kind == DiagnosticFieldKind::QuickCheck {
             quick_check_override.unwrap_or(&field_value)
         } else {


### PR DESCRIPTION
## Problem
SQLite diagnostic state values currently format user-facing text inside the domain layer.

## Approach
Keep the domain model limited to diagnostic state and format those states in the application diagnostics model without changing rendered output.