### PR TITLE
fix: restore terminal on TUI failures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,8 @@ async fn main() -> Result<()> {
         let deadline = next_animation_deadline(&runtime.state, now);
 
         tokio::select! {
-            Some(event) = runtime.tui.next_event() => {
+            event = runtime.tui.next_event() => {
+                let event = event?;
                 let action = handle_event(event, &runtime.state);
                 if !action.is_none() {
                     runtime.process_terminal_event_burst(action).await?;
@@ -394,7 +395,7 @@ impl Runtime {
         // end of the burst so N input events produce one draw, not N.
         let mut drained = 0;
         while drained < MAX_DRAIN {
-            let Some(event) = self.tui.try_next_event() else {
+            let Some(event) = self.tui.try_next_event()? else {
                 break;
             };
             drained += 1;

--- a/src/panic_hooks.rs
+++ b/src/panic_hooks.rs
@@ -4,6 +4,7 @@ use std::panic;
 use color_eyre::eyre::Result;
 use crossterm::{
     cursor::SetCursorStyle,
+    event::{DisableBracketedPaste, DisableMouseCapture},
     execute,
     terminal::{LeaveAlternateScreen, disable_raw_mode},
 };
@@ -26,10 +27,83 @@ pub fn install_hooks() -> Result<()> {
 }
 
 fn restore_terminal() -> Result<()> {
-    if crossterm::terminal::is_raw_mode_enabled()? {
-        let _ = execute!(stdout(), SetCursorStyle::DefaultUserShape);
-        execute!(stdout(), LeaveAlternateScreen)?;
-        disable_raw_mode()?;
+    if !crossterm::terminal::is_raw_mode_enabled()? {
+        return Ok(());
     }
-    Ok(())
+
+    restore_terminal_steps(|step| match step {
+        RestoreStep::Cursor => {
+            execute!(stdout(), SetCursorStyle::DefaultUserShape).map_err(Into::into)
+        }
+        RestoreStep::AlternateScreen => {
+            execute!(stdout(), LeaveAlternateScreen).map_err(Into::into)
+        }
+        RestoreStep::MouseCapture => execute!(stdout(), DisableMouseCapture).map_err(Into::into),
+        RestoreStep::BracketedPaste => {
+            execute!(stdout(), DisableBracketedPaste).map_err(Into::into)
+        }
+        RestoreStep::Raw => disable_raw_mode().map_err(Into::into),
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RestoreStep {
+    Cursor,
+    BracketedPaste,
+    MouseCapture,
+    AlternateScreen,
+    Raw,
+}
+
+fn restore_terminal_steps<F>(mut restore: F) -> Result<()>
+where
+    F: FnMut(RestoreStep) -> Result<()>,
+{
+    let mut first_error = None;
+    for step in [
+        RestoreStep::Cursor,
+        RestoreStep::BracketedPaste,
+        RestoreStep::MouseCapture,
+        RestoreStep::AlternateScreen,
+        RestoreStep::Raw,
+    ] {
+        if let Err(error) = restore(step)
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continues_restore_steps_after_a_failure() {
+        let mut restored = Vec::new();
+
+        let error = restore_terminal_steps(|step| {
+            restored.push(step);
+            if step == RestoreStep::BracketedPaste {
+                Err(color_eyre::eyre::eyre!("bracketed paste restore failed"))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "bracketed paste restore failed");
+        assert_eq!(
+            restored,
+            vec![
+                RestoreStep::Cursor,
+                RestoreStep::BracketedPaste,
+                RestoreStep::MouseCapture,
+                RestoreStep::AlternateScreen,
+                RestoreStep::Raw,
+            ]
+        );
+    }
 }

--- a/src/panic_hooks.rs
+++ b/src/panic_hooks.rs
@@ -27,23 +27,42 @@ pub fn install_hooks() -> Result<()> {
 }
 
 fn restore_terminal() -> Result<()> {
-    if !crossterm::terminal::is_raw_mode_enabled()? {
-        return Ok(());
-    }
+    restore_terminal_with_probe(
+        crossterm::terminal::is_raw_mode_enabled().map_err(Into::into),
+        |step| match step {
+            RestoreStep::Cursor => {
+                execute!(stdout(), SetCursorStyle::DefaultUserShape).map_err(Into::into)
+            }
+            RestoreStep::AlternateScreen => {
+                execute!(stdout(), LeaveAlternateScreen).map_err(Into::into)
+            }
+            RestoreStep::MouseCapture => {
+                execute!(stdout(), DisableMouseCapture).map_err(Into::into)
+            }
+            RestoreStep::BracketedPaste => {
+                execute!(stdout(), DisableBracketedPaste).map_err(Into::into)
+            }
+            RestoreStep::Raw => disable_raw_mode().map_err(Into::into),
+        },
+    )
+}
 
-    restore_terminal_steps(|step| match step {
-        RestoreStep::Cursor => {
-            execute!(stdout(), SetCursorStyle::DefaultUserShape).map_err(Into::into)
-        }
-        RestoreStep::AlternateScreen => {
-            execute!(stdout(), LeaveAlternateScreen).map_err(Into::into)
-        }
-        RestoreStep::MouseCapture => execute!(stdout(), DisableMouseCapture).map_err(Into::into),
-        RestoreStep::BracketedPaste => {
-            execute!(stdout(), DisableBracketedPaste).map_err(Into::into)
-        }
-        RestoreStep::Raw => disable_raw_mode().map_err(Into::into),
-    })
+fn restore_terminal_with_probe<F>(raw_mode: Result<bool>, restore: F) -> Result<()>
+where
+    F: FnMut(RestoreStep) -> Result<()>,
+{
+    let mut first_error = match raw_mode {
+        Ok(true) => None,
+        Ok(false) => return Ok(()),
+        Err(error) => Some(error),
+    };
+
+    if let Err(error) = restore_terminal_steps(restore)
+        && first_error.is_none()
+    {
+        first_error = Some(error);
+    }
+    first_error.map_or(Ok(()), Err)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -95,6 +114,32 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.to_string(), "bracketed paste restore failed");
+        assert_eq!(
+            restored,
+            vec![
+                RestoreStep::Cursor,
+                RestoreStep::BracketedPaste,
+                RestoreStep::MouseCapture,
+                RestoreStep::AlternateScreen,
+                RestoreStep::Raw,
+            ]
+        );
+    }
+
+    #[test]
+    fn continues_restore_when_raw_mode_probe_fails() {
+        let mut restored = Vec::new();
+
+        let error = restore_terminal_with_probe(
+            Err(std::io::Error::other("raw mode probe failed").into()),
+            |step| {
+                restored.push(step);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "raw mode probe failed");
         assert_eq!(
             restored,
             vec![

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -1,6 +1,6 @@
-use std::io::{Stdout, stdout};
+use std::io::{self, Stdout, stdout};
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use crossterm::cursor::SetCursorStyle;
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
@@ -13,6 +13,7 @@ use crossterm::terminal::{
 use futures::{FutureExt, StreamExt};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -20,13 +21,57 @@ use tokio_util::sync::CancellationToken;
 use crate::app::ports::inbound::InputEvent;
 
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;
+type TerminalEvent = Result<InputEvent, io::Error>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminalMode {
+    Raw,
+    AlternateScreen,
+    MouseCapture,
+    BracketedPaste,
+}
+
+#[derive(Default)]
+struct TerminalState {
+    enabled_modes: u8,
+}
+
+impl TerminalState {
+    fn enable(&mut self, mode: TerminalMode) {
+        self.enabled_modes |= mode.mask();
+    }
+
+    fn is_enabled(&self, mode: TerminalMode) -> bool {
+        self.enabled_modes & mode.mask() != 0
+    }
+
+    fn disable(&mut self, mode: TerminalMode) {
+        self.enabled_modes &= !mode.mask();
+    }
+
+    fn any_enabled(&self) -> bool {
+        self.enabled_modes != 0
+    }
+}
+
+impl TerminalMode {
+    fn mask(self) -> u8 {
+        match self {
+            Self::Raw => 1 << 0,
+            Self::AlternateScreen => 1 << 1,
+            Self::MouseCapture => 1 << 2,
+            Self::BracketedPaste => 1 << 3,
+        }
+    }
+}
 
 pub struct TuiRunner {
     terminal: Tui,
-    event_rx: UnboundedReceiver<InputEvent>,
-    event_tx: UnboundedSender<InputEvent>,
+    event_rx: UnboundedReceiver<TerminalEvent>,
+    event_tx: UnboundedSender<TerminalEvent>,
     task: Option<JoinHandle<()>>,
     cancellation_token: CancellationToken,
+    terminal_state: TerminalState,
 }
 
 impl TuiRunner {
@@ -41,34 +86,30 @@ impl TuiRunner {
             event_tx,
             task: None,
             cancellation_token,
+            terminal_state: TerminalState::default(),
         })
     }
 
     pub fn enter(&mut self) -> Result<()> {
-        enable_raw_mode()?;
-        execute!(
-            stdout(),
-            EnterAlternateScreen,
-            EnableMouseCapture,
-            EnableBracketedPaste
-        )?;
+        enter_terminal_modes(&mut self.terminal_state, |mode| match mode {
+            TerminalMode::Raw => enable_raw_mode().map_err(Into::into),
+            TerminalMode::AlternateScreen => {
+                execute!(stdout(), EnterAlternateScreen).map_err(Into::into)
+            }
+            TerminalMode::MouseCapture => {
+                execute!(stdout(), EnableMouseCapture).map_err(Into::into)
+            }
+            TerminalMode::BracketedPaste => {
+                execute!(stdout(), EnableBracketedPaste).map_err(Into::into)
+            }
+        })?;
         self.start_event_loop();
         Ok(())
     }
 
     pub fn exit(&mut self) -> Result<()> {
         self.stop_event_loop();
-        if crossterm::terminal::is_raw_mode_enabled()? {
-            let _ = execute!(stdout(), SetCursorStyle::DefaultUserShape);
-            execute!(
-                stdout(),
-                LeaveAlternateScreen,
-                DisableMouseCapture,
-                DisableBracketedPaste
-            )?;
-            disable_raw_mode()?;
-        }
-        Ok(())
+        self.restore_terminal()
     }
 
     fn start_event_loop(&mut self) {
@@ -78,27 +119,37 @@ impl TuiRunner {
         self.task = Some(tokio::spawn(async move {
             let mut event_stream = EventStream::new();
 
-            let _ = event_tx.send(InputEvent::Init);
+            let _ = event_tx.send(Ok(InputEvent::Init));
 
             loop {
-                let event = tokio::select! {
+                let crossterm_event = tokio::select! {
                     () = cancellation_token.cancelled() => break,
-                    crossterm_event = event_stream.next().fuse() => {
-                        match crossterm_event {
-                            Some(Ok(evt)) => match evt {
-                                CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat => {
-                                    InputEvent::Key(super::event::key_translator::translate(key))
-                                }
-                                CrosstermEvent::Resize(x, y) => InputEvent::Resize(x, y),
-                                CrosstermEvent::Paste(text) => InputEvent::Paste(text),
-                                _ => continue,
-                            },
-                            Some(Err(_)) | None => break,
-                        }
-                    }
+                    crossterm_event = event_stream.next().fuse() => crossterm_event,
                 };
 
-                if event_tx.send(event).is_err() {
+                let Some(crossterm_event) = crossterm_event else {
+                    let _ = event_tx.send(Err(event_stream_ended()));
+                    break;
+                };
+                let crossterm_event = match crossterm_event {
+                    Ok(event) => event,
+                    Err(error) => {
+                        let _ = event_tx.send(Err(error));
+                        break;
+                    }
+                };
+                let event = match crossterm_event {
+                    CrosstermEvent::Key(key)
+                        if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat =>
+                    {
+                        InputEvent::Key(super::event::key_translator::translate(key))
+                    }
+                    CrosstermEvent::Resize(x, y) => InputEvent::Resize(x, y),
+                    CrosstermEvent::Paste(text) => InputEvent::Paste(text),
+                    _ => continue,
+                };
+
+                if event_tx.send(Ok(event)).is_err() {
                     break;
                 }
             }
@@ -112,15 +163,218 @@ impl TuiRunner {
         }
     }
 
-    pub async fn next_event(&mut self) -> Option<InputEvent> {
-        self.event_rx.recv().await
+    pub async fn next_event(&mut self) -> Result<InputEvent> {
+        receive_event(self.event_rx.recv().await)
     }
 
-    pub fn try_next_event(&mut self) -> Option<InputEvent> {
-        self.event_rx.try_recv().ok()
+    pub fn try_next_event(&mut self) -> Result<Option<InputEvent>> {
+        match self.event_rx.try_recv() {
+            Ok(event) => receive_event(Some(event)).map(Some),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => {
+                Err(eyre!("terminal event channel closed unexpectedly"))
+            }
+        }
     }
 
     pub fn terminal(&mut self) -> &mut Tui {
         &mut self.terminal
+    }
+
+    fn restore_terminal(&mut self) -> Result<()> {
+        let mut first_error = if self.terminal_state.any_enabled()
+            && let Err(error) = execute!(stdout(), SetCursorStyle::DefaultUserShape)
+        {
+            Some(error.into())
+        } else {
+            None
+        };
+
+        if let Err(error) = restore_terminal_modes(&mut self.terminal_state, |mode| match mode {
+            TerminalMode::Raw => disable_raw_mode().map_err(Into::into),
+            TerminalMode::AlternateScreen => {
+                execute!(stdout(), LeaveAlternateScreen).map_err(Into::into)
+            }
+            TerminalMode::MouseCapture => {
+                execute!(stdout(), DisableMouseCapture).map_err(Into::into)
+            }
+            TerminalMode::BracketedPaste => {
+                execute!(stdout(), DisableBracketedPaste).map_err(Into::into)
+            }
+        }) && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+impl Drop for TuiRunner {
+    fn drop(&mut self) {
+        self.stop_event_loop();
+        let _ = self.restore_terminal();
+    }
+}
+
+fn restore_terminal_modes<F>(state: &mut TerminalState, mut restore: F) -> Result<()>
+where
+    F: FnMut(TerminalMode) -> Result<()>,
+{
+    let mut first_error = None;
+    for mode in [
+        TerminalMode::BracketedPaste,
+        TerminalMode::MouseCapture,
+        TerminalMode::AlternateScreen,
+        TerminalMode::Raw,
+    ] {
+        if !state.is_enabled(mode) {
+            continue;
+        }
+
+        match restore(mode) {
+            Ok(()) => state.disable(mode),
+            Err(error) if first_error.is_none() => first_error = Some(error),
+            Err(_) => {}
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+fn enter_terminal_modes<F>(state: &mut TerminalState, mut enter: F) -> Result<()>
+where
+    F: FnMut(TerminalMode) -> Result<()>,
+{
+    for mode in [
+        TerminalMode::Raw,
+        TerminalMode::AlternateScreen,
+        TerminalMode::MouseCapture,
+        TerminalMode::BracketedPaste,
+    ] {
+        state.enable(mode);
+        enter(mode)?;
+    }
+    Ok(())
+}
+
+fn receive_event(event: Option<TerminalEvent>) -> Result<InputEvent> {
+    match event {
+        Some(Ok(event)) => Ok(event),
+        Some(Err(error)) => Err(error.into()),
+        None => Err(eyre!("terminal event channel closed unexpectedly")),
+    }
+}
+
+fn event_stream_ended() -> io::Error {
+    io::Error::new(io::ErrorKind::UnexpectedEof, "terminal event stream ended")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::*;
+
+    #[test]
+    fn restores_enabled_modes_in_reverse_order() {
+        let mut state = TerminalState {
+            enabled_modes: 0b1111,
+        };
+        let mut restored = Vec::new();
+
+        restore_terminal_modes(&mut state, |mode| {
+            restored.push(mode);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            restored,
+            vec![
+                TerminalMode::BracketedPaste,
+                TerminalMode::MouseCapture,
+                TerminalMode::AlternateScreen,
+                TerminalMode::Raw,
+            ]
+        );
+        assert!(!state.any_enabled());
+    }
+
+    #[test]
+    fn continues_restoring_after_a_mode_failure() {
+        let mut state = TerminalState {
+            enabled_modes: 0b1111,
+        };
+        let mut restored = VecDeque::new();
+
+        let error = restore_terminal_modes(&mut state, |mode| {
+            restored.push_back(mode);
+            if mode == TerminalMode::MouseCapture {
+                Err(eyre!("mouse restore failed"))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "mouse restore failed");
+        assert_eq!(
+            restored.into_iter().collect::<Vec<_>>(),
+            vec![
+                TerminalMode::BracketedPaste,
+                TerminalMode::MouseCapture,
+                TerminalMode::AlternateScreen,
+                TerminalMode::Raw,
+            ]
+        );
+        assert!(!state.is_enabled(TerminalMode::BracketedPaste));
+        assert!(state.is_enabled(TerminalMode::MouseCapture));
+        assert!(!state.is_enabled(TerminalMode::AlternateScreen));
+        assert!(!state.is_enabled(TerminalMode::Raw));
+    }
+
+    #[test]
+    fn failed_enter_stage_remains_owned_for_cleanup() {
+        for failed_mode in [
+            TerminalMode::Raw,
+            TerminalMode::AlternateScreen,
+            TerminalMode::MouseCapture,
+            TerminalMode::BracketedPaste,
+        ] {
+            let mut state = TerminalState::default();
+            let mut entered = Vec::new();
+
+            let error = enter_terminal_modes(&mut state, |mode| {
+                entered.push(mode);
+                if mode == failed_mode {
+                    Err(eyre!("terminal enter failed"))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+
+            assert_eq!(error.to_string(), "terminal enter failed");
+            assert_eq!(entered.last(), Some(&failed_mode));
+            assert!(state.is_enabled(failed_mode));
+        }
+    }
+
+    #[test]
+    fn receive_event_returns_event_stream_errors() {
+        let error = receive_event(Some(Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "event read failed",
+        ))))
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "event read failed");
+    }
+
+    #[test]
+    fn receive_event_returns_event_stream_eof_as_error() {
+        let error = receive_event(Some(Err(event_stream_ended()))).unwrap_err();
+
+        assert_eq!(error.to_string(), "terminal event stream ended");
     }
 }


### PR DESCRIPTION
## Problem
TUI event-stream failures and errors after terminal setup can leave raw, alternate-screen, mouse-capture, or bracketed-paste state active.

## Background
Event-stream Err/EOF was discarded, and terminal setup/cleanup used short-circuiting error paths that bypassed later restoration steps.

## Approach
Track each terminal mode as it is acquired, restore acquired modes in reverse order through both normal and drop cleanup, propagate event-stream failures to the main loop, and make panic restoration best-effort per operation.