### PR TITLE
refactor(app): shrink connection error source state

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -570,7 +570,7 @@ mod tests {
             );
             state
                 .connection_error
-                .set_save_and_connect_error(retryable_error(), DatabaseType::MySQL);
+                .set_save_and_connect_error(retryable_error());
 
             assert!(!state.can_retry_connection_error());
         }

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -1,18 +1,13 @@
 use std::time::{Duration, Instant};
 
 use super::error::ConnectionErrorInfo;
-use crate::domain::DatabaseType;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 enum ConnectionErrorSource {
     #[default]
     ActiveConnection,
-    SaveAndConnect {
-        database_type: DatabaseType,
-    },
-    ConnectionSwitch {
-        database_type: DatabaseType,
-    },
+    SaveAndConnect,
+    ConnectionSwitch,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -31,26 +26,12 @@ impl ConnectionErrorState {
         self.set_error_with_source(info, ConnectionErrorSource::ActiveConnection);
     }
 
-    pub fn set_save_and_connect_error(
-        &mut self,
-        info: ConnectionErrorInfo,
-        database_type: DatabaseType,
-    ) {
-        self.set_error_with_source(
-            info,
-            ConnectionErrorSource::SaveAndConnect { database_type },
-        );
+    pub fn set_save_and_connect_error(&mut self, info: ConnectionErrorInfo) {
+        self.set_error_with_source(info, ConnectionErrorSource::SaveAndConnect);
     }
 
-    pub fn set_connection_switch_error(
-        &mut self,
-        info: ConnectionErrorInfo,
-        database_type: DatabaseType,
-    ) {
-        self.set_error_with_source(
-            info,
-            ConnectionErrorSource::ConnectionSwitch { database_type },
-        );
+    pub fn set_connection_switch_error(&mut self, info: ConnectionErrorInfo) {
+        self.set_error_with_source(info, ConnectionErrorSource::ConnectionSwitch);
     }
 
     fn set_error_with_source(&mut self, info: ConnectionErrorInfo, source: ConnectionErrorSource) {
@@ -70,15 +51,11 @@ impl ConnectionErrorState {
     }
 
     pub fn is_save_and_connect_failure(&self) -> bool {
-        matches!(self.source, ConnectionErrorSource::SaveAndConnect { .. })
+        matches!(self.source, ConnectionErrorSource::SaveAndConnect)
     }
 
-    pub fn destination_database_type(&self) -> Option<DatabaseType> {
-        match self.source {
-            ConnectionErrorSource::ActiveConnection => None,
-            ConnectionErrorSource::SaveAndConnect { database_type }
-            | ConnectionErrorSource::ConnectionSwitch { database_type } => Some(database_type),
-        }
+    pub fn has_destination(&self) -> bool {
+        !matches!(self.source, ConnectionErrorSource::ActiveConnection)
     }
 
     pub fn can_retry(&self) -> bool {
@@ -183,6 +160,18 @@ mod tests {
             assert!(!state.details_expanded());
             assert_eq!(state.scroll_offset(), 0);
             assert!(!state.is_copied_visible_at(now()));
+        }
+
+        #[test]
+        fn tracks_destination_presence_without_database_type() {
+            let mut state = ConnectionErrorState::default();
+            assert!(!state.has_destination());
+
+            state.set_save_and_connect_error(sample_error());
+            assert!(state.has_destination());
+
+            state.set_connection_switch_error(sample_error());
+            assert!(state.has_destination());
         }
 
         #[test]

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -55,7 +55,10 @@ impl ConnectionErrorState {
     }
 
     pub fn has_destination(&self) -> bool {
-        !matches!(self.source, ConnectionErrorSource::ActiveConnection)
+        matches!(
+            self.source,
+            ConnectionErrorSource::SaveAndConnect | ConnectionErrorSource::ConnectionSwitch
+        )
     }
 
     pub fn can_retry(&self) -> bool {

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -180,7 +180,6 @@ pub fn reduce_connection_lifecycle(
             }
             state.connection_error.set_connection_switch_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
-                target.database_type,
             );
             state.modal.replace_mode(InputMode::ConnectionError);
             DispatchResult::handled_with(table_detail_retry.into_iter().collect())

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -314,7 +314,7 @@ pub fn reduce_connection_setup(
             if let Some(error_info) = mysql_error {
                 state
                     .connection_error
-                    .set_save_and_connect_error(error_info, *database_type);
+                    .set_save_and_connect_error(error_info);
                 state.modal.replace_mode(InputMode::ConnectionError);
                 return DispatchResult::handled();
             }
@@ -983,10 +983,7 @@ mod tests {
             );
 
             assert!(state.connection_error.is_save_and_connect_failure());
-            assert_eq!(
-                state.connection_error.destination_database_type(),
-                Some(DatabaseType::MySQL)
-            );
+            assert!(state.connection_error.has_destination());
             let effects =
                 reduce_connection_error(&mut state, &Action::RetryConnection, Instant::now())
                     .into_effects()

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -449,15 +449,19 @@ fn render_service_error_without_service_file_hint(save_and_connect: bool) -> Str
         .runtime
         .set_service_file_path(Some(std::path::PathBuf::from("/etc/pg_service.conf")));
     if save_and_connect {
-        state.connection_error.set_save_and_connect_error(
-            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Unknown, "mysql save failed"),
-            DatabaseType::MySQL,
-        );
+        state
+            .connection_error
+            .set_save_and_connect_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::Unknown,
+                "mysql save failed",
+            ));
     } else {
-        state.connection_error.set_connection_switch_error(
-            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Unknown, "mysql switch failed"),
-            DatabaseType::MySQL,
-        );
+        state
+            .connection_error
+            .set_connection_switch_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::Unknown,
+                "mysql switch failed",
+            ));
     }
     state.modal.set_mode(InputMode::ConnectionError);
 

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -95,7 +95,7 @@ impl ConnectionError {
             Span::styled(hint, Style::default().fg(theme.semantic.text.secondary)),
         ];
         if state.session.is_service_connection()
-            && state.connection_error.destination_database_type().is_none()
+            && !state.connection_error.has_destination()
             && let Some(path) = state.runtime.service_file_path()
         {
             spans.push(Span::styled(

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -712,10 +712,12 @@ mod tests {
             DatabaseType::MySQL,
             "mysql://user@localhost:3306/app?ssl-mode=PREFERRED",
         );
-        state.connection_error.set_save_and_connect_error(
-            ConnectionErrorInfo::with_kind(ConnectionErrorKind::Timeout, "connection timed out"),
-            DatabaseType::MySQL,
-        );
+        state
+            .connection_error
+            .set_save_and_connect_error(ConnectionErrorInfo::with_kind(
+                ConnectionErrorKind::Timeout,
+                "connection timed out",
+            ));
         state.modal.set_mode(InputMode::ConnectionError);
 
         let hints = Footer::get_context_hints(&state);


### PR DESCRIPTION
## Problem
`ConnectionErrorSource` stored destination `DatabaseType` values even though consumers only needed to know whether a destination existed.

## Background
The database value was forwarded through both destination error setters and exposed through an accessor whose only production use checked `is_none()`.

## Approach
Represent destination errors as payload-free source variants and expose a presence predicate. Preserve the existing save-and-connect, connection-switch, retry, and service-file hint behavior.

## Screenshots

## Linear Issue Link (optional)