### PR TITLE
fix(app): preserve SQLite path errors

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -310,7 +310,7 @@ mod tests {
     use crate::cmd::effect::Effect;
     use crate::cmd::test_fixtures;
 
-    use crate::domain::DatabaseMetadata;
+    use crate::domain::{DatabaseMetadata, SqlitePathError};
     use crate::model::app_state::AppState;
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::MockConnectionStore;
@@ -414,8 +414,10 @@ mod tests {
                     Action::MetadataFailed {
                         ref dsn,
                         run_id: 7,
-                        error: DbOperationError::ConnectionFailed(_),
-                    } if *dsn == expected_dsn
+                        error: DbOperationError::SqlitePath(SqlitePathError::FileNotFound(
+                            ref file_path,
+                        )),
+                    } if *dsn == expected_dsn && file_path == &path.display().to_string()
                 ),
                 "expected MetadataFailed, got {action:?}"
             );

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,4 +1,5 @@
 use crate::policy::password_masking::mask_password;
+use crate::policy::sqlite_path::connection_error_kind;
 use crate::ports::outbound::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
     SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
@@ -183,10 +184,7 @@ impl ConnectionErrorInfo {
                     ConnectionErrorKind::MySqlConnectionFailure(*kind)
                 }
             },
-            DbOperationError::ConnectionFailed(details) => {
-                classify_sqlite_path_connection_error(details)
-                    .unwrap_or(ConnectionErrorKind::Unknown)
-            }
+            DbOperationError::SqlitePath(error) => connection_error_kind(error),
             _ => ConnectionErrorKind::Unknown,
         };
         Self::with_kind(kind, raw_details)
@@ -230,16 +228,10 @@ impl ConnectionErrorInfo {
     }
 }
 
-fn classify_sqlite_path_connection_error(message: &str) -> Option<ConnectionErrorKind> {
-    use crate::domain::SqlitePathError;
-    use crate::policy::sqlite_path::connection_error_kind;
-
-    SqlitePathError::from_display_message(message).map(|error| connection_error_kind(&error))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::SqlitePathError;
     use rstest::rstest;
 
     mod error_kind {
@@ -384,10 +376,9 @@ mod tests {
 
         #[test]
         fn from_db_operation_error_classifies_sqlite_missing_file() {
-            let info =
-                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::ConnectionFailed(
-                    "SQLite database file not found: /tmp/missing.db".to_string(),
-                ));
+            let info = ConnectionErrorInfo::from_db_operation_error(&DbOperationError::SqlitePath(
+                SqlitePathError::FileNotFound("/tmp/missing.db".to_string()),
+            ));
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteFileNotFound);
             assert_eq!(info.kind.summary(), "SQLite database file not found");
@@ -513,38 +504,51 @@ mod tests {
 
         #[rstest]
         #[case(
-            "SQLite path is a directory, not a file: /tmp/dir.db",
+            SqlitePathError::IsDirectory("/tmp/dir.db".to_string()),
             ConnectionErrorKind::SqlitePathIsDirectory
         )]
         #[case(
-            "SQLite path is not a regular file: /tmp/pipe.db",
+            SqlitePathError::NotRegularFile("/tmp/pipe.db".to_string()),
             ConnectionErrorKind::SqlitePathNotRegularFile
         )]
         #[case(
-            "File is readable but not a SQLite database: /tmp/not-db",
+            SqlitePathError::NotDatabaseFile("/tmp/not-db".to_string()),
             ConnectionErrorKind::SqliteNotDatabaseFile
         )]
         #[case(
-            "Cannot read SQLite database file: /tmp/app.db: permission denied",
+            SqlitePathError::ReadAccessDenied(
+                "/tmp/app.db: permission denied".to_string(),
+            ),
             ConnectionErrorKind::SqliteReadAccessDenied
         )]
         #[case(
-            "Cannot access SQLite database file: /tmp/app.db: permission denied",
+            SqlitePathError::PathAccessDenied(
+                "/tmp/app.db: permission denied".to_string(),
+            ),
             ConnectionErrorKind::SqlitePathAccessDenied
         )]
         #[case(
-            "Cannot read SQLite database file metadata: /tmp/app.db: device offline",
+            SqlitePathError::Io("/tmp/app.db: device offline".to_string()),
             ConnectionErrorKind::SqlitePathIo
         )]
         fn from_db_operation_error_classifies_sqlite_path_errors(
-            #[case] details: &str,
+            #[case] error: SqlitePathError,
             #[case] expected_kind: ConnectionErrorKind,
         ) {
-            let info = ConnectionErrorInfo::from_db_operation_error(
-                &DbOperationError::ConnectionFailed(details.to_string()),
-            );
+            let info =
+                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::SqlitePath(error));
 
             assert_eq!(info.kind, expected_kind);
