### PR TITLE
refactor(app): clarify tracked task cancellation

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -96,7 +96,7 @@ pub enum Effect {
         query: String,
         access_mode: AccessMode,
     },
-    CancelActiveTasks,
+    CancelTrackedTasks,
     CountRowsForExport {
         dsn: String,
         run_id: u64,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -113,7 +113,7 @@ impl EffectRunner {
         self.metadata_tasks.cancel().await;
     }
 
-    async fn cancel_active_tasks(&self) {
+    async fn cancel_tracked_tasks(&self) {
         self.query_tasks.cancel();
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
@@ -255,8 +255,8 @@ impl EffectRunner {
                 Ok(vec![])
             }
 
-            Effect::CancelActiveTasks => {
-                self.cancel_active_tasks().await;
+            Effect::CancelTrackedTasks => {
+                self.cancel_tracked_tasks().await;
                 Ok(vec![])
             }
 
@@ -1212,7 +1212,7 @@ mod tests {
 
             runner
                 .execute_effects(
-                    vec![Effect::CancelActiveTasks],
+                    vec![Effect::CancelTrackedTasks],
                     &mut renderer,
                     &mut state,
                     &completion_engine,
@@ -1285,7 +1285,7 @@ mod tests {
 
             runner
                 .execute_effects(
-                    vec![Effect::CancelActiveTasks],
+                    vec![Effect::CancelTrackedTasks],
                     &mut renderer,
                     &mut state,
                     &completion_engine,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -202,7 +202,7 @@ pub fn reduce_execution(
             DispatchResult::handled_with(match follow_up {
                 Action::Quit => {
                     state.should_quit = true;
-                    vec![Effect::CancelActiveTasks]
+                    vec![Effect::CancelTrackedTasks]
                 }
                 Action::ToggleModal(ModalKind::Help) => {
                     state.ui.help_mut().open(HelpOrigin::CommandLine);
@@ -621,7 +621,7 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.should_quit);
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1118,7 +1118,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|effect| matches!(effect, Effect::CancelActiveTasks))
+                    .any(|effect| matches!(effect, Effect::CancelTrackedTasks))
             );
             assert!(
                 !effects
@@ -1651,7 +1651,7 @@ mod tests {
             assert!(state.connection_error.error_info().is_some());
             assert!(matches!(
                 error_effects.as_slice(),
-                [Effect::CancelActiveTasks]
+                [Effect::CancelTrackedTasks]
             ));
         }
 
@@ -1960,7 +1960,7 @@ mod tests {
                     _ => None,
                 })
                 .unwrap();
-            assert!(matches!(effects.first(), Some(Effect::CancelActiveTasks)));
+            assert!(matches!(effects.first(), Some(Effect::CancelTrackedTasks)));
             assert!(!state.query.is_running());
             assert!(!state.query.is_current_run(query_run_id));
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1026,7 +1026,7 @@ mod tests {
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
             assert!(matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveTasks, Effect::SaveAndConnect { .. }]
+                [Effect::CancelTrackedTasks, Effect::SaveAndConnect { .. }]
             ));
         }
 
@@ -1038,7 +1038,7 @@ mod tests {
             let first_effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
             assert!(first_effects.is_some_and(|effects| matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveTasks, Effect::SaveAndConnect { .. }]
+                [Effect::CancelTrackedTasks, Effect::SaveAndConnect { .. }]
             )));
 
             let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
@@ -1068,7 +1068,7 @@ mod tests {
             assert!(!state.connection_setup.ssl_dropdown().is_open());
             assert!(matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveTasks, Effect::SaveAndConnect {
+                [Effect::CancelTrackedTasks, Effect::SaveAndConnect {
                     config: ConnectionConfig::PostgreSQL(config),
                     ..
                 }] if config.ssl_mode == SslMode::Require
@@ -1106,7 +1106,7 @@ mod tests {
 
             assert!(matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveTasks, Effect::SaveAndConnect {
+                [Effect::CancelTrackedTasks, Effect::SaveAndConnect {
                     name,
                     config: ConnectionConfig::PostgreSQL(config),
                     ..

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -30,7 +30,7 @@ pub(super) fn reduce_confirm_dialog(
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    DispatchResult::handled_with(vec![Effect::CancelActiveTasks])
+                    DispatchResult::handled_with(vec![Effect::CancelTrackedTasks])
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
                     DispatchResult::handled_with(vec![Effect::DeleteConnection { id }])

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -606,7 +606,7 @@ mod tests {
 
                 assert!(state.should_quit);
                 assert!(state.confirm_dialog.intent().is_none());
-                assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
+                assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
             }
 
             #[test]

--- a/src/app/update/query_context.rs
+++ b/src/app/update/query_context.rs
@@ -9,7 +9,7 @@ pub fn termination_effects(query: &QueryExecution, follow_up: Vec<Effect>) -> Ve
     );
 
     let mut effects = Vec::with_capacity(follow_up.len() + 1);
-    effects.push(Effect::CancelActiveTasks);
+    effects.push(Effect::CancelTrackedTasks);
     effects.extend(follow_up);
     effects
 }
@@ -26,7 +26,7 @@ mod tests {
 
         let effects = termination_effects(&query, vec![Effect::ClearCompletionEngineCache]);
 
-        assert!(matches!(effects[0], Effect::CancelActiveTasks));
+        assert!(matches!(effects[0], Effect::CancelTrackedTasks));
         assert!(matches!(effects[1], Effect::ClearCompletionEngineCache));
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -82,7 +82,7 @@ fn dispatch_enabled_action(
         }
         Action::Quit => {
             state.should_quit = true;
-            vec![Effect::CancelActiveTasks]
+            vec![Effect::CancelTrackedTasks]
         }
         Action::Resize(w, h) => {
             state.ui.set_terminal_width(w);
@@ -215,14 +215,14 @@ mod tests {
         use rstest::rstest;
 
         #[test]
-        fn quit_sets_should_quit_and_cancels_active_tasks() {
+        fn quit_sets_should_quit_and_cancels_tracked_tasks() {
             let mut state = create_test_state();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::Quit, now, &AppServices::stub());
 
             assert!(state.should_quit);
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]
@@ -320,7 +320,7 @@ mod tests {
                 state.session.table_detail_state(),
                 TableDetailState::Error(message) if message == "No active connection"
             ));
-            assert!(matches!(effects.first(), Some(Effect::CancelActiveTasks)));
+            assert!(matches!(effects.first(), Some(Effect::CancelTrackedTasks)));
         }
     }
 
@@ -1358,7 +1358,7 @@ mod tests {
             ));
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
             assert!(state.connection_error.has_error());
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]
@@ -2175,7 +2175,7 @@ mod tests {
 
             assert!(state.should_quit);
             assert!(state.confirm_dialog.intent().is_none());
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]
@@ -2706,7 +2706,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|effect| matches!(effect, Effect::CancelActiveTasks))
+                    .any(|effect| matches!(effect, Effect::CancelTrackedTasks))
             );
             assert!(
                 effects

--- a/src/app/update/test_fixtures.rs
+++ b/src/app/update/test_fixtures.rs
@@ -37,7 +37,7 @@ pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: D
                 panic!("expected Sequence, got {effects:?}");
             };
             assert_eq!(seq.len(), 4);
-            assert!(matches!(seq[0], Effect::CancelActiveTasks));
+            assert!(matches!(seq[0], Effect::CancelTrackedTasks));
             assert!(matches!(seq[1], Effect::CacheInvalidate { .. }));
             assert!(matches!(seq[2], Effect::ClearCompletionEngineCache));
             assert!(matches!(seq[3], Effect::FetchMetadata { .. }));
@@ -48,7 +48,7 @@ pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: D
                 3,
                 "postgres save should preserve prefetched metadata cache"
             );
-            assert!(matches!(effects[0], Effect::CancelActiveTasks));
+            assert!(matches!(effects[0], Effect::CancelTrackedTasks));
             assert!(matches!(effects[1], Effect::ClearCompletionEngineCache));
             assert!(matches!(effects[2], Effect::FetchMetadata { .. }));
         }


### PR DESCRIPTION
## Problem

The cancellation effect name implied that every active asynchronous task was stopped, although only registry-tracked work is owned by this path.

## Approach

Name the effect and runner operation after their tracked-task ownership while preserving the cancellation targets and order.