### PR TITLE
refactor(app): remove dead Action variants

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -386,7 +386,6 @@ pub enum Action {
     SwitchConnection(ConnectionTarget),
     ConnectionsLoaded(ConnectionsLoadedPayload),
     ConfirmConnectionSelection,
-    StartEditConnection(ConnectionId),
     ConnectionSetupNextField,
     ConnectionSetupPrevField,
     ConnectionSetupToggleDropdown,
@@ -456,7 +455,6 @@ pub enum Action {
     SettingsSaveFailed(SettingsStoreError),
 
     // Database structure
-    LoadMetadata,
     ReloadMetadata,
     MetadataLoaded {
         dsn: String,
@@ -586,7 +584,6 @@ pub enum Action {
     // Query results
     ExecutePreview(TableTarget),
     ExecuteAdhoc(String),
-    ExecuteWrite(String),
     QueryCompleted {
         dsn: String,
         run_id: u64,
@@ -635,7 +632,6 @@ pub enum Action {
     StageRowForDelete,
     UnstageLastStagedRow,
     ClearStagedDeletes,
-    RequestDeleteActiveRow,
     ResultEnterCellEdit,
     ResultOpenCellDetail,
     ResultCancelCellEdit,

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -133,17 +133,6 @@ pub(super) fn reduce_loading(
                 termination_effects(&state.query, vec![])
             })
         }
-        Action::LoadMetadata => {
-            if reject_pending_mysql_connection_probe(state, now) {
-                return DispatchResult::handled();
-            }
-            if let Some(dsn) = state.session.dsn().map(String::from) {
-                let run_id = state.session.begin_metadata_refresh();
-                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
-            } else {
-                DispatchResult::handled()
-            }
-        }
         Action::ReloadMetadata => {
             if reject_pending_mysql_connection_probe(state, now) {
                 return DispatchResult::handled();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -220,7 +220,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_metadata_actions_start_fetches() {
+        fn mysql_reload_metadata_starts_fetch() {
             let mut state = AppState::new("test".to_string());
             state.session.activate_connection_with_target(
                 &ConnectionId::new(),
@@ -242,7 +242,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_metadata_actions_during_pending_switch_preserve_probe() {
+        fn mysql_reload_metadata_during_pending_switch_preserves_probe() {
             let mut state = AppState::new("test".to_string());
             let current_id = ConnectionId::from_string("mysql-a");
             let target_id = ConnectionId::from_string("mysql-b");
@@ -282,7 +282,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_metadata_actions_during_same_connection_retry_preserve_probe() {
+        fn mysql_reload_metadata_during_same_connection_retry_preserves_probe() {
             let mut state = AppState::new("test".to_string());
             let id = ConnectionId::from_string("mysql-a");
             let dsn = "mysql://user@localhost:3306/a";

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -233,13 +233,11 @@ mod tests {
                 .session
                 .set_connection_state(ConnectionState::Connected);
 
-            for action in [Action::LoadMetadata, Action::ReloadMetadata] {
-                let effects = dispatch_metadata(&mut state, &action, Instant::now())
-                    .into_effects()
-                    .unwrap();
+            let effects = dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now())
+                .into_effects()
+                .unwrap();
 
-                assert!(effects.iter().any(contains_fetch_metadata));
-            }
+            assert!(effects.iter().any(contains_fetch_metadata));
             assert!(state.messages.last_error().is_none());
         }
 
@@ -265,24 +263,22 @@ mod tests {
                 Some("b"),
             );
 
-            for action in [Action::LoadMetadata, Action::ReloadMetadata] {
-                let effects = dispatch_metadata(&mut state, &action, Instant::now())
-                    .into_effects()
-                    .unwrap();
+            let effects = dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now())
+                .into_effects()
+                .unwrap();
 
-                assert!(effects.is_empty());
-                assert_eq!(
-                    state
-                        .session
-                        .pending_mysql_connection_probe()
-                        .map(|pending| pending.run_id),
-                    Some(probe_run_id)
-                );
-                assert_eq!(
-                    state.messages.last_error(),
-                    Some("Connection switch in progress")
-                );
-            }
+            assert!(effects.is_empty());
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(probe_run_id)
+            );
+            assert_eq!(
+                state.messages.last_error(),
+                Some("Connection switch in progress")
+            );
         }
 
         #[test]
@@ -305,24 +301,22 @@ mod tests {
                     .session
                     .begin_mysql_connection_probe(&id, "mysql-a", dsn, Some("a"));
 
-            for action in [Action::LoadMetadata, Action::ReloadMetadata] {
-                let effects = dispatch_metadata(&mut state, &action, Instant::now())
-                    .into_effects()
-                    .unwrap();
+            let effects = dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now())
+                .into_effects()
+                .unwrap();
 
-                assert!(effects.is_empty());
-                assert_eq!(
-                    state
-                        .session
-                        .pending_mysql_connection_probe()
-                        .map(|pending| pending.run_id),
-                    Some(probe_run_id)
-                );
-                assert_eq!(
-                    state.messages.last_error(),
-                    Some("Connection switch in progress")
-                );
-            }
+            assert!(effects.is_empty());
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(probe_run_id)
+            );
+            assert_eq!(
+                state.messages.last_error(),
+                Some("Connection switch in progress")
+            );
         }
 
         fn contains_fetch_metadata(effect: &Effect) -> bool {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::domain::{DatabaseDiagnostic, DiagnosticLevel, RefreshScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
@@ -16,7 +15,6 @@ use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
 use crate::policy::write::write_update::escape_preview_value;
-use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::browse::query::{
@@ -214,33 +212,6 @@ pub fn reduce_write(
                     state.messages.set_error_at(err.to_string(), now);
                     DispatchResult::handled()
                 }
-            }
-        }
-
-        Action::ExecuteWrite(query) => {
-            if reject_pending_mysql_connection_probe(state, now) {
-                return DispatchResult::handled();
-            }
-            if state.session.is_read_only() {
-                state.messages.set_error_at(
-                    "Read-only mode: write operations are disabled".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
-            }
-            if let Some(dsn) = state.session.dsn().map(String::from) {
-                let run_id = state.query.begin_running(now);
-                DispatchResult::handled_with(vec![Effect::ExecuteWrite {
-                    dsn,
-                    run_id,
-                    query: query.clone(),
-                    access_mode: AccessMode::from_read_only(state.session.is_read_only()),
-                }])
-            } else {
-                state
-                    .messages
-                    .set_error_at("No active connection".to_string(), now);
-                DispatchResult::handled()
             }
         }
 
@@ -451,6 +422,7 @@ fn open_write_preview_confirm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmd::effect::Effect;
     use crate::test_support;
     use crate::update::test_fixtures;
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -39,9 +39,6 @@ pub fn reduce_connection_setup(
             state.modal.set_mode(InputMode::ConnectionSetup);
             DispatchResult::handled()
         }
-        Action::StartEditConnection(id) => {
-            DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
-        }
         Action::ConnectionEditLoaded(profile) => {
             state.session.cancel_connection_save_and_disconnect();
             state.connection_setup = ConnectionSetupState::from(&**profile);

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1597,34 +1597,7 @@ mod tests {
 
     mod effect_producing_actions {
         use super::*;
-        use crate::domain::{DatabaseMetadata, MetadataState};
-
-        #[test]
-        fn load_metadata_with_dsn_returns_fetch_effect() {
-            let mut state = create_test_state();
-            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let now = Instant::now();
-
-            let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
-
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::FetchMetadata { .. }));
-            assert!(matches!(
-                state.session.metadata_state(),
-                MetadataState::Loading
-            ));
-        }
-
-        #[test]
-        fn load_metadata_without_dsn_returns_no_effects() {
-            let mut state = create_test_state();
-            state.session.clear_connection();
-            let now = Instant::now();
-
-            let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
-
-            assert!(effects.is_empty());
-        }
+        use crate::domain::DatabaseMetadata;
 
         #[test]
         fn reload_metadata_returns_sequence_effect() {


### PR DESCRIPTION
## Problem

Four Action variants remain without workspace producers, leaving unreachable reducer arms and dedicated tests.

## Background

The live metadata, write, delete, and connection-edit flows use different Action or Effect paths.

## Approach

Remove the unproduced variants, their unreachable reducer arms, and tests that exercise only the removed metadata action. Keep the existing ReloadMetadata, write confirmation and completion, staged-delete, and RequestEditSelectedConnection flows unchanged.