### PR TITLE
refactor(test): name SQLite diagnostics rejection test

### DIFF
--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -583,7 +583,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn postgres_dsn_is_rejected() {
+    async fn sqlite_diagnostics_rejects_postgres_dsn() {
         let registry = DbAdapterRegistry::new();
 
         let result = registry


### PR DESCRIPTION
## Problem
The registry test name does not identify that it exercises SQLite diagnostics or the PostgreSQL unsupported boundary.

## Background
The test calls the SQLite diagnostics API, while its old name describes only the rejected DSN.

## Approach
Use a name that states the tested API and unsupported input boundary while preserving the test body, assertions, routing, diagnostics API, and production behavior.