### PR TITLE
refactor(test): share MySQL query order assertion

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -628,7 +628,7 @@ mod tests {
     use super::single::test_support::run_mysql_single_statement_process;
     use super::*;
     use crate::adapters::csv_export::export_to_path;
-    use crate::adapters::mysql::test_support::query_assertions::assert_queries_in_order;
+    use crate::adapters::mysql::test_query_assertions::assert_queries_in_order;
     use crate::domain::mysql_sql::{classify_mysql_statement, split_mysql_statements};
     use crate::domain::{
         CommandTag, DatabaseDiagnostic, DiagnosticLevel, QueryValue, RefreshScope,

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -628,6 +628,7 @@ mod tests {
     use super::single::test_support::run_mysql_single_statement_process;
     use super::*;
     use crate::adapters::csv_export::export_to_path;
+    use crate::adapters::mysql::test_support::query_assertions::assert_queries_in_order;
     use crate::domain::mysql_sql::{classify_mysql_statement, split_mysql_statements};
     use crate::domain::{
         CommandTag, DatabaseDiagnostic, DiagnosticLevel, QueryValue, RefreshScope,
@@ -1108,16 +1109,15 @@ done
             assert_eq!(result.columns, vec!["value"]);
             assert_eq!(result.values[0][0].as_str(), Some("ok"));
             let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-            let positions = [
-                MYSQL_SESSION_SETTINGS,
-                MYSQL_SESSION_MARKER_COLUMN,
-                "__sabiql_sql_mode",
-                "SELECT 123",
-            ]
-            .into_iter()
-            .map(|query| log.find(query).expect("query in transcript"))
-            .collect::<Vec<_>>();
-            assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+            assert_queries_in_order(
+                &log,
+                &[
+                    MYSQL_SESSION_SETTINGS,
+                    MYSQL_SESSION_MARKER_COLUMN,
+                    "__sabiql_sql_mode",
+                    "SELECT 123",
+                ],
+            );
             assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
         }
 
@@ -1397,23 +1397,22 @@ done
             let argv = log.lines().find(|line| line.starts_with("argv=")).unwrap();
             assert!(!argv.contains("--quick"), "{argv}");
             assert!(!argv.contains("--max-allowed-packet="), "{argv}");
-            let positions = [
-                MYSQL_SESSION_SETTINGS,
-                MYSQL_READ_ONLY_STATEMENT,
-                MYSQL_SESSION_MARKER_COLUMN,
-                "__sabiql_sql_mode",
-                "__sabiql_probe",
-                "SELECT TABLES",
-                "SELECT COLUMNS",
-                "SELECT INDEXES",
-                "SELECT FOREIGN_KEYS",
-                "SELECT TRIGGERS",
-                "SHOW CREATE TABLE items",
-            ]
-            .into_iter()
-            .map(|query| log.find(query).expect("query in transcript"))
-            .collect::<Vec<_>>();
-            assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+            assert_queries_in_order(
+                &log,
+                &[
+                    MYSQL_SESSION_SETTINGS,
+                    MYSQL_READ_ONLY_STATEMENT,
+                    MYSQL_SESSION_MARKER_COLUMN,
+                    "__sabiql_sql_mode",
+                    "__sabiql_probe",
+                    "SELECT TABLES",
+                    "SELECT COLUMNS",
+                    "SELECT INDEXES",
+                    "SELECT FOREIGN_KEYS",
+                    "SELECT TRIGGERS",
+                    "SHOW CREATE TABLE items",
+                ],
+            );
         }
 
         #[tokio::test]
@@ -1434,17 +1433,16 @@ done
 
             assert_eq!(columns, ["Database"]);
             let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-            let positions = [
-                MYSQL_SESSION_SETTINGS,
-                MYSQL_READ_ONLY_STATEMENT,
-                MYSQL_SESSION_MARKER_COLUMN,
-                "__sabiql_sql_mode",
-                "SHOW DATABASES",
-            ]
-            .into_iter()
-            .map(|query| log.find(query).expect("query in transcript"))
-            .collect::<Vec<_>>();
-            assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+            assert_queries_in_order(
+                &log,
+                &[
+                    MYSQL_SESSION_SETTINGS,
+                    MYSQL_READ_ONLY_STATEMENT,
+                    MYSQL_SESSION_MARKER_COLUMN,
+                    "__sabiql_sql_mode",
+                    "SHOW DATABASES",
+                ],
+            );
         }
 
         #[tokio::test]

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -391,7 +391,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::adapters::mysql::test_support::query_assertions::assert_queries_in_order;
+    use crate::adapters::mysql::test_query_assertions::assert_queries_in_order;
     use crate::domain::ColumnAttributes;
 
     fn convert_preview_values(

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -391,6 +391,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::adapters::mysql::test_support::query_assertions::assert_queries_in_order;
     use crate::domain::ColumnAttributes;
 
     fn convert_preview_values(
@@ -575,20 +576,19 @@ done
             1,
             "{argv}"
         );
-        let positions = [
-            "SET SESSION autocommit=1, completion_type=NO_CHAIN",
-            "SET SESSION TRANSACTION READ ONLY",
-            "__sabiql_session_marker",
-            "__sabiql_sql_mode",
-            "__sabiql_probe",
-            "INFORMATION_SCHEMA.COLUMNS",
-            "LIMIT 2 OFFSET 1",
-            "__sabiql_preview_completion",
-        ]
-        .into_iter()
-        .map(|query| log.find(query).expect("query in transcript"))
-        .collect::<Vec<_>>();
-        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+        assert_queries_in_order(
+            &log,
+            &[
+                "SET SESSION autocommit=1, completion_type=NO_CHAIN",
+                "SET SESSION TRANSACTION READ ONLY",
+                "__sabiql_session_marker",
+                "__sabiql_sql_mode",
+                "__sabiql_probe",
+                "INFORMATION_SCHEMA.COLUMNS",
+                "LIMIT 2 OFFSET 1",
+                "__sabiql_preview_completion",
+            ],
+        );
         assert!(!log.contains("INFORMATION_SCHEMA.STATISTICS"), "{log}");
         assert_option_file_removed(&log_path);
     }

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -10,4 +10,15 @@ mod sql;
 #[cfg(feature = "test-support")]
 pub mod test_support;
 
+#[cfg(test)]
+pub(in crate::adapters::mysql) mod test_query_assertions {
+    pub(in crate::adapters::mysql) fn assert_queries_in_order(log: &str, queries: &[&str]) {
+        let positions = queries
+            .iter()
+            .map(|query| log.find(*query).expect("query in transcript"))
+            .collect::<Vec<_>>();
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+    }
+}
+
 pub use adapter::MySqlAdapter;

--- a/src/infra/adapters/mysql/test_support.rs
+++ b/src/infra/adapters/mysql/test_support.rs
@@ -18,6 +18,17 @@ use super::cli::{
 use super::dsn::parse_and_validate_mysql_dsn;
 use super::option_file::MySqlOptionFile;
 
+#[cfg(test)]
+pub(in crate::adapters::mysql) mod query_assertions {
+    pub(in crate::adapters::mysql) fn assert_queries_in_order(log: &str, queries: &[&str]) {
+        let positions = queries
+            .iter()
+            .map(|query| log.find(*query).expect("query in transcript"))
+            .collect::<Vec<_>>();
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+    }
+}
+
 #[cfg(unix)]
 use super::cli::MYSQL_QUERY_TIMEOUT;
 #[cfg(unix)]

--- a/src/infra/adapters/mysql/test_support.rs
+++ b/src/infra/adapters/mysql/test_support.rs
@@ -18,17 +18,6 @@ use super::cli::{
 use super::dsn::parse_and_validate_mysql_dsn;
 use super::option_file::MySqlOptionFile;
 
-#[cfg(test)]
-pub(in crate::adapters::mysql) mod query_assertions {
-    pub(in crate::adapters::mysql) fn assert_queries_in_order(log: &str, queries: &[&str]) {
-        let positions = queries
-            .iter()
-            .map(|query| log.find(*query).expect("query in transcript"))
-            .collect::<Vec<_>>();
-        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
-    }
-}
-
 #[cfg(unix)]
 use super::cli::MYSQL_QUERY_TIMEOUT;
 #[cfg(unix)]


### PR DESCRIPTION
## Problem
MySQL fake CLI tests repeat transcript substring position extraction and strict-order assertions.

## Approach
Share a test-only MySQL helper for strict ordering while keeping each caller's substring list local. Repeated-substring count assertions and production behavior remain unchanged.