### PR TITLE
refactor(test): name PostgreSQL snapshot fixtures

### DIFF
--- a/src/tests/harness/fixtures.rs
+++ b/src/tests/harness/fixtures.rs
@@ -45,7 +45,7 @@ pub fn sample_metadata() -> DatabaseMetadata {
     metadata
 }
 
-pub fn sample_table_detail() -> Table {
+pub fn sample_postgres_table_detail() -> Table {
     let mut table = minimal_table("public", "users");
     table.owner = Some("postgres".to_string());
     table.columns = vec![

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -172,7 +172,7 @@ fn buffer_to_string(buffer: &Buffer) -> String {
     result
 }
 
-pub fn connected_state() -> AppState {
+pub fn postgres_connected_state() -> AppState {
     let mut state = create_test_state();
     state
         .session
@@ -181,7 +181,7 @@ pub fn connected_state() -> AppState {
 }
 
 pub fn explorer_selected_state() -> AppState {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     state.ui.set_explorer_selection(Some(0));
     state
 }
@@ -190,7 +190,7 @@ pub fn table_detail_loaded_state() -> AppState {
     let mut state = explorer_selected_state();
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
     state
 }
 

--- a/src/tests/render_snapshots/confirm_dialogs.rs
+++ b/src/tests/render_snapshots/confirm_dialogs.rs
@@ -57,12 +57,12 @@ fn confirm_dialog() {
 
 #[test]
 fn confirm_dialog_update_preview() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
     state.modal.set_mode(InputMode::ConfirmDialog);
     state.confirm_dialog.open(
         "Confirm UPDATE: users",
@@ -80,12 +80,12 @@ fn confirm_dialog_update_preview() {
 
 #[test]
 fn confirm_dialog_update_preview_rich() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let sql = "UPDATE \"public\".\"users\"\nSET \"email\" = 'new@example.com'\nWHERE \"id\" = '2';"
         .to_string();
@@ -118,12 +118,12 @@ fn confirm_dialog_update_preview_rich() {
 
 #[test]
 fn confirm_dialog_delete_preview_low_risk() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '3';".to_string();
     state.result_interaction.set_write_preview(WritePreview {
@@ -151,12 +151,12 @@ fn confirm_dialog_delete_preview_low_risk() {
 
 #[test]
 fn confirm_dialog_update_preview_long_json() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let long_before = r#"{"industries": ["tech", "finance", "healthcare"], "company_size": "enterprise", "preferences": {"notifications": true, "theme": "dark"}}"#;
     let long_after = r#"{"industries": ["tech", "retail"], "company_size": "startup", "preferences": {"notifications": false, "theme": "light", "language": "ja"}}"#;
@@ -189,12 +189,12 @@ fn confirm_dialog_update_preview_long_json() {
 
 #[test]
 fn confirm_dialog_update_preview_json_key_order_normalized() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     // Snapshot uses pre-normalized jsonb strings; normalization behavior is covered in
     // preview_cell_text policy tests.
@@ -235,12 +235,12 @@ fn confirm_dialog_update_preview_json_key_order_normalized() {
 
 #[test]
 fn confirm_dialog_update_preview_scrollable() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let sql = "UPDATE \"public\".\"users\"\nSET \"a\" = '1', \"b\" = '2', \"c\" = '3', \"d\" = '4', \"e\" = '5'\nWHERE \"id\" = '1';".to_string();
     state
@@ -293,12 +293,12 @@ fn confirm_dialog_update_preview_scrollable() {
 
 #[test]
 fn confirm_dialog_update_preview_narrow_terminal() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal_sized(40, 12);
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let long_before = r#"{"industries": ["tech", "finance"], "company_size": "enterprise"}"#;
     let long_after = r#"{"industries": ["tech"], "company_size": "startup"}"#;
@@ -331,12 +331,12 @@ fn confirm_dialog_update_preview_narrow_terminal() {
 
 #[test]
 fn confirm_dialog_update_preview_multi_column() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let sql = "UPDATE \"public\".\"users\"\nSET \"email\" = 'new@example.com', \"name\" = 'New Name'\nWHERE \"id\" = '2';".to_string();
     state
@@ -368,12 +368,12 @@ fn confirm_dialog_update_preview_multi_column() {
 
 #[test]
 fn confirm_dialog_update_preview_json_structured_diff_with_ellipsis() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     // Large nested JSON where only one deep value changes, forcing ellipsis
     let before = r#"{"alpha": 1, "beta": 2, "gamma": 3, "delta": 4, "epsilon": 5, "zeta": {"nested_a": "unchanged", "nested_b": "old_value", "nested_c": "unchanged"}, "eta": 7, "theta": 8}"#;
@@ -410,12 +410,12 @@ fn confirm_dialog_update_preview_json_structured_diff_with_ellipsis() {
 
 #[test]
 fn confirm_dialog_update_preview_json_and_string_mixed() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
 
     let json_before = r#"{"status": "active", "role": "admin"}"#;
     let json_after = r#"{"status": "inactive", "role": "admin"}"#;

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -25,7 +25,7 @@ fn er_waiting_progress() {
 
 #[test]
 fn er_table_picker_modal() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ErTablePicker);
@@ -37,7 +37,7 @@ fn er_table_picker_modal() {
 
 #[test]
 fn er_table_picker_filtered() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ErTablePicker);
@@ -50,7 +50,7 @@ fn er_table_picker_filtered() {
 
 #[test]
 fn er_table_picker_single_select() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ErTablePicker);
@@ -65,7 +65,7 @@ fn er_table_picker_single_select() {
 
 #[test]
 fn er_table_picker_multi_select() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ErTablePicker);
@@ -80,7 +80,7 @@ fn er_table_picker_multi_select() {
 
 #[test]
 fn er_table_picker_all_selected() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ErTablePicker);

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -24,7 +24,7 @@ fn explorer_shows_not_connected_when_no_active_connection() {
 
 #[test]
 fn header_shows_effective_user_at_normal_width() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "test",
@@ -43,7 +43,7 @@ fn header_shows_effective_user_at_normal_width() {
 
 #[test]
 fn mysql_header_shows_effective_user_without_dsn_password() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "test",
@@ -63,7 +63,7 @@ fn mysql_header_shows_effective_user_without_dsn_password() {
 
 #[test]
 fn header_truncates_connection_name_at_narrow_width() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "very-long-connection-name-that-must-yield-space-to-the-user",
@@ -82,7 +82,7 @@ fn header_truncates_connection_name_at_narrow_width() {
 
 #[test]
 fn header_shows_read_only_badge_at_narrow_width() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "test",

--- a/src/tests/render_snapshots/inspector.rs
+++ b/src/tests/render_snapshots/inspector.rs
@@ -11,7 +11,7 @@ fn inspector_columns_narrow_pane_keeps_horizontal_scroll() {
     // Split-pane terminal: the comment column alone exceeds the pane width
     let mut terminal = create_test_terminal_sized(110, 40);
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns[0].comment = Some(
         "Primary key, generated from the tenant sequence and never reused after deletion"
             .to_string(),
@@ -30,7 +30,7 @@ fn inspector_columns_narrow_pane_caps_wide_comment() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal_sized(110, 40);
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns[0].comment = Some(
         "Primary key, generated from the tenant sequence and never reused after deletion"
             .to_string(),
@@ -54,7 +54,7 @@ fn inspector_columns_narrow_pane_right_edge_truncates_cjk_comment() {
 
     // CJK renders two cells per char; the comment must end with an ellipsis
     // instead of being clipped mid-text at the pane border
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns[0].comment = Some(
         "ステータス（PENDING:判断待ち、APPROVED:承認済み、REJECTED:却下済み、CANCELED:取消済み）"
             .to_string(),
@@ -74,7 +74,7 @@ fn inspector_columns_marks_read_only_generated_columns() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns[1].attributes =
         ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED | ColumnAttributes::NULLABLE;
     let _ = state.session.set_table_detail(table, 0);
@@ -91,7 +91,7 @@ fn inspector_columns_shows_mysql_column_metadata() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns[1].character_set_name = Some("utf8mb4".to_string());
     table.columns[1].collation_name = Some("utf8mb4_bin".to_string());
     table.columns[2].attributes =
@@ -131,7 +131,7 @@ fn inspector_indexes_tab_for_mysql_hides_unsupported_partial_column() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.indexes = vec![Index {
         name: "idx_users_email_lower".to_string(),
         columns: vec!["lower(email)".to_string()],
@@ -161,7 +161,7 @@ fn inspector_indexes_tab_for_sqlite_hides_unknown_type() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     for index in &mut table.indexes {
         index.index_type = IndexType::Unknown;
     }
@@ -185,7 +185,7 @@ fn inspector_indexes_tab_shows_sqlite_partial_index_definition() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.indexes = vec![Index {
         name: "idx_users_email_active".to_string(),
         columns: vec!["email".to_string()],
@@ -216,7 +216,7 @@ fn inspector_indexes_tab_shows_sqlite_descending_index_definition() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.indexes = vec![Index {
         name: "idx_users_name_desc".to_string(),
         columns: vec!["name".to_string()],
@@ -244,7 +244,7 @@ fn inspector_indexes_tab_shows_sqlite_collation_index_definition() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.indexes = vec![Index {
         name: "idx_users_name_nocase".to_string(),
         columns: vec!["name".to_string()],
@@ -274,7 +274,7 @@ fn inspector_indexes_tab_shows_sqlite_partial_expression_details() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.indexes = vec![Index {
         name: "idx_users_email_lower".to_string(),
         columns: vec!["<expression>".to_string()],
@@ -319,7 +319,7 @@ fn inspector_foreign_keys_tab_with_data() {
 fn inspector_foreign_keys_tab_marks_unresolved_reference() {
     let mut state = table_detail_loaded_state();
     let mut terminal = create_test_terminal();
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.foreign_keys.push(ForeignKey {
         name: "fk_users_missing_org".to_string(),
         from_schema: "public".to_string(),
@@ -360,7 +360,7 @@ fn inspector_triggers_tab_empty() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.triggers = vec![];
     let _ = state.session.set_table_detail(table, 0);
     state.ui.set_inspector_tab(InspectorTab::Triggers);
@@ -389,7 +389,7 @@ fn inspector_info_tab_with_no_metadata() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.owner = None;
     table.comment = None;
     table.row_count_estimate = None;
@@ -407,7 +407,7 @@ fn inspector_info_tab_for_sqlite_hides_postgres_only_fields() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.owner = Some("postgres".to_string());
     table.comment = Some("SQLite should hide this comment".to_string());
     table.rls = None;
@@ -434,7 +434,7 @@ fn inspector_info_tab_for_mysql_hides_schema_field() {
 
     let _ = state
         .session
-        .set_table_detail(fixtures::sample_table_detail(), 0);
+        .set_table_detail(fixtures::sample_postgres_table_detail(), 0);
     state.session.activate_connection_with_dsn(
         &ConnectionId::from_string("mysql-test"),
         "app",
@@ -454,7 +454,7 @@ fn inspector_info_tab_for_mysql_shows_storage_attributes() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.storage_attributes = TableStorageAttributes {
         engine: Some("InnoDB".to_string()),
         row_format: Some("Compressed".to_string()),
@@ -490,7 +490,7 @@ fn inspector_ddl_tab_uses_source_ddl() {
     let mut services = AppServices::stub();
     services.ddl_generator = Arc::new(SourceDdlGenerator);
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.source_ddl = Some(
         "CREATE VIRTUAL TABLE users USING fts5(name, email);\n-- source ddl is not rebuilt"
             .to_string(),
@@ -513,7 +513,7 @@ fn inspector_info_tab_for_sqlite_shows_table_kind_fields() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.schema = "main".to_string();
     table.name = "notes_fts".to_string();
     table.owner = None;
@@ -545,7 +545,7 @@ fn inspector_info_tab_for_sqlite_shows_view_kind() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.schema = "main".to_string();
     table.name = "active_users".to_string();
     table.owner = None;

--- a/src/tests/render_snapshots/mod.rs
+++ b/src/tests/render_snapshots/mod.rs
@@ -2,7 +2,7 @@ use crate::tests::harness;
 
 use harness::fixtures;
 use harness::{
-    connected_state, create_test_state, create_test_terminal, create_test_terminal_sized,
+    create_test_state, create_test_terminal, create_test_terminal_sized, postgres_connected_state,
     render_and_get_buffer_at, render_to_string, test_instant,
 };
 

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -16,7 +16,7 @@ const POSTGRES_PLAN_QUERY: &str = "SELECT * FROM users WHERE id > 10";
 
 #[test]
 fn sql_modal_with_completion() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -33,7 +33,7 @@ fn sql_modal_with_completion() {
 
 #[test]
 fn sql_modal_completion_popup_with_scroll() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -109,7 +109,7 @@ fn sql_modal_completion_popup_with_scroll() {
 
 #[test]
 fn sql_modal_unknown_risk_acknowledge() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -131,7 +131,7 @@ fn sql_modal_unknown_risk_acknowledge() {
 
 #[test]
 fn sql_modal_high_risk_without_target_acknowledge() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -153,7 +153,7 @@ fn sql_modal_high_risk_without_target_acknowledge() {
 
 #[test]
 fn sql_modal_non_atomic_transaction_acknowledge() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -175,7 +175,7 @@ fn sql_modal_non_atomic_transaction_acknowledge() {
 
 #[test]
 fn sql_modal_analyze_unknown_risk_acknowledge() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -194,7 +194,7 @@ fn sql_modal_analyze_unknown_risk_acknowledge() {
 
 #[test]
 fn sql_modal_analyze_read_only_acknowledge() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -519,7 +519,7 @@ fn sql_modal_confirming_high_unmatched() {
 
 #[test]
 fn help_overlay() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
@@ -531,7 +531,7 @@ fn help_overlay() {
 
 #[test]
 fn help_overlay_filtered_current_result() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.ui.set_focused_pane(FocusedPane::Result);
@@ -551,7 +551,7 @@ fn help_overlay_filtered_current_result() {
 
 #[test]
 fn help_overlay_long_key_rows() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
@@ -564,7 +564,7 @@ fn help_overlay_long_key_rows() {
 
 #[test]
 fn help_overlay_narrow_horizontal_scroll() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal_sized(50, 24);
 
     state.modal.set_mode(InputMode::Help);
@@ -580,7 +580,7 @@ fn help_overlay_narrow_horizontal_scroll() {
 
 #[test]
 fn command_palette_overlay() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::CommandPalette);
@@ -592,7 +592,7 @@ fn command_palette_overlay() {
 
 #[test]
 fn settings_overlay() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.settings.open(state.ui.theme_id());
@@ -605,7 +605,7 @@ fn settings_overlay() {
 
 #[test]
 fn settings_overlay_keymap() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.settings.open(state.ui.theme_id());
@@ -619,7 +619,7 @@ fn settings_overlay_keymap() {
 
 #[test]
 fn settings_overlay_er_diagram() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.settings.open(state.ui.theme_id());
@@ -634,7 +634,7 @@ fn settings_overlay_er_diagram() {
 
 #[test]
 fn settings_overlay_er_diagram_custom_browser() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state
@@ -652,7 +652,7 @@ fn settings_overlay_er_diagram_custom_browser() {
 
 #[test]
 fn table_picker_overlay() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::TablePicker);
@@ -688,7 +688,7 @@ fn mysql_table_picker_shows_table_names_without_database() {
 
 #[test]
 fn command_line_input() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::CommandLine);

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -11,7 +11,7 @@ fn json_detail_state() -> (AppState, std::time::Instant) {
     state
         .session
         .mark_connected(Arc::new(fixtures::sample_metadata()));
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns.push(Column {
         name: "settings".to_string(),
         data_type: "jsonb".to_string(),
@@ -120,7 +120,7 @@ fn sqlite_json_text_cell_detail_state() -> (AppState, std::time::Instant) {
         false,
     )];
     state.session.mark_connected(Arc::new(metadata));
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.name = "notes".to_string();
     table.columns = vec![
         Column {

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use super::*;
 use harness::{
-    TEST_HEIGHT, TEST_WIDTH, connected_state, render_and_get_buffer,
+    TEST_HEIGHT, TEST_WIDTH, postgres_connected_state, render_and_get_buffer,
     render_and_get_buffer_at_with_theme, render_and_get_cursor_position, table_detail_loaded_state,
     with_current_result,
 };

--- a/src/tests/render_snapshots/style_assertions/completion_popup.rs
+++ b/src/tests/render_snapshots/style_assertions/completion_popup.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn sql_completion_popup_uses_injected_theme_styles() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let now = test_instant();
     let mut terminal = create_test_terminal();
     let theme = ThemePalette {

--- a/src/tests/render_snapshots/style_assertions/cursor_geometry.rs
+++ b/src/tests/render_snapshots/style_assertions/cursor_geometry.rs
@@ -6,7 +6,7 @@ fn json_detail_state() -> (AppState, Instant) {
     state
         .session
         .mark_connected(Arc::new(fixtures::sample_metadata()));
-    let mut table = fixtures::sample_table_detail();
+    let mut table = fixtures::sample_postgres_table_detail();
     table.columns.push(Column {
         name: "settings".to_string(),
         data_type: "jsonb".to_string(),
@@ -103,7 +103,7 @@ fn sql_modal_normal_and_insert_use_distinct_cursor_styles() {
 
 #[test]
 fn help_uses_block_cursor_while_browsing_and_terminal_cursor_while_filtering() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);

--- a/src/tests/render_snapshots/style_assertions/style_colors.rs
+++ b/src/tests/render_snapshots/style_assertions/style_colors.rs
@@ -76,7 +76,7 @@ fn staged_delete_row_uses_dark_red_bg() {
 
 #[test]
 fn scrim_applies_dim_modifier() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
@@ -131,7 +131,7 @@ fn result_highlight_respects_injected_now() {
 
 #[test]
 fn modal_border_uses_theme_color() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
@@ -196,7 +196,7 @@ fn header_status_uses_success_warning_and_error_colors() {
 
 #[test]
 fn read_only_header_uses_warning_badge_style() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "test",
@@ -222,7 +222,7 @@ fn read_only_header_uses_warning_badge_style() {
 
 #[test]
 fn help_overlay_uses_section_header_and_scrollbar_colors() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let now = test_instant();
     let mut terminal = create_test_terminal();
 
@@ -259,7 +259,7 @@ fn help_overlay_uses_section_header_and_scrollbar_colors() {
 
 #[test]
 fn help_overlay_omits_scrollbars_when_content_fits() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let mut terminal = create_test_terminal_sized(180, 300);
 
     state.modal.set_mode(InputMode::Help);
@@ -282,7 +282,7 @@ fn help_overlay_omits_scrollbars_when_content_fits() {
 
 #[test]
 fn test_contrast_theme_applies_help_overlay_navigation_colors() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let now = test_instant();
     let mut terminal = create_test_terminal();
 

--- a/src/tests/render_snapshots/style_assertions/theme_injection.rs
+++ b/src/tests/render_snapshots/style_assertions/theme_injection.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn injected_palette_changes_shell_modal_and_picker_styles() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let now = test_instant();
     let mut terminal = create_test_terminal();
     let theme = ThemePalette {
@@ -72,7 +72,7 @@ mod settings_theme {
 
     #[test]
     fn preview_uses_selected_theme_while_chrome_keeps_current() {
-        let mut state = connected_state();
+        let mut state = postgres_connected_state();
         let mut terminal = create_test_terminal();
 
         state.settings.open(ThemeId::Default);
@@ -162,7 +162,7 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
 
 #[test]
 fn light_theme_applies_shell_and_sql_colors() {
-    let mut state = connected_state();
+    let mut state = postgres_connected_state();
     let now = test_instant();
     let mut terminal = create_test_terminal();
 


### PR DESCRIPTION
## Problem
Snapshot test default fixtures encode PostgreSQL-specific state and table metadata without identifying the database.

## Background
The generic names make database-specific assumptions easy to miss when reading snapshot callers.

## Approach
Name the default connected state and table detail fixture after PostgreSQL while preserving every fixture value and snapshot payload.
