### PR TITLE
fix(app): await aborted query tasks

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -57,7 +57,8 @@ pub async fn run(
                 generation,
                 run_id,
                 table_detail_tasks,
-            );
+            )
+            .await;
         }
         Effect::PrefetchTableColumnsAndFks {
             dsn,
@@ -186,7 +187,7 @@ fn fetch_effective_user(
     });
 }
 
-fn fetch_table_detail(
+async fn fetch_table_detail(
     action_tx: &mpsc::Sender<Action>,
     metadata_provider: &Arc<dyn MetadataProvider>,
     dsn: String,
@@ -199,30 +200,32 @@ fn fetch_table_detail(
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
 
-    table_detail_tasks.spawn(async move {
-        match provider.fetch_table_detail(&dsn, &schema, &table).await {
-            Ok(detail) => {
-                tx.send(Action::TableDetailLoaded {
-                    dsn,
-                    run_id,
-                    detail: Box::new(detail),
-                    generation,
-                })
-                .await
-                .ok();
+    table_detail_tasks
+        .spawn(async move {
+            match provider.fetch_table_detail(&dsn, &schema, &table).await {
+                Ok(detail) => {
+                    tx.send(Action::TableDetailLoaded {
+                        dsn,
+                        run_id,
+                        detail: Box::new(detail),
+                        generation,
+                    })
+                    .await
+                    .ok();
+                }
+                Err(e) => {
+                    tx.send(Action::TableDetailFailed {
+                        dsn,
+                        run_id,
+                        error: e,
+                        generation,
+                    })
+                    .await
+                    .ok();
+                }
             }
-            Err(e) => {
-                tx.send(Action::TableDetailFailed {
-                    dsn,
-                    run_id,
-                    error: e,
-                    generation,
-                })
-                .await
-                .ok();
-            }
-        }
-    });
+        })
+        .await;
 }
 
 async fn prefetch_table_detail(

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -69,7 +69,7 @@ fn spawn_query_history_append(
     });
 }
 
-pub fn run(
+pub async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
     query_executor: &Arc<dyn QueryExecutor>,
@@ -92,36 +92,38 @@ pub fn run(
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
 
-            query_tasks.spawn(async move {
-                match executor
-                    .execute_preview(&dsn, &schema, &table, limit, offset)
-                    .await
-                {
-                    Ok(result) => {
-                        tx.send(Action::QueryCompleted {
-                            dsn,
-                            run_id,
-                            result: Arc::new(result),
-                            context: QueryCompletionContext::Preview {
-                                generation,
-                                target_page,
-                            },
-                        })
+            query_tasks
+                .spawn(async move {
+                    match executor
+                        .execute_preview(&dsn, &schema, &table, limit, offset)
                         .await
-                        .ok();
+                    {
+                        Ok(result) => {
+                            tx.send(Action::QueryCompleted {
+                                dsn,
+                                run_id,
+                                result: Arc::new(result),
+                                context: QueryCompletionContext::Preview {
+                                    generation,
+                                    target_page,
+                                },
+                            })
+                            .await
+                            .ok();
+                        }
+                        Err(e) => {
+                            tx.send(Action::QueryFailed {
+                                dsn,
+                                run_id,
+                                error: e,
+                                context: QueryFailureContext::Preview { generation },
+                            })
+                            .await
+                            .ok();
+                        }
                     }
-                    Err(e) => {
-                        tx.send(Action::QueryFailed {
-                            dsn,
-                            run_id,
-                            error: e,
-                            context: QueryFailureContext::Preview { generation },
-                        })
-                        .await
-                        .ok();
-                    }
-                }
-            });
+                })
+                .await;
         }
 
         Effect::ExecuteExplain {
@@ -137,44 +139,46 @@ pub fn run(
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
 
-            query_tasks.spawn(async move {
-                match executor.execute_adhoc(&dsn, &query, access_mode).await {
-                    Ok(result) => {
-                        let plan_text = match database_type {
-                            DatabaseType::SQLite => {
-                                sqlite_explain_query_plan_text_from_result(&result)
-                            }
-                            DatabaseType::PostgreSQL => {
-                                postgres_explain_plan_text_from_result(&result)
-                            }
-                            DatabaseType::MySQL => mysql_explain_plan_text_from_result(&result),
-                        };
-                        tx.send(Action::ExplainCompleted {
-                            dsn,
-                            database_type,
-                            database_generation,
-                            run_id,
-                            query: source_query,
-                            plan_text,
-                            is_analyze,
-                            execution_time_ms: result.execution_time_ms,
-                        })
-                        .await
-                        .ok();
+            query_tasks
+                .spawn(async move {
+                    match executor.execute_adhoc(&dsn, &query, access_mode).await {
+                        Ok(result) => {
+                            let plan_text = match database_type {
+                                DatabaseType::SQLite => {
+                                    sqlite_explain_query_plan_text_from_result(&result)
+                                }
+                                DatabaseType::PostgreSQL => {
+                                    postgres_explain_plan_text_from_result(&result)
+                                }
+                                DatabaseType::MySQL => mysql_explain_plan_text_from_result(&result),
+                            };
+                            tx.send(Action::ExplainCompleted {
+                                dsn,
+                                database_type,
+                                database_generation,
+                                run_id,
+                                query: source_query,
+                                plan_text,
+                                is_analyze,
+                                execution_time_ms: result.execution_time_ms,
+                            })
+                            .await
+                            .ok();
+                        }
+                        Err(e) => {
+                            tx.send(Action::ExplainFailed {
+                                dsn,
+                                database_generation,
+                                run_id,
+                                error: e,
+                                is_analyze,
+                            })
+                            .await
+                            .ok();
+                        }
                     }
-                    Err(e) => {
-                        tx.send(Action::ExplainFailed {
-                            dsn,
-                            database_generation,
-                            run_id,
-                            error: e,
-                            is_analyze,
-                        })
-                        .await
-                        .ok();
-                    }
-                }
-            });
+                })
+                .await;
         }
 
         Effect::ExecuteAdhoc {
@@ -189,55 +193,57 @@ pub fn run(
             let project = state.runtime.project_name().to_string();
             let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
-            query_tasks.spawn(async move {
-                let result = executor.execute_adhoc(&dsn, &query, access_mode).await;
-                match result {
-                    Ok(result) => {
-                        if let Some(scope) = &history_scope {
-                            let rows = result
-                                .command_tag
-                                .as_ref()
-                                .and_then(CommandTag::affected_rows);
-                            spawn_query_history_append(
-                                &history_store,
-                                &project,
-                                scope,
-                                &query_for_history,
-                                QueryResultStatus::Success,
-                                rows,
-                            );
+            query_tasks
+                .spawn(async move {
+                    let result = executor.execute_adhoc(&dsn, &query, access_mode).await;
+                    match result {
+                        Ok(result) => {
+                            if let Some(scope) = &history_scope {
+                                let rows = result
+                                    .command_tag
+                                    .as_ref()
+                                    .and_then(CommandTag::affected_rows);
+                                spawn_query_history_append(
+                                    &history_store,
+                                    &project,
+                                    scope,
+                                    &query_for_history,
+                                    QueryResultStatus::Success,
+                                    rows,
+                                );
+                            }
+                            tx.send(Action::QueryCompleted {
+                                dsn,
+                                run_id,
+                                result: Arc::new(result),
+                                context: QueryCompletionContext::Adhoc,
+                            })
+                            .await
+                            .ok();
                         }
-                        tx.send(Action::QueryCompleted {
-                            dsn,
-                            run_id,
-                            result: Arc::new(result),
-                            context: QueryCompletionContext::Adhoc,
-                        })
-                        .await
-                        .ok();
-                    }
-                    Err(e) => {
-                        if let Some(scope) = &history_scope {
-                            spawn_query_history_append(
-                                &history_store,
-                                &project,
-                                scope,
-                                &query_for_history,
-                                QueryResultStatus::Failed,
-                                None,
-                            );
+                        Err(e) => {
+                            if let Some(scope) = &history_scope {
+                                spawn_query_history_append(
+                                    &history_store,
+                                    &project,
+                                    scope,
+                                    &query_for_history,
+                                    QueryResultStatus::Failed,
+                                    None,
+                                );
+                            }
+                            tx.send(Action::QueryFailed {
+                                dsn,
+                                run_id,
+                                error: e,
+                                context: QueryFailureContext::Adhoc,
+                            })
+                            .await
+                            .ok();
                         }
-                        tx.send(Action::QueryFailed {
-                            dsn,
-                            run_id,
-                            error: e,
-                            context: QueryFailureContext::Adhoc,
-                        })
-                        .await
-                        .ok();
                     }
-                }
-            });
+                })
+                .await;
         }
 
         Effect::ExecuteWrite {
@@ -253,49 +259,51 @@ pub fn run(
             let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
-            query_tasks.spawn(async move {
-                match executor.execute_write(&dsn, &query, access_mode).await {
-                    Ok(result) => {
-                        if let Some(scope) = &history_scope {
-                            spawn_query_history_append(
-                                &history_store,
-                                &project,
-                                scope,
-                                &query_for_history,
-                                QueryResultStatus::Success,
-                                Some(result.affected_rows as u64),
-                            );
+            query_tasks
+                .spawn(async move {
+                    match executor.execute_write(&dsn, &query, access_mode).await {
+                        Ok(result) => {
+                            if let Some(scope) = &history_scope {
+                                spawn_query_history_append(
+                                    &history_store,
+                                    &project,
+                                    scope,
+                                    &query_for_history,
+                                    QueryResultStatus::Success,
+                                    Some(result.affected_rows as u64),
+                                );
+                            }
+                            tx.send(Action::ExecuteWriteSucceeded {
+                                dsn,
+                                run_id,
+                                affected_rows: result.affected_rows,
+                                diagnostics: result.diagnostics,
+                            })
+                            .await
+                            .ok();
                         }
-                        tx.send(Action::ExecuteWriteSucceeded {
-                            dsn,
-                            run_id,
-                            affected_rows: result.affected_rows,
-                            diagnostics: result.diagnostics,
-                        })
-                        .await
-                        .ok();
-                    }
-                    Err(e) => {
-                        if let Some(scope) = &history_scope {
-                            spawn_query_history_append(
-                                &history_store,
-                                &project,
-                                scope,
-                                &query_for_history,
-                                QueryResultStatus::Failed,
-                                None,
-                            );
+                        Err(e) => {
+                            if let Some(scope) = &history_scope {
+                                spawn_query_history_append(
+                                    &history_store,
+                                    &project,
+                                    scope,
+                                    &query_for_history,
+                                    QueryResultStatus::Failed,
+                                    None,
+                                );
+                            }
+                            tx.send(Action::ExecuteWriteFailed {
+                                dsn,
+                                run_id,
+                                error: e,
+                            })
+                            .await
+                            .ok();
                         }
-                        tx.send(Action::ExecuteWriteFailed {
-                            dsn,
-                            run_id,
-                            error: e,
-                        })
-                        .await
-                        .ok();
                     }
-                }
-            });
+                })
+                .await;
         }
 
         Effect::CountRowsForExport {
@@ -308,18 +316,20 @@ pub fn run(
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
 
-            query_tasks.spawn(async move {
-                let row_count = executor.count_query_rows(&dsn, &count_query).await.ok();
-                tx.send(Action::CsvExportRowsCounted {
-                    dsn,
-                    run_id,
-                    row_count,
-                    export_query,
-                    file_name,
+            query_tasks
+                .spawn(async move {
+                    let row_count = executor.count_query_rows(&dsn, &count_query).await.ok();
+                    tx.send(Action::CsvExportRowsCounted {
+                        dsn,
+                        run_id,
+                        row_count,
+                        export_query,
+                        file_name,
+                    })
+                    .await
+                    .ok();
                 })
-                .await
-                .ok();
-            });
+                .await;
         }
 
         Effect::ExportCsv {
@@ -333,32 +343,34 @@ pub fn run(
             let tx = action_tx.clone();
             let export_dsn = dsn.clone();
 
-            query_tasks.spawn(async move {
-                let result = executor
-                    .export_to_csv(&export_dsn, &query, &file_name)
-                    .await;
-                match result {
-                    Ok(path) => {
-                        tx.send(Action::CsvExportSucceeded {
-                            dsn,
-                            run_id,
-                            path: path.display().to_string(),
-                            row_count,
-                        })
-                        .await
-                        .ok();
+            query_tasks
+                .spawn(async move {
+                    let result = executor
+                        .export_to_csv(&export_dsn, &query, &file_name)
+                        .await;
+                    match result {
+                        Ok(path) => {
+                            tx.send(Action::CsvExportSucceeded {
+                                dsn,
+                                run_id,
+                                path: path.display().to_string(),
+                                row_count,
+                            })
+                            .await
+                            .ok();
+                        }
+                        Err(e) => {
+                            tx.send(Action::CsvExportFailed {
+                                dsn,
+                                run_id,
+                                error: e,
+                            })
+                            .await
+                            .ok();
+                        }
                     }
-                    Err(e) => {
-                        tx.send(Action::CsvExportFailed {
-                            dsn,
-                            run_id,
-                            error: e,
-                        })
-                        .await
-                        .ok();
-                    }
-                }
-            });
+                })
+                .await;
         }
 
         Effect::ExportCsvFromCache {
@@ -372,29 +384,31 @@ pub fn run(
             let tx = action_tx.clone();
             let exporter = Arc::clone(cached_result_exporter);
 
-            query_tasks.spawn(async move {
-                let result = exporter
-                    .export_cached_result_to_csv(file_name, columns, values)
-                    .await;
+            query_tasks
+                .spawn(async move {
+                    let result = exporter
+                        .export_cached_result_to_csv(file_name, columns, values)
+                        .await;
 
-                match result {
-                    Ok(path) => {
-                        tx.send(Action::CsvExportSucceeded {
-                            dsn,
-                            run_id,
-                            path: path.display().to_string(),
-                            row_count,
-                        })
-                        .await
-                        .ok();
-                    }
-                    Err(error) => {
-                        tx.send(Action::CsvExportFailed { dsn, run_id, error })
+                    match result {
+                        Ok(path) => {
+                            tx.send(Action::CsvExportSucceeded {
+                                dsn,
+                                run_id,
+                                path: path.display().to_string(),
+                                row_count,
+                            })
                             .await
                             .ok();
+                        }
+                        Err(error) => {
+                            tx.send(Action::CsvExportFailed { dsn, run_id, error })
+                                .await
+                                .ok();
+                        }
                     }
-                }
-            });
+                })
+                .await;
         }
 
         _ => unreachable!("query::run called with non-query effect"),

--- a/src/app/cmd/query_task.rs
+++ b/src/app/cmd/query_task.rs
@@ -1,10 +1,9 @@
-use std::sync::Mutex;
-
-use tokio::task::AbortHandle;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 #[derive(Default)]
 pub struct TaskRegistry {
-    active: Mutex<Option<AbortHandle>>,
+    active: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl TaskRegistry {
@@ -12,26 +11,24 @@ impl TaskRegistry {
     ///
     /// Each registry instance intentionally permits only one active task at a
     /// time; separate instances are used for queries and table details.
-    pub fn spawn<F>(&self, task: F)
+    pub async fn spawn<F>(&self, task: F)
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        let mut active = self.active.lock().expect("task registry lock poisoned");
+        let mut active = self.active.lock().await;
         if let Some(handle) = active.take() {
             handle.abort();
+            let _ = handle.await;
         }
         let handle = tokio::spawn(task);
-        *active = Some(handle.abort_handle());
+        *active = Some(handle);
     }
 
-    pub fn cancel(&self) {
-        let handle = self
-            .active
-            .lock()
-            .expect("task registry lock poisoned")
-            .take();
+    pub async fn cancel(&self) {
+        let handle = self.active.lock().await.take();
         if let Some(handle) = handle {
             handle.abort();
+            let _ = handle.await;
         }
     }
 }
@@ -44,7 +41,6 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::sync::oneshot;
-    use tokio::time::{Duration, timeout};
 
     use super::*;
 
@@ -63,21 +59,48 @@ mod tests {
         let (started_tx, started_rx) = oneshot::channel();
         let guard = DropSignal(Arc::clone(&dropped));
 
-        registry.spawn(async move {
-            let _guard = guard;
-            started_tx.send(()).ok();
-            std::future::pending::<()>().await;
-        });
+        registry
+            .spawn(async move {
+                let _guard = guard;
+                started_tx.send(()).ok();
+                std::future::pending::<()>().await;
+            })
+            .await;
 
         started_rx.await.expect("query task should start");
-        registry.cancel();
+        registry.cancel().await;
 
-        timeout(Duration::from_secs(1), async {
-            while !dropped.load(Ordering::SeqCst) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("cancelled query task should be dropped");
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn replacement_waits_for_previous_query_task_to_drop() {
+        let registry = QueryTaskRegistry::default();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = oneshot::channel();
+        let first_guard = DropSignal(Arc::clone(&dropped));
+
+        registry
+            .spawn(async move {
+                let _guard = first_guard;
+                started_tx.send(()).ok();
+                std::future::pending::<()>().await;
+            })
+            .await;
+
+        started_rx.await.expect("query task should start");
+
+        let (replacement_started_tx, replacement_started_rx) = oneshot::channel();
+        registry
+            .spawn(async move {
+                assert!(dropped.load(Ordering::SeqCst));
+                replacement_started_tx.send(()).ok();
+            })
+            .await;
+
+        replacement_started_rx
+            .await
+            .expect("replacement query task should start");
+        registry.cancel().await;
     }
 }

--- a/src/app/cmd/query_task.rs
+++ b/src/app/cmd/query_task.rs
@@ -24,10 +24,16 @@ impl TaskRegistry {
         *active = Some(handle);
     }
 
-    pub async fn cancel(&self) {
+    pub async fn abort(&self) -> Option<JoinHandle<()>> {
         let handle = self.active.lock().await.take();
-        if let Some(handle) = handle {
+        if let Some(handle) = &handle {
             handle.abort();
+        }
+        handle
+    }
+
+    pub async fn cancel(&self) {
+        if let Some(handle) = self.abort().await {
             let _ = handle.await;
         }
     }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -516,7 +516,8 @@ mod tests {
     mod task_cancellation {
         use std::future::pending;
         use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Barrier, Mutex};
+        use std::sync::{Condvar, Mutex};
+        use std::time::Duration as StdDuration;
 
         use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
@@ -525,7 +526,15 @@ mod tests {
 
         struct BlockingDropState {
             entered: Mutex<Option<oneshot::Sender<()>>>,
-            barrier: Arc<Barrier>,
+            released: (Mutex<bool>, Condvar),
+        }
+
+        impl BlockingDropState {
+            fn release(&self) {
+                let (released, condvar) = &self.released;
+                *released.lock().expect("release lock poisoned") = true;
+                condvar.notify_one();
+            }
         }
 
         struct BlockingDrop(Arc<BlockingDropState>);
@@ -540,7 +549,17 @@ mod tests {
                     .expect("drop signal should be observed once")
                     .send(())
                     .ok();
-                self.0.barrier.wait();
+                let (released, condvar) = &self.0.released;
+                let mut released = released.lock().expect("release lock poisoned");
+                while !*released {
+                    let (next, result) = condvar
+                        .wait_timeout(released, StdDuration::from_secs(1))
+                        .expect("release wait poisoned");
+                    released = next;
+                    if result.timed_out() {
+                        break;
+                    }
+                }
             }
         }
 
@@ -565,14 +584,14 @@ mod tests {
 
             let (query_started_tx, query_started_rx) = oneshot::channel();
             let (query_drop_tx, mut query_drop_rx) = oneshot::channel();
-            let query_barrier = Arc::new(Barrier::new(2));
+            let query_drop_state = Arc::new(BlockingDropState {
+                entered: Mutex::new(Some(query_drop_tx)),
+                released: (Mutex::new(false), Condvar::new()),
+            });
             runner
                 .query_tasks
                 .spawn({
-                    let drop_state = Arc::new(BlockingDropState {
-                        entered: Mutex::new(Some(query_drop_tx)),
-                        barrier: Arc::clone(&query_barrier),
-                    });
+                    let drop_state = Arc::clone(&query_drop_state);
                     async move {
                         let _drop_signal = BlockingDrop(drop_state);
                         query_started_tx.send(()).ok();
@@ -601,21 +620,27 @@ mod tests {
 
             let cancel = runner.cancel_tracked_tasks();
             tokio::pin!(cancel);
-            tokio::select! {
-                () = &mut cancel => panic!("cancellation should wait for the blocked query drop"),
+            let observed = tokio::select! {
+                () = &mut cancel => "cancellation finished before query drop",
                 result = &mut query_drop_rx => {
-                    result.expect("query drop should start");
-                    assert!(table_dropped.load(Ordering::SeqCst));
+                    match result {
+                        Ok(()) if table_dropped.load(Ordering::SeqCst) => "",
+                        Ok(()) => "table detail task was not aborted",
+                        Err(_) => "query drop signal was lost",
+                    }
                 }
                 () = tokio::time::sleep(Duration::from_secs(1)) => {
-                    panic!("query task should be aborted");
+                    "query task was not aborted"
                 }
-            }
+            };
 
-            query_barrier.wait();
-            timeout(Duration::from_secs(1), cancel)
-                .await
-                .expect("cancellation should finish after query drop is released");
+            query_drop_state.release();
+            let cancellation_finished = timeout(Duration::from_secs(1), cancel).await.is_ok();
+            assert!(
+                cancellation_finished,
+                "cancellation did not finish: {observed}"
+            );
+            assert!(observed.is_empty(), "{observed}");
         }
     }
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -114,8 +114,14 @@ impl EffectRunner {
     }
 
     async fn cancel_tracked_tasks(&self) {
-        self.query_tasks.cancel().await;
-        self.table_detail_tasks.cancel().await;
+        let (query_task, table_detail_task) =
+            tokio::join!(self.query_tasks.abort(), self.table_detail_tasks.abort());
+        if let Some(task) = query_task {
+            let _ = task.await;
+        }
+        if let Some(task) = table_detail_task {
+            let _ = task.await;
+        }
         self.cancel_metadata_tasks().await;
         self.mysql_connection_probe_task.cancel().await;
     }
@@ -504,6 +510,112 @@ mod tests {
             assert_eq!(state.ui.json_detail_editor_visible_rows(), 2);
             assert_eq!(state.json_detail.editor().cursor_to_position().0, 3);
             assert_eq!(state.json_detail.editor().scroll_row(), 2);
+        }
+    }
+
+    mod task_cancellation {
+        use std::future::pending;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Barrier, Mutex};
+
+        use tokio::sync::oneshot;
+        use tokio::time::{Duration, timeout};
+
+        use super::*;
+
+        struct BlockingDropState {
+            entered: Mutex<Option<oneshot::Sender<()>>>,
+            barrier: Arc<Barrier>,
+        }
+
+        struct BlockingDrop(Arc<BlockingDropState>);
+
+        impl Drop for BlockingDrop {
+            fn drop(&mut self) {
+                self.0
+                    .entered
+                    .lock()
+                    .expect("drop signal lock poisoned")
+                    .take()
+                    .expect("drop signal should be observed once")
+                    .send(())
+                    .ok();
+                self.0.barrier.wait();
+            }
+        }
+
+        struct DropSignal(Arc<AtomicBool>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn cancel_tracked_tasks_aborts_both_groups_before_joining() {
+            let (tx, _rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                tx,
+            );
+
+            let (query_started_tx, query_started_rx) = oneshot::channel();
+            let (query_drop_tx, mut query_drop_rx) = oneshot::channel();
+            let query_barrier = Arc::new(Barrier::new(2));
+            runner
+                .query_tasks
+                .spawn({
+                    let drop_state = Arc::new(BlockingDropState {
+                        entered: Mutex::new(Some(query_drop_tx)),
+                        barrier: Arc::clone(&query_barrier),
+                    });
+                    async move {
+                        let _drop_signal = BlockingDrop(drop_state);
+                        query_started_tx.send(()).ok();
+                        pending::<()>().await;
+                    }
+                })
+                .await;
+            query_started_rx.await.expect("query task should start");
+
+            let table_dropped = Arc::new(AtomicBool::new(false));
+            let (table_started_tx, table_started_rx) = oneshot::channel();
+            runner
+                .table_detail_tasks
+                .spawn({
+                    let dropped = Arc::clone(&table_dropped);
+                    async move {
+                        let _drop_signal = DropSignal(dropped);
+                        table_started_tx.send(()).ok();
+                        pending::<()>().await;
+                    }
+                })
+                .await;
+            table_started_rx
+                .await
+                .expect("table detail task should start");
+
+            let cancel = runner.cancel_tracked_tasks();
+            tokio::pin!(cancel);
+            tokio::select! {
+                () = &mut cancel => panic!("cancellation should wait for the blocked query drop"),
+                result = &mut query_drop_rx => {
+                    result.expect("query drop should start");
+                    assert!(table_dropped.load(Ordering::SeqCst));
+                }
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    panic!("query task should be aborted");
+                }
+            }
+
+            query_barrier.wait();
+            timeout(Duration::from_secs(1), cancel)
+                .await
+                .expect("cancellation should finish after query drop is released");
         }
     }
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -114,8 +114,8 @@ impl EffectRunner {
     }
 
     async fn cancel_tracked_tasks(&self) {
-        self.query_tasks.cancel();
-        self.table_detail_tasks.cancel();
+        self.query_tasks.cancel().await;
+        self.table_detail_tasks.cancel().await;
         self.cancel_metadata_tasks().await;
         self.mysql_connection_probe_task.cancel().await;
     }
@@ -216,7 +216,7 @@ impl EffectRunner {
                     self.cancel_metadata_tasks().await;
                 }
                 if matches!(&e, Effect::ProbeMySqlConnection { .. }) {
-                    self.table_detail_tasks.cancel();
+                    self.table_detail_tasks.cancel().await;
                 }
                 cmd_connection::run(
                     e,
@@ -275,7 +275,8 @@ impl EffectRunner {
                     &self.query.cached_result_exporter,
                     &self.query_tasks,
                     state,
-                );
+                )
+                .await;
                 Ok(vec![])
             }
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -515,7 +515,6 @@ mod tests {
 
     mod task_cancellation {
         use std::future::pending;
-        use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::{Condvar, Mutex};
         use std::time::Duration as StdDuration;
 
@@ -563,11 +562,17 @@ mod tests {
             }
         }
 
-        struct DropSignal(Arc<AtomicBool>);
+        struct DropSignal(Mutex<Option<oneshot::Sender<()>>>);
 
         impl Drop for DropSignal {
             fn drop(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
+                self.0
+                    .lock()
+                    .expect("table drop signal lock poisoned")
+                    .take()
+                    .expect("table drop signal should be observed once")
+                    .send(())
+                    .ok();
             }
         }
 
@@ -601,14 +606,13 @@ mod tests {
                 .await;
             query_started_rx.await.expect("query task should start");
 
-            let table_dropped = Arc::new(AtomicBool::new(false));
             let (table_started_tx, table_started_rx) = oneshot::channel();
+            let (table_drop_tx, mut table_drop_rx) = oneshot::channel();
             runner
                 .table_detail_tasks
                 .spawn({
-                    let dropped = Arc::clone(&table_dropped);
                     async move {
-                        let _drop_signal = DropSignal(dropped);
+                        let _drop_signal = DropSignal(Mutex::new(Some(table_drop_tx)));
                         table_started_tx.send(()).ok();
                         pending::<()>().await;
                     }
@@ -624,8 +628,16 @@ mod tests {
                 () = &mut cancel => "cancellation finished before query drop",
                 result = &mut query_drop_rx => {
                     match result {
-                        Ok(()) if table_dropped.load(Ordering::SeqCst) => "",
-                        Ok(()) => "table detail task was not aborted",
+                        Ok(()) => match timeout(
+                            Duration::from_secs(1),
+                            &mut table_drop_rx,
+                        )
+                        .await
+                        {
+                            Ok(Ok(())) => "",
+                            Ok(Err(_)) => "table drop signal was lost",
+                            Err(_) => "table detail task was not aborted",
+                        },
                         Err(_) => "query drop signal was lost",
                     }
                 }


### PR DESCRIPTION
## Problem
Query and table-detail registries aborted the previous task without awaiting its completion, allowing the replacement task to start before the old future had been dropped.

## Background
Run IDs reject stale actions but do not guarantee resource-release ordering between successive tasks.

## Approach
The registry now owns each task JoinHandle and awaits an aborted handle before replacement or cancellation completes. Query and table-detail runner boundaries await registry operations while preserving existing action payloads and database protocols.