### PR TITLE
refactor(test): share action receive timeout helper

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -309,7 +309,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures::{self, NoopRenderer};
+    use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
 
     use crate::domain::DatabaseMetadata;
     use crate::model::app_state::AppState;
@@ -363,10 +363,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(200)).await;
             assert!(
                 matches!(
                     action,
@@ -420,10 +418,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(200)).await;
             assert!(
                 matches!(
                     action,
@@ -483,10 +479,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -536,10 +530,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -590,10 +582,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -646,10 +636,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(matches!(
                 action,
                 Action::EffectiveUserLoaded {
@@ -715,10 +703,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -772,10 +758,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(action, Action::TableDetailCached { .. }),
                 "expected TableDetailCached, got {action:?}"

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -412,7 +412,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures::{self, NoopRenderer};
+    use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
     use crate::domain::{DatabaseDiagnostic, DiagnosticLevel, WriteExecutionResult};
     use crate::model::app_state::AppState;
     use crate::ports::outbound::AccessMode;
@@ -485,7 +485,7 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures::{self, NoopRenderer};
+        use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
         use crate::domain::QueryValue;
         use crate::model::app_state::AppState;
         use crate::ports::outbound::connection_store::MockConnectionStore;
@@ -549,10 +549,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action = recv_action_with_timeout(&mut rx, Duration::from_millis(500)).await;
             let Action::CsvExportSucceeded {
                 path, row_count, ..
             } = action
@@ -598,10 +595,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action = recv_action_with_timeout(&mut rx, Duration::from_millis(500)).await;
             assert!(matches!(action, Action::CsvExportFailed { run_id: 8, .. }));
         }
     }
@@ -615,7 +609,7 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures::{self, NoopRenderer};
+        use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
 
         use crate::model::app_state::AppState;
         use crate::ports::outbound::DbOperationError;
@@ -667,10 +661,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(action, Action::QueryCompleted { .. }),
                 "expected QueryCompleted, got {action:?}"
@@ -721,10 +713,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -767,10 +757,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            tokio::time::timeout(Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed")
+            recv_action_with_timeout(&mut rx, Duration::from_millis(500)).await
         }
 
         #[tokio::test]

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -434,7 +434,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures::{self, NoopRenderer};
+    use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
     use crate::domain::connection::{
         ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
         MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig, SqlitePathError, SslMode,
@@ -553,10 +553,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .unwrap()
-                .unwrap();
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(matches!(
                 action,
                 Action::ConnectionSaveCompleted {
@@ -618,10 +616,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .unwrap()
-                .unwrap();
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(matches!(
                 action,
                 Action::ConnectionSaveFailed {
@@ -768,10 +764,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -828,10 +822,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,
@@ -882,10 +874,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(action, Action::ConnectionDeleted(_)),
                 "expected ConnectionDeleted, got {action:?}"
@@ -926,10 +916,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(action, Action::ConnectionDeleteFailed(_)),
                 "expected ConnectionDeleteFailed, got {action:?}"
@@ -978,10 +966,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(action, Action::ConnectionsLoaded(ConnectionsLoadedPayload { ref profiles, .. }) if profiles.is_empty()),
                 "expected ConnectionsLoaded with empty profiles, got {action:?}"
@@ -1041,10 +1027,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-                .await
-                .expect("action timeout")
-                .expect("channel closed");
+            let action =
+                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
             assert!(
                 matches!(
                     action,

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -58,6 +58,7 @@ pub fn spawn_er_diagram_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmd::test_fixtures::recv_action_with_timeout;
     use crate::ports::outbound::ErExportResult;
     use std::path::Path;
     use std::time::Duration;
@@ -107,13 +108,6 @@ mod tests {
             }
         }
 
-        async fn receive_action(rx: &mut mpsc::Receiver<Action>) -> Action {
-            tokio::time::timeout(Duration::from_secs(1), rx.recv())
-                .await
-                .expect("timeout")
-                .expect("channel closed")
-        }
-
         #[tokio::test]
         async fn success_sends_opened_action() {
             let temp_dir = tempfile::tempdir().unwrap();
@@ -134,7 +128,7 @@ mod tests {
                 None,
             );
 
-            let action = receive_action(&mut rx).await;
+            let action = recv_action_with_timeout(&mut rx, Duration::from_secs(1)).await;
             match action {
                 Action::ErDiagramOpened(ErDiagramInfo {
                     run_id,
@@ -168,7 +162,7 @@ mod tests {
                 None,
             );
 
-            let action = receive_action(&mut rx).await;
+            let action = recv_action_with_timeout(&mut rx, Duration::from_secs(1)).await;
             match action {
                 Action::ErDiagramFailed { run_id, error } => {
                     assert!(error.contains("export failed"));
@@ -195,7 +189,7 @@ mod tests {
                 None,
             );
 
-            let action = receive_action(&mut rx).await;
+            let action = recv_action_with_timeout(&mut rx, Duration::from_secs(1)).await;
             match action {
                 Action::ErDiagramFailed { run_id, error } => {
                     assert!(error.contains("Task panicked"));

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc;
 
@@ -168,6 +168,16 @@ impl Renderer for NoopRenderer {
     ) -> RenderResult<RenderOutput> {
         Ok(RenderOutput::default())
     }
+}
+
+pub async fn recv_action_with_timeout(
+    rx: &mut mpsc::Receiver<Action>,
+    timeout: Duration,
+) -> Action {
+    tokio::time::timeout(timeout, rx.recv())
+        .await
+        .expect("action timeout")
+        .expect("channel closed")
 }
 
 pub struct NoopQueryHistoryStore;


### PR DESCRIPTION
## Problem
Command tests duplicate timed Action reception and channel-close handling, obscuring the test-specific Action assertions.

## Background
MDB12-008 targets the repeated test-only timeout pattern.

## Approach
Centralize only timed Action reception in the cfg(test) fixture helper while keeping caller-owned durations, payload matching, no-action assertions, and ER success/error/panic fake semantics local.