### PR TITLE
refactor(app): type connection failures at adapters

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,8 +1,7 @@
 use crate::policy::password_masking::mask_password;
 use crate::ports::outbound::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
-    SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind, is_mysql_connect_timeout_message,
-    mysql_server_error_code,
+    SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
 };
 use sabiql_domain::connection::MySqlSslMode;
 use url::Url;
@@ -34,72 +33,6 @@ pub enum ConnectionErrorKind {
 }
 
 impl ConnectionErrorKind {
-    pub fn classify(stderr: &str) -> Self {
-        let stderr_lower = stderr.to_lowercase();
-
-        if stderr_lower.contains("command not found")
-            || stderr_lower.contains("not found: psql")
-            || stderr_lower.contains("not found: mysql")
-            || stderr_lower.contains("not recognized")
-        {
-            return Self::CliNotFound;
-        }
-
-        if stderr_lower.contains("could not translate host name")
-            || stderr_lower.contains("name or service not known")
-            || stderr_lower.contains("nodename nor servname provided")
-            || stderr_lower.contains("no such host")
-            || stderr_lower.contains("unknown mysql server host")
-        {
-            return Self::HostUnreachable;
-        }
-
-        if let Some(error_code) = mysql_server_error_code(&stderr_lower) {
-            match error_code {
-                1044 => return Self::PermissionDenied,
-                1045 => return Self::AuthFailed,
-                1049 => return Self::DatabaseNotFound,
-                2003 => {}
-                2006 | 2013 => return Self::ConnectionLost,
-                _ => return Self::Unknown,
-            }
-        }
-
-        if stderr_lower.contains("password authentication failed")
-            || stderr_lower.contains("authentication failed")
-            || stderr_lower.contains("access denied for user")
-            || (stderr_lower.contains("fatal:") && stderr_lower.contains("password"))
-        {
-            return Self::AuthFailed;
-        }
-
-        if stderr_lower.contains("does not exist")
-            && (stderr_lower.contains("database") || stderr_lower.contains("fatal:"))
-        {
-            return Self::DatabaseNotFound;
-        }
-
-        if is_mysql_connect_timeout_message(stderr)
-            || stderr_lower.contains("timeout expired")
-            || stderr_lower.contains("timed out")
-            || stderr_lower.contains("connection timed out")
-        {
-            return Self::Timeout;
-        }
-
-        if stderr_lower.contains("connection refused")
-            || stderr_lower.contains("can't connect to mysql server")
-        {
-            return Self::ConnectionRefused;
-        }
-
-        if is_connection_lost_message(&stderr_lower) {
-            return Self::ConnectionLost;
-        }
-
-        Self::Unknown
-    }
-
     fn presentation(self) -> (&'static str, &'static str) {
         match self {
             Self::CliNotFound => (
@@ -237,12 +170,22 @@ impl ConnectionErrorInfo {
             {
                 ConnectionErrorKind::SqliteVersionTooOld
             }
-            DbOperationError::ConnectionFailedWithKind { kind, .. } => {
-                ConnectionErrorKind::MySqlConnectionFailure(*kind)
-            }
+            DbOperationError::ConnectionFailedWithKind { kind, .. } => match kind {
+                ConnectionFailureKind::HostUnreachable => ConnectionErrorKind::HostUnreachable,
+                ConnectionFailureKind::Auth => ConnectionErrorKind::AuthFailed,
+                ConnectionFailureKind::DatabaseNotFound => ConnectionErrorKind::DatabaseNotFound,
+                ConnectionFailureKind::ConnectionRefused => ConnectionErrorKind::ConnectionRefused,
+                ConnectionFailureKind::TlsHandshake
+                | ConnectionFailureKind::TlsCaVerification
+                | ConnectionFailureKind::TlsHostnameVerification
+                | ConnectionFailureKind::TlsClientCertificateRejected
+                | ConnectionFailureKind::TlsCertificateVerification => {
+                    ConnectionErrorKind::MySqlConnectionFailure(*kind)
+                }
+            },
             DbOperationError::ConnectionFailed(details) => {
                 classify_sqlite_path_connection_error(details)
-                    .unwrap_or_else(|| ConnectionErrorKind::classify(&raw_details))
+                    .unwrap_or(ConnectionErrorKind::Unknown)
             }
             _ => ConnectionErrorKind::Unknown,
         };
@@ -294,139 +237,10 @@ fn classify_sqlite_path_connection_error(message: &str) -> Option<ConnectionErro
     SqlitePathError::from_display_message(message).map(|error| connection_error_kind(&error))
 }
 
-fn is_connection_lost_message(lower: &str) -> bool {
-    lower.contains("server closed the connection unexpectedly")
-        || lower.contains("connection to server was lost")
-        || lower.contains("terminating connection")
-        || lower.contains("connection not open")
-        || lower.contains("broken pipe")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use rstest::rstest;
-
-    mod classify {
-        use super::*;
-
-        #[rstest]
-        #[case("psql: command not found")]
-        #[case("/bin/sh: psql: command not found")]
-        #[case("zsh: command not found: psql")]
-        #[case("not found: mysql")]
-        fn stderr_as_cli_not_found(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::CliNotFound
-            );
-        }
-
-        #[rstest]
-        #[case(r#"psql: error: could not translate host name "host" to address: nodename nor servname provided"#)]
-        #[case(r#"psql: error: could not translate host name "host" to address: Name or service not known"#)]
-        fn stderr_as_host_unreachable(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::HostUnreachable
-            );
-        }
-
-        #[rstest]
-        #[case(r#"FATAL: password authentication failed for user "user""#)]
-        #[case(r"psql: error: FATAL:  password authentication failed")]
-        fn stderr_as_auth_failed(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::AuthFailed
-            );
-        }
-
-        #[rstest]
-        #[case(
-            "ERROR 1044 (42000): Access denied for user 'user' to database 'mysql'",
-            ConnectionErrorKind::PermissionDenied
-        )]
-        #[case(
-            "ERROR 1045 (28000): Access denied for user 'user'",
-            ConnectionErrorKind::AuthFailed
-        )]
-        #[case(
-            "ERROR 1049 (42000): Unknown database 'missing'",
-            ConnectionErrorKind::DatabaseNotFound
-        )]
-        fn mysql_server_error_codes_use_specific_connection_guidance(
-            #[case] stderr: &str,
-            #[case] expected: ConnectionErrorKind,
-        ) {
-            assert_eq!(ConnectionErrorKind::classify(stderr), expected);
-        }
-
-        #[test]
-        fn unknown_mysql_server_error_code_fails_closed() {
-            assert_eq!(
-                ConnectionErrorKind::classify("ERROR 9999 (HY000): Access denied for user 'user'"),
-                ConnectionErrorKind::Unknown
-            );
-        }
-
-        #[test]
-        fn stderr_as_database_not_found() {
-            assert_eq!(
-                ConnectionErrorKind::classify(r#"FATAL: database "nonexistent" does not exist"#),
-                ConnectionErrorKind::DatabaseNotFound
-            );
-        }
-
-        #[rstest]
-        #[case("psql: error: timeout expired")]
-        #[case("Connection timed out")]
-        fn stderr_as_timeout(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::Timeout
-            );
-        }
-
-        #[rstest]
-        #[case("psql: error: connection to server was lost")]
-        #[case("server closed the connection unexpectedly")]
-        fn stderr_as_connection_lost(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::ConnectionLost
-            );
-        }
-
-        #[rstest]
-        #[case("Some random error")]
-        #[case("")]
-        fn stderr_as_unknown_fallback(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::Unknown
-            );
-        }
-
-        #[test]
-        fn stderr_as_connection_refused() {
-            assert_eq!(
-                ConnectionErrorKind::classify("Can't connect to MySQL server on 'localhost' (111)"),
-                ConnectionErrorKind::ConnectionRefused
-            );
-        }
-
-        #[rstest]
-        #[case("ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (110)")]
-        #[case("ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (10060)")]
-        #[case("ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (60)")]
-        fn stderr_as_mysql_timeout(#[case] stderr: &str) {
-            assert_eq!(
-                ConnectionErrorKind::classify(stderr),
-                ConnectionErrorKind::Timeout
-            );
-        }
-    }
 
     mod error_kind {
         use super::*;
@@ -485,18 +299,38 @@ mod tests {
             assert_eq!(info.kind, ConnectionErrorKind::Timeout);
         }
 
-        #[test]
-        fn from_db_operation_error_classifies_from_raw_details() {
-            let info =
-                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::ConnectionFailed(
-                    r#"FATAL: database "nonexistent" does not exist"#.to_string(),
-                ));
-
-            assert_eq!(info.kind, ConnectionErrorKind::DatabaseNotFound);
-            assert_eq!(
-                info.masked_details(),
-                "FATAL: database \"nonexistent\" does not exist"
+        #[rstest]
+        #[case(
+            ConnectionFailureKind::HostUnreachable,
+            ConnectionErrorKind::HostUnreachable,
+            true
+        )]
+        #[case(ConnectionFailureKind::Auth, ConnectionErrorKind::AuthFailed, false)]
+        #[case(
+            ConnectionFailureKind::DatabaseNotFound,
+            ConnectionErrorKind::DatabaseNotFound,
+            false
+        )]
+        #[case(
+            ConnectionFailureKind::ConnectionRefused,
+            ConnectionErrorKind::ConnectionRefused,
+            true
+        )]
+        fn from_db_operation_error_maps_typed_connection_failures(
+            #[case] kind: ConnectionFailureKind,
+            #[case] expected_kind: ConnectionErrorKind,
+            #[case] expected_retryable: bool,
+        ) {
+            let info = ConnectionErrorInfo::from_db_operation_error(
+                &DbOperationError::ConnectionFailedWithKind {
+                    kind,
+                    details: "password=secret provider details".to_string(),
+                },
             );
+
+            assert_eq!(info.kind, expected_kind);
+            assert!(!info.masked_details().contains("secret"));
+            assert_eq!(info.is_retryable(), expected_retryable);
         }
 
         #[test]

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -79,6 +79,10 @@ impl UnsupportedOperationKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectionFailureKind {
+    HostUnreachable,
+    Auth,
+    DatabaseNotFound,
+    ConnectionRefused,
     TlsHandshake,
     TlsCaVerification,
     TlsHostnameVerification,
@@ -89,6 +93,13 @@ pub enum ConnectionFailureKind {
 impl ConnectionFailureKind {
     pub(crate) const fn presentation(self) -> (&'static str, &'static str) {
         match self {
+            Self::HostUnreachable
+            | Self::Auth
+            | Self::DatabaseNotFound
+            | Self::ConnectionRefused => (
+                "Connection failed",
+                "Check the connection settings and database availability",
+            ),
             Self::TlsHandshake | Self::TlsCertificateVerification => (
                 "MySQL TLS handshake failed",
                 "Check that the server and client support the selected TLS settings",
@@ -429,6 +440,26 @@ mod tests {
             assert!(!error.summary().is_empty());
             assert!(!error.hint().is_empty());
             assert!(!error.user_message().is_empty());
+        }
+
+        #[rstest]
+        #[case(ConnectionFailureKind::HostUnreachable)]
+        #[case(ConnectionFailureKind::Auth)]
+        #[case(ConnectionFailureKind::DatabaseNotFound)]
+        #[case(ConnectionFailureKind::ConnectionRefused)]
+        fn typed_connection_failures_keep_generic_operation_presentation(
+            #[case] kind: ConnectionFailureKind,
+        ) {
+            let error = DbOperationError::ConnectionFailedWithKind {
+                kind,
+                details: "provider details".to_string(),
+            };
+
+            assert_eq!(error.summary(), "Connection failed");
+            assert_eq!(
+                error.hint(),
+                "Check the connection settings and database availability"
+            );
         }
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -261,7 +261,7 @@ mod tests {
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::model::shared::ui_state::ResultNavMode;
     use crate::model::sql_editor::modal::SqlModalStatus;
-    use crate::ports::outbound::DbOperationError;
+    use crate::ports::outbound::{ConnectionFailureKind, DbOperationError};
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
     };
@@ -2413,9 +2413,10 @@ mod tests {
                 &Action::MySqlConnectionProbeFailed {
                     target,
                     run_id,
-                    error: DbOperationError::ConnectionFailed(
-                        "ERROR 1045: Access denied for user 'user'".to_string(),
-                    ),
+                    error: DbOperationError::ConnectionFailedWithKind {
+                        kind: ConnectionFailureKind::Auth,
+                        details: "ERROR 1045: Access denied for user 'user'".to_string(),
+                    },
                 },
             );
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -778,18 +778,27 @@ mod tests {
         }
 
         #[test]
-        fn mysql_probe_failure_uses_server_error_codes_for_connection_guidance() {
-            for (stderr, expected) in [
+        fn mysql_probe_failure_uses_typed_errors_for_connection_guidance() {
+            for (error, expected) in [
                 (
-                    "ERROR 1044 (42000): Access denied for user 'user' to database 'mysql'",
+                    DbOperationError::PermissionDenied(
+                        "ERROR 1044 (42000): Access denied for user 'user' to database 'mysql'"
+                            .to_string(),
+                    ),
                     ConnectionErrorKind::PermissionDenied,
                 ),
                 (
-                    "ERROR 1045 (28000): Access denied for user 'user'",
+                    DbOperationError::ConnectionFailedWithKind {
+                        kind: ConnectionFailureKind::Auth,
+                        details: "ERROR 1045 (28000): Access denied for user 'user'".to_string(),
+                    },
                     ConnectionErrorKind::AuthFailed,
                 ),
                 (
-                    "ERROR 1049 (42000): Unknown database 'missing'",
+                    DbOperationError::ConnectionFailedWithKind {
+                        kind: ConnectionFailureKind::DatabaseNotFound,
+                        details: "ERROR 1049 (42000): Unknown database 'missing'".to_string(),
+                    },
                     ConnectionErrorKind::DatabaseNotFound,
                 ),
             ] {
@@ -803,7 +812,7 @@ mod tests {
                     &mut state,
                     &Action::ConnectionSaveFailed {
                         error: ConnectionSaveError::Probe {
-                            error: DbOperationError::ConnectionFailed(stderr.to_string()),
+                            error,
                             dsn: "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED"
                                 .to_string(),
                         },

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -1,7 +1,8 @@
 use std::io::{self, Write};
 
 use crate::app::ports::outbound::{
-    DatabaseCli, DbOperationError, is_mysql_connect_timeout_message, mysql_server_error_code,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, is_mysql_connect_timeout_message,
+    mysql_server_error_code,
 };
 
 use super::probe::mysql_tls_failure_kind;
@@ -87,7 +88,7 @@ pub(super) fn classify_mysql_query_failure_with_packet_limit(
     } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
         DbOperationError::ObjectMissing(details)
     } else if lower.contains("access denied") || lower.contains("authentication") {
-        DbOperationError::ConnectionFailed(details)
+        connection_failed_with_kind(ConnectionFailureKind::Auth, details)
     } else if lower.contains("lost connection") || lower.contains("server has gone away") {
         DbOperationError::ConnectionLost(details)
     } else if lower.contains("lock wait timeout") || lower.contains("deadlock found") {
@@ -115,7 +116,11 @@ fn classify_mysql_server_error(
     Some(match error_code {
         1022 | 1062 => error(DbOperationError::UniqueViolation),
         1044 | 1142 | 1143 | 1227 => error(DbOperationError::PermissionDenied),
-        1045 | 1049 => error(DbOperationError::ConnectionFailed),
+        1045 => connection_failed_with_kind(ConnectionFailureKind::Auth, details.to_string()),
+        1049 => connection_failed_with_kind(
+            ConnectionFailureKind::DatabaseNotFound,
+            details.to_string(),
+        ),
         1051 | 1054 | 1109 | 1146 => error(DbOperationError::ObjectMissing),
         1205 | 1213 => error(DbOperationError::LockTimeout),
         1215 | 1216 | 1217 | 1451 | 1452 => error(DbOperationError::ForeignKeyViolation),
@@ -127,10 +132,17 @@ fn classify_mysql_server_error(
         {
             DbOperationError::Timeout(details.to_string())
         }
-        2003 => DbOperationError::ConnectionFailed(details.to_string()),
+        2003 => connection_failed_with_kind(
+            ConnectionFailureKind::ConnectionRefused,
+            details.to_string(),
+        ),
         3024 => error(DbOperationError::Timeout),
         _ => return None,
     })
+}
+
+fn connection_failed_with_kind(kind: ConnectionFailureKind, details: String) -> DbOperationError {
+    DbOperationError::ConnectionFailedWithKind { kind, details }
 }
 
 pub(super) fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
@@ -145,7 +157,6 @@ pub(super) fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::ports::outbound::ConnectionFailureKind;
 
     #[test]
     fn classifies_mysql_query_failures_by_server_error() {
@@ -153,7 +164,10 @@ mod tests {
             classify_mysql_query_failure(
                 b"ERROR 1045 (28000): Access denied for user 'app'@'localhost' (using password: YES)"
             ),
-            DbOperationError::ConnectionFailed(_)
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::Auth,
+                ..
+            }
         ));
         assert!(matches!(
             classify_mysql_query_failure(
@@ -165,11 +179,17 @@ mod tests {
             classify_mysql_query_failure(
                 b"ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (111)"
             ),
-            DbOperationError::ConnectionFailed(_)
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::ConnectionRefused,
+                ..
+            }
         ));
         assert!(matches!(
             classify_mysql_query_failure(b"ERROR 1049 (42000): schema selection failed"),
-            DbOperationError::ConnectionFailed(_)
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::DatabaseNotFound,
+                ..
+            }
         ));
         assert!(matches!(
             classify_mysql_query_failure(b"ERROR 1054 (42S22): column lookup failed"),

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -198,7 +198,10 @@ fn classify_mysql_probe_failure(stderr: String) -> DbOperationError {
         .to_ascii_lowercase()
         .contains("can't connect to mysql server")
     {
-        DbOperationError::ConnectionFailed(stderr)
+        DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::ConnectionRefused,
+            details: stderr,
+        }
     } else {
         super::error::classify_mysql_query_failure(stderr.as_bytes())
     }
@@ -372,7 +375,10 @@ mod probe_tests {
                 "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (111)"
                     .to_string()
             ),
-            DbOperationError::ConnectionFailed(_)
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::ConnectionRefused,
+                ..
+            }
         ));
         assert!(matches!(
             classify_mysql_probe_failure(
@@ -410,13 +416,19 @@ mod probe_tests {
             classify_mysql_probe_failure(
                 "ERROR 1045 (28000): Access denied for user 'user'".to_string()
             ),
-            DbOperationError::ConnectionFailed(_)
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::Auth,
+                ..
+            }
         ));
         assert!(matches!(
             classify_mysql_probe_failure(
                 "ERROR 1049 (42000): Unknown database 'missing'".to_string()
             ),
-            DbOperationError::ConnectionFailed(_)
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::DatabaseNotFound,
+                ..
+            }
         ));
     }
 

--- a/src/infra/adapters/mysql/cli/process/tests/single.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/single.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::app::ports::outbound::ConnectionFailureKind;
 
 #[tokio::test]
 async fn diagnostics_use_adhoc_args_and_follow_resultset_to_marker() {
@@ -136,5 +137,11 @@ async fn classifies_connection_refusal_from_the_shared_cli_error_path() {
     )
     .await;
 
-    assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
+    assert!(matches!(
+        result,
+        Err(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::ConnectionRefused,
+            ..
+        })
+    ));
 }

--- a/src/infra/adapters/postgres/psql/error.rs
+++ b/src/infra/adapters/postgres/psql/error.rs
@@ -1,4 +1,4 @@
-use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
+use crate::app::ports::outbound::{ConnectionFailureKind, DatabaseCli, DbOperationError};
 
 pub(in crate::adapters::postgres) fn classify_cli_spawn_error(
     error: std::io::Error,
@@ -29,10 +29,9 @@ pub(in crate::adapters::postgres) fn classify_query_error(stderr: &str) -> DbOpe
 fn classify_by_sqlstate(sqlstate: &str, details: &str) -> DbOperationError {
     match sqlstate {
         "08003" | "08006" | "08P01" => DbOperationError::ConnectionLost(details.to_string()),
-        "08000" | "08001" | "08004" | "08007" => {
-            DbOperationError::ConnectionFailed(details.to_string())
-        }
-        "28P01" | "3D000" => DbOperationError::ConnectionFailed(details.to_string()),
+        "08000" | "08001" | "08004" | "08007" => classify_connection_failure(details),
+        "28P01" => connection_failed_with_kind(ConnectionFailureKind::Auth, details),
+        "3D000" => connection_failed_with_kind(ConnectionFailureKind::DatabaseNotFound, details),
         "42501" => DbOperationError::PermissionDenied(details.to_string()),
         "23503" => DbOperationError::ForeignKeyViolation(details.to_string()),
         "23505" => DbOperationError::UniqueViolation(details.to_string()),
@@ -43,7 +42,7 @@ fn classify_by_sqlstate(sqlstate: &str, details: &str) -> DbOperationError {
             if is_connection_lost_message(&details.to_lowercase()) {
                 DbOperationError::ConnectionLost(details.to_string())
             } else {
-                DbOperationError::ConnectionFailed(details.to_string())
+                classify_connection_failure(details)
             }
         }
         _ => DbOperationError::QueryFailed(details.to_string()),
@@ -57,15 +56,15 @@ fn classify_by_stderr(details: &str) -> DbOperationError {
         return DbOperationError::PermissionDenied(details.to_string());
     }
 
-    if lower.contains("password authentication failed")
-        || lower.contains("authentication failed")
-        || lower.contains("could not translate host name")
-        || lower.contains("name or service not known")
-        || lower.contains("nodename nor servname provided")
-        || is_missing_database_or_role(&lower)
-        || lower.contains("connection refused")
-        || lower.contains("could not connect to server")
-    {
+    if let Some(kind) = connection_failure_kind(&lower) {
+        return connection_failed_with_kind(kind, details);
+    }
+
+    if lower.contains("connection refused") {
+        return connection_failed_with_kind(ConnectionFailureKind::ConnectionRefused, details);
+    }
+
+    if lower.contains("could not connect to server") {
         return DbOperationError::ConnectionFailed(details.to_string());
     }
 
@@ -114,6 +113,45 @@ fn is_missing_database_or_role(lower: &str) -> bool {
     lower.contains("fatal:")
         && lower.contains("does not exist")
         && (lower.contains("database") || lower.contains("role"))
+}
+
+fn classify_connection_failure(details: &str) -> DbOperationError {
+    let lower = details.to_lowercase();
+    if let Some(kind) = connection_failure_kind(&lower) {
+        connection_failed_with_kind(kind, details)
+    } else if lower.contains("timeout expired") || lower.contains("timed out") {
+        DbOperationError::Timeout(details.to_string())
+    } else if lower.contains("connection refused") {
+        connection_failed_with_kind(ConnectionFailureKind::ConnectionRefused, details)
+    } else if is_connection_lost_message(&lower) {
+        DbOperationError::ConnectionLost(details.to_string())
+    } else {
+        DbOperationError::ConnectionFailed(details.to_string())
+    }
+}
+
+fn connection_failure_kind(lower: &str) -> Option<ConnectionFailureKind> {
+    if lower.contains("could not translate host name")
+        || lower.contains("name or service not known")
+        || lower.contains("nodename nor servname provided")
+    {
+        Some(ConnectionFailureKind::HostUnreachable)
+    } else if lower.contains("password authentication failed")
+        || lower.contains("authentication failed")
+    {
+        Some(ConnectionFailureKind::Auth)
+    } else if is_missing_database_or_role(lower) {
+        Some(ConnectionFailureKind::DatabaseNotFound)
+    } else {
+        None
+    }
+}
+
+fn connection_failed_with_kind(kind: ConnectionFailureKind, details: &str) -> DbOperationError {
+    DbOperationError::ConnectionFailedWithKind {
+        kind,
+        details: details.to_string(),
+    }
 }
 
 fn is_missing_object(lower: &str) -> bool {
@@ -220,6 +258,28 @@ mod tests {
     mod classification {
         use super::*;
 
+        fn classification_name(error: DbOperationError) -> &'static str {
+            match error {
+                DbOperationError::PermissionDenied(_) => "PermissionDenied",
+                DbOperationError::ForeignKeyViolation(_) => "ForeignKeyViolation",
+                DbOperationError::UniqueViolation(_) => "UniqueViolation",
+                DbOperationError::LockTimeout(_) => "LockTimeout",
+                DbOperationError::Timeout(_) => "Timeout",
+                DbOperationError::ObjectMissing(_) => "ObjectMissing",
+                DbOperationError::ConnectionLost(_) => "ConnectionLost",
+                DbOperationError::ConnectionFailed(_) => "ConnectionFailed",
+                DbOperationError::ConnectionFailedWithKind { kind, .. } => match kind {
+                    ConnectionFailureKind::HostUnreachable => "HostUnreachable",
+                    ConnectionFailureKind::Auth => "Auth",
+                    ConnectionFailureKind::DatabaseNotFound => "DatabaseNotFound",
+                    ConnectionFailureKind::ConnectionRefused => "ConnectionRefused",
+                    _ => "TypedConnectionFailure",
+                },
+                DbOperationError::QueryFailed(_) => "QueryFailed",
+                _ => "Other",
+            }
+        }
+
         #[rstest]
         #[case("ERROR:  42501: permission denied for table users", "PermissionDenied")]
         #[case(
@@ -243,21 +303,17 @@ mod tests {
         #[case("ERROR:  08006: connection to server was lost", "ConnectionLost")]
         #[case("ERROR:  08006: could not receive data from server", "ConnectionLost")]
         #[case("ERROR:  08001: could not connect to server", "ConnectionFailed")]
+        #[case("FATAL:  08001: could not translate host name", "HostUnreachable")]
+        #[case("FATAL:  08001: timeout expired", "Timeout")]
+        #[case("FATAL:  08001: connection refused", "ConnectionRefused")]
+        #[case(
+            "FATAL:  08001: server closed the connection unexpectedly",
+            "ConnectionLost"
+        )]
+        #[case("FATAL:  28P01: opaque authentication failure", "Auth")]
+        #[case("FATAL:  3D000: opaque database failure", "DatabaseNotFound")]
         fn classifies_sqlstate_first(#[case] input: &str, #[case] expected: &str) {
-            let error = classify_query_error(input);
-            let actual = match error {
-                DbOperationError::PermissionDenied(_) => "PermissionDenied",
-                DbOperationError::ForeignKeyViolation(_) => "ForeignKeyViolation",
-                DbOperationError::UniqueViolation(_) => "UniqueViolation",
-                DbOperationError::LockTimeout(_) => "LockTimeout",
-                DbOperationError::Timeout(_) => "Timeout",
-                DbOperationError::ObjectMissing(_) => "ObjectMissing",
-                DbOperationError::ConnectionLost(_) => "ConnectionLost",
-                DbOperationError::ConnectionFailed(_) => "ConnectionFailed",
-                _ => "Other",
-            };
-
-            assert_eq!(actual, expected);
+            assert_eq!(classification_name(classify_query_error(input)), expected);
         }
 
         #[rstest]
@@ -269,22 +325,19 @@ mod tests {
         #[case("ERROR: relation \"users\" does not exist", "ObjectMissing")]
         #[case("server closed the connection unexpectedly", "ConnectionLost")]
         #[case("ERROR: canceling statement due to statement timeout", "Timeout")]
-        #[case(r#"FATAL: role "alice" does not exist"#, "ConnectionFailed")]
+        #[case(r#"FATAL: role "alice" does not exist"#, "DatabaseNotFound")]
         #[case(r#"ERROR: role "alice" does not exist"#, "QueryFailed")]
+        #[case(r#"FATAL: password authentication failed for user "alice""#, "Auth")]
+        #[case(
+            r#"psql: error: could not translate host name "host" to address: Name or service not known"#,
+            "HostUnreachable"
+        )]
+        #[case(
+            r#"psql: error: connection to server at "host", port 5432 failed: Connection refused"#,
+            "ConnectionRefused"
+        )]
         fn falls_back_to_stderr_matching(#[case] input: &str, #[case] expected: &str) {
-            let error = classify_query_error(input);
-            let actual = match error {
-                DbOperationError::PermissionDenied(_) => "PermissionDenied",
-                DbOperationError::UniqueViolation(_) => "UniqueViolation",
-                DbOperationError::ObjectMissing(_) => "ObjectMissing",
-                DbOperationError::ConnectionLost(_) => "ConnectionLost",
-                DbOperationError::Timeout(_) => "Timeout",
-                DbOperationError::ConnectionFailed(_) => "ConnectionFailed",
-                DbOperationError::QueryFailed(_) => "QueryFailed",
-                _ => "Other",
-            };
-
-            assert_eq!(actual, expected);
+            assert_eq!(classification_name(classify_query_error(input)), expected);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Connection failures were reclassified from raw stderr in the application layer after adapters had already inspected database-specific error evidence.

## Approach

Have PostgreSQL and MySQL adapters emit typed connection failure kinds while preserving SQLSTATE, errno, TLS precedence, retry behavior, operation details, masking, and SQLite behavior.