### PR TITLE
refactor(sqlite): clarify core diagnostics naming

### DIFF
--- a/src/app/cmd/sqlite_diagnostics.rs
+++ b/src/app/cmd/sqlite_diagnostics.rs
@@ -17,7 +17,7 @@ pub fn run(
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
             tokio::spawn(async move {
-                let action = match provider.fetch_diagnostics_core(&dsn).await {
+                let action = match provider.fetch_core_diagnostics(&dsn).await {
                     Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
                         dsn,
                         run_id,
@@ -62,7 +62,7 @@ mod tests {
     async fn dispatches_core_snapshot_on_success() {
         let (tx, mut rx) = mpsc::channel(1);
         let mut provider = MockSqliteDiagnosticsProvider::new();
-        provider.expect_fetch_diagnostics_core().returning(|_| {
+        provider.expect_fetch_core_diagnostics().returning(|_| {
             Ok(SqliteDiagnosticsSnapshot {
                 sqlite_version: DiagnosticField::ok("3.45.0"),
                 ..Default::default()
@@ -122,7 +122,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let mut provider = MockSqliteDiagnosticsProvider::new();
         provider
-            .expect_fetch_diagnostics_core()
+            .expect_fetch_core_diagnostics()
             .returning(|_| Err(DbOperationError::QueryFailed("boom".to_string())));
 
         let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -260,7 +260,7 @@ impl SettingsStore for NoopSettingsStore {
 pub struct NoopSqliteDiagnosticsProvider;
 #[async_trait::async_trait]
 impl SqliteDiagnosticsProvider for NoopSqliteDiagnosticsProvider {
-    async fn fetch_diagnostics_core(
+    async fn fetch_core_diagnostics(
         &self,
         _dsn: &str,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {

--- a/src/app/model/sqlite/diagnostics.rs
+++ b/src/app/model/sqlite/diagnostics.rs
@@ -59,7 +59,7 @@ pub struct SqliteDiagnosticsState {
 }
 
 impl SqliteDiagnosticsState {
-    pub fn begin_fetch(&mut self) -> u64 {
+    pub fn begin_core_fetch(&mut self) -> u64 {
         self.next_run_id = self.next_run_id.wrapping_add(1);
         let run_id = self.next_run_id;
         self.load_state = LoadState::LoadingCore { run_id };
@@ -230,11 +230,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn begin_fetch_assigns_monotonic_run_id() {
+    fn begin_core_fetch_assigns_monotonic_run_id() {
         let mut state = SqliteDiagnosticsState::default();
 
-        let first = state.begin_fetch();
-        let second = state.begin_fetch();
+        let first = state.begin_core_fetch();
+        let second = state.begin_core_fetch();
 
         assert_eq!(first, 1);
         assert_eq!(second, 2);
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn stale_run_does_not_replace_loaded_snapshot() {
         let mut state = SqliteDiagnosticsState::default();
-        let run_id = state.begin_fetch();
+        let run_id = state.begin_core_fetch();
         state.set_core_loaded(
             run_id,
             SqliteDiagnosticsSnapshot {
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn core_loaded_leaves_quick_check_idle() {
         let mut state = SqliteDiagnosticsState::default();
-        let run_id = state.begin_fetch();
+        let run_id = state.begin_core_fetch();
         state.set_core_loaded(
             run_id,
             SqliteDiagnosticsSnapshot {
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn begin_quick_check_marks_loaded_snapshot_running() {
         let mut state = SqliteDiagnosticsState::default();
-        let run_id = state.begin_fetch();
+        let run_id = state.begin_core_fetch();
         state.set_core_loaded(run_id, SqliteDiagnosticsSnapshot::default());
 
         let quick_check_run_id = state.begin_quick_check();
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn loading_core_cannot_run_quick_check() {
         let mut state = SqliteDiagnosticsState::default();
-        state.begin_fetch();
+        state.begin_core_fetch();
 
         let quick_check_run_id = state.begin_quick_check();
 
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn quick_check_loaded_clears_running_flag() {
         let mut state = SqliteDiagnosticsState::default();
-        let run_id = state.begin_fetch();
+        let run_id = state.begin_core_fetch();
         state.set_core_loaded(run_id, SqliteDiagnosticsSnapshot::default());
         state.begin_quick_check();
         state.set_quick_check_loaded(run_id, DiagnosticField::ok("ok"));

--- a/src/app/ports/outbound/sqlite_diagnostics.rs
+++ b/src/app/ports/outbound/sqlite_diagnostics.rs
@@ -7,7 +7,7 @@ use super::DbOperationError;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SqliteDiagnosticsProvider: Send + Sync {
-    async fn fetch_diagnostics_core(
+    async fn fetch_core_diagnostics(
         &self,
         dsn: &str,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError>;

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -826,7 +826,7 @@ mod tests {
         }
 
         fn seed_sqlite_diagnostics(state: &mut AppState) {
-            let run_id = state.sqlite_diagnostics.begin_fetch();
+            let run_id = state.sqlite_diagnostics.begin_core_fetch();
             state
                 .sqlite_diagnostics
                 .set_core_loaded(run_id, SqliteDiagnosticsSnapshot::default());

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -561,7 +561,7 @@ mod tests {
                 "SELECT * FROM users",
             );
             state.explain.set_error("stale error".to_string());
-            let diagnostics_run_id = state.sqlite_diagnostics.begin_fetch();
+            let diagnostics_run_id = state.sqlite_diagnostics.begin_core_fetch();
             state
                 .sqlite_diagnostics
                 .set_core_loaded(diagnostics_run_id, SqliteDiagnosticsSnapshot::default());

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -16,7 +16,7 @@ pub(super) fn reduce_sqlite_diagnostics(
             let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
-            let run_id = state.sqlite_diagnostics.begin_fetch();
+            let run_id = state.sqlite_diagnostics.begin_core_fetch();
             state.modal.set_mode(InputMode::SqliteDiagnostics);
             DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsCore { dsn, run_id }])
         }
@@ -118,7 +118,7 @@ mod tests {
     fn run_quick_check_starts_read_only_effect_for_loaded_snapshot() {
         let mut state = AppState::new("test".to_string());
         test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
-        let run_id = state.sqlite_diagnostics.begin_fetch();
+        let run_id = state.sqlite_diagnostics.begin_core_fetch();
         state.sqlite_diagnostics.set_core_loaded(
             run_id,
             SqliteDiagnosticsSnapshot {
@@ -163,7 +163,7 @@ mod tests {
             DatabaseType::PostgreSQL,
             "postgres://localhost/db",
         );
-        let run_id = state.sqlite_diagnostics.begin_fetch();
+        let run_id = state.sqlite_diagnostics.begin_core_fetch();
         state.sqlite_diagnostics.set_core_loaded(
             run_id,
             SqliteDiagnosticsSnapshot {
@@ -204,7 +204,7 @@ mod tests {
     fn quick_check_loaded_ignores_stale_run_id() {
         let mut state = AppState::new("test".to_string());
         test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
-        let run_id = state.sqlite_diagnostics.begin_fetch();
+        let run_id = state.sqlite_diagnostics.begin_core_fetch();
         state.sqlite_diagnostics.set_core_loaded(
             run_id,
             SqliteDiagnosticsSnapshot {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -470,7 +470,7 @@ mod tests {
             );
 
             let mut diagnostics_state = postgres_state();
-            let run_id = diagnostics_state.sqlite_diagnostics.begin_fetch();
+            let run_id = diagnostics_state.sqlite_diagnostics.begin_core_fetch();
             assert_unsupported_action_is_a_noop(
                 &mut diagnostics_state,
                 Action::SqliteDiagnosticsCoreLoaded {

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -277,7 +277,7 @@ impl MySqlConnectionProbe for DbAdapterRegistry {
 
 #[async_trait]
 impl SqliteDiagnosticsProvider for DbAdapterRegistry {
-    async fn fetch_diagnostics_core(
+    async fn fetch_core_diagnostics(
         &self,
         dsn: &str,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
@@ -287,7 +287,7 @@ impl SqliteDiagnosticsProvider for DbAdapterRegistry {
                     "SQLite diagnostics are unavailable for non-SQLite connections".to_string(),
                 ))
             }
-            DatabaseType::SQLite => self.sqlite.fetch_diagnostics_core(dsn).await,
+            DatabaseType::SQLite => self.sqlite.fetch_core_diagnostics(dsn).await,
         }
     }
 
@@ -587,7 +587,7 @@ mod tests {
         let registry = DbAdapterRegistry::new();
 
         let result = registry
-            .fetch_diagnostics_core("postgres://localhost/db")
+            .fetch_core_diagnostics("postgres://localhost/db")
             .await;
 
         assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));

--- a/src/infra/adapters/sqlite/diagnostics.rs
+++ b/src/infra/adapters/sqlite/diagnostics.rs
@@ -9,7 +9,7 @@ use super::SqliteAdapter;
 
 #[async_trait]
 impl SqliteDiagnosticsProvider for SqliteAdapter {
-    async fn fetch_diagnostics_core(
+    async fn fetch_core_diagnostics(
         &self,
         dsn: &str,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
@@ -274,12 +274,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_diagnostics_core_reports_pragmas_without_quick_check() {
+    async fn fetch_core_diagnostics_reports_pragmas_without_quick_check() {
         let (_dir, dsn) =
             test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
         let adapter = SqliteAdapter::new();
 
-        let snapshot = adapter.fetch_diagnostics_core(&dsn).await.unwrap();
+        let snapshot = adapter.fetch_core_diagnostics(&dsn).await.unwrap();
 
         assert!(snapshot.db_file.is_ok());
         assert!(snapshot.sqlite_version.is_ok());

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -811,7 +811,7 @@ mod tests {
                     .execute_preview(&dsn, "main", "users", 10, 0)
                     .await
                     .unwrap();
-                let diagnostics = adapter.fetch_diagnostics_core(&dsn).await.unwrap();
+                let diagnostics = adapter.fetch_core_diagnostics(&dsn).await.unwrap();
 
                 assert_eq!(write.affected_rows, 1);
                 assert_eq!(

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -1016,7 +1016,7 @@ fn sqlite_diagnostics_overlay_loading() {
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
-    state.sqlite_diagnostics.begin_fetch();
+    state.sqlite_diagnostics.begin_core_fetch();
     state.modal.set_mode(InputMode::SqliteDiagnostics);
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -1031,7 +1031,7 @@ fn sqlite_diagnostics_overlay_loaded() {
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
-    let run_id = state.sqlite_diagnostics.begin_fetch();
+    let run_id = state.sqlite_diagnostics.begin_core_fetch();
     state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
@@ -1062,7 +1062,7 @@ fn sqlite_diagnostics_overlay_partial_failure() {
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
-    let run_id = state.sqlite_diagnostics.begin_fetch();
+    let run_id = state.sqlite_diagnostics.begin_core_fetch();
     state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
@@ -1091,7 +1091,7 @@ fn sqlite_diagnostics_overlay_quick_check_pending() {
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
-    let run_id = state.sqlite_diagnostics.begin_fetch();
+    let run_id = state.sqlite_diagnostics.begin_core_fetch();
     state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
@@ -1123,7 +1123,7 @@ fn sqlite_diagnostics_overlay_quick_check_not_run() {
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
-    let run_id = state.sqlite_diagnostics.begin_fetch();
+    let run_id = state.sqlite_diagnostics.begin_core_fetch();
     state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {
@@ -1154,7 +1154,7 @@ fn sqlite_diagnostics_overlay_wrapped_scroll() {
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal_sized(50, 24);
 
-    let run_id = state.sqlite_diagnostics.begin_fetch();
+    let run_id = state.sqlite_diagnostics.begin_core_fetch();
     state.sqlite_diagnostics.set_core_loaded(
         run_id,
         SqliteDiagnosticsSnapshot {


### PR DESCRIPTION
## Problem

SQLite diagnostics used inconsistent names for the initial core snapshot, obscuring the boundary from the separate quick check.

## Approach

Use the core diagnostics vocabulary consistently across the port, model, command, adapter, and callers while preserving the staged load behavior.