+        }
+
+        #[test]
+        fn generic_connection_failure_with_sqlite_prefix_stays_unknown() {
+            let info =
+                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::ConnectionFailed(
+                    "SQLite database file not found: /tmp/missing.db".to_string(),
+                ));
+
+            assert_eq!(info.kind, ConnectionErrorKind::Unknown);
         }
 
         #[test]

--- a/src/app/policy/sqlite_path.rs
+++ b/src/app/policy/sqlite_path.rs
@@ -15,5 +15,20 @@ pub fn connection_error_kind(error: &SqlitePathError) -> ConnectionErrorKind {
 }
 
 pub fn to_db_operation_error(error: &SqlitePathError) -> DbOperationError {
-    DbOperationError::ConnectionFailed(error.to_string())
+    DbOperationError::SqlitePath(error.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_sqlite_path_error_in_db_operation_error() {
+        let path_error = SqlitePathError::FileNotFound("/tmp/missing.db".to_string());
+
+        assert!(matches!(
+            to_db_operation_error(&path_error),
+            DbOperationError::SqlitePath(error) if error == path_error
+        ));
+    }
 }

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
-use crate::domain::RefreshScope;
+use crate::domain::{RefreshScope, SqlitePathError};
 use crate::policy::password_masking::mask_password;
 
 pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
@@ -125,6 +125,8 @@ impl ConnectionFailureKind {
 pub enum DbOperationError {
     #[error("Connection failed")]
     ConnectionFailed(String),
+    #[error("Connection failed")]
+    SqlitePath(#[source] SqlitePathError),
     #[error("Connection lost")]
     ConnectionLost(String),
     #[error("Permission denied")]
@@ -190,7 +192,7 @@ impl DbOperationError {
 
     fn presentation(&self) -> (&'static str, &'static str) {
         match self {
-            Self::ConnectionFailed(_) => (
+            Self::ConnectionFailed(_) | Self::SqlitePath(_) => (
                 "Connection failed",
                 "Check the connection settings and database availability",
             ),
@@ -334,6 +336,7 @@ impl DbOperationError {
             | Self::Timeout(details)
             | Self::Canceled(details)
             | Self::CommandNotFound { details, .. } => Cow::Borrowed(details.as_str()),
+            Self::SqlitePath(error) => Cow::Owned(error.to_string()),
             Self::InvalidJson(err) => Cow::Owned(err.to_string()),
             Self::CsvParse(err) => Cow::Owned(err.to_string()),
             Self::QueryFailedAfterChange { source, .. } => source.raw_details(),
@@ -405,6 +408,9 @@ mod tests {
 
         #[rstest]
         #[case(DbOperationError::ConnectionFailed("boom".to_string()))]
+        #[case(DbOperationError::SqlitePath(SqlitePathError::FileNotFound(
+            "/tmp/missing.db".to_string(),
+        )))]
         #[case(DbOperationError::ConnectionLost("boom".to_string()))]
         #[case(DbOperationError::PermissionDenied("boom".to_string()))]
         #[case(DbOperationError::ForeignKeyViolation("boom".to_string()))]
@@ -498,6 +504,7 @@ mod tests {
 
     mod user_messages {
         use super::*;
+        use std::error::Error;
 
         #[test]
         fn sqlite_cli_not_found_has_sqlite_specific_guidance() {
@@ -508,6 +515,25 @@ mod tests {
 
             assert_eq!(error.summary(), "sqlite3 not found");
             assert_eq!(error.hint(), "Install sqlite3 and add it to PATH");
+        }
+
+        #[test]
+        fn sqlite_path_preserves_source_and_masks_details() {
+            let error =
+                DbOperationError::SqlitePath(SqlitePathError::Io("password=secret".to_string()));
+
+            assert_eq!(
+                error.masked_details(),
+                "Cannot read SQLite database file metadata: password=****"
+            );
+            assert_eq!(
+                error
+                    .source()
+                    .expect("SQLite path error source")
+                    .to_string(),
+                "Cannot read SQLite database file metadata: password=secret"
+            );
+            assert!(!error.user_message().contains("secret"));
         }
 
         #[test]

--- a/src/domain/connection/sqlite_path.rs
+++ b/src/domain/connection/sqlite_path.rs
@@ -16,36 +16,6 @@ pub enum SqlitePathError {
     Io(String),
 }
 
-impl SqlitePathError {
-    pub fn from_display_message(message: &str) -> Option<Self> {
-        const NOT_FOUND: &str = "SQLite database file not found: ";
-        const IS_DIRECTORY: &str = "SQLite path is a directory, not a file: ";
-        const NOT_REGULAR_FILE: &str = "SQLite path is not a regular file: ";
-        const NOT_DATABASE_FILE: &str = "File is readable but not a SQLite database: ";
-        const READ_ACCESS_DENIED: &str = "Cannot read SQLite database file: ";
-        const PATH_ACCESS_DENIED: &str = "Cannot access SQLite database file: ";
-        const IO: &str = "Cannot read SQLite database file metadata: ";
-
-        if let Some(path) = message.strip_prefix(NOT_FOUND) {
-            Some(Self::FileNotFound(path.to_string()))
-        } else if let Some(path) = message.strip_prefix(IS_DIRECTORY) {
-            Some(Self::IsDirectory(path.to_string()))
-        } else if let Some(path) = message.strip_prefix(NOT_REGULAR_FILE) {
-            Some(Self::NotRegularFile(path.to_string()))
-        } else if let Some(path) = message.strip_prefix(NOT_DATABASE_FILE) {
-            Some(Self::NotDatabaseFile(path.to_string()))
-        } else if let Some(details) = message.strip_prefix(READ_ACCESS_DENIED) {
-            Some(Self::ReadAccessDenied(details.to_string()))
-        } else if let Some(details) = message.strip_prefix(PATH_ACCESS_DENIED) {
-            Some(Self::PathAccessDenied(details.to_string()))
-        } else {
-            message
-                .strip_prefix(IO)
-                .map(|details| Self::Io(details.to_string()))
-        }
-    }
-}
-
 pub fn sqlite_path_from_dsn(dsn: &str) -> Option<&str> {
     dsn.strip_prefix("sqlite://")
         .filter(|path| !path.is_empty())

--- a/src/infra/adapters/sqlite/executor_export_tests.rs
+++ b/src/infra/adapters/sqlite/executor_export_tests.rs
@@ -206,8 +206,8 @@ async fn missing_database_is_rejected_without_creating_an_empty_file() {
 
     assert!(matches!(
         result,
-        Err(DbOperationError::ConnectionFailed(details))
-            if details.contains("SQLite database file not found")
+        Err(DbOperationError::SqlitePath(SqlitePathError::FileNotFound(file_path)))
+            if file_path == path.display().to_string()
     ));
     assert!(!path.exists());
 }

--- a/src/infra/adapters/sqlite/executor_tests.rs
+++ b/src/infra/adapters/sqlite/executor_tests.rs
@@ -1,7 +1,7 @@
 use crate::adapters::test_support;
 use crate::app::ports::outbound::{AccessMode, SqlDialect};
 use crate::domain::{
-    CommandTag, DatabaseType, QueryResult, QuerySource, QueryValue,
+    CommandTag, DatabaseType, QueryResult, QuerySource, QueryValue, SqlitePathError,
     sqlite_explain_query_plan_text_from_result,
 };
 

--- a/src/infra/adapters/sqlite/metadata/catalog_tests.rs
+++ b/src/infra/adapters/sqlite/metadata/catalog_tests.rs
@@ -1,7 +1,7 @@
 use crate::app::ports::outbound::{
     DbOperationError, MetadataProvider, SQLITE_SAFE_MODE_REQUIRED_MARKER,
 };
-use crate::domain::{Schema, TableKind, TableKindInfo};
+use crate::domain::{Schema, SqlitePathError, TableKind, TableKindInfo};
 
 use super::super::super::sqlite3::metadata::RawTable;
 use super::super::SqliteAdapter;
@@ -68,8 +68,8 @@ mod metadata {
 
         assert!(matches!(
             result,
-            Err(DbOperationError::ConnectionFailed(details))
-                if details.contains("SQLite database file not found")
+            Err(DbOperationError::SqlitePath(SqlitePathError::FileNotFound(file_path)))
+                if file_path == path.display().to_string()
         ));
         assert!(!path.exists());
     }

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -298,7 +298,7 @@ impl SqliteCli {
 
     fn ensure_database_path(path: &str) -> Result<(), DbOperationError> {
         path_validation::validate_sqlite_database_path(Path::new(path))
-            .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))
+            .map_err(DbOperationError::SqlitePath)
     }
 
     fn apply_session_options(cmd: &mut Command, read_only: bool) {


### PR DESCRIPTION
## Problem
SQLite path validation errors were converted to display strings and later classified by matching their text prefixes. This made connection error classification depend on presentation wording.

## Background
The validation boundary already produced a typed `SqlitePathError`, but the common operation error carrier discarded that type before the connection model received it.

## Approach
Preserve `SqlitePathError` in a dedicated `DbOperationError::SqlitePath` source payload. Keep the existing summaries, hints, masked details, and seven path classifications while mapping the typed error directly at the connection boundary.

## Verification
- `cargo test -p sabiql-app --lib model::connection::error`
- `cargo test -p sabiql-app --lib policy::sqlite_path`
- `cargo test -p sabiql-app --lib ports::outbound::db_operation_error`
- `cargo test -p sabiql-domain --lib sqlite_path`
- `cargo test -p sabiql-infra --lib missing_database`
- `cargo test -p sabiql-infra --lib path_validation`
- `cargo check --workspace --all-targets`
- `cargo clippy -p sabiql-app -p sabiql-infra --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/lint_all.sh`