### PR TITLE
fix(app): own Smart ER refresh task

### DIFF
--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -27,7 +27,6 @@ struct GenerateErDiagramRequest {
 pub async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
-    metadata_provider: &Arc<dyn MetadataProvider>,
     er_exporter: &Arc<dyn ErDiagramExporter>,
     config_writer: &Arc<dyn ConfigWriter>,
     er_log_writer: &Arc<dyn ErLogWriter>,
@@ -70,10 +69,6 @@ pub async fn run(
             )
             .await
         }
-        Effect::SmartErRefresh { dsn, run_id } => {
-            handle_smart_refresh(action_tx, metadata_provider, dsn, run_id);
-            Ok(())
-        }
         Effect::SmartErRefreshCacheAndDiff {
             dsn,
             run_id,
@@ -93,6 +88,57 @@ pub async fn run(
         }
 
         _ => unreachable!("er::run called with non-er effect"),
+    }
+}
+
+pub fn smart_refresh_task(
+    action_tx: mpsc::Sender<Action>,
+    metadata_provider: Arc<dyn MetadataProvider>,
+    dsn: String,
+    run_id: u64,
+) -> impl Future<Output = ()> + Send + 'static {
+    let tx = action_tx;
+
+    async move {
+        let new_metadata = match metadata_provider.fetch_metadata(&dsn).await {
+            Ok(m) => m,
+            Err(e) => {
+                tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn,
+                    run_id,
+                    error: e,
+                    new_metadata: None,
+                }))
+                .await
+                .ok();
+                return;
+            }
+        };
+
+        let signature_snapshot = match metadata_provider.fetch_table_signatures(&dsn).await {
+            Ok(s) => s,
+            Err(e) => {
+                let new_metadata = Arc::new(new_metadata);
+                tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn,
+                    run_id,
+                    error: e,
+                    new_metadata: Some(Arc::clone(&new_metadata)),
+                }))
+                .await
+                .ok();
+                return;
+            }
+        };
+
+        tx.send(Action::SmartErRefreshFetched(SmartErRefreshFetched {
+            dsn,
+            run_id,
+            new_metadata: Arc::new(new_metadata),
+            signature_snapshot: Arc::new(signature_snapshot),
+        }))
+        .await
+        .ok();
     }
 }
 
@@ -201,58 +247,6 @@ async fn handle_write_failure_log(
         }
     }
     Ok(())
