### PR TITLE
refactor(test): share MySQL metadata result fixture

### DIFF
--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -648,14 +648,8 @@ pub(super) fn metadata_shape_error(field: &str) -> DbOperationError {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_support::result;
     use super::*;
-
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
-        MySqlResultSet {
-            columns: columns.iter().map(|value| (*value).to_string()).collect(),
-            values,
-        }
-    }
 
     #[test]
     fn optional_nonempty_string_preserves_catalog_value_boundaries() {

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -13,6 +13,20 @@ mod preview;
 mod signature;
 mod table_detail;
 
+#[cfg(test)]
+mod test_support {
+    use crate::domain::QueryValue;
+
+    use super::MySqlResultSet;
+
+    pub(super) fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
+        MySqlResultSet {
+            columns: columns.iter().map(|value| (*value).to_string()).collect(),
+            values,
+        }
+    }
+}
+
 pub(super) use preview::{convert_preview_values_with_binary_charset, execute_preview};
 
 #[async_trait]

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -390,6 +390,7 @@ mod tests {
     #[cfg(unix)]
     use std::path::PathBuf;
 
+    use super::super::test_support::result;
     use super::*;
     use crate::domain::ColumnAttributes;
 
@@ -482,13 +483,6 @@ done
             !std::path::Path::new(option).exists(),
             "option file remains"
         );
-    }
-
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
-        MySqlResultSet {
-            columns: columns.iter().map(|value| (*value).to_string()).collect(),
-            values,
-        }
     }
 
     fn column(name: &str, data_type: &str) -> Column {

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -355,15 +355,9 @@ fn parse_signature_unique_column_metadata(
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_support::result;
     use super::*;
     use crate::domain::{Column, ColumnAttributes, ForeignKey, QueryValue, TableStorageAttributes};
-
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
-        MySqlResultSet {
-            columns: columns.iter().map(|value| (*value).to_string()).collect(),
-            values,
-        }
-    }
 
     fn signature_table() -> Table {
         Table {

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -875,15 +875,9 @@ done
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_support::result;
     use super::*;
     use crate::domain::QueryValue;
-
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
-        MySqlResultSet {
-            columns: columns.iter().map(|value| (*value).to_string()).collect(),
-            values,
-        }
-    }
 
     #[test]
     fn trigger_metadata_preserves_action_order_context_and_definition() {


### PR DESCRIPTION
## Problem
Four MySQL metadata test modules repeat the same MySqlResultSet construction, making fixture setup harder to scan.

## Background
The catalog, preview, signature, and table-detail tests share only the result-set structure; their columns, values, and transcripts remain responsibility-specific.

## Approach
Add a metadata-scoped test-only helper for the shared MySqlResultSet assembly and keep every caller's fixture data and ordering unchanged. Production code and SQLite fixtures are untouched.