### PR TITLE
refactor(error): classify CSV filesystem failures

### DIFF
--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -139,6 +139,8 @@ pub enum DbOperationError {
     ObjectMissing(String),
     #[error("Query failed")]
     QueryFailed(String),
+    #[error("CSV export failed")]
+    ExportIo(#[source] Arc<std::io::Error>),
     #[error("Preview exceeded its byte budget")]
     PreviewSizeExceeded(String),
     #[error("Query failed after a change")]
@@ -218,6 +220,10 @@ impl DbOperationError {
                 "Check the table, column, or connected database",
             ),
             Self::QueryFailed(_) => ("Query failed", "Review the database error details and SQL"),
+            Self::ExportIo(_) => (
+                "CSV export failed",
+                "Check the export folder and available disk space",
+            ),
             Self::PreviewSizeExceeded(_) => (
                 "Preview exceeded its byte budget",
                 "Reduce the preview value size and retry",
@@ -334,6 +340,7 @@ impl DbOperationError {
             | Self::Timeout(details)
             | Self::Canceled(details)
             | Self::CommandNotFound { details, .. } => Cow::Borrowed(details.as_str()),
+            Self::ExportIo(error) => Cow::Owned(error.to_string()),
             Self::InvalidJson(err) => Cow::Owned(err.to_string()),
             Self::CsvParse(err) => Cow::Owned(err.to_string()),
             Self::QueryFailedAfterChange { source, .. } => source.raw_details(),
@@ -412,6 +419,7 @@ mod tests {
         #[case(DbOperationError::LockTimeout("boom".to_string()))]
         #[case(DbOperationError::ObjectMissing("boom".to_string()))]
         #[case(DbOperationError::QueryFailed("boom".to_string()))]
+        #[case(DbOperationError::ExportIo(Arc::new(std::io::Error::other("boom"))))]
         #[case(DbOperationError::UnsupportedOperation("boom".to_string()))]
         #[case(DbOperationError::UnsupportedOperationWithKind {
             kind: UnsupportedOperationKind::ClientVersion,
@@ -545,6 +553,23 @@ mod tests {
             assert_eq!(
                 error.user_message(),
                 "Query failed: syntax error at or near SELECT. Review the database error details and SQL."
+            );
+        }
+
+        #[test]
+        fn export_io_uses_export_guidance_and_preserves_source() {
+            let error = DbOperationError::ExportIo(Arc::new(std::io::Error::other("disk full")));
+
+            assert_eq!(error.summary(), "CSV export failed");
+            assert_eq!(
+                error.hint(),
+                "Check the export folder and available disk space"
+            );
+            assert_eq!(error.masked_details(), "disk full");
+            assert!(std::error::Error::source(&error).is_some());
+            assert_eq!(
+                error.user_message(),
+                "CSV export failed: disk full. Check the export folder and available disk space."
             );
         }
 

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -140,7 +140,7 @@ pub enum DbOperationError {
     #[error("Query failed")]
     QueryFailed(String),
     #[error("CSV export failed")]
-    ExportIo(#[source] Arc<std::io::Error>),
+    ExportIo(#[source] ExportIoSource),
     #[error("Preview exceeded its byte budget")]
     PreviewSizeExceeded(String),
     #[error("Query failed after a change")]
@@ -180,6 +180,29 @@ pub enum DbOperationError {
     Timeout(String),
     #[error("Operation canceled")]
     Canceled(String),
+}
+
+#[derive(Clone)]
+pub struct ExportIoSource(Arc<std::io::Error>);
+
+impl ExportIoSource {
+    pub fn new(error: std::io::Error) -> Self {
+        Self(Arc::new(error))
+    }
+}
+
+impl std::ops::Deref for ExportIoSource {
+    type Target = std::io::Error;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl fmt::Display for ExportIoSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl DbOperationError {
@@ -419,7 +442,7 @@ mod tests {
         #[case(DbOperationError::LockTimeout("boom".to_string()))]
         #[case(DbOperationError::ObjectMissing("boom".to_string()))]
         #[case(DbOperationError::QueryFailed("boom".to_string()))]
-        #[case(DbOperationError::ExportIo(Arc::new(std::io::Error::other("boom"))))]
+        #[case(DbOperationError::ExportIo(ExportIoSource::new(std::io::Error::other("boom"))))]
         #[case(DbOperationError::UnsupportedOperation("boom".to_string()))]
         #[case(DbOperationError::UnsupportedOperationWithKind {
             kind: UnsupportedOperationKind::ClientVersion,
@@ -558,19 +581,23 @@ mod tests {
 
         #[test]
         fn export_io_uses_export_guidance_and_preserves_source() {
-            let error = DbOperationError::ExportIo(Arc::new(std::io::Error::other("disk full")));
+            let error = DbOperationError::ExportIo(ExportIoSource::new(std::io::Error::other(
+                "password=mysecret host=localhost",
+            )));
 
             assert_eq!(error.summary(), "CSV export failed");
             assert_eq!(
                 error.hint(),
                 "Check the export folder and available disk space"
             );
-            assert_eq!(error.masked_details(), "disk full");
+            assert_eq!(error.masked_details(), "password=**** host=localhost");
             assert!(std::error::Error::source(&error).is_some());
             assert_eq!(
                 error.user_message(),
-                "CSV export failed: disk full. Check the export folder and available disk space."
+                "CSV export failed: password=**** host=localhost. Check the export folder and available disk space."
             );
+            assert!(!error.user_message().contains("mysecret"));
+            assert!(!format!("{error:?}").contains("mysecret"));
         }
 
         #[test]

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -31,9 +31,10 @@ pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
-    SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
-    is_mysql_connect_timeout_message, mysql_server_error_code,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, ExportIoSource,
+    MYSQL_CONNECT_TIMEOUT_ERRNOS, SQLITE_SAFE_MODE_REQUIRED_MARKER,
+    SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind, is_mysql_connect_timeout_message,
+    mysql_server_error_code,
 };
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -195,7 +195,8 @@ mod tests {
                 .await
                 .unwrap_err();
 
-            assert!(matches!(error, DbOperationError::QueryFailed(_)));
+            assert!(matches!(error, DbOperationError::ExportIo(_)));
+            assert!(std::error::Error::source(&error).is_some());
         }
     }
 }

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
@@ -84,6 +85,26 @@ impl Drop for RemoveOnDropGuard {
     }
 }
 
+pub enum CsvOutputError {
+    File(std::io::Error),
+    Process(std::io::Error),
+}
+
+impl From<std::io::Error> for CsvOutputError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Process(error)
+    }
+}
+
+impl CsvOutputError {
+    pub fn into_db_operation_error(self) -> DbOperationError {
+        match self {
+            Self::File(error) => DbOperationError::ExportIo(Arc::new(error)),
+            Self::Process(error) => DbOperationError::QueryFailed(error.to_string()),
+        }
+    }
+}
+
 pub async fn export_to_downloads<F, Fut>(
     file_name: &str,
     write: F,
@@ -116,7 +137,7 @@ impl CsvFileWriter {
     pub(crate) async fn create(path: PathBuf) -> Result<Self, DbOperationError> {
         let file = tokio::fs::File::create(path)
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         Ok(Self {
             file: BufWriter::new(file),
             csv_writer: new_csv_writer(),
@@ -148,11 +169,11 @@ impl CsvFileWriter {
         self.file
             .write_all(&encoded)
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         self.file
             .flush()
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))
     }
 
     async fn flush_buffer(&mut self) -> Result<(), DbOperationError> {
@@ -163,11 +184,11 @@ impl CsvFileWriter {
         self.file
             .write_all(&encoded)
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         self.file
             .flush()
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         self.bytes_since_flush = 0;
         Ok(())
     }
@@ -189,7 +210,7 @@ where
 
     tokio::fs::hard_link(&temporary_path, &final_path)
         .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
     let mut published_file = RemoveOnDropGuard::new(final_path.clone());
 
     if cleanup(&temporary_path).is_ok() {
@@ -202,7 +223,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::future::pending;
-    use std::sync::Arc;
 
     use tempfile::tempdir;
     use tokio::sync::Barrier;
@@ -274,7 +294,8 @@ mod tests {
         let error = export_to_path(final_path.clone(), |_| async { Ok(()) })
             .await
             .unwrap_err();
-        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+        assert!(matches!(error, DbOperationError::ExportIo(_)));
+        assert!(std::error::Error::source(&error).is_some());
         assert_eq!(
             tokio::fs::read_to_string(final_path).await.unwrap(),
             "complete,csv\n"
@@ -310,7 +331,8 @@ mod tests {
         })
         .await
         .unwrap_err();
-        assert!(matches!(rename_error, DbOperationError::QueryFailed(_)));
+        assert!(matches!(rename_error, DbOperationError::ExportIo(_)));
+        assert!(std::error::Error::source(&rename_error).is_some());
         assert!(!rename_dir.exists());
     }
 
@@ -399,14 +421,8 @@ mod tests {
         let second = second.await.unwrap();
 
         assert!(first.is_ok() ^ second.is_ok());
-        assert!(matches!(
-            first,
-            Ok(_) | Err(DbOperationError::QueryFailed(_))
-        ));
-        assert!(matches!(
-            second,
-            Ok(_) | Err(DbOperationError::QueryFailed(_))
-        ));
+        assert!(matches!(first, Ok(_) | Err(DbOperationError::ExportIo(_))));
+        assert!(matches!(second, Ok(_) | Err(DbOperationError::ExportIo(_))));
         assert!(matches!(
             tokio::fs::read_to_string(final_path)
                 .await

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -1,9 +1,8 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
-use sabiql_app::ports::outbound::DbOperationError;
+use sabiql_app::ports::outbound::{DbOperationError, ExportIoSource};
 use tokio::io::{AsyncWriteExt, BufWriter};
 
 pub const CSV_FLUSH_THRESHOLD: usize = 64 * 1024;
@@ -85,7 +84,7 @@ impl Drop for RemoveOnDropGuard {
     }
 }
 
-pub enum CsvOutputError {
+pub(super) enum CsvOutputError {
     File(std::io::Error),
     Process(std::io::Error),
 }
@@ -97,9 +96,9 @@ impl From<std::io::Error> for CsvOutputError {
 }
 
 impl CsvOutputError {
-    pub fn into_db_operation_error(self) -> DbOperationError {
+    pub(super) fn into_db_operation_error(self) -> DbOperationError {
         match self {
-            Self::File(error) => DbOperationError::ExportIo(Arc::new(error)),
+            Self::File(error) => DbOperationError::ExportIo(ExportIoSource::new(error)),
             Self::Process(error) => DbOperationError::QueryFailed(error.to_string()),
         }
     }
@@ -137,7 +136,7 @@ impl CsvFileWriter {
     pub(crate) async fn create(path: PathBuf) -> Result<Self, DbOperationError> {
         let file = tokio::fs::File::create(path)
             .await
-            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
         Ok(Self {
             file: BufWriter::new(file),
             csv_writer: new_csv_writer(),
@@ -169,11 +168,11 @@ impl CsvFileWriter {
         self.file
             .write_all(&encoded)
             .await
-            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
         self.file
             .flush()
             .await
-            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))
+            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))
     }
 
     async fn flush_buffer(&mut self) -> Result<(), DbOperationError> {
@@ -184,11 +183,11 @@ impl CsvFileWriter {
         self.file
             .write_all(&encoded)
             .await
-            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
         self.file
             .flush()
             .await
-            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
         self.bytes_since_flush = 0;
         Ok(())
     }
@@ -210,7 +209,7 @@ where
 
     tokio::fs::hard_link(&temporary_path, &final_path)
         .await
-        .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
+        .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
     let mut published_file = RemoveOnDropGuard::new(final_path.clone());
 
     if cleanup(&temporary_path).is_ok() {
@@ -223,6 +222,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::future::pending;
+    use std::sync::Arc;
 
     use tempfile::tempdir;
     use tokio::sync::Barrier;
@@ -231,6 +231,67 @@ mod tests {
     use super::*;
 
     const MEMORY_MEASUREMENT_FIELD_BYTES: usize = 8 * 1024 * 1024;
+
+    fn assert_export_io_source(error: &DbOperationError) {
+        assert!(matches!(error, DbOperationError::ExportIo(_)));
+        let source = std::error::Error::source(error).expect("ExportIo source");
+        assert!(source.downcast_ref::<std::io::Error>().is_some());
+    }
+
+    #[cfg(unix)]
+    async fn read_only_csv_writer(path: &Path) -> CsvFileWriter {
+        tokio::fs::write(path, []).await.unwrap();
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .open(path)
+            .await
+            .unwrap();
+        CsvFileWriter {
+            file: BufWriter::new(file),
+            csv_writer: new_csv_writer(),
+            bytes_since_flush: 0,
+        }
+    }
+
+    #[test]
+    fn csv_output_errors_keep_file_and_process_failures_distinct() {
+        let file_error =
+            CsvOutputError::File(std::io::Error::other("disk full")).into_db_operation_error();
+        assert_export_io_source(&file_error);
+
+        let process_error =
+            CsvOutputError::Process(std::io::Error::other("pipe closed")).into_db_operation_error();
+        assert!(matches!(
+            &process_error,
+            DbOperationError::QueryFailed(details) if details == "pipe closed"
+        ));
+        assert!(std::error::Error::source(&process_error).is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_only_file_flush_failure_is_export_io() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("read-only.csv");
+        let mut writer = read_only_csv_writer(&path).await;
+        writer.csv_writer.write_record(["row"]).unwrap();
+        writer.csv_writer.flush().unwrap();
+
+        let error = writer.finish().await.unwrap_err();
+        assert_export_io_source(&error);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_only_file_write_failure_is_export_io() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("read-only.csv");
+        let mut writer = read_only_csv_writer(&path).await;
+        let value = "x".repeat(CSV_FLUSH_THRESHOLD);
+
+        let error = writer.write_record([value.as_str()]).await.unwrap_err();
+        assert_export_io_source(&error);
+    }
 
     #[tokio::test]
     async fn writes_large_record_without_changing_csv_bytes() {

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -1,11 +1,13 @@
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::timeout;
 
+use crate::adapters::csv_export::CsvOutputError;
 use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{CommandTag, QueryResult, QuerySource, WriteExecutionResult};
 
@@ -23,7 +25,7 @@ async fn collect_csv_output(
 
     let file = tokio::fs::File::create(path)
         .await
-        .map_err(|e| DbOperationError::QueryFailed(format!("Failed to create file: {e}")))?;
+        .map_err(|e| DbOperationError::ExportIo(Arc::new(e)))?;
     let mut writer = tokio::io::BufWriter::new(file);
 
     let result = timeout(timeout_duration, async {
@@ -36,23 +38,26 @@ async fn collect_csv_output(
                         if n == 0 {
                             break;
                         }
-                        writer.write_all(&buf[..n]).await?;
+                        writer
+                            .write_all(&buf[..n])
+                            .await
+                            .map_err(CsvOutputError::File)?;
                     }
-                    writer.flush().await?;
+                    writer.flush().await.map_err(CsvOutputError::File)?;
                 }
-                Ok::<_, std::io::Error>(())
+                Ok::<_, CsvOutputError>(())
             },
             async {
                 let mut buf = Vec::new();
                 if let Some(mut err) = stderr_handle {
                     err.read_to_end(&mut buf).await?;
                 }
-                Ok::<_, std::io::Error>(String::from_utf8_lossy(&buf).into_owned())
+                Ok::<_, CsvOutputError>(String::from_utf8_lossy(&buf).into_owned())
             },
-            child.wait(),
+            async { Ok::<_, CsvOutputError>(child.wait().await?) },
         )?;
 
-        Ok::<_, std::io::Error>((status, stderr))
+        Ok::<_, CsvOutputError>((status, stderr))
     })
     .await;
 
@@ -65,7 +70,7 @@ async fn collect_csv_output(
         }
         Ok(Err(e)) => {
             let _ = tokio::fs::remove_file(path).await;
-            Err(DbOperationError::QueryFailed(e.to_string()))
+            Err(e.into_db_operation_error())
         }
         Err(e) => {
             let _ = tokio::fs::remove_file(path).await;

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 use std::process::Stdio;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8,7 +7,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::adapters::csv_export::CsvOutputError;
-use crate::app::ports::outbound::DbOperationError;
+use crate::app::ports::outbound::{DbOperationError, ExportIoSource};
 use crate::domain::{CommandTag, QueryResult, QuerySource, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
@@ -25,7 +24,7 @@ async fn collect_csv_output(
 
     let file = tokio::fs::File::create(path)
         .await
-        .map_err(|e| DbOperationError::ExportIo(Arc::new(e)))?;
+        .map_err(|e| DbOperationError::ExportIo(ExportIoSource::new(e)))?;
     let mut writer = tokio::io::BufWriter::new(file);
 
     let result = timeout(timeout_duration, async {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 use std::process::{ExitStatus, Stdio};
-use std::sync::Arc;
 use std::time::Duration;
 
 use serde::de::DeserializeOwned;
@@ -9,7 +8,9 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::adapters::csv_export::CsvOutputError;
-use crate::app::ports::outbound::{DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER};
+use crate::app::ports::outbound::{
+    DbOperationError, ExportIoSource, SQLITE_SAFE_MODE_REQUIRED_MARKER,
+};
 
 use super::super::path_validation;
 use super::error::{classify_cli_spawn_error, classify_query_error};
@@ -197,7 +198,7 @@ impl SqliteCli {
 
         let file = tokio::fs::File::create(output_path)
             .await
-            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
         let mut writer = tokio::io::BufWriter::new(file);
 
         let result = timeout(Duration::from_secs(self.timeout_secs * 10), async {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::{ExitStatus, Stdio};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::de::DeserializeOwned;
@@ -7,6 +8,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::timeout;
 
+use crate::adapters::csv_export::CsvOutputError;
 use crate::app::ports::outbound::{DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER};
 
 use super::super::path_validation;
@@ -195,12 +197,12 @@ impl SqliteCli {
 
         let file = tokio::fs::File::create(output_path)
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         let mut writer = tokio::io::BufWriter::new(file);
 
         let result = timeout(Duration::from_secs(self.timeout_secs * 10), async {
             let (stdin_result, stdout_result, stderr_result) = tokio::join!(
-                write_sql_to_stdin(stdin, &sql),
+                async { Ok::<_, CsvOutputError>(write_sql_to_stdin(stdin, &sql).await?) },
                 async {
                     if let Some(mut stdout) = stdout {
                         let mut buf = [0u8; 8192];
@@ -217,25 +219,34 @@ impl SqliteCli {
                             {
                                 let output =
                                     newline_normalizer.normalize(&buf[..n], &mut normalized_buf);
-                                writer.write_all(output).await?;
+                                writer
+                                    .write_all(output)
+                                    .await
+                                    .map_err(CsvOutputError::File)?;
                             }
                             #[cfg(not(windows))]
-                            writer.write_all(&buf[..n]).await?;
+                            writer
+                                .write_all(&buf[..n])
+                                .await
+                                .map_err(CsvOutputError::File)?;
                         }
                         #[cfg(windows)]
                         if let Some(trailing_carriage_return) = newline_normalizer.finish() {
-                            writer.write_all(&[trailing_carriage_return]).await?;
+                            writer
+                                .write_all(&[trailing_carriage_return])
+                                .await
+                                .map_err(CsvOutputError::File)?;
                         }
-                        writer.flush().await?;
+                        writer.flush().await.map_err(CsvOutputError::File)?;
                     }
-                    Ok::<_, std::io::Error>(())
+                    Ok::<_, CsvOutputError>(())
                 },
                 async {
                     let mut buf = Vec::new();
                     if let Some(ref mut stderr) = stderr_handle {
                         stderr.read_to_end(&mut buf).await?;
                     }
-                    Ok::<_, std::io::Error>(String::from_utf8_lossy(&buf).into_owned())
+                    Ok::<_, CsvOutputError>(String::from_utf8_lossy(&buf).into_owned())
                 }
             );
 
@@ -243,7 +254,7 @@ impl SqliteCli {
             stdout_result?;
             let stderr = stderr_result?;
             let status = child.wait().await?;
-            Ok::<_, std::io::Error>((status, stderr))
+            Ok::<_, CsvOutputError>((status, stderr))
         })
         .await;
 
@@ -252,7 +263,7 @@ impl SqliteCli {
                 Ok(values) => values,
                 Err(error) => {
                     let _ = tokio::fs::remove_file(output_path).await;
-                    return Err(DbOperationError::QueryFailed(error.to_string()));
+                    return Err(error.into_db_operation_error());
                 }
             },
             Err(error) => {


### PR DESCRIPTION
## Problem
CSV filesystem failures were reported as `QueryFailed`, which showed SQL-oriented guidance and discarded the underlying I/O source.

## Background
CSV exports share file-writing code across the cached and database adapters, while the PostgreSQL and SQLite CLI paths handle output concurrently with process I/O.

## Approach
Classify export file creation, writes, flushes, and publication failures as source-preserving `ExportIo` errors with export-specific guidance. Keep CSV encoding, process/DB failures, cleanup behavior, and export protocols unchanged.