### PR TITLE
refactor(test): share MySQL process stop assertion

### DIFF
--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -19,6 +19,26 @@ mod test_support {
 
     use super::MySqlResultSet;
 
+    #[cfg(unix)]
+    pub(super) fn assert_process_stopped(transcript: &std::path::Path) {
+        for _ in 0..200 {
+            let pid = std::fs::read_to_string(transcript)
+                .unwrap()
+                .lines()
+                .find_map(|line| line.strip_prefix("process=")?.parse::<libc::pid_t>().ok());
+            if let Some(pid) = pid
+                && unsafe { libc::kill(pid, 0) } == -1
+            {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        panic!(
+            "fake mysql process is alive or did not start: {}",
+            std::fs::read_to_string(transcript).unwrap()
+        );
+    }
+
     pub(super) fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
         MySqlResultSet {
             columns: columns.iter().map(|value| (*value).to_string()).collect(),

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -687,6 +687,7 @@ mod session_tests {
 
     use tempfile::TempDir;
 
+    use super::super::test_support::assert_process_stopped;
     use super::*;
 
     fn fake_signature_cli() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
@@ -738,25 +739,6 @@ done
         permissions.set_mode(0o755);
         std::fs::set_permissions(&program, permissions).unwrap();
         (directory, program, transcript)
-    }
-
-    fn assert_process_stopped(transcript: &std::path::Path) {
-        for _ in 0..200 {
-            let pid = std::fs::read_to_string(transcript)
-                .unwrap()
-                .lines()
-                .find_map(|line| line.strip_prefix("process=")?.parse::<libc::pid_t>().ok());
-            if let Some(pid) = pid
-                && unsafe { libc::kill(pid, 0) } == -1
-            {
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
-        panic!(
-            "fake mysql process is alive or did not start: {}",
-            std::fs::read_to_string(transcript).unwrap()
-        );
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -454,6 +454,7 @@ mod session_tests {
 
     use tempfile::TempDir;
 
+    use super::super::test_support::assert_process_stopped;
     use super::*;
 
     fn fake_metadata_cli(mode: &str) -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
@@ -553,25 +554,6 @@ done
         permissions.set_mode(0o755);
         std::fs::set_permissions(&program, permissions).unwrap();
         (directory, program, transcript)
-    }
-
-    fn assert_process_stopped(transcript: &std::path::Path) {
-        for _ in 0..200 {
-            let pid = std::fs::read_to_string(transcript)
-                .unwrap()
-                .lines()
-                .find_map(|line| line.strip_prefix("process=")?.parse::<libc::pid_t>().ok());
-            if let Some(pid) = pid
-                && unsafe { libc::kill(pid, 0) } == -1
-            {
-                return;
-            }
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        panic!(
-            "fake mysql process is alive or did not start: {}",
-            std::fs::read_to_string(transcript).unwrap()
-        );
     }
 
     fn assert_option_file_removed(transcript: &std::path::Path) {


### PR DESCRIPTION
## Problem
MySQL metadata tests duplicate the same fake-process stop polling assertion in table detail and signature coverage.

## Background
The duplicate PID polling makes the MySQL fake CLI lifecycle check harder to maintain.

## Approach
Keep the process= transcript lifecycle assertion in MySQL metadata test support and use it from both existing test modules. Production code, fake CLI transcripts, and other transports remain unchanged.