-}
-
-fn handle_smart_refresh(
-    action_tx: &mpsc::Sender<Action>,
-    metadata_provider: &Arc<dyn MetadataProvider>,
-    dsn: String,
-    run_id: u64,
-) {
-    let provider = Arc::clone(metadata_provider);
-    let tx = action_tx.clone();
-
-    tokio::spawn(async move {
-        let new_metadata = match provider.fetch_metadata(&dsn).await {
-            Ok(m) => m,
-            Err(e) => {
-                tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
-                    dsn,
-                    run_id,
-                    error: e,
-                    new_metadata: None,
-                }))
-                .await
-                .ok();
-                return;
-            }
-        };
-
-        let signature_snapshot = match provider.fetch_table_signatures(&dsn).await {
-            Ok(s) => s,
-            Err(e) => {
-                let new_metadata = Arc::new(new_metadata);
-                tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
-                    dsn,
-                    run_id,
-                    error: e,
-                    new_metadata: Some(Arc::clone(&new_metadata)),
-                }))
-                .await
-                .ok();
-                return;
-            }
-        };
-
-        tx.send(Action::SmartErRefreshFetched(SmartErRefreshFetched {
-            dsn,
-            run_id,
-            new_metadata: Arc::new(new_metadata),
-            signature_snapshot: Arc::new(signature_snapshot),
-        }))
-        .await
-        .ok();
-    });
 }
 
 async fn handle_smart_refresh_cache_and_diff(

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -1,11 +1,57 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::domain::ErTableInfo;
 use crate::ports::outbound::ErDiagramExporter;
 use crate::update::action::{Action, ErDiagramInfo};
+
+#[derive(Default)]
+pub(crate) struct SmartErRefreshTaskOwner {
+    active: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl SmartErRefreshTaskOwner {
+    pub(crate) async fn replace<F>(&self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.cancel().await;
+        let task = tokio::spawn(task);
+        *self
+            .active
+            .lock()
+            .expect("Smart ER refresh task lock poisoned") = Some(task);
+    }
+
+    pub(crate) async fn cancel(&self) {
+        let task = self
+            .active
+            .lock()
+            .expect("Smart ER refresh task lock poisoned")
+            .take();
+        if let Some(task) = task {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for SmartErRefreshTaskOwner {
+    fn drop(&mut self) {
+        if let Some(task) = self
+            .active
+            .get_mut()
+            .expect("Smart ER refresh task lock poisoned")
+            .take()
+        {
+            task.abort();
+        }
+    }
+}
 
 pub fn spawn_er_diagram_task(
     exporter: Arc<dyn ErDiagramExporter>,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -15,6 +15,7 @@ use crate::cmd::connection as cmd_connection;
 use crate::cmd::connection::MySqlConnectionProbeTaskOwner;
 use crate::cmd::effect::Effect;
 use crate::cmd::er::handler as cmd_er;
+use crate::cmd::er::task::SmartErRefreshTaskOwner;
 use crate::cmd::metadata_task::MetadataTaskRegistry;
 use crate::cmd::query_task::{QueryTaskRegistry, TableDetailTaskRegistry};
 use crate::cmd::settings as cmd_settings;
@@ -76,6 +77,7 @@ pub struct EffectRunner {
     table_detail_tasks: TableDetailTaskRegistry,
     metadata_tasks: Arc<MetadataTaskRegistry>,
     mysql_connection_probe_task: MySqlConnectionProbeTaskOwner,
+    smart_er_refresh_task: SmartErRefreshTaskOwner,
 }
 
 impl EffectRunner {
@@ -102,6 +104,7 @@ impl EffectRunner {
             table_detail_tasks: TableDetailTaskRegistry::default(),
             metadata_tasks: Arc::new(MetadataTaskRegistry::default()),
             mysql_connection_probe_task: MySqlConnectionProbeTaskOwner::default(),
+            smart_er_refresh_task: SmartErRefreshTaskOwner::default(),
         }
     }
 
@@ -118,6 +121,7 @@ impl EffectRunner {
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
         self.mysql_connection_probe_task.cancel().await;
+        self.smart_er_refresh_task.cancel().await;
     }
 
     pub async fn execute_effects<T: Renderer>(
@@ -215,6 +219,12 @@ impl EffectRunner {
                 ) {
                     self.cancel_metadata_tasks().await;
                 }
+                if matches!(
+                    &e,
+                    Effect::SwitchConnection { .. } | Effect::SwitchToService { .. }
+                ) {
+                    self.smart_er_refresh_task.cancel().await;
+                }
                 if matches!(&e, Effect::ProbeMySqlConnection { .. }) {
                     self.table_detail_tasks.cancel();
                 }
@@ -240,6 +250,7 @@ impl EffectRunner {
             | Effect::CacheInvalidate { .. }) => {
                 if matches!(&e, Effect::FetchMetadata { .. }) {
                     self.cancel_metadata_tasks().await;
+                    self.smart_er_refresh_task.cancel().await;
                 }
                 cmd_browse::metadata::run(
                     e,
@@ -282,12 +293,10 @@ impl EffectRunner {
             e @ (Effect::GenerateErDiagramFromCache { .. }
             | Effect::ExtractFkNeighbors { .. }
             | Effect::WriteErFailureLog { .. }
-            | Effect::SmartErRefresh { .. }
             | Effect::SmartErRefreshCacheAndDiff { .. }) => {
                 cmd_er::run(
                     e,
                     &self.action_tx,
-                    &self.metadata_provider,
                     &self.er.er_exporter,
                     &self.er.config_writer,
                     &self.er.er_log_writer,
@@ -295,6 +304,18 @@ impl EffectRunner {
                     completion_engine,
                 )
                 .await?;
+                Ok(vec![])
+            }
+
+            Effect::SmartErRefresh { dsn, run_id } => {
+                self.smart_er_refresh_task
+                    .replace(cmd_er::smart_refresh_task(
+                        self.action_tx.clone(),
+                        Arc::clone(&self.metadata_provider),
+                        dsn,
+                        run_id,
+                    ))
+                    .await;
                 Ok(vec![])
             }
 
@@ -1359,6 +1380,282 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    mod smart_er_refresh_lifecycle {
+        use std::future::pending;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use tokio::sync::mpsc::UnboundedSender;
+        use tokio::time::{Duration, timeout};
+
+        use super::*;
+        use crate::domain::Table;
+        use crate::ports::outbound::DbOperationError;
+        use crate::update::reducer::reduce;
+
+        struct DropSignal(Arc<AtomicUsize>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        struct PendingSmartErProvider {
+            started: UnboundedSender<String>,
+            dropped: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl MetadataProvider for PendingSmartErProvider {
+            async fn fetch_metadata(
+                &self,
+                dsn: &str,
+            ) -> Result<DatabaseMetadata, DbOperationError> {
+                let _guard = DropSignal(Arc::clone(&self.dropped));
+                self.started.send(dsn.to_string()).ok();
+                pending().await
+            }
+
+            async fn fetch_table_detail(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                unreachable!("test only starts smart ER refresh")
+            }
+
+            async fn fetch_table_columns_and_fks(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                unreachable!("test only starts smart ER refresh")
+            }
+
+            async fn fetch_table_signatures(
+                &self,
+                _dsn: &str,
+            ) -> Result<TableSignatureSnapshot, DbOperationError> {
+                unreachable!("test only starts smart ER refresh")
+            }
+        }
+
+        async fn wait_for_no_action(action_rx: &mut mpsc::Receiver<Action>) {
+            assert!(
+                timeout(Duration::from_millis(100), action_rx.recv())
+                    .await
+                    .is_err()
+            );
+        }
+
+        fn runner_with_pending_provider(
+            started: UnboundedSender<String>,
+            dropped: Arc<AtomicUsize>,
+            action_tx: mpsc::Sender<Action>,
+        ) -> EffectRunner {
+            test_fixtures::make_runner(
+                Arc::new(PendingSmartErProvider { started, dropped }),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+            )
+        }
+
+        #[tokio::test]
+        async fn rerun_aborts_previous_refresh_before_starting_new_one() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = runner_with_pending_provider(started_tx, Arc::clone(&dropped), action_tx);
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::SmartErRefresh {
+                        dsn: "postgres://localhost/old".to_string(),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("postgres://localhost/old")
+            );
+
+            runner
+                .execute_effects(
+                    vec![Effect::SmartErRefresh {
+                        dsn: "postgres://localhost/new".to_string(),
+                        run_id: 2,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("postgres://localhost/new")
+            );
+            wait_for_no_action(&mut action_rx).await;
+        }
+
+        #[tokio::test]
+        async fn connection_switch_aborts_pending_refresh_and_emits_no_action() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = runner_with_pending_provider(started_tx, Arc::clone(&dropped), action_tx);
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::SmartErRefresh {
+                        dsn: "postgres://localhost/current".to_string(),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("postgres://localhost/current")
+            );
+
+            runner
+                .execute_effects(
+                    vec![Effect::SwitchConnection {
+                        connection_index: usize::MAX,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            wait_for_no_action(&mut action_rx).await;
+        }
+
+        #[tokio::test]
+        async fn metadata_refresh_aborts_pending_smart_er_refresh() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = runner_with_pending_provider(started_tx, Arc::clone(&dropped), action_tx);
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::SmartErRefresh {
+                        dsn: "postgres://localhost/current".to_string(),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("postgres://localhost/current")
+            );
+
+            runner
+                .execute_effects(
+                    vec![Effect::FetchMetadata {
+                        dsn: "postgres://localhost/current".to_string(),
+                        run_id: 2,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            wait_for_no_action(&mut action_rx).await;
+        }
+
+        #[tokio::test]
+        async fn quit_aborts_pending_refresh_and_emits_no_action() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = runner_with_pending_provider(started_tx, Arc::clone(&dropped), action_tx);
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::SmartErRefresh {
+                        dsn: "postgres://localhost/current".to_string(),
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                started_rx.recv().await.as_deref(),
+                Some("postgres://localhost/current")
+            );
+
+            let shutdown_effects = reduce(
+                &mut state,
+                Action::Quit,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.should_quit);
+            runner
+                .execute_effects(
+                    shutdown_effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            wait_for_no_action(&mut action_rx).await;
         }
     }
 }


### PR DESCRIPTION
## Problem
Smart ER refresh was launched as an untracked task, so connection switches, metadata refreshes, and quit could leave provider work running.

## Background
The run and DSN guards discard stale actions after completion but do not stop the provider future itself.

## Approach
Track the Smart ER refresh handle in a dedicated owner that replaces and cancels the task at the existing lifecycle boundaries, while preserving the existing provider sequence and stale guards.

## Screenshots

## Linear Issue Link (optional)