### PR TITLE
refactor(app): clarify table prefetch effect

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -59,7 +59,7 @@ pub async fn run(
                 table_detail_tasks,
             );
         }
-        Effect::PrefetchTableDetail {
+        Effect::PrefetchTableColumnsAndFks {
             dsn,
             run_id,
             schema,
@@ -703,7 +703,7 @@ mod tests {
 
             let run = test_fixtures::run_one_effect(
                 &runner,
-                Effect::PrefetchTableDetail {
+                Effect::PrefetchTableColumnsAndFks {
                     dsn: "dsn://test".to_string(),
                     run_id: 3,
                     schema: "public".to_string(),

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -50,7 +50,7 @@ pub enum Effect {
         run_id: u64,
     },
     // Only caches in completion_engine, does NOT update state.table_detail
-    PrefetchTableDetail {
+    PrefetchTableColumnsAndFks {
         dsn: String,
         run_id: u64,
         schema: String,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -234,7 +234,7 @@ impl EffectRunner {
             e @ (Effect::FetchMetadata { .. }
             | Effect::FetchEffectiveUser { .. }
             | Effect::FetchTableDetail { .. }
-            | Effect::PrefetchTableDetail { .. }
+            | Effect::PrefetchTableColumnsAndFks { .. }
             | Effect::ProcessPrefetchQueue { .. }
             | Effect::DelayedProcessPrefetchQueue { .. }
             | Effect::CacheInvalidate { .. }) => {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -614,7 +614,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|e| matches!(e, Effect::PrefetchTableDetail { .. }))
+                    .any(|e| matches!(e, Effect::PrefetchTableColumnsAndFks { .. }))
             );
         }
     }
@@ -1034,7 +1034,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .all(|effect| matches!(effect, Effect::PrefetchTableDetail { .. }))
+                    .all(|effect| matches!(effect, Effect::PrefetchTableColumnsAndFks { .. }))
             );
             assert!(
                 !effects

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -81,7 +81,7 @@ fn prefetch_table_detail(
         state.er_preparation.start_fetching(&qualified_name);
     }
 
-    vec![Effect::PrefetchTableDetail {
+    vec![Effect::PrefetchTableColumnsAndFks {
         dsn,
         run_id,
         schema: schema.to_string(),


### PR DESCRIPTION
## Problem

The lightweight metadata prefetch effect was named like a full table-detail fetch, hiding the actual cached payload.

## Approach

Name the effect after its columns-and-foreign-keys result while preserving provider selection, timeout, actions, and cache behavior.