### PR TITLE
test: align query test DSN identities

### DIFF
--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -503,14 +503,14 @@ mod tests {
 
         let inspector_action = if inspector_failed {
             Action::TableDetailFailed {
-                dsn: "postgres://localhost/test".to_string(),
+                dsn: active_dsn(&state),
                 run_id: detail_run_id,
                 error: DbOperationError::QueryFailed("inspector failed".to_string()),
                 generation,
             }
         } else {
             Action::TableDetailLoaded {
-                dsn: "postgres://localhost/test".to_string(),
+                dsn: active_dsn(&state),
                 run_id: detail_run_id,
                 detail: Box::new(users_table_detail()),
                 generation,
@@ -584,11 +584,16 @@ mod tests {
 
     fn state_with_selected_table(database_type: DatabaseType) -> (AppState, u64, u64) {
         let mut state = AppState::new("test".to_string());
+        let dsn = match database_type {
+            DatabaseType::PostgreSQL => "postgres://localhost/test",
+            DatabaseType::MySQL => "mysql://localhost/test",
+            DatabaseType::SQLite => "sqlite:///tmp/test.db",
+        };
         state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "test",
             database_type,
-            "postgres://localhost/test",
+            dsn,
         );
         let generation = state
             .session
@@ -983,11 +988,12 @@ mod tests {
         ) {
             let (mut state, generation, detail_run_id) = state_with_selected_table(database_type);
             let now = Instant::now();
+            let dsn = active_dsn(&state);
 
             let inspector_effects = dispatch_metadata(
                 &mut state,
                 &Action::TableDetailLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
+                    dsn,
                     run_id: detail_run_id,
                     detail: Box::new(users_table_detail()),
                     generation,

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -76,6 +76,14 @@ pub(super) mod tests {
         state
     }
 
+    pub fn active_dsn(state: &AppState) -> String {
+        state
+            .session
+            .dsn()
+            .expect("query test state must have an active connection")
+            .to_string()
+    }
+
     pub fn begin_query_run(state: &mut AppState) -> u64 {
         state.query.begin_running(Instant::now())
     }
@@ -88,7 +96,7 @@ pub(super) mod tests {
     ) -> Action {
         let run_id = begin_query_run(state);
         Action::QueryCompleted {
-            dsn: "postgres://localhost/test".to_string(),
+            dsn: active_dsn(state),
             run_id,
             result,
             context: match target_page {


### PR DESCRIPTION
## Problem
The all-engine query completion test used a PostgreSQL DSN for MySQL and SQLite cases, so stale-response identity was not exercised for those engines.

## Background
The test activates each database type but passed a fixed DSN through the metadata and query completion actions.

## Approach
Use explicit database-specific DSNs in the test connection fixture and reuse the active connection DSN for metadata and query completion actions. Production stale checks, result building, and runtime behavior remain unchanged.