### PR TITLE
refactor: remove unused metadata error payload

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -513,8 +513,8 @@ impl BrowseSession {
 
     // On reload failure (already Connected), keeps Connected to preserve
     // the current browse session while surfacing the error.
-    pub fn mark_connection_failed(&mut self, error: String) {
-        self.metadata_state = MetadataState::Error(error);
+    pub fn mark_connection_failed(&mut self) {
+        self.metadata_state = MetadataState::Error;
         self.is_reloading = false;
         self.metadata_run.clear_active();
         if !self.connection_state.is_connected() {
@@ -1398,13 +1398,10 @@ mod tests {
             let mut session = BrowseSession::default();
             session.set_connection_state(ConnectionState::Connecting);
 
-            session.mark_connection_failed("timeout".to_string());
+            session.mark_connection_failed();
 
             assert!(session.connection_state().is_failed());
-            assert_eq!(
-                session.metadata_state(),
-                &MetadataState::Error("timeout".to_string())
-            );
+            assert_eq!(session.metadata_state(), &MetadataState::Error);
             assert!(!session.is_reloading());
         }
 
@@ -1415,13 +1412,10 @@ mod tests {
             let _ = session.begin_reload();
             session.mark_effective_user_loaded(Some("postgres".to_string()));
 
-            session.mark_connection_failed("reload timeout".to_string());
+            session.mark_connection_failed();
 
             assert!(session.connection_state().is_connected());
-            assert_eq!(
-                session.metadata_state(),
-                &MetadataState::Error("reload timeout".to_string())
-            );
+            assert_eq!(session.metadata_state(), &MetadataState::Error);
             assert!(!session.is_reloading());
             assert_eq!(session.effective_user(), Some("postgres"));
         }

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -115,7 +115,7 @@ pub(super) fn reduce_loading(
             let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(error, dsn);
             state.connection_error.set_error(error_info);
             let was_connected = state.session.connection_state().is_connected();
-            state.session.mark_connection_failed(error.masked_details());
+            state.session.mark_connection_failed();
             if !was_connected {
                 state.session.set_metadata(None);
                 state.session.clear_table_selection(&mut state.query);

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -175,8 +175,8 @@ pub fn reduce_connection_lifecycle(
             if state.session.dsn_matches(&target.dsn) {
                 state
                     .session
-                    .mark_table_detail_probe_failed(&target.dsn, message.clone());
-                state.session.mark_connection_failed(message);
+                    .mark_table_detail_probe_failed(&target.dsn, message);
+                state.session.mark_connection_failed();
             }
             state.connection_error.set_connection_switch_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1354,10 +1354,14 @@ mod tests {
 
             assert!(matches!(
                 state.session.metadata_state(),
-                MetadataState::Error(_)
+                MetadataState::Error
             ));
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
             assert!(state.connection_error.has_error());
+            assert_eq!(
+                state.connection_error.masked_details(),
+                Some("psql: error: connection refused")
+            );
             assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
@@ -1443,9 +1447,7 @@ mod tests {
         #[test]
         fn reopen_modal_after_close_shows_same_error() {
             let mut state = state_with_error();
-            state
-                .session
-                .set_metadata_state(MetadataState::Error("error".to_string()));
+            state.session.set_metadata_state(MetadataState::Error);
             state.ui.set_focused_pane(FocusedPane::Explorer);
             let now = Instant::now();
 
@@ -2474,7 +2476,7 @@ mod tests {
             assert!(state.session.connection_state().is_failed());
             assert!(matches!(
                 state.session.metadata_state(),
-                MetadataState::Error(_)
+                MetadataState::Error
             ));
         }
 
@@ -2512,7 +2514,7 @@ mod tests {
             // But metadata state should be Error
             assert!(matches!(
                 state.session.metadata_state(),
-                MetadataState::Error(_)
+                MetadataState::Error
             ));
         }
 
@@ -2520,9 +2522,7 @@ mod tests {
         fn reenter_connection_setup_resets_all_states() {
             let mut state = create_test_state();
             state.session.set_connection_state(ConnectionState::Failed);
-            state
-                .session
-                .set_metadata_state(MetadataState::Error("error".to_string()));
+            state.session.set_metadata_state(MetadataState::Error);
             state.modal.set_mode(InputMode::ConnectionError);
             let now = Instant::now();
 

--- a/src/domain/metadata.rs
+++ b/src/domain/metadata.rs
@@ -25,5 +25,5 @@ pub enum MetadataState {
     NotLoaded,
     Loading,
     Loaded,
-    Error(String),
+    Error,
 }

--- a/src/ui/features/browse/explorer.rs
+++ b/src/ui/features/browse/explorer.rs
@@ -24,7 +24,7 @@ impl Explorer {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let is_error = matches!(state.session.metadata_state(), MetadataState::Error(_));
+        let is_error = matches!(state.session.metadata_state(), MetadataState::Error);
         let has_cached_data =
             !is_error && state.session.metadata().is_some() && !state.tables().is_empty();
         Self::render_tables_section(frame, inner, state, has_cached_data, theme);
@@ -70,7 +70,7 @@ impl Explorer {
                 MetadataState::Loading => {
                     vec![ListItem::new(" Loading metadata...")]
                 }
-                MetadataState::Error(_) => {
+                MetadataState::Error => {
                     vec![
                         ListItem::new(" Metadata load failed"),
                         ListItem::new(" (r: retry, Enter: details)"),

--- a/src/ui/shell/header.rs
+++ b/src/ui/shell/header.rs
@@ -39,7 +39,7 @@ impl Header {
             match &state.session.metadata_state() {
                 MetadataState::Loaded => ("connected", theme.semantic.status.success),
                 MetadataState::Loading => ("loading...", theme.semantic.status.warning),
-                MetadataState::Error(_) => ("error", theme.semantic.status.error),
+                MetadataState::Error => ("error", theme.semantic.status.error),
                 MetadataState::NotLoaded => ("not loaded", theme.semantic.text.muted),
             }
         };


### PR DESCRIPTION
## Problem
MetadataState duplicated masked metadata failure details in a payload that no consumer reads.

## Background
ConnectionErrorInfo already owns the details shown by the connection-error modal.

## Approach
Represent metadata failure as a unit state while keeping the existing connection-error information and lifecycle transitions unchanged.