### PR TITLE
test: cover registry DSN classification

### DIFF
--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -305,6 +305,8 @@ impl SqliteDiagnosticsProvider for DbAdapterRegistry {
 mod tests {
     use crate::adapters::test_support;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::domain::connection::SslMode;
     use crate::domain::{Column, ColumnAttributes};
@@ -478,12 +480,14 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn mysql_dsn_scheme_is_recognized() {
-        assert_eq!(
-            DbAdapterRegistry::db_type_from_dsn("mysql://localhost/db").unwrap(),
-            DatabaseType::MySQL
-        );
+    #[rstest]
+    #[case::sqlite_url("sqlite:///tmp/app.db", Some(DatabaseType::SQLite))]
+    #[case::mysql_url("mysql://localhost/db", Some(DatabaseType::MySQL))]
+    #[case::postgres_url("postgres://localhost/db", Some(DatabaseType::PostgreSQL))]
+    #[case::postgres_conninfo("host='localhost' dbname='db'", Some(DatabaseType::PostgreSQL))]
+    #[case::unsupported_scheme("redis://localhost", None)]
+    fn classifies_named_dsn_inputs(#[case] dsn: &str, #[case] expected: Option<DatabaseType>) {
+        assert_eq!(DbAdapterRegistry::db_type_from_dsn(dsn).ok(), expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
Registry tests directly covered only the MySQL scheme, leaving PostgreSQL URL/conninfo, SQLite, and unsupported classifier inputs implicit through dispatch tests.

## Background
The classifier is the registry boundary for selecting database adapters.

## Approach
Replace the single scheme assertion with named cases covering each supported DSN form and an unsupported scheme directly. Keep routing, SQL, metadata, and integration fixtures unchanged.