### PR TITLE
refactor(app): clarify connection save transitions

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -73,7 +73,7 @@ fn claim_and_save<T>(
     run_id: u64,
     save: impl FnOnce() -> T,
 ) -> Option<T> {
-    if !run_guard.claim(run_id) || !run_guard.start_save(run_id) {
+    if !run_guard.claim(run_id) || !run_guard.begin_persistence(run_id) {
         return None;
     }
     let result = save();
@@ -675,7 +675,7 @@ mod tests {
             assert!(run_guard.claim(1));
 
             run_guard.cancel();
-            assert!(!run_guard.start_save(1));
+            assert!(!run_guard.begin_persistence(1));
         }
 
         #[test]
@@ -683,10 +683,10 @@ mod tests {
             let run_guard = test_fixtures::active_connection_save_guard(1);
 
             assert!(run_guard.claim(1));
-            assert!(run_guard.start_save(1));
+            assert!(run_guard.begin_persistence(1));
 
             run_guard.cancel();
-            run_guard.start(2);
+            run_guard.arm_save(2);
             run_guard.finish_save(1);
 
             assert!(run_guard.claim(2));

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -178,7 +178,7 @@ impl Renderer for NoopRenderer {
 
 pub fn active_connection_save_guard(run_id: u64) -> Arc<ConnectionSaveGuard> {
     let guard = Arc::new(ConnectionSaveGuard::default());
-    guard.start(run_id);
+    guard.arm_save(run_id);
     guard
 }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -30,7 +30,7 @@ enum ConnectionSaveState {
 }
 
 impl ConnectionSaveGuard {
-    pub(crate) fn start(&self, run_id: u64) {
+    pub(crate) fn arm_save(&self, run_id: u64) {
         *self.state.lock().expect("connection save guard poisoned") =
             ConnectionSaveState::Active(run_id);
     }
@@ -48,7 +48,7 @@ impl ConnectionSaveGuard {
         true
     }
 
-    pub(crate) fn start_save(&self, run_id: u64) -> bool {
+    pub(crate) fn begin_persistence(&self, run_id: u64) -> bool {
         let mut state = self.state.lock().expect("connection save guard poisoned");
         if *state != ConnectionSaveState::Claimed(run_id) {
             return false;
@@ -311,7 +311,7 @@ impl BrowseSession {
     #[must_use]
     pub fn begin_connection_save(&mut self) -> u64 {
         let run_id = self.connection_save_run.begin();
-        self.connection_save_guard.start(run_id);
+        self.connection_save_guard.arm_save(run_id);
         run_id
     }
 


### PR DESCRIPTION
## Problem

Connection save lifecycle methods used similar start-oriented names for distinct state transitions, making guard ownership difficult to follow.

## Approach

Name reservation and persistence transitions by their separate responsibilities while preserving lifecycle state and cancellation behavior.