### PR TITLE
Cancel SQLite diagnostics with modal lifecycle

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -96,6 +96,7 @@ pub enum Effect {
         query: String,
         access_mode: AccessMode,
     },
+    CancelSqliteDiagnostics,
     CancelTrackedTasks,
     CountRowsForExport {
         dsn: String,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -120,7 +120,6 @@ impl EffectRunner {
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
         self.mysql_connection_probe_task.cancel().await;
-        self.sqlite_diagnostics_task.cancel().await;
     }
 
     pub async fn execute_effects<T: Renderer>(

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -76,6 +76,7 @@ pub struct EffectRunner {
     table_detail_tasks: TableDetailTaskRegistry,
     metadata_tasks: Arc<MetadataTaskRegistry>,
     mysql_connection_probe_task: MySqlConnectionProbeTaskOwner,
+    sqlite_diagnostics_task: sqlite_diagnostics::SqliteDiagnosticsTaskOwner,
 }
 
 impl EffectRunner {
@@ -102,6 +103,7 @@ impl EffectRunner {
             table_detail_tasks: TableDetailTaskRegistry::default(),
             metadata_tasks: Arc::new(MetadataTaskRegistry::default()),
             mysql_connection_probe_task: MySqlConnectionProbeTaskOwner::default(),
+            sqlite_diagnostics_task: sqlite_diagnostics::SqliteDiagnosticsTaskOwner::default(),
         }
     }
 
@@ -118,6 +120,7 @@ impl EffectRunner {
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
         self.mysql_connection_probe_task.cancel().await;
+        self.sqlite_diagnostics_task.cancel().await;
     }
 
     pub async fn execute_effects<T: Renderer>(
@@ -255,6 +258,11 @@ impl EffectRunner {
                 Ok(vec![])
             }
 
+            Effect::CancelSqliteDiagnostics => {
+                self.sqlite_diagnostics_task.cancel().await;
+                Ok(vec![])
+            }
+
             Effect::CancelTrackedTasks => {
                 self.cancel_tracked_tasks().await;
                 Ok(vec![])
@@ -310,11 +318,13 @@ impl EffectRunner {
 
             e @ (Effect::FetchSqliteDiagnosticsCore { .. }
             | Effect::FetchSqliteDiagnosticsQuickCheck { .. }) => {
-                sqlite_diagnostics::spawn_sqlite_diagnostics(
+                sqlite_diagnostics::run(
                     e,
                     &self.action_tx,
                     &self.query.sqlite_diagnostics,
-                );
+                    &self.sqlite_diagnostics_task,
+                )
+                .await;
                 Ok(vec![])
             }
 

--- a/src/app/cmd/sqlite_diagnostics.rs
+++ b/src/app/cmd/sqlite_diagnostics.rs
@@ -10,44 +10,48 @@ use crate::update::action::Action;
 
 #[derive(Default)]
 pub(crate) struct SqliteDiagnosticsTaskOwner {
-    active: std::sync::Mutex<Option<JoinHandle<()>>>,
+    core: std::sync::Mutex<Option<JoinHandle<()>>>,
+    quick_check: std::sync::Mutex<Option<JoinHandle<()>>>,
 }
 
 impl SqliteDiagnosticsTaskOwner {
-    pub(crate) async fn replace<F>(&self, task: F)
+    async fn replace<F>(slot: &std::sync::Mutex<Option<JoinHandle<()>>>, task: F)
     where
         F: std::future::Future<Output = ()> + Send + 'static,
     {
-        self.cancel().await;
+        Self::cancel_slot(slot).await;
         let task = tokio::spawn(task);
-        *self
-            .active
-            .lock()
-            .expect("SQLite diagnostics task lock poisoned") = Some(task);
+        *slot.lock().expect("SQLite diagnostics task lock poisoned") = Some(task);
     }
 
-    pub(crate) async fn cancel(&self) {
-        let task = self
-            .active
-            .lock()
-            .expect("SQLite diagnostics task lock poisoned")
-            .take();
+    async fn cancel_slot(slot: &std::sync::Mutex<Option<JoinHandle<()>>>) {
+        let task = {
+            slot.lock()
+                .expect("SQLite diagnostics task lock poisoned")
+                .take()
+        };
         if let Some(task) = task {
             task.abort();
             let _ = task.await;
         }
     }
+
+    pub(crate) async fn cancel(&self) {
+        Self::cancel_slot(&self.core).await;
+        Self::cancel_slot(&self.quick_check).await;
+    }
 }
 
 impl Drop for SqliteDiagnosticsTaskOwner {
     fn drop(&mut self) {
-        if let Some(task) = self
-            .active
-            .get_mut()
-            .expect("SQLite diagnostics task lock poisoned")
-            .take()
-        {
-            task.abort();
+        for slot in [&mut self.core, &mut self.quick_check] {
+            if let Some(task) = slot
+                .get_mut()
+                .expect("SQLite diagnostics task lock poisoned")
+                .take()
+            {
+                task.abort();
+            }
         }
     }
 }
@@ -62,41 +66,39 @@ pub(crate) async fn run(
         Effect::FetchSqliteDiagnosticsCore { dsn, run_id } => {
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
-            task_owner
-                .replace(async move {
-                    let action = match provider.fetch_core_diagnostics(&dsn).await {
-                        Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
-                            dsn,
-                            run_id,
-                            snapshot: Box::new(snapshot),
-                        },
-                        Err(error) => Action::SqliteDiagnosticsCoreLoaded {
-                            dsn,
-                            run_id,
-                            snapshot: Box::new(SqliteDiagnosticsSnapshot::core_fetch_failed(
-                                DiagnosticField::err(error.masked_details()),
-                            )),
-                        },
-                    };
-                    let _ = action_tx.send(action).await;
-                })
-                .await;
+            SqliteDiagnosticsTaskOwner::replace(&task_owner.core, async move {
+                let action = match provider.fetch_core_diagnostics(&dsn).await {
+                    Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
+                        dsn,
+                        run_id,
+                        snapshot: Box::new(snapshot),
+                    },
+                    Err(error) => Action::SqliteDiagnosticsCoreLoaded {
+                        dsn,
+                        run_id,
+                        snapshot: Box::new(SqliteDiagnosticsSnapshot::core_fetch_failed(
+                            DiagnosticField::err(error.masked_details()),
+                        )),
+                    },
+                };
+                let _ = action_tx.send(action).await;
+            })
+            .await;
         }
         Effect::FetchSqliteDiagnosticsQuickCheck { dsn, run_id } => {
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
-            task_owner
-                .replace(async move {
-                    let quick_check = provider.fetch_quick_check(&dsn).await;
-                    let _ = action_tx
-                        .send(Action::SqliteDiagnosticsQuickCheckLoaded {
-                            dsn,
-                            run_id,
-                            quick_check,
-                        })
-                        .await;
-                })
-                .await;
+            SqliteDiagnosticsTaskOwner::replace(&task_owner.quick_check, async move {
+                let quick_check = provider.fetch_quick_check(&dsn).await;
+                let _ = action_tx
+                    .send(Action::SqliteDiagnosticsQuickCheckLoaded {
+                        dsn,
+                        run_id,
+                        quick_check,
+                    })
+                    .await;
+            })
+            .await;
         }
         _ => {}
     }
@@ -170,6 +172,62 @@ mod tests {
                 quick_check,
                 ..
             } if quick_check.ok_value() == Some("ok")
+        ));
+    }
+
+    #[tokio::test]
+    async fn core_and_quick_check_tasks_can_run_together() {
+        use tokio::time::{Duration, timeout};
+
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut provider = MockSqliteDiagnosticsProvider::new();
+        provider
+            .expect_fetch_core_diagnostics()
+            .returning(|_| Ok(SqliteDiagnosticsSnapshot::default()));
+        provider
+            .expect_fetch_quick_check()
+            .returning(|_| DiagnosticField::ok("ok"));
+
+        let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;
+        let owner = SqliteDiagnosticsTaskOwner::default();
+        run(
+            Effect::FetchSqliteDiagnosticsCore {
+                dsn: "sqlite:///tmp/app.db".to_string(),
+                run_id: 1,
+            },
+            &tx,
+            &provider,
+            &owner,
+        )
+        .await;
+        run(
+            Effect::FetchSqliteDiagnosticsQuickCheck {
+                dsn: "sqlite:///tmp/app.db".to_string(),
+                run_id: 1,
+            },
+            &tx,
+            &provider,
+            &owner,
+        )
+        .await;
+
+        let first = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("core and quick-check tasks should both complete")
+            .expect("first diagnostics action should be sent");
+        let second = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("core and quick-check tasks should both complete")
+            .expect("second diagnostics action should be sent");
+        assert!(matches!(
+            (first, second),
+            (
+                Action::SqliteDiagnosticsCoreLoaded { .. },
+                Action::SqliteDiagnosticsQuickCheckLoaded { .. }
+            ) | (
+                Action::SqliteDiagnosticsQuickCheckLoaded { .. },
+                Action::SqliteDiagnosticsCoreLoaded { .. }
+            )
         ));
     }
 

--- a/src/app/cmd/sqlite_diagnostics.rs
+++ b/src/app/cmd/sqlite_diagnostics.rs
@@ -1,4 +1,5 @@
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use std::sync::Arc;
 
@@ -7,46 +8,95 @@ use crate::domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
 use crate::ports::outbound::SqliteDiagnosticsProvider;
 use crate::update::action::Action;
 
-pub fn spawn_sqlite_diagnostics(
+#[derive(Default)]
+pub(crate) struct SqliteDiagnosticsTaskOwner {
+    active: std::sync::Mutex<Option<JoinHandle<()>>>,
+}
+
+impl SqliteDiagnosticsTaskOwner {
+    pub(crate) async fn replace<F>(&self, task: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        self.cancel().await;
+        let task = tokio::spawn(task);
+        *self
+            .active
+            .lock()
+            .expect("SQLite diagnostics task lock poisoned") = Some(task);
+    }
+
+    pub(crate) async fn cancel(&self) {
+        let task = self
+            .active
+            .lock()
+            .expect("SQLite diagnostics task lock poisoned")
+            .take();
+        if let Some(task) = task {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for SqliteDiagnosticsTaskOwner {
+    fn drop(&mut self) {
+        if let Some(task) = self
+            .active
+            .get_mut()
+            .expect("SQLite diagnostics task lock poisoned")
+            .take()
+        {
+            task.abort();
+        }
+    }
+}
+
+pub(crate) async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
     provider: &Arc<dyn SqliteDiagnosticsProvider>,
+    task_owner: &SqliteDiagnosticsTaskOwner,
 ) {
     match effect {
         Effect::FetchSqliteDiagnosticsCore { dsn, run_id } => {
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
-            tokio::spawn(async move {
-                let action = match provider.fetch_core_diagnostics(&dsn).await {
-                    Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
-                        dsn,
-                        run_id,
-                        snapshot: Box::new(snapshot),
-                    },
-                    Err(error) => Action::SqliteDiagnosticsCoreLoaded {
-                        dsn,
-                        run_id,
-                        snapshot: Box::new(SqliteDiagnosticsSnapshot::core_fetch_failed(
-                            DiagnosticField::err(error.masked_details()),
-                        )),
-                    },
-                };
-                let _ = action_tx.send(action).await;
-            });
+            task_owner
+                .replace(async move {
+                    let action = match provider.fetch_core_diagnostics(&dsn).await {
+                        Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
+                            dsn,
+                            run_id,
+                            snapshot: Box::new(snapshot),
+                        },
+                        Err(error) => Action::SqliteDiagnosticsCoreLoaded {
+                            dsn,
+                            run_id,
+                            snapshot: Box::new(SqliteDiagnosticsSnapshot::core_fetch_failed(
+                                DiagnosticField::err(error.masked_details()),
+                            )),
+                        },
+                    };
+                    let _ = action_tx.send(action).await;
+                })
+                .await;
         }
         Effect::FetchSqliteDiagnosticsQuickCheck { dsn, run_id } => {
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
-            tokio::spawn(async move {
-                let quick_check = provider.fetch_quick_check(&dsn).await;
-                let _ = action_tx
-                    .send(Action::SqliteDiagnosticsQuickCheckLoaded {
-                        dsn,
-                        run_id,
-                        quick_check,
-                    })
-                    .await;
-            });
+            task_owner
+                .replace(async move {
+                    let quick_check = provider.fetch_quick_check(&dsn).await;
+                    let _ = action_tx
+                        .send(Action::SqliteDiagnosticsQuickCheckLoaded {
+                            dsn,
+                            run_id,
+                            quick_check,
+                        })
+                        .await;
+                })
+                .await;
         }
         _ => {}
     }
@@ -70,14 +120,17 @@ mod tests {
         });
 
         let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;
-        spawn_sqlite_diagnostics(
+        let owner = SqliteDiagnosticsTaskOwner::default();
+        run(
             Effect::FetchSqliteDiagnosticsCore {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: 1,
             },
             &tx,
             &provider,
-        );
+            &owner,
+        )
+        .await;
 
         let action = rx.recv().await.unwrap();
         assert!(matches!(
@@ -98,14 +151,17 @@ mod tests {
             .returning(|_| DiagnosticField::ok("ok"));
 
         let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;
-        spawn_sqlite_diagnostics(
+        let owner = SqliteDiagnosticsTaskOwner::default();
+        run(
             Effect::FetchSqliteDiagnosticsQuickCheck {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: 1,
             },
             &tx,
             &provider,
-        );
+            &owner,
+        )
+        .await;
 
         let action = rx.recv().await.unwrap();
         assert!(matches!(
@@ -126,14 +182,17 @@ mod tests {
             .returning(|_| Err(DbOperationError::QueryFailed("boom".to_string())));
 
         let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;
-        spawn_sqlite_diagnostics(
+        let owner = SqliteDiagnosticsTaskOwner::default();
+        run(
             Effect::FetchSqliteDiagnosticsCore {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: 1,
             },
             &tx,
             &provider,
-        );
+            &owner,
+        )
+        .await;
 
         let action = rx.recv().await.unwrap();
         assert!(matches!(
@@ -143,5 +202,68 @@ mod tests {
                 ..
             } if snapshot.db_file.is_err()
         ));
+    }
+
+    struct BlockingProvider {
+        started: Arc<tokio::sync::Notify>,
+        dropped: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl Drop for BlockingProvider {
+        fn drop(&mut self) {
+            self.dropped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SqliteDiagnosticsProvider for BlockingProvider {
+        async fn fetch_core_diagnostics(
+            &self,
+            _dsn: &str,
+        ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
+            self.started.notify_one();
+            std::future::pending().await
+        }
+
+        async fn fetch_quick_check(&self, _dsn: &str) -> DiagnosticField {
+            self.started.notify_one();
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_drops_provider_and_sends_no_late_action() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::time::{Duration, timeout};
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let started = Arc::new(tokio::sync::Notify::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let provider = Arc::new(BlockingProvider {
+            started: Arc::clone(&started),
+            dropped: Arc::clone(&dropped),
+        }) as Arc<dyn SqliteDiagnosticsProvider>;
+        let owner = SqliteDiagnosticsTaskOwner::default();
+
+        run(
+            Effect::FetchSqliteDiagnosticsCore {
+                dsn: "sqlite:///tmp/app.db".to_string(),
+                run_id: 1,
+            },
+            &tx,
+            &provider,
+            &owner,
+        )
+        .await;
+        timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("diagnostics provider should start");
+
+        owner.cancel().await;
+        drop(provider);
+
+        assert!(dropped.load(Ordering::SeqCst));
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -76,6 +76,17 @@ mod tests {
         state
     }
 
+    fn sqlite_state_with_dsn(dsn: &str) -> AppState {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "sqlite",
+            DatabaseType::SQLite,
+            dsn,
+        );
+        state
+    }
+
     fn empty_table(schema: &str, name: &str) -> Box<Table> {
         Box::new(test_support::table::minimal(schema, name))
     }
@@ -875,6 +886,42 @@ mod tests {
             assert!(state.session.table_detail().is_none());
             assert!(state.session.selected_table_key().is_none());
             assert_eq!(state.ui.explorer_selected(), 0);
+        }
+
+        #[test]
+        fn metadata_reload_does_not_cancel_diagnostics_modal_task() {
+            let mut state = sqlite_state_with_dsn("sqlite:///tmp/test.db");
+            let _ = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let diagnostics_run_id = state.sqlite_diagnostics.begin_core_fetch();
+            state.modal.set_mode(InputMode::SqliteDiagnostics);
+            let metadata_run_id = state.session.begin_metadata_refresh();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::MetadataLoaded {
+                    dsn: "sqlite:///tmp/test.db".to_string(),
+                    run_id: metadata_run_id,
+                    metadata: make_metadata(vec![("public", "orders")]),
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::CancelTrackedTasks))
+            );
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::CancelSqliteDiagnostics))
+            );
+            assert_eq!(state.input_mode(), InputMode::SqliteDiagnostics);
+            assert!(state.sqlite_diagnostics.is_current_run(diagnostics_run_id));
+            assert!(state.sqlite_diagnostics.snapshot().is_none());
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -202,7 +202,7 @@ pub fn reduce_execution(
             DispatchResult::handled_with(match follow_up {
                 Action::Quit => {
                     state.should_quit = true;
-                    vec![Effect::CancelTrackedTasks]
+                    vec![Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
                 }
                 Action::ToggleModal(ModalKind::Help) => {
                     state.ui.help_mut().open(HelpOrigin::CommandLine);
@@ -621,7 +621,10 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.should_quit);
-            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
+            ));
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -59,10 +59,13 @@ pub fn reduce_connection_lifecycle(
                 state.query.reset_for_context_change();
                 return DispatchResult::handled_with(termination_effects(
                     &state.query,
-                    vec![Effect::ProbeMySqlConnection {
-                        target: target.clone(),
-                        run_id,
-                    }],
+                    vec![
+                        Effect::CancelSqliteDiagnostics,
+                        Effect::ProbeMySqlConnection {
+                            target: target.clone(),
+                            run_id,
+                        },
+                    ],
                 ));
             }
 
@@ -70,7 +73,10 @@ pub fn reduce_connection_lifecycle(
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, target);
-                let mut effects = vec![Effect::ClearCompletionEngineCache];
+                let mut effects = vec![
+                    Effect::CancelSqliteDiagnostics,
+                    Effect::ClearCompletionEngineCache,
+                ];
                 if state.session.effective_user().is_none() {
                     let run_id = state.session.begin_effective_user_fetch();
                     effects.push(Effect::FetchEffectiveUser {
@@ -86,6 +92,7 @@ pub fn reduce_connection_lifecycle(
                 DispatchResult::handled_with(termination_effects(
                     &state.query,
                     vec![
+                        Effect::CancelSqliteDiagnostics,
                         Effect::ClearCompletionEngineCache,
                         Effect::FetchMetadata {
                             dsn: dsn.clone(),

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -30,7 +30,10 @@ pub(super) fn reduce_confirm_dialog(
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    DispatchResult::handled_with(vec![Effect::CancelTrackedTasks])
+                    DispatchResult::handled_with(vec![
+                        Effect::CancelSqliteDiagnostics,
+                        Effect::CancelTrackedTasks,
+                    ])
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
                     DispatchResult::handled_with(vec![Effect::DeleteConnection { id }])

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -606,7 +606,10 @@ mod tests {
 
                 assert!(state.should_quit);
                 assert!(state.confirm_dialog.intent().is_none());
-                assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
+                assert!(matches!(
+                    effects.as_slice(),
+                    [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
+                ));
             }
 
             #[test]

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -35,7 +35,7 @@ pub(super) fn reduce_sqlite_diagnostics(
         Action::CloseModal(ModalKind::SqliteDiagnostics) => {
             state.sqlite_diagnostics.clear();
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::handled()
+            DispatchResult::handled_with(vec![Effect::CancelSqliteDiagnostics])
         }
         Action::SqliteDiagnosticsCoreLoaded {
             dsn,
@@ -198,6 +198,24 @@ mod tests {
 
         assert!(effects.is_empty());
         assert!(!state.sqlite_diagnostics.is_quick_check_running());
+    }
+
+    #[test]
+    fn close_cancels_diagnostics_task_after_clearing_modal_state() {
+        let mut state = AppState::new("test".to_string());
+        test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        state.modal.set_mode(InputMode::SqliteDiagnostics);
+        state.sqlite_diagnostics.begin_core_fetch();
+
+        let effects =
+            reduce_at_boundary(&mut state, Action::CloseModal(ModalKind::SqliteDiagnostics));
+
+        assert_eq!(state.input_mode(), InputMode::Normal);
+        assert!(state.sqlite_diagnostics.snapshot().is_none());
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::CancelSqliteDiagnostics]
+        ));
     }
 
     #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -82,7 +82,7 @@ fn dispatch_enabled_action(
         }
         Action::Quit => {
             state.should_quit = true;
-            vec![Effect::CancelTrackedTasks]
+            vec![Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
         }
         Action::Resize(w, h) => {
             state.ui.set_terminal_width(w);
@@ -222,7 +222,10 @@ mod tests {
             let effects = reduce(&mut state, Action::Quit, now, &AppServices::stub());
 
             assert!(state.should_quit);
-            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
+            ));
         }
 
         #[test]
@@ -2175,7 +2178,10 @@ mod tests {
 
             assert!(state.should_quit);
             assert!(state.confirm_dialog.intent().is_none());
-            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
+            ));
         }
 
         #[test]
@@ -2652,7 +2658,7 @@ mod tests {
                     .explorer_selected,
                 5
             );
-            assert_eq!(effects.len(), 3);
+            assert_eq!(effects.len(), 4);
         }
 
         #[test]
@@ -2702,7 +2708,7 @@ mod tests {
                 state.session.metadata().as_ref().unwrap().database_name,
                 "cached_db"
             );
-            assert_eq!(effects.len(), 3);
+            assert_eq!(effects.len(), 4);
             assert!(
                 effects
                     .iter()


### PR DESCRIPTION
## Problem
SQLite diagnostics tasks were spawned without an owner, so closing the modal or changing connections could leave SQLite CLI work running after the UI lifecycle ended.

## Background
Run IDs reject stale actions, but they do not stop the provider or its external work.

## Approach
Track the diagnostics task with a dedicated owner that aborts and awaits replacement or cancellation. Close-modal cancellation uses a dedicated effect, while connection switches and quit reuse the existing tracked-task cancellation path.