### PR TITLE
refactor(test): share command no-op renderer fixture

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -309,29 +309,16 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures;
-    use std::time::Instant;
+    use crate::cmd::test_fixtures::{self, NoopRenderer};
 
     use crate::domain::DatabaseMetadata;
     use crate::model::app_state::AppState;
+    use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
-    use crate::ports::outbound::{DbOperationError, RenderOutput, RenderResult, Renderer};
     use crate::services::AppServices;
     use crate::update::action::Action;
-
-    struct NoopRenderer;
-    impl Renderer for NoopRenderer {
-        fn draw(
-            &mut self,
-            _state: &AppState,
-            _services: &AppServices,
-            _now: Instant,
-        ) -> RenderResult<RenderOutput> {
-            Ok(RenderOutput::default())
-        }
-    }
 
     mod fetch_metadata {
         use super::*;

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -412,13 +412,13 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures;
+    use crate::cmd::test_fixtures::{self, NoopRenderer};
     use crate::domain::{DatabaseDiagnostic, DiagnosticLevel, WriteExecutionResult};
     use crate::model::app_state::AppState;
+    use crate::ports::outbound::AccessMode;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
-    use crate::ports::outbound::{AccessMode, RenderOutput, RenderResult, Renderer};
     use crate::services::AppServices;
     use crate::update::action::Action;
 
@@ -485,29 +485,15 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures;
+        use crate::cmd::test_fixtures::{self, NoopRenderer};
         use crate::domain::QueryValue;
         use crate::model::app_state::AppState;
         use crate::ports::outbound::connection_store::MockConnectionStore;
         use crate::ports::outbound::metadata::MockMetadataProvider;
         use crate::ports::outbound::query_executor::MockQueryExecutor;
-        use crate::ports::outbound::{
-            CachedResultExporter, DbOperationError, RenderOutput, RenderResult, Renderer,
-        };
+        use crate::ports::outbound::{CachedResultExporter, DbOperationError};
         use crate::services::AppServices;
         use crate::update::action::Action;
-
-        struct NoopRenderer;
-        impl Renderer for NoopRenderer {
-            fn draw(
-                &mut self,
-                _state: &AppState,
-                _services: &AppServices,
-                _now: std::time::Instant,
-            ) -> RenderResult<RenderOutput> {
-                Ok(RenderOutput::default())
-            }
-        }
 
         fn test_file_name(label: &str) -> String {
             format!("cached_{label}_{}", std::process::id())
@@ -629,28 +615,15 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures;
-        use std::time::Instant;
+        use crate::cmd::test_fixtures::{self, NoopRenderer};
 
         use crate::model::app_state::AppState;
+        use crate::ports::outbound::DbOperationError;
         use crate::ports::outbound::connection_store::MockConnectionStore;
         use crate::ports::outbound::metadata::MockMetadataProvider;
         use crate::ports::outbound::query_executor::MockQueryExecutor;
-        use crate::ports::outbound::{DbOperationError, RenderOutput, RenderResult, Renderer};
         use crate::services::AppServices;
         use crate::update::action::{Action, QueryFailureContext};
-
-        struct NoopRenderer;
-        impl Renderer for NoopRenderer {
-            fn draw(
-                &mut self,
-                _state: &AppState,
-                _services: &AppServices,
-                _now: Instant,
-            ) -> RenderResult<RenderOutput> {
-                Ok(RenderOutput::default())
-            }
-        }
 
         #[tokio::test]
         async fn success_returns_query_completed() {
@@ -768,18 +741,6 @@ mod tests {
     mod execute_access_mode {
         use super::*;
         use crate::domain::DatabaseType;
-
-        struct NoopRenderer;
-        impl Renderer for NoopRenderer {
-            fn draw(
-                &mut self,
-                _state: &AppState,
-                _services: &AppServices,
-                _now: std::time::Instant,
-            ) -> RenderResult<RenderOutput> {
-                Ok(RenderOutput::default())
-            }
-        }
 
         async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
             let cache = TtlCache::new(300);

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -429,14 +429,12 @@ async fn normalize_sqlite_profile(
 mod tests {
     use std::cell::RefCell;
     use std::sync::Arc;
-    use std::time::Instant;
-
     use tokio::sync::mpsc;
 
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures;
+    use crate::cmd::test_fixtures::{self, NoopRenderer};
     use crate::domain::connection::{
         ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
         MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig, SqlitePathError, SslMode,
@@ -449,24 +447,11 @@ mod tests {
     use crate::ports::outbound::query_executor::MockQueryExecutor;
     use crate::ports::outbound::{
         ConnectionStoreError, DbOperationError, DsnBuilder, MySqlConnectionProbeResult,
-        RenderOutput, RenderResult, Renderer,
     };
     use crate::services::AppServices;
     use crate::update::action::{
         Action, ConnectionSaveError, ConnectionTarget, ConnectionsLoadedPayload,
     };
-
-    struct NoopRenderer;
-    impl Renderer for NoopRenderer {
-        fn draw(
-            &mut self,
-            _state: &AppState,
-            _services: &AppServices,
-            _now: Instant,
-        ) -> RenderResult<RenderOutput> {
-            Ok(RenderOutput::default())
-        }
-    }
 
     mod save_connection {
         use super::*;

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -329,7 +329,7 @@ impl EffectRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd::test_fixtures;
+    use crate::cmd::test_fixtures::{self, NoopRenderer};
     use crate::domain::{DatabaseMetadata, TableSignatureSnapshot, TableSummary};
     use crate::model::shared::render_output::{
         BrowseLayout, DetailLayout, ExplorerLayout, JsonDetailLayout,
@@ -340,18 +340,6 @@ mod tests {
     use crate::ports::outbound::{MySqlConnectionProbeResult, RenderOutput, RenderResult};
     use crate::services::AppServices;
     use tokio::sync::mpsc;
-
-    struct NoopRenderer;
-    impl Renderer for NoopRenderer {
-        fn draw(
-            &mut self,
-            _state: &AppState,
-            _services: &AppServices,
-            _now: Instant,
-        ) -> RenderResult<RenderOutput> {
-            Ok(RenderOutput::default())
-        }
-    }
 
     mod render {
         use super::*;

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::mpsc;
 
@@ -14,15 +15,17 @@ use crate::domain::{
     DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource, QueryValue,
     SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
 };
+use crate::model::app_state::AppState;
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
     AppSettings, CachedResultExporter, ClipboardError, ClipboardWriter, ConfigWriter,
     ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter,
     FolderOpenError, FolderOpener, MetadataProvider, MySqlConnectionProbe,
     MySqlConnectionProbeResult, PgServiceEntryReader, QueryExecutor, QueryHistoryError,
-    QueryHistoryStore, ServiceFileError, SettingsStore, SettingsStoreError,
-    SqliteDiagnosticsProvider, SqlitePathValidator,
+    QueryHistoryStore, RenderOutput, RenderResult, Renderer, ServiceFileError, SettingsStore,
+    SettingsStoreError, SqliteDiagnosticsProvider, SqlitePathValidator,
 };
+use crate::services::AppServices;
 use crate::update::action::Action;
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -152,6 +155,18 @@ pub struct NoopFolderOpener;
 impl FolderOpener for NoopFolderOpener {
     fn open(&self, _path: &Path) -> Result<(), FolderOpenError> {
         Ok(())
+    }
+}
+
+pub struct NoopRenderer;
+impl Renderer for NoopRenderer {
+    fn draw(
+        &mut self,
+        _state: &AppState,
+        _services: &AppServices,
+        _now: Instant,
+    ) -> RenderResult<RenderOutput> {
+        Ok(RenderOutput::default())
     }
 }
 


### PR DESCRIPTION
## Problem
Command tests duplicate the same renderer stub in multiple test modules.

## Background
The renderer is database-independent and only returns the default render output, so each copy tests the same fixture behavior.

## Approach
Place the shared implementation in the existing `#[cfg(test)]` command fixture module and import it from the affected tests. Keep observation renderers and rendering assertions local.

## Screenshots
Not applicable.