### PR TITLE
refactor(postgres): trim service entry contract

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1525,10 +1525,6 @@ mod tests {
         fn make_service(name: &str) -> ServiceEntry {
             ServiceEntry {
                 service_name: name.to_string(),
-                host: None,
-                dbname: None,
-                port: None,
-                user: None,
             }
         }
 

--- a/src/app/ports/outbound/service_file.rs
+++ b/src/app/ports/outbound/service_file.rs
@@ -13,8 +13,6 @@ pub enum ServiceFileError {
         #[source]
         source: Arc<std::io::Error>,
     },
-    #[error("Parse error: {0}")]
-    ParseError(String),
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -644,10 +644,6 @@ mod tests {
                 vec![profile],
                 vec![ServiceEntry {
                     service_name: "mydb".to_string(),
-                    host: None,
-                    dbname: None,
-                    port: None,
-                    user: None,
                 }],
             );
             state.modal.set_mode(InputMode::Normal);

--- a/src/domain/connection/service_entry.rs
+++ b/src/domain/connection/service_entry.rs
@@ -7,10 +7,6 @@ const SERVICE_ID_PREFIX: &str = "service:";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceEntry {
     pub service_name: String,
-    pub host: Option<String>,
-    pub dbname: Option<String>,
-    pub port: Option<u16>,
-    pub user: Option<String>,
 }
 
 impl ServiceEntry {
@@ -36,10 +32,6 @@ mod tests {
     fn sample() -> ServiceEntry {
         ServiceEntry {
             service_name: "mydb".to_string(),
-            host: None,
-            dbname: None,
-            port: None,
-            user: None,
         }
     }
 

--- a/src/infra/adapters/postgres/pg_service.rs
+++ b/src/infra/adapters/postgres/pg_service.rs
@@ -108,28 +108,7 @@ fn parse(content: &str) -> Vec<ServiceEntry> {
                 entries.push(entry);
             }
             let name = line[1..line.len() - 1].trim().to_string();
-            current = Some(ServiceEntry {
-                service_name: name,
-                host: None,
-                dbname: None,
-                port: None,
-                user: None,
-            });
-            continue;
-        }
-
-        if let Some(ref mut entry) = current
-            && let Some((key, value)) = line.split_once('=')
-        {
-            let key = key.trim();
-            let value = value.trim();
-            match key {
-                "host" | "hostaddr" => entry.host = Some(value.to_string()),
-                "dbname" => entry.dbname = Some(value.to_string()),
-                "port" => entry.port = value.parse().ok(),
-                "user" => entry.user = Some(value.to_string()),
-                _ => {}
-            }
+            current = Some(ServiceEntry { service_name: name });
         }
     }
 
@@ -164,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    fn single_section_parsed() {
+    fn single_section_returns_service_name() {
         let content = "\
 [mydb]
 host=localhost
@@ -175,10 +154,6 @@ user=admin
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
-        assert_eq!(entries[0].host, Some("localhost".to_string()));
-        assert_eq!(entries[0].port, Some(5432));
-        assert_eq!(entries[0].dbname, Some("mydb".to_string()));
-        assert_eq!(entries[0].user, Some("admin".to_string()));
     }
 
     #[test]
@@ -195,10 +170,13 @@ port=5433
 ";
         let entries = parse(content);
         assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].service_name, "dev");
-        assert_eq!(entries[0].host, Some("dev.example.com".to_string()));
-        assert_eq!(entries[1].service_name, "prod");
-        assert_eq!(entries[1].port, Some(5433));
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.service_name.as_str())
+                .collect::<Vec<_>>(),
+            ["dev", "prod"]
+        );
     }
 
     #[test]
@@ -216,8 +194,6 @@ port=5432
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
-        assert_eq!(entries[0].host, Some("localhost".to_string()));
-        assert_eq!(entries[0].port, Some(5432));
     }
 
     #[test]
@@ -230,23 +206,11 @@ port=5432
 ";
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].host, Some("localhost".to_string()));
-        assert_eq!(entries[0].port, Some(5432));
+        assert_eq!(entries[0].service_name, "mydb");
     }
 
     #[test]
-    fn invalid_port_stored_as_none() {
-        let content = "\
-[mydb]
-port=not_a_number
-";
-        let entries = parse(content);
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].port, None);
-    }
-
-    #[test]
-    fn duplicate_sections_last_wins() {
+    fn duplicate_sections_are_collapsed() {
         let content = "\
 [mydb]
 host=first.example.com
@@ -258,8 +222,7 @@ port=5433
 ";
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].host, Some("second.example.com".to_string()));
-        assert_eq!(entries[0].port, Some(5433));
+        assert_eq!(entries[0].service_name, "mydb");
     }
 
     #[test]
@@ -270,10 +233,6 @@ port=5433
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "empty");
-        assert_eq!(entries[0].host, None);
-        assert_eq!(entries[0].dbname, None);
-        assert_eq!(entries[0].port, None);
-        assert_eq!(entries[0].user, None);
     }
 
     #[test]
@@ -288,29 +247,6 @@ host=localhost
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
-        assert_eq!(entries[0].host, Some("localhost".to_string()));
-    }
-
-    #[test]
-    fn whitespace_around_keys_and_values_trimmed() {
-        let content = "\
-[mydb]
-  host  =  db.example.com
-  port  =  5432
-";
-        let entries = parse(content);
-        assert_eq!(entries[0].host, Some("db.example.com".to_string()));
-        assert_eq!(entries[0].port, Some(5432));
-    }
-
-    #[test]
-    fn hostaddr_maps_to_host() {
-        let content = "\
-[mydb]
-hostaddr=192.168.1.1
-";
-        let entries = parse(content);
-        assert_eq!(entries[0].host, Some("192.168.1.1".to_string()));
     }
 
     #[test]
@@ -324,8 +260,7 @@ application_name=myapp
 ";
         let entries = parse(content);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].host, Some("localhost".to_string()));
-        assert_eq!(entries[0].dbname, None);
+        assert_eq!(entries[0].service_name, "mydb");
     }
 
     #[test]

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -72,17 +72,9 @@ fn connection_selector_with_service_entries() {
         vec![
             ServiceEntry {
                 service_name: "dev-db".to_string(),
-                host: Some("localhost".to_string()),
-                dbname: Some("devdb".to_string()),
-                port: Some(5432),
-                user: Some("dev".to_string()),
             },
             ServiceEntry {
                 service_name: "prod-replica".to_string(),
-                host: Some("replica.example.com".to_string()),
-                dbname: Some("proddb".to_string()),
-                port: Some(5433),
-                user: None,
             },
         ],
     );
@@ -107,17 +99,9 @@ fn connection_selector_with_long_service_name() {
     state.set_service_entries(vec![
         ServiceEntry {
             service_name: "my-very-long-service-name-that-exceeds-normal-length".to_string(),
-            host: Some("db.example.com".to_string()),
-            dbname: Some("mydb".to_string()),
-            port: Some(5432),
-            user: None,
         },
         ServiceEntry {
             service_name: "short".to_string(),
-            host: Some("localhost".to_string()),
-            dbname: None,
-            port: None,
-            user: None,
         },
     ]);
     state.modal.set_mode(InputMode::ConnectionSelector);
@@ -136,17 +120,9 @@ fn connection_selector_with_active_service() {
     state.set_service_entries(vec![
         ServiceEntry {
             service_name: "dev-local".to_string(),
-            host: Some("localhost".to_string()),
-            dbname: Some("devdb".to_string()),
-            port: Some(5432),
-            user: Some("dev".to_string()),
         },
         ServiceEntry {
             service_name: "prod-replica".to_string(),
-            host: Some("replica.example.com".to_string()),
-            dbname: Some("proddb".to_string()),
-            port: Some(5433),
-            user: None,
         },
     ]);
     // Set active connection to the first service entry
@@ -172,10 +148,6 @@ fn connection_selector_with_multibyte_service_name() {
 
     state.set_service_entries(vec![ServiceEntry {
         service_name: "本番データベース接続".to_string(),
-        host: Some("db.example.com".to_string()),
-        dbname: Some("mydb".to_string()),
-        port: Some(5432),
-        user: None,
     }]);
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));


### PR DESCRIPTION
## Problem
The PostgreSQL service-file model exposes parsed connection fields and an error variant that have no workspace consumers.

## Background
Service selection delegates through the service name, while the parser currently retains unused connection values in the public model.

## Approach
Keep service-section discovery, lenient key handling, duplicate-section behavior, and service-name rendering while reducing the port and domain contracts to the values consumed by the workspace.