### PR TITLE
refactor(test): share MySQL metadata Column builder

### DIFF
--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -390,9 +390,9 @@ mod tests {
     #[cfg(unix)]
     use std::path::PathBuf;
 
+    use super::super::super::metadata_test_support::column;
     use super::super::test_support::result;
     use super::*;
-    use crate::domain::ColumnAttributes;
 
     fn convert_preview_values(
         result: &MySqlResultSet,
@@ -483,21 +483,6 @@ done
             !std::path::Path::new(option).exists(),
             "option file remains"
         );
-    }
-
-    fn column(name: &str, data_type: &str) -> Column {
-        Column {
-            name: name.to_string(),
-            data_type: data_type.to_string(),
-            default: None,
-            attributes: ColumnAttributes::empty(),
-            comment: None,
-            ordinal_position: 1,
-            character_set_name: None,
-            collation_name: None,
-            generation_expression: None,
-            generation_kind: None,
-        }
     }
 
     fn binary_charset_column(name: &str, data_type: &str) -> Column {

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -11,3 +11,23 @@ mod sql;
 pub mod test_support;
 
 pub use adapter::MySqlAdapter;
+
+#[cfg(test)]
+mod metadata_test_support {
+    use crate::domain::{Column, ColumnAttributes};
+
+    pub(super) fn column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            default: None,
+            attributes: ColumnAttributes::empty(),
+            comment: None,
+            ordinal_position: 1,
+            character_set_name: None,
+            collation_name: None,
+            generation_expression: None,
+            generation_kind: None,
+        }
+    }
+}

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -251,23 +251,8 @@ pub(in crate::adapters::mysql) fn build_metadata_select_query(
 
 #[cfg(test)]
 mod tests {
+    use super::super::super::metadata_test_support::column;
     use super::*;
-    use crate::domain::ColumnAttributes;
-
-    fn column(name: &str, data_type: &str) -> Column {
-        Column {
-            name: name.to_string(),
-            data_type: data_type.to_string(),
-            default: None,
-            attributes: ColumnAttributes::empty(),
-            comment: None,
-            ordinal_position: 1,
-            character_set_name: None,
-            collation_name: None,
-            generation_expression: None,
-            generation_kind: None,
-        }
-    }
 
     #[test]
     fn metadata_queries_escape_literals_and_preserve_scope_conditions() {


### PR DESCRIPTION
## Problem
Repeated identical MySQL metadata Column baseline setup makes the behavior-specific differences harder to see.

## Background
The same test fixture baseline is defined independently by preview conversion tests and MySQL metadata SQL tests.

## Approach
Keep one cfg(test)-only baseline builder in the MySQL adapter scope, separate from the metadata result-set helper. Leave caller-specific charset and other metadata differences explicit at each call site.