### PR TITLE
refactor(test): add single-effect command harness

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -749,7 +749,7 @@ mod tests {
                 tx,
             );
 
-            let _run = test_fixtures::run_one_effect(
+            let run = test_fixtures::run_one_effect(
                 &runner,
                 Effect::CacheInvalidate {
                     dsn: "dsn://target".to_string(),
@@ -762,6 +762,7 @@ mod tests {
             .await
             .unwrap();
 
+            assert_eq!(run.state.runtime.project_name(), "test");
             assert!(cache.get(&"dsn://target".to_string()).await.is_none());
         }
     }

--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -300,7 +300,6 @@ async fn prefetch_table_detail(
 
 #[cfg(test)]
 mod tests {
-    use crate::cmd::test_fixtures::make_runner;
     use std::cell::RefCell;
     use std::sync::Arc;
 
@@ -309,7 +308,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
+    use crate::cmd::test_fixtures;
 
     use crate::domain::DatabaseMetadata;
     use crate::model::app_state::AppState;
@@ -317,7 +316,6 @@ mod tests {
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
-    use crate::services::AppServices;
     use crate::update::action::Action;
 
     mod fetch_metadata {
@@ -345,26 +343,21 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchMetadata {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 7,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(200)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchMetadata {
-                        dsn: "dsn://test".to_string(),
-                        run_id: 7,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(200)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -400,26 +393,21 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id: 7,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(200)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchMetadata {
-                        dsn: dsn.clone(),
-                        run_id: 7,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(200)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -461,26 +449,21 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id: 7,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchMetadata {
-                        dsn: dsn.clone(),
-                        run_id: 7,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -512,26 +495,21 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchMetadata {
+                    dsn: "dsn://miss".to_string(),
+                    run_id: 7,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchMetadata {
-                        dsn: "dsn://miss".to_string(),
-                        run_id: 7,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -564,26 +542,21 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchMetadata {
+                    dsn: "dsn://err".to_string(),
+                    run_id: 7,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchMetadata {
-                        dsn: "dsn://err".to_string(),
-                        run_id: 7,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -610,7 +583,7 @@ mod tests {
                 });
 
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -618,26 +591,21 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchEffectiveUser {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 7,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchEffectiveUser {
-                        dsn: "dsn://test".to_string(),
-                        run_id: 7,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(matches!(
                 action,
                 Action::EffectiveUserLoaded {
@@ -682,29 +650,24 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::FetchTableDetail {
+                    dsn: "dsn://test".to_string(),
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation: 1,
+                    run_id: 9,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::FetchTableDetail {
-                        dsn: "dsn://test".to_string(),
-                        schema: "public".to_string(),
-                        table: "users".to_string(),
-                        generation: 1,
-                        run_id: 9,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -738,28 +701,23 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::PrefetchTableDetail {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 3,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::PrefetchTableDetail {
-                        dsn: "dsn://test".to_string(),
-                        run_id: 3,
-                        schema: "public".to_string(),
-                        table: "users".to_string(),
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(action, Action::TableDetailCached { .. }),
                 "expected TableDetailCached, got {action:?}"
@@ -782,7 +740,7 @@ mod tests {
 
             assert!(cache.get(&"dsn://target".to_string()).await.is_some());
 
-            let (tx, _rx) = mpsc::channel(8);
+            let (tx, mut _rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
@@ -791,22 +749,18 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
-
-            runner
-                .execute_effects(
-                    vec![Effect::CacheInvalidate {
-                        dsn: "dsn://target".to_string(),
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
+            let _run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::CacheInvalidate {
+                    dsn: "dsn://target".to_string(),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut _rx,
+                None,
+            )
+            .await
+            .unwrap();
 
             assert!(cache.get(&"dsn://target".to_string()).await.is_none());
         }

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -412,14 +412,13 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
+    use crate::cmd::test_fixtures;
     use crate::domain::{DatabaseDiagnostic, DiagnosticLevel, WriteExecutionResult};
     use crate::model::app_state::AppState;
     use crate::ports::outbound::AccessMode;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
-    use crate::services::AppServices;
     use crate::update::action::Action;
 
     mod explain_plan_text {
@@ -485,14 +484,13 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
+        use crate::cmd::test_fixtures;
         use crate::domain::QueryValue;
         use crate::model::app_state::AppState;
         use crate::ports::outbound::connection_store::MockConnectionStore;
         use crate::ports::outbound::metadata::MockMetadataProvider;
         use crate::ports::outbound::query_executor::MockQueryExecutor;
         use crate::ports::outbound::{CachedResultExporter, DbOperationError};
-        use crate::services::AppServices;
         use crate::update::action::Action;
 
         fn test_file_name(label: &str) -> String {
@@ -524,32 +522,28 @@ mod tests {
                 cache,
                 tx,
             );
-            let mut state = AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::ExportCsvFromCache {
+                    dsn: "sqlite:///tmp/test.db".to_string(),
+                    run_id: 7,
+                    file_name: test_file_name("success"),
+                    columns: vec!["id".to_string(), "payload".to_string()],
+                    values: vec![vec![
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::Blob(vec![0xAB, 0xCD]),
+                    ]],
+                    row_count: Some(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::ExportCsvFromCache {
-                        dsn: "sqlite:///tmp/test.db".to_string(),
-                        run_id: 7,
-                        file_name: test_file_name("success"),
-                        columns: vec!["id".to_string(), "payload".to_string()],
-                        values: vec![vec![
-                            QueryValue::SqlLiteral("1".to_string()),
-                            QueryValue::Blob(vec![0xAB, 0xCD]),
-                        ]],
-                        row_count: Some(1),
-                    }],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action = recv_action_with_timeout(&mut rx, Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             let Action::CsvExportSucceeded {
                 path, row_count, ..
             } = action
@@ -573,29 +567,25 @@ mod tests {
                 tx,
                 Arc::new(FailingCachedResultExporter),
             );
-            let mut state = AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::ExportCsvFromCache {
+                    dsn: "sqlite:///tmp/test.db".to_string(),
+                    run_id: 8,
+                    file_name: test_file_name("failure"),
+                    columns: vec!["id".to_string()],
+                    values: vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+                    row_count: Some(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::ExportCsvFromCache {
-                        dsn: "sqlite:///tmp/test.db".to_string(),
-                        run_id: 8,
-                        file_name: test_file_name("failure"),
-                        columns: vec!["id".to_string()],
-                        values: vec![vec![QueryValue::SqlLiteral("1".to_string())]],
-                        row_count: Some(1),
-                    }],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action = recv_action_with_timeout(&mut rx, Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(matches!(action, Action::CsvExportFailed { run_id: 8, .. }));
         }
     }
@@ -603,20 +593,20 @@ mod tests {
     mod execute_preview {
         use std::cell::RefCell;
         use std::sync::Arc;
+        use std::time::Duration;
 
         use tokio::sync::mpsc;
 
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
+        use crate::cmd::test_fixtures;
 
         use crate::model::app_state::AppState;
         use crate::ports::outbound::DbOperationError;
         use crate::ports::outbound::connection_store::MockConnectionStore;
         use crate::ports::outbound::metadata::MockMetadataProvider;
         use crate::ports::outbound::query_executor::MockQueryExecutor;
-        use crate::services::AppServices;
         use crate::update::action::{Action, QueryFailureContext};
 
         #[tokio::test]
@@ -637,32 +627,27 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::ExecutePreview {
+                    dsn: "dsn://test".to_string(),
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation: 1,
+                    run_id: 8,
+                    limit: 100,
+                    offset: 0,
+                    target_page: 0,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::ExecutePreview {
-                        dsn: "dsn://test".to_string(),
-                        schema: "public".to_string(),
-                        table: "users".to_string(),
-                        generation: 1,
-                        run_id: 8,
-                        limit: 100,
-                        offset: 0,
-                        target_page: 0,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(action, Action::QueryCompleted { .. }),
                 "expected QueryCompleted, got {action:?}"
@@ -689,32 +674,27 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::ExecutePreview {
+                    dsn: "dsn://test".to_string(),
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation: 1,
+                    run_id: 8,
+                    limit: 100,
+                    offset: 0,
+                    target_page: 0,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::ExecutePreview {
-                        dsn: "dsn://test".to_string(),
-                        schema: "public".to_string(),
-                        table: "users".to_string(),
-                        generation: 1,
-                        run_id: 8,
-                        limit: 100,
-                        offset: 0,
-                        target_page: 0,
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -742,22 +722,18 @@ mod tests {
                 cache,
                 tx,
             );
-            let mut state = AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                effect,
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![effect],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            recv_action_with_timeout(&mut rx, Duration::from_millis(500)).await
+            run.actions.into_iter().next().expect("action dispatched")
         }
 
         #[tokio::test]

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -1046,20 +1046,22 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.set_connections(vec![profile]);
 
-            let run = test_fixtures::run_one_effect(
-                &runner,
-                Effect::SwitchConnection {
-                    connection_index: 0,
-                },
-                state,
-                RefCell::new(CompletionEngine::new()),
-                &mut rx,
-                Some(std::time::Duration::from_millis(500)),
-            )
-            .await
-            .unwrap();
+            let mut renderer = NoopRenderer;
+            let ce = RefCell::new(CompletionEngine::new());
+            runner
+                .execute_effects(
+                    vec![Effect::SwitchConnection {
+                        connection_index: 0,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
 
-            let action = run.actions.into_iter().next().expect("action dispatched");
+            let action = rx.recv().await.expect("action dispatched");
             match action {
                 Action::SwitchConnection(ConnectionTarget {
                     id,
@@ -1070,7 +1072,7 @@ mod tests {
                 }) => {
                     assert_eq!(dsn, "fake://db.example.com:5432/mydb");
                     assert_eq!(name, "My DB");
-                    assert_eq!(id, run.state.connections()[0].id);
+                    assert_eq!(id, state.connections()[0].id);
                     assert_eq!(database_type, DatabaseType::PostgreSQL);
                 }
                 other => panic!("expected SwitchConnection, got {other:?}"),
@@ -1082,20 +1084,23 @@ mod tests {
             let (tx, mut rx) = mpsc::channel::<Action>(16);
             let runner = make_runner_with_dsn_builder(tx);
 
-            let run = test_fixtures::run_one_effect(
-                &runner,
-                Effect::SwitchConnection {
-                    connection_index: 99,
-                },
-                AppState::new("test".to_string()),
-                RefCell::new(CompletionEngine::new()),
-                &mut rx,
-                None,
-            )
-            .await
-            .unwrap();
+            let mut state = AppState::new("test".to_string());
+            let mut renderer = NoopRenderer;
+            let ce = RefCell::new(CompletionEngine::new());
+            runner
+                .execute_effects(
+                    vec![Effect::SwitchConnection {
+                        connection_index: 99,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
 
-            assert!(run.actions.is_empty());
+            assert!(rx.try_recv().is_err());
         }
     }
 }

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -434,7 +434,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_fixtures::{self, NoopRenderer, recv_action_with_timeout};
+    use crate::cmd::test_fixtures::{self, NoopRenderer};
     use crate::domain::connection::{
         ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
         MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig, SqlitePathError, SslMode,
@@ -532,29 +532,24 @@ mod tests {
                 Arc::new(MySqlDsnBuilder),
                 Arc::new(probe),
             );
-            let mut renderer = NoopRenderer;
-            let mut state = AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SaveAndConnect {
+                    id: None,
+                    name: "MySQL".to_string(),
+                    config: mysql_config(Some("app")),
+                    run_id: 1,
+                    run_guard: active_run_guard(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::SaveAndConnect {
-                        id: None,
-                        name: "MySQL".to_string(),
-                        config: mysql_config(Some("app")),
-                        run_id: 1,
-                        run_guard: active_run_guard(1),
-                    }],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(matches!(
                 action,
                 Action::ConnectionSaveCompleted {
@@ -595,29 +590,24 @@ mod tests {
                 Arc::new(MySqlDsnBuilder),
                 Arc::new(probe),
             );
-            let mut renderer = NoopRenderer;
-            let mut state = AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SaveAndConnect {
+                    id: None,
+                    name: "MySQL".to_string(),
+                    config: mysql_config(None),
+                    run_id: 1,
+                    run_guard: active_run_guard(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::SaveAndConnect {
-                        id: None,
-                        name: "MySQL".to_string(),
-                        config: mysql_config(None),
-                        run_id: 1,
-                        run_guard: active_run_guard(1),
-                    }],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(matches!(
                 action,
                 Action::ConnectionSaveFailed {
@@ -741,31 +731,26 @@ mod tests {
                 Arc::new(SqliteDsnBuilder),
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SaveAndConnect {
+                    id: None,
+                    name: "Local".to_string(),
+                    config: ConnectionConfig::SQLite(
+                        SqliteConnectionConfig::new(input_path).unwrap(),
+                    ),
+                    run_id: 1,
+                    run_guard: active_run_guard(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::SaveAndConnect {
-                        id: None,
-                        name: "Local".to_string(),
-                        config: ConnectionConfig::SQLite(
-                            SqliteConnectionConfig::new(input_path).unwrap(),
-                        ),
-                        run_id: 1,
-                        run_guard: active_run_guard(1),
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -799,31 +784,26 @@ mod tests {
                 Arc::new(SqliteDsnBuilder),
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SaveAndConnect {
+                    id: None,
+                    name: "Local".to_string(),
+                    config: ConnectionConfig::SQLite(
+                        SqliteConnectionConfig::new(path_str).unwrap(),
+                    ),
+                    run_id: 1,
+                    run_guard: active_run_guard(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::SaveAndConnect {
-                        id: None,
-                        name: "Local".to_string(),
-                        config: ConnectionConfig::SQLite(
-                            SqliteConnectionConfig::new(path_str).unwrap(),
-                        ),
-                        run_id: 1,
-                        run_guard: active_run_guard(1),
-                    }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -859,23 +839,18 @@ mod tests {
             );
 
             let id = ConnectionId::new();
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::DeleteConnection { id: id.clone() },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::DeleteConnection { id: id.clone() }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(action, Action::ConnectionDeleted(_)),
                 "expected ConnectionDeleted, got {action:?}"
@@ -901,23 +876,18 @@ mod tests {
             );
 
             let id = ConnectionId::new();
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::DeleteConnection { id },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::DeleteConnection { id }],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(action, Action::ConnectionDeleteFailed(_)),
                 "expected ConnectionDeleteFailed, got {action:?}"
@@ -951,23 +921,18 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::LoadConnections,
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::LoadConnections],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(action, Action::ConnectionsLoaded(ConnectionsLoadedPayload { ref profiles, .. }) if profiles.is_empty()),
                 "expected ConnectionsLoaded with empty profiles, got {action:?}"
@@ -1012,23 +977,18 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::LoadConnections,
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::LoadConnections],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action =
-                recv_action_with_timeout(&mut rx, std::time::Duration::from_millis(500)).await;
+            let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
                 matches!(
                     action,
@@ -1086,23 +1046,20 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.set_connections(vec![profile]);
 
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SwitchConnection {
+                    connection_index: 0,
+                },
+                state,
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
 
-            runner
-                .execute_effects(
-                    vec![Effect::SwitchConnection {
-                        connection_index: 0,
-                    }],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            let action = rx.recv().await.expect("action dispatched");
+            let action = run.actions.into_iter().next().expect("action dispatched");
             match action {
                 Action::SwitchConnection(ConnectionTarget {
                     id,
@@ -1113,7 +1070,7 @@ mod tests {
                 }) => {
                     assert_eq!(dsn, "fake://db.example.com:5432/mydb");
                     assert_eq!(name, "My DB");
-                    assert_eq!(id, state.connections()[0].id);
+                    assert_eq!(id, run.state.connections()[0].id);
                     assert_eq!(database_type, DatabaseType::PostgreSQL);
                 }
                 other => panic!("expected SwitchConnection, got {other:?}"),
@@ -1125,25 +1082,20 @@ mod tests {
             let (tx, mut rx) = mpsc::channel::<Action>(16);
             let runner = make_runner_with_dsn_builder(tx);
 
-            let mut state = AppState::new("test".to_string());
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SwitchConnection {
+                    connection_index: 99,
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                None,
+            )
+            .await
+            .unwrap();
 
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
-
-            runner
-                .execute_effects(
-                    vec![Effect::SwitchConnection {
-                        connection_index: 99,
-                    }],
-                    &mut renderer,
-                    &mut state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            assert!(rx.try_recv().is_err());
+            assert!(run.actions.is_empty());
         }
     }
 }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -394,7 +394,7 @@ mod tests {
 
         #[tokio::test]
         async fn calls_draw() {
-            let (tx, _rx) = mpsc::channel(8);
+            let (tx, mut _rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
@@ -403,20 +403,16 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
-
-            runner
-                .execute_effects(
-                    vec![Effect::Render],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
+            test_fixtures::run_one_effect(
+                &runner,
+                Effect::Render,
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut _rx,
+                None,
+            )
+            .await
+            .unwrap();
         }
 
         #[tokio::test]
@@ -511,7 +507,7 @@ mod tests {
 
         #[tokio::test]
         async fn dispatches_all_actions() {
-            let (tx, _rx) = mpsc::channel(8);
+            let (tx, mut _rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
@@ -520,31 +516,27 @@ mod tests {
                 tx,
             );
 
-            let state = &mut AppState::new("test".to_string());
-            let ce = RefCell::new(CompletionEngine::new());
-            let mut renderer = NoopRenderer;
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::DispatchActions(vec![
+                    Action::ProcessPrefetchQueue { run_id: 1 },
+                    Action::ProcessPrefetchQueue { run_id: 1 },
+                ]),
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut _rx,
+                None,
+            )
+            .await
+            .unwrap();
 
-            let result = runner
-                .execute_effects(
-                    vec![Effect::DispatchActions(vec![
-                        Action::ProcessPrefetchQueue { run_id: 1 },
-                        Action::ProcessPrefetchQueue { run_id: 1 },
-                    ])],
-                    &mut renderer,
-                    state,
-                    &ce,
-                    &AppServices::stub(),
-                )
-                .await
-                .unwrap();
-
-            assert_eq!(result.len(), 2);
+            assert_eq!(run.actions.len(), 2);
             assert!(matches!(
-                result[0],
+                run.actions[0],
                 Action::ProcessPrefetchQueue { run_id: 1 }
             ));
             assert!(matches!(
-                result[1],
+                run.actions[1],
                 Action::ProcessPrefetchQueue { run_id: 1 }
             ));
         }

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -1,10 +1,15 @@
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 
 use crate::cmd::cache::TtlCache;
+use crate::cmd::completion_engine::CompletionEngine;
+use crate::cmd::effect::Effect;
 use crate::cmd::runner::{
     ConnectionDeps, EffectRunner, ErDeps, QueryDeps, SettingsDeps, UtilityDeps,
 };
@@ -168,6 +173,39 @@ impl Renderer for NoopRenderer {
     ) -> RenderResult<RenderOutput> {
         Ok(RenderOutput::default())
     }
+}
+
+pub struct EffectRun {
+    pub state: AppState,
+    pub actions: Vec<Action>,
+}
+
+pub fn run_one_effect<'a>(
+    runner: &'a EffectRunner,
+    effect: Effect,
+    mut state: AppState,
+    completion_engine: RefCell<CompletionEngine>,
+    action_rx: &'a mut mpsc::Receiver<Action>,
+    action_timeout: Option<Duration>,
+) -> Pin<Box<dyn Future<Output = Result<EffectRun>> + 'a>> {
+    Box::pin(async move {
+        let mut renderer = NoopRenderer;
+        let mut actions = runner
+            .execute_effects(
+                vec![effect],
+                &mut renderer,
+                &mut state,
+                &completion_engine,
+                &AppServices::stub(),
+            )
+            .await?;
+
+        if let Some(timeout) = action_timeout {
+            actions.push(recv_action_with_timeout(action_rx, timeout).await);
+        }
+
+        Ok(EffectRun { state, actions })
+    })
 }
 
 pub async fn recv_action_with_timeout(


### PR DESCRIPTION
## Problem
Single-effect command tests repeat runner setup and action observation, making the behavior under test harder to see.

## Background
The command tests already share the no-op renderer and timeout receiver, but still duplicate the full single-effect execution lifecycle.

## Approach
Add a test-only `run_one_effect` harness that returns post-run state and observed actions while keeping effect payloads, caller-visible timeouts, DB-specific DSN builders, probes, SQLite validation, PostgreSQL service readers, custom renderers, and lifecycle tests local.