### PR TITLE
refactor(app): rename connection error destination

### DIFF
--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -73,7 +73,7 @@ impl ConnectionErrorState {
         matches!(self.source, ConnectionErrorSource::SaveAndConnect { .. })
     }
 
-    pub fn target_database_type(&self) -> Option<DatabaseType> {
+    pub fn destination_database_type(&self) -> Option<DatabaseType> {
         match self.source {
             ConnectionErrorSource::ActiveConnection => None,
             ConnectionErrorSource::SaveAndConnect { database_type }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -984,7 +984,7 @@ mod tests {
 
             assert!(state.connection_error.is_save_and_connect_failure());
             assert_eq!(
-                state.connection_error.target_database_type(),
+                state.connection_error.destination_database_type(),
                 Some(DatabaseType::MySQL)
             );
             let effects =

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -95,7 +95,7 @@ impl ConnectionError {
             Span::styled(hint, Style::default().fg(theme.semantic.text.secondary)),
         ];
         if state.session.is_service_connection()
-            && state.connection_error.target_database_type().is_none()
+            && state.connection_error.destination_database_type().is_none()
             && let Some(path) = state.runtime.service_file_path()
         {
             spans.push(Span::styled(


### PR DESCRIPTION
## Summary

Connection error state used target terminology for the destination of save-and-connect and connection-switch failures, making it easy to confuse with the active connection.

## Approach

Use destination terminology while preserving the source distinction: active-connection failures have no destination database type, while save-and-connect and switch failures retain theirs.