### PR TITLE
fix(mysql): clean up option file after open failure

### DIFF
--- a/src/infra/adapters/mysql/cli/process/tests/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/metadata.rs
@@ -7,6 +7,7 @@ async fn reuses_one_process_for_ordered_resultsets() {
     let (_directory, program, option_file_path) = fake_mysql_multi();
     let option_file = MySqlOptionFile {
         path: option_file_path.clone(),
+        file: None,
     };
     let mut session =
         MySqlMetadataSession::spawn_with_metadata_program(OsStr::new(&program), option_file)

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::fs::{self, OpenOptions};
-#[cfg(windows)]
 use std::io;
 use std::io::Write;
 use std::path::PathBuf;
@@ -52,6 +51,8 @@ impl MySqlOptionFile {
             path,
             file: Some(file),
         };
+        #[cfg(test)]
+        tests::record_creation_path(&option_file.path);
         #[cfg(windows)]
         set_file_permissions(option_file.file.as_ref().unwrap()).map_err(|error| {
             DbOperationError::ConnectionFailed(format!(
@@ -59,19 +60,23 @@ impl MySqlOptionFile {
             ))
         })?;
         let contents = serialize_option_file(target);
-        option_file
-            .file
-            .as_mut()
-            .unwrap()
-            .write_all(contents.as_bytes())
-            .map_err(|error| {
-                DbOperationError::ConnectionFailed(format!(
-                    "Unable to write MySQL option file: {error}"
-                ))
-            })?;
+        write_option_file(option_file.file.as_mut().unwrap(), &contents).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "Unable to write MySQL option file: {error}"
+            ))
+        })?;
         drop(option_file.file.take());
         Ok(option_file)
     }
+}
+
+fn write_option_file(file: &mut File, contents: &str) -> io::Result<()> {
+    #[cfg(test)]
+    if tests::current_failure() == Some(tests::CreationFailure::PartialWrite) {
+        file.write_all(b"[client]\npassword = \"partial")?;
+        return Err(io::Error::other("injected partial write"));
+    }
+    file.write_all(contents.as_bytes())
 }
 
 fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
@@ -349,6 +354,13 @@ fn der_element(input: &[u8], expected_tag: u8) -> Option<(&[u8], &[u8])> {
 
 #[cfg(windows)]
 fn set_file_permissions(file: &File) -> io::Result<()> {
+    #[cfg(test)]
+    if tests::current_failure() == Some(tests::CreationFailure::Permission) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "injected ACL failure",
+        ));
+    }
     use std::os::windows::io::AsRawHandle;
     use std::ptr::{null, null_mut};
 
@@ -527,7 +539,9 @@ fn quote_option_value(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::{Cell, RefCell};
     use std::collections::HashSet;
+    use std::path::Path;
     use std::sync::{Arc, Barrier};
 
     use crate::domain::connection::MySqlSslMode;
@@ -542,6 +556,51 @@ mod tests {
         MEgCQQCkUPNQeEgyJX6XS2qlrU20cleKptQX/Llyrm6tzLzVI8JF3wcCiQ0R4KgX\n\
         x/4oCDpO8lWDRl+SFkUlLz4xJ4zdAgMBAAE=\n\
         -----END RSA PUBLIC KEY-----\n";
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub(super) enum CreationFailure {
+        #[cfg(windows)]
+        Permission,
+        PartialWrite,
+    }
+
+    thread_local! {
+        static CREATION_FAILURE: Cell<Option<CreationFailure>> = const { Cell::new(None) };
+        static CREATION_PATH: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+    }
+
+    struct FailureGuard;
+
+    fn inject_failure(failure: CreationFailure) -> FailureGuard {
+        CREATION_FAILURE.with(|current| assert!(current.replace(Some(failure)).is_none()));
+        CREATION_PATH.with(|path| path.borrow_mut().take());
+        FailureGuard
+    }
+
+    pub(super) fn current_failure() -> Option<CreationFailure> {
+        CREATION_FAILURE.with(Cell::get)
+    }
+
+    pub(super) fn record_creation_path(path: &Path) {
+        if current_failure().is_some() {
+            CREATION_PATH.with(|stored| *stored.borrow_mut() = Some(path.to_path_buf()));
+        }
+    }
+
+    fn take_creation_path() -> PathBuf {
+        CREATION_PATH.with(|path| {
+            path.borrow_mut()
+                .take()
+                .expect("option file creation should record its path")
+        })
+    }
+
+    impl Drop for FailureGuard {
+        fn drop(&mut self) {
+            CREATION_FAILURE.with(|current| current.set(None));
+            CREATION_PATH.with(|path| path.borrow_mut().take());
+        }
+    }
 
     fn target() -> MySqlDsn {
         MySqlDsn {
@@ -852,21 +911,37 @@ ssl-mode = \"REQUIRED\"\n"
     }
 
     #[test]
-    fn option_file_drop_closes_open_handle_before_cleanup() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("partial.cnf");
-        let file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .unwrap();
-        let option_file = MySqlOptionFile {
-            path: path.clone(),
-            file: Some(file),
-        };
+    fn partial_write_failure_removes_option_file_and_preserves_error() {
+        let _failure = inject_failure(CreationFailure::PartialWrite);
 
-        drop(option_file);
+        let error = MySqlOptionFile::create(&target())
+            .err()
+            .expect("partial write should fail option file creation");
+        let path = take_creation_path();
 
+        assert!(matches!(
+            &error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "Unable to write MySQL option file: injected partial write"
+        ));
+        assert!(!path.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn acl_failure_removes_option_file_and_preserves_error() {
+        let _failure = inject_failure(CreationFailure::Permission);
+
+        let error = MySqlOptionFile::create(&target())
+            .err()
+            .expect("ACL failure should fail option file creation");
+        let path = take_creation_path();
+
+        assert!(matches!(
+            &error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "Unable to secure MySQL option file: injected ACL failure"
+        ));
         assert!(!path.exists());
     }
 

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -1,4 +1,3 @@
-#[cfg(windows)]
 use std::fs::File;
 use std::fs::{self, OpenOptions};
 #[cfg(windows)]
@@ -17,6 +16,7 @@ use super::dsn::{
 
 pub(super) struct MySqlOptionFile {
     pub(super) path: PathBuf,
+    pub(super) file: Option<File>,
 }
 
 impl MySqlOptionFile {
@@ -43,27 +43,34 @@ impl MySqlOptionFile {
             windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE
                 | windows_sys::Win32::Storage::FileSystem::WRITE_DAC,
         );
-        let mut file = options.open(&path).map_err(|error| {
+        let file = options.open(&path).map_err(|error| {
             DbOperationError::ConnectionFailed(format!(
                 "Unable to create MySQL option file: {error}"
             ))
         })?;
+        let mut option_file = Self {
+            path,
+            file: Some(file),
+        };
         #[cfg(windows)]
-        if let Err(error) = set_file_permissions(&file) {
-            drop(file);
-            let _ = fs::remove_file(&path);
-            return Err(DbOperationError::ConnectionFailed(format!(
+        set_file_permissions(option_file.file.as_ref().unwrap()).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
                 "Unable to secure MySQL option file: {error}"
-            )));
-        }
+            ))
+        })?;
         let contents = serialize_option_file(target);
-        if let Err(error) = file.write_all(contents.as_bytes()) {
-            let _ = fs::remove_file(&path);
-            return Err(DbOperationError::ConnectionFailed(format!(
-                "Unable to write MySQL option file: {error}"
-            )));
-        }
-        Ok(Self { path })
+        option_file
+            .file
+            .as_mut()
+            .unwrap()
+            .write_all(contents.as_bytes())
+            .map_err(|error| {
+                DbOperationError::ConnectionFailed(format!(
+                    "Unable to write MySQL option file: {error}"
+                ))
+            })?;
+        drop(option_file.file.take());
+        Ok(option_file)
     }
 }
 
@@ -453,6 +460,7 @@ fn current_user_sid(token: windows_sys::Win32::Foundation::HANDLE) -> io::Result
 
 impl Drop for MySqlOptionFile {
     fn drop(&mut self) {
+        drop(self.file.take());
         let _ = fs::remove_file(&self.path);
     }
 }
@@ -840,6 +848,25 @@ ssl-mode = \"REQUIRED\"\n"
         assert_owner_only_acl(&option_file.path);
         let path = option_file.path.clone();
         drop(option_file);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn option_file_drop_closes_open_handle_before_cleanup() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("partial.cnf");
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        let option_file = MySqlOptionFile {
+            path: path.clone(),
+            file: Some(file),
+        };
+
+        drop(option_file);
+
         assert!(!path.exists());
     }
 


### PR DESCRIPTION
## Problem
MySQL option-file creation failures can leave a partial credential file when cleanup tries to remove it while the file handle is still open on Windows.

## Background
The option file contains connection credentials and must not outlive the failed creation path.

## Approach
The option-file owner holds the open handle for the remainder of creation, closes it before returning successfully, and closes it before Drop removes the file on every later failure.