### PR TITLE
refactor(test): share active connection save guard

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -440,7 +440,6 @@ mod tests {
         MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig, SqlitePathError, SslMode,
     };
     use crate::model::app_state::AppState;
-    use crate::model::browse::session::ConnectionSaveGuard;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::mysql_connection_probe::MockMySqlConnectionProbe;
@@ -492,12 +491,6 @@ mod tests {
             ))
         }
 
-        fn active_run_guard(run_id: u64) -> Arc<ConnectionSaveGuard> {
-            let guard = Arc::new(ConnectionSaveGuard::default());
-            guard.start(run_id);
-            guard
-        }
-
         #[tokio::test]
         async fn mysql_profile_is_saved_only_after_probe_success() {
             let dsn = "mysql://user:secret@localhost:3306/app?ssl-mode=REQUIRED";
@@ -539,7 +532,7 @@ mod tests {
                     name: "MySQL".to_string(),
                     config: mysql_config(Some("app")),
                     run_id: 1,
-                    run_guard: active_run_guard(1),
+                    run_guard: test_fixtures::active_connection_save_guard(1),
                 },
                 AppState::new("test".to_string()),
                 RefCell::new(CompletionEngine::new()),
@@ -597,7 +590,7 @@ mod tests {
                     name: "MySQL".to_string(),
                     config: mysql_config(None),
                     run_id: 1,
-                    run_guard: active_run_guard(1),
+                    run_guard: test_fixtures::active_connection_save_guard(1),
                 },
                 AppState::new("test".to_string()),
                 RefCell::new(CompletionEngine::new()),
@@ -621,7 +614,7 @@ mod tests {
         #[tokio::test]
         async fn mysql_profile_is_not_saved_when_run_is_cancelled_after_probe() {
             let dsn = "mysql://user:secret@localhost:3306/app?ssl-mode=REQUIRED";
-            let run_guard = active_run_guard(1);
+            let run_guard = test_fixtures::active_connection_save_guard(1);
             let guard_for_probe = Arc::clone(&run_guard);
             let mut probe = MockMySqlConnectionProbe::new();
             probe
@@ -677,7 +670,7 @@ mod tests {
 
         #[test]
         fn cancel_after_claim_prevents_save_from_starting() {
-            let run_guard = active_run_guard(1);
+            let run_guard = test_fixtures::active_connection_save_guard(1);
 
             assert!(run_guard.claim(1));
 
@@ -687,7 +680,7 @@ mod tests {
 
         #[test]
         fn finishing_cancelled_save_does_not_clear_new_run() {
-            let run_guard = active_run_guard(1);
+            let run_guard = test_fixtures::active_connection_save_guard(1);
 
             assert!(run_guard.claim(1));
             assert!(run_guard.start_save(1));
@@ -740,7 +733,7 @@ mod tests {
                         SqliteConnectionConfig::new(input_path).unwrap(),
                     ),
                     run_id: 1,
-                    run_guard: active_run_guard(1),
+                    run_guard: test_fixtures::active_connection_save_guard(1),
                 },
                 AppState::new("test".to_string()),
                 RefCell::new(CompletionEngine::new()),
@@ -793,7 +786,7 @@ mod tests {
                         SqliteConnectionConfig::new(path_str).unwrap(),
                     ),
                     run_id: 1,
-                    run_guard: active_run_guard(1),
+                    run_guard: test_fixtures::active_connection_save_guard(1),
                 },
                 AppState::new("test".to_string()),
                 RefCell::new(CompletionEngine::new()),

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -1098,7 +1098,6 @@ mod tests {
         use crate::domain::connection::{
             ConnectionConfig, ConnectionId, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
         };
-        use crate::model::browse::session::ConnectionSaveGuard;
         use crate::ports::outbound::DbOperationError;
         use crate::update::action::ConnectionTarget;
         use crate::update::reducer::reduce;
@@ -1149,12 +1148,6 @@ mod tests {
                 "secret",
                 MySqlSslMode::Required,
             ))
-        }
-
-        fn active_run_guard(run_id: u64) -> Arc<ConnectionSaveGuard> {
-            let guard = Arc::new(ConnectionSaveGuard::default());
-            guard.start(run_id);
-            guard
         }
 
         #[tokio::test]
@@ -1259,7 +1252,7 @@ mod tests {
                         name: "old".to_string(),
                         config: mysql_config(),
                         run_id: 1,
-                        run_guard: active_run_guard(1),
+                        run_guard: test_fixtures::active_connection_save_guard(1),
                     }],
                     &mut renderer,
                     &mut state,

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -21,6 +21,7 @@ use crate::domain::{
     SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
 };
 use crate::model::app_state::AppState;
+use crate::model::browse::session::ConnectionSaveGuard;
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
     AppSettings, CachedResultExporter, ClipboardError, ClipboardWriter, ConfigWriter,
@@ -173,6 +174,12 @@ impl Renderer for NoopRenderer {
     ) -> RenderResult<RenderOutput> {
         Ok(RenderOutput::default())
     }
+}
+
+pub fn active_connection_save_guard(run_id: u64) -> Arc<ConnectionSaveGuard> {
+    let guard = Arc::new(ConnectionSaveGuard::default());
+    guard.start(run_id);
+    guard
 }
 
 pub struct EffectRun {


### PR DESCRIPTION
## Problem
Connection save and MySQL probe lifecycle tests duplicate the setup that activates a connection-save guard, allowing the setup to drift between test groups.

## Approach
Centralize the test-only setup in cmd/test_fixtures with an explicit run_id and start the guard before returning it. Use it only from the connection-save and runner probe lifecycle tests; production behavior remains unchanged.