### PR TITLE
fix(app): own all connection save tasks

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -25,28 +25,25 @@ use crate::update::action::{
 };
 
 #[derive(Default)]
-pub(crate) struct MySqlConnectionProbeTaskOwner {
+pub(crate) struct ConnectionTaskOwner {
     active: std::sync::Mutex<Option<JoinHandle<()>>>,
 }
 
-impl MySqlConnectionProbeTaskOwner {
+impl ConnectionTaskOwner {
     pub(crate) async fn replace<F>(&self, task: F)
     where
         F: std::future::Future<Output = ()> + Send + 'static,
     {
         self.cancel().await;
         let task = tokio::spawn(task);
-        *self
-            .active
-            .lock()
-            .expect("MySQL connection probe task lock poisoned") = Some(task);
+        *self.active.lock().expect("connection task lock poisoned") = Some(task);
     }
 
     pub(crate) async fn cancel(&self) {
         let task = self
             .active
             .lock()
-            .expect("MySQL connection probe task lock poisoned")
+            .expect("connection task lock poisoned")
             .take();
         if let Some(task) = task {
             task.abort();
@@ -55,12 +52,12 @@ impl MySqlConnectionProbeTaskOwner {
     }
 }
 
-impl Drop for MySqlConnectionProbeTaskOwner {
+impl Drop for ConnectionTaskOwner {
     fn drop(&mut self) {
         if let Some(task) = self
             .active
             .get_mut()
-            .expect("MySQL connection probe task lock poisoned")
+            .expect("connection task lock poisoned")
             .take()
         {
             task.abort();
@@ -85,7 +82,7 @@ pub(crate) async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
     connection: &ConnectionDeps,
-    mysql_connection_probe_task: &MySqlConnectionProbeTaskOwner,
+    connection_task: &ConnectionTaskOwner,
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     state: &AppState,
@@ -142,27 +139,33 @@ pub(crate) async fn run(
                 let target = ConnectionTarget::from_profile(&profile, dsn);
                 let database_type = target.database_type;
 
-                tokio::task::spawn_blocking(move || {
-                    match claim_and_save(&run_guard, run_id, || store.save(&profile)) {
-                        Some(Ok(())) => {
-                            tx.blocking_send(Action::ConnectionSaveCompleted {
-                                target,
-                                run_id,
-                                mysql_lower_case_table_names: None,
-                            })
-                            .ok();
-                        }
-                        Some(Err(e)) => {
-                            tx.blocking_send(Action::ConnectionSaveFailed {
-                                error: e.into(),
-                                database_type,
-                                run_id,
-                            })
-                            .ok();
-                        }
-                        None => {}
-                    }
-                });
+                connection_task
+                    .replace(async move {
+                        tokio::task::spawn_blocking(move || {
+                            match claim_and_save(&run_guard, run_id, || store.save(&profile)) {
+                                Some(Ok(())) => {
+                                    tx.blocking_send(Action::ConnectionSaveCompleted {
+                                        target,
+                                        run_id,
+                                        mysql_lower_case_table_names: None,
+                                    })
+                                    .ok();
+                                }
+                                Some(Err(e)) => {
+                                    tx.blocking_send(Action::ConnectionSaveFailed {
+                                        error: e.into(),
+                                        database_type,
+                                        run_id,
+                                    })
+                                    .ok();
+                                }
+                                None => {}
+                            }
+                        })
+                        .await
+                        .expect("connection store save task panicked");
+                    })
+                    .await;
                 return;
             }
 
@@ -172,7 +175,7 @@ pub(crate) async fn run(
             if database_type == DatabaseType::MySQL {
                 let target = ConnectionTarget::from_profile(&profile, dsn);
                 let probe = Arc::clone(&connection.mysql_connection_probe);
-                mysql_connection_probe_task
+                connection_task
                     .replace(async move {
                         match probe.probe(&target.dsn).await {
                             Ok(probe_result) => {
@@ -227,55 +230,57 @@ pub(crate) async fn run(
             let cache = metadata_cache.clone();
             let provider = Arc::clone(metadata_provider);
             let dsn = target.dsn.clone();
-            tokio::spawn(async move {
-                match provider.fetch_metadata(&dsn).await {
-                    Ok(metadata) => {
-                        cache.set(dsn.clone(), Arc::new(metadata)).await;
-                        let save_result = tokio::task::spawn_blocking(move || {
-                            claim_and_save(&run_guard, run_id, || store.save(&profile))
-                        })
-                        .await
-                        .expect("connection store save task panicked");
-                        match save_result {
-                            Some(Ok(())) => {
-                                tx.send(Action::ConnectionSaveCompleted {
-                                    target,
-                                    run_id,
-                                    mysql_lower_case_table_names: None,
-                                })
-                                .await
-                                .ok();
+            connection_task
+                .replace(async move {
+                    match provider.fetch_metadata(&dsn).await {
+                        Ok(metadata) => {
+                            let save_result = tokio::task::spawn_blocking(move || {
+                                claim_and_save(&run_guard, run_id, || store.save(&profile))
+                            })
+                            .await
+                            .expect("connection store save task panicked");
+                            match save_result {
+                                Some(Ok(())) => {
+                                    cache.set(dsn.clone(), Arc::new(metadata)).await;
+                                    tx.send(Action::ConnectionSaveCompleted {
+                                        target,
+                                        run_id,
+                                        mysql_lower_case_table_names: None,
+                                    })
+                                    .await
+                                    .ok();
+                                }
+                                Some(Err(e)) => {
+                                    cache.invalidate(&dsn).await;
+                                    tx.send(Action::ConnectionSaveFailed {
+                                        error: e.into(),
+                                        database_type,
+                                        run_id,
+                                    })
+                                    .await
+                                    .ok();
+                                }
+                                None => {}
                             }
-                            Some(Err(e)) => {
-                                cache.invalidate(&dsn).await;
-                                tx.send(Action::ConnectionSaveFailed {
-                                    error: e.into(),
-                                    database_type,
-                                    run_id,
-                                })
-                                .await
-                                .ok();
-                            }
-                            None => {}
+                        }
+                        Err(e) => {
+                            tx.send(Action::ConnectionSaveFailed {
+                                error: e.into(),
+                                database_type,
+                                run_id,
+                            })
+                            .await
+                            .ok();
                         }
                     }
-                    Err(e) => {
-                        tx.send(Action::ConnectionSaveFailed {
-                            error: e.into(),
-                            database_type,
-                            run_id,
-                        })
-                        .await
-                        .ok();
-                    }
-                }
-            });
+                })
+                .await;
         }
 
         Effect::ProbeMySqlConnection { target, run_id } => {
             let probe = Arc::clone(&connection.mysql_connection_probe);
             let tx = action_tx.clone();
-            mysql_connection_probe_task
+            connection_task
                 .replace(async move {
                     match probe.probe(&target.dsn).await {
                         Ok(probe_result) => tx
@@ -435,9 +440,11 @@ mod tests {
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
     use crate::cmd::test_fixtures::{self, NoopRenderer};
+    use crate::domain::DatabaseMetadata;
     use crate::domain::connection::{
         ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
-        MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig, SqlitePathError, SslMode,
+        MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig, SqliteConnectionConfig,
+        SqlitePathError, SslMode,
     };
     use crate::model::app_state::AppState;
     use crate::ports::outbound::connection_store::MockConnectionStore;
@@ -480,6 +487,13 @@ mod tests {
             }
         }
 
+        struct PostgresDsnBuilder;
+        impl DsnBuilder for PostgresDsnBuilder {
+            fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
+                "postgres://localhost/app".to_string()
+            }
+        }
+
         fn mysql_config(database: Option<&str>) -> ConnectionConfig {
             ConnectionConfig::MySQL(MySqlConnectionConfig::new(
                 "localhost",
@@ -488,6 +502,17 @@ mod tests {
                 "user",
                 "secret",
                 MySqlSslMode::Required,
+            ))
+        }
+
+        fn postgres_config() -> ConnectionConfig {
+            ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                "localhost",
+                5432,
+                "app",
+                "user",
+                "secret",
+                SslMode::Prefer,
             ))
         }
 
@@ -668,6 +693,171 @@ mod tests {
             );
         }
 
+        #[tokio::test]
+        async fn postgres_metadata_cache_is_not_published_when_save_is_cancelled() {
+            let dsn = "postgres://localhost/app".to_string();
+            let run_guard = test_fixtures::active_connection_save_guard(1);
+            let guard_for_provider = Arc::clone(&run_guard);
+            let mut provider = MockMetadataProvider::new();
+            provider
+                .expect_fetch_metadata()
+                .with(eq(dsn.clone()))
+                .once()
+                .returning(move |_| {
+                    guard_for_provider.cancel();
+                    Ok(DatabaseMetadata::new("app".to_string()))
+                });
+
+            let mut store = MockConnectionStore::new();
+            store.expect_save().never();
+            let cache = TtlCache::new(300);
+            let observed_cache = cache.clone();
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(store),
+                cache,
+                tx,
+                Arc::new(PostgresDsnBuilder),
+            );
+
+            runner
+                .execute_effects(
+                    vec![Effect::SaveAndConnect {
+                        id: None,
+                        name: "PostgreSQL".to_string(),
+                        config: postgres_config(),
+                        run_id: 1,
+                        run_guard,
+                    }],
+                    &mut NoopRenderer,
+                    &mut AppState::new("test".to_string()),
+                    &RefCell::new(CompletionEngine::new()),
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                    .await
+                    .is_err()
+            );
+            assert!(observed_cache.get(&dsn).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn postgres_metadata_cache_is_published_after_save_succeeds() {
+            let dsn = "postgres://localhost/app".to_string();
+            let mut provider = MockMetadataProvider::new();
+            provider
+                .expect_fetch_metadata()
+                .with(eq(dsn.clone()))
+                .once()
+                .returning(|_| Ok(DatabaseMetadata::new("app".to_string())));
+
+            let mut store = MockConnectionStore::new();
+            store.expect_save().once().returning(|_| Ok(()));
+            let cache = TtlCache::new(300);
+            let observed_cache = cache.clone();
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(store),
+                cache,
+                tx,
+                Arc::new(PostgresDsnBuilder),
+            );
+
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SaveAndConnect {
+                    id: None,
+                    name: "PostgreSQL".to_string(),
+                    config: postgres_config(),
+                    run_id: 1,
+                    run_guard: test_fixtures::active_connection_save_guard(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
+
+            assert!(matches!(
+                run.actions.into_iter().next(),
+                Some(Action::ConnectionSaveCompleted { run_id: 1, .. })
+            ));
+            assert_eq!(
+                observed_cache
+                    .get(&dsn)
+                    .await
+                    .expect("successful save should publish metadata")
+                    .database_name,
+                "app"
+            );
+        }
+
+        #[tokio::test]
+        async fn postgres_store_failure_invalidates_metadata_cache() {
+            let dsn = "postgres://localhost/app".to_string();
+            let mut provider = MockMetadataProvider::new();
+            provider
+                .expect_fetch_metadata()
+                .with(eq(dsn.clone()))
+                .once()
+                .returning(|_| Ok(DatabaseMetadata::new("app".to_string())));
+
+            let mut store = MockConnectionStore::new();
+            store.expect_save().once().returning(|_| {
+                Err(ConnectionStoreError::Io(Arc::new(std::io::Error::other(
+                    "save failed",
+                ))))
+            });
+            let cache = TtlCache::new(300);
+            let observed_cache = cache.clone();
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(store),
+                cache,
+                tx,
+                Arc::new(PostgresDsnBuilder),
+            );
+
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::SaveAndConnect {
+                    id: None,
+                    name: "PostgreSQL".to_string(),
+                    config: postgres_config(),
+                    run_id: 1,
+                    run_guard: test_fixtures::active_connection_save_guard(1),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
+
+            assert!(matches!(
+                run.actions.into_iter().next(),
+                Some(Action::ConnectionSaveFailed {
+                    database_type: DatabaseType::PostgreSQL,
+                    run_id: 1,
+                    ..
+                })
+            ));
+            assert!(observed_cache.get(&dsn).await.is_none());
+        }
+
         #[test]
         fn cancel_after_claim_prevents_save_from_starting() {
             let run_guard = test_fixtures::active_connection_save_guard(1);
@@ -754,6 +944,59 @@ mod tests {
                     } if dsn == &expected_dsn
                 ),
                 "expected sqlite ConnectionSaveCompleted, got {action:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn sqlite_profile_is_not_saved_when_run_is_cancelled() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("app.db");
+            fs::write(&path, b"").unwrap();
+            let path = path.to_str().unwrap().to_string();
+            let run_guard = test_fixtures::active_connection_save_guard(1);
+            run_guard.cancel();
+
+            let mut store = MockConnectionStore::new();
+            store.expect_save().never();
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(store),
+                TtlCache::new(300),
+                tx,
+                Arc::new(SqliteDsnBuilder),
+            );
+            let mut renderer = NoopRenderer;
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+
+            runner
+                .execute_effects(
+                    vec![
+                        Effect::SaveAndConnect {
+                            id: None,
+                            name: "Local".to_string(),
+                            config: ConnectionConfig::SQLite(
+                                SqliteConnectionConfig::new(path).unwrap(),
+                            ),
+                            run_id: 1,
+                            run_guard,
+                        },
+                        Effect::CancelConnectionTask,
+                    ],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+                    .await
+                    .is_err()
             );
         }
 

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -40,15 +40,21 @@ impl ConnectionTaskOwner {
     }
 
     pub(crate) async fn cancel(&self) {
+        if let Some(task) = self.abort() {
+            let _ = task.await;
+        }
+    }
+
+    pub(crate) fn abort(&self) -> Option<JoinHandle<()>> {
         let task = self
             .active
             .lock()
             .expect("connection task lock poisoned")
             .take();
-        if let Some(task) = task {
+        if let Some(task) = &task {
             task.abort();
-            let _ = task.await;
         }
+        task
     }
 }
 

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -96,6 +96,7 @@ pub enum Effect {
         query: String,
         access_mode: AccessMode,
     },
+    CancelConnectionTask,
     CancelTrackedTasks,
     CountRowsForExport {
         dsn: String,

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -28,15 +28,21 @@ impl SmartErRefreshTaskOwner {
     }
 
     pub(crate) async fn cancel(&self) {
+        if let Some(task) = self.abort() {
+            let _ = task.await;
+        }
+    }
+
+    pub(crate) fn abort(&self) -> Option<JoinHandle<()>> {
         let task = self
             .active
             .lock()
             .expect("Smart ER refresh task lock poisoned")
             .take();
-        if let Some(task) = task {
+        if let Some(task) = &task {
             task.abort();
-            let _ = task.await;
         }
+        task
     }
 }
 

--- a/src/app/cmd/metadata_task.rs
+++ b/src/app/cmd/metadata_task.rs
@@ -71,6 +71,12 @@ impl MetadataTaskRegistry {
     }
 
     pub async fn cancel(&self) {
+        for handle in self.abort() {
+            let _ = handle.await;
+        }
+    }
+
+    pub fn abort(&self) -> Vec<JoinHandle<()>> {
         let handles = self
             .active
             .lock()
@@ -79,10 +85,10 @@ impl MetadataTaskRegistry {
             .filter_map(|(_, entry)| entry.handle)
             .collect::<Vec<_>>();
 
-        for handle in handles {
+        for handle in &handles {
             handle.abort();
-            let _ = handle.await;
         }
+        handles
     }
 
     fn remove_released(&self, task_id: u64, released: &Arc<AtomicBool>) {

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -12,7 +12,7 @@ use crate::cmd::browse as cmd_browse;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::connection as cmd_connection;
-use crate::cmd::connection::MySqlConnectionProbeTaskOwner;
+use crate::cmd::connection::ConnectionTaskOwner;
 use crate::cmd::effect::Effect;
 use crate::cmd::er::handler as cmd_er;
 use crate::cmd::metadata_task::MetadataTaskRegistry;
@@ -75,7 +75,7 @@ pub struct EffectRunner {
     query_tasks: QueryTaskRegistry,
     table_detail_tasks: TableDetailTaskRegistry,
     metadata_tasks: Arc<MetadataTaskRegistry>,
-    mysql_connection_probe_task: MySqlConnectionProbeTaskOwner,
+    connection_task: ConnectionTaskOwner,
 }
 
 impl EffectRunner {
@@ -101,7 +101,7 @@ impl EffectRunner {
             query_tasks: QueryTaskRegistry::default(),
             table_detail_tasks: TableDetailTaskRegistry::default(),
             metadata_tasks: Arc::new(MetadataTaskRegistry::default()),
-            mysql_connection_probe_task: MySqlConnectionProbeTaskOwner::default(),
+            connection_task: ConnectionTaskOwner::default(),
         }
     }
 
@@ -117,7 +117,7 @@ impl EffectRunner {
         self.query_tasks.cancel();
         self.table_detail_tasks.cancel();
         self.cancel_metadata_tasks().await;
-        self.mysql_connection_probe_task.cancel().await;
+        self.connection_task.cancel().await;
     }
 
     pub async fn execute_effects<T: Renderer>(
@@ -222,7 +222,7 @@ impl EffectRunner {
                     e,
                     &self.action_tx,
                     &self.connection,
-                    &self.mysql_connection_probe_task,
+                    &self.connection_task,
                     &self.metadata_provider,
                     &self.metadata_cache,
                     state,
@@ -252,6 +252,11 @@ impl EffectRunner {
                     completion_engine,
                 )
                 .await;
+                Ok(vec![])
+            }
+
+            Effect::CancelConnectionTask => {
+                self.connection_task.cancel().await;
                 Ok(vec![])
             }
 
@@ -1091,7 +1096,7 @@ mod tests {
         }
     }
 
-    mod mysql_connection_probe_lifecycle {
+    mod connection_task_lifecycle {
         use std::future::pending;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1099,8 +1104,10 @@ mod tests {
         use tokio::time::{Duration, timeout};
 
         use super::*;
+        use crate::domain::Table;
         use crate::domain::connection::{
             ConnectionConfig, ConnectionId, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
+            PostgresConnectionConfig, SslMode,
         };
         use crate::ports::outbound::DbOperationError;
         use crate::update::action::ConnectionTarget;
@@ -1119,6 +1126,11 @@ mod tests {
             dropped: Arc<AtomicUsize>,
         }
 
+        struct PendingMetadataProvider {
+            started: UnboundedSender<String>,
+            dropped: Arc<AtomicUsize>,
+        }
+
         #[async_trait::async_trait]
         impl MySqlConnectionProbe for PendingMySqlConnectionProbe {
             async fn probe(
@@ -1129,6 +1141,45 @@ mod tests {
                 self.started
                     .send(dsn.to_string())
                     .expect("probe receiver should stay alive");
+                pending().await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl MetadataProvider for PendingMetadataProvider {
+            async fn fetch_metadata(
+                &self,
+                dsn: &str,
+            ) -> Result<DatabaseMetadata, DbOperationError> {
+                let _drop_signal = DropSignal(Arc::clone(&self.dropped));
+                self.started
+                    .send(dsn.to_string())
+                    .expect("metadata receiver should stay alive");
+                pending().await
+            }
+
+            async fn fetch_table_detail(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                pending().await
+            }
+
+            async fn fetch_table_columns_and_fks(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                pending().await
+            }
+
+            async fn fetch_table_signatures(
+                &self,
+                _dsn: &str,
+            ) -> Result<TableSignatureSnapshot, DbOperationError> {
                 pending().await
             }
         }
@@ -1151,6 +1202,17 @@ mod tests {
                 "user",
                 "secret",
                 MySqlSslMode::Required,
+            ))
+        }
+
+        fn postgres_config() -> ConnectionConfig {
+            ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                "localhost",
+                5432,
+                "app",
+                "user",
+                "secret",
+                SslMode::Prefer,
             ))
         }
 
@@ -1359,6 +1421,66 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn cancelling_postgres_save_aborts_metadata_before_cache_or_action() {
+            let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+            let dropped = Arc::new(AtomicUsize::new(0));
+            let provider = PendingMetadataProvider {
+                started: started_tx,
+                dropped: Arc::clone(&dropped),
+            };
+            let cache = TtlCache::new(300);
+            let observed_cache = cache.clone();
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                cache,
+                action_tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::SaveAndConnect {
+                        id: None,
+                        name: "PostgreSQL".to_string(),
+                        config: postgres_config(),
+                        run_id: 1,
+                        run_guard: test_fixtures::active_connection_save_guard(1),
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(started_rx.recv().await.as_deref(), Some(""));
+
+            runner
+                .execute_effects(
+                    vec![Effect::CancelConnectionTask],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert!(
+                timeout(Duration::from_millis(100), action_rx.recv())
+                    .await
+                    .is_err()
+            );
+            assert!(observed_cache.get(&String::new()).await.is_none());
         }
     }
 }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -119,6 +119,10 @@ impl EffectRunner {
     }
 
     async fn cancel_tracked_tasks(&self) {
+        let connection_task = self.connection_task.abort();
+        let metadata_tasks = self.metadata_tasks.abort();
+        let smart_er_task = self.smart_er_refresh_task.abort();
+        let sqlite_diagnostics_tasks = self.sqlite_diagnostics_task.abort();
         let (query_task, table_detail_task) =
             tokio::join!(self.query_tasks.abort(), self.table_detail_tasks.abort());
         if let Some(task) = query_task {
@@ -127,9 +131,16 @@ impl EffectRunner {
         if let Some(task) = table_detail_task {
             let _ = task.await;
         }
-        self.cancel_metadata_tasks().await;
-        self.connection_task.cancel().await;
-        self.smart_er_refresh_task.cancel().await;
+        if let Some(task) = connection_task {
+            let _ = task.await;
+        }
+        for task in metadata_tasks
+            .into_iter()
+            .chain(smart_er_task)
+            .chain(sqlite_diagnostics_tasks)
+        {
+            let _ = task.await;
+        }
     }
 
     pub async fn execute_effects<T: Renderer>(
@@ -597,22 +608,22 @@ mod tests {
             }
         }
 
-        struct DropSignal(Mutex<Option<oneshot::Sender<()>>>);
+        struct TaskDropSignal(Mutex<Option<oneshot::Sender<()>>>);
 
-        impl Drop for DropSignal {
+        impl Drop for TaskDropSignal {
             fn drop(&mut self) {
                 self.0
                     .lock()
-                    .expect("table drop signal lock poisoned")
+                    .expect("task drop signal lock poisoned")
                     .take()
-                    .expect("table drop signal should be observed once")
+                    .expect("task drop signal should be observed once")
                     .send(())
                     .ok();
             }
         }
 
-        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-        async fn cancel_tracked_tasks_aborts_both_groups_before_joining() {
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn cancel_tracked_tasks_aborts_all_groups_before_joining() {
             let (tx, _rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
@@ -647,7 +658,7 @@ mod tests {
                 .table_detail_tasks
                 .spawn({
                     async move {
-                        let _drop_signal = DropSignal(Mutex::new(Some(table_drop_tx)));
+                        let _drop_signal = TaskDropSignal(Mutex::new(Some(table_drop_tx)));
                         table_started_tx.send(()).ok();
                         pending::<()>().await;
                     }
@@ -657,37 +668,40 @@ mod tests {
                 .await
                 .expect("table detail task should start");
 
+            let (connection_started_tx, connection_started_rx) = oneshot::channel();
+            let (connection_drop_tx, mut connection_drop_rx) = oneshot::channel();
+            runner
+                .connection_task
+                .replace(async move {
+                    let _drop_signal = TaskDropSignal(Mutex::new(Some(connection_drop_tx)));
+                    connection_started_tx.send(()).ok();
+                    pending::<()>().await;
+                })
+                .await;
+            connection_started_rx
+                .await
+                .expect("connection task should start");
+
             let cancel = runner.cancel_tracked_tasks();
             tokio::pin!(cancel);
-            let observed = tokio::select! {
-                () = &mut cancel => "cancellation finished before query drop",
-                result = &mut query_drop_rx => {
-                    match result {
-                        Ok(()) => match timeout(
-                            Duration::from_secs(1),
-                            &mut table_drop_rx,
-                        )
-                        .await
-                        {
-                            Ok(Ok(())) => "",
-                            Ok(Err(_)) => "table drop signal was lost",
-                            Err(_) => "table detail task was not aborted",
-                        },
-                        Err(_) => "query drop signal was lost",
-                    }
-                }
-                () = tokio::time::sleep(Duration::from_secs(1)) => {
-                    "query task was not aborted"
-                }
+            let connection_aborted = tokio::select! {
+                result = &mut connection_drop_rx => result.is_ok(),
+                () = &mut cancel => false,
+                () = tokio::time::sleep(Duration::from_secs(1)) => false,
             };
 
             query_drop_state.release();
+            let query_dropped = timeout(Duration::from_secs(1), &mut query_drop_rx)
+                .await
+                .is_ok();
+            let table_dropped = timeout(Duration::from_secs(1), &mut table_drop_rx)
+                .await
+                .is_ok();
             let cancellation_finished = timeout(Duration::from_secs(1), cancel).await.is_ok();
-            assert!(
-                cancellation_finished,
-                "cancellation did not finish: {observed}"
-            );
-            assert!(observed.is_empty(), "{observed}");
+            assert!(connection_aborted, "connection task was not aborted first");
+            assert!(query_dropped, "query task was not aborted");
+            assert!(table_dropped, "table detail task was not aborted");
+            assert!(cancellation_finished, "cancellation did not finish");
         }
     }
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -1097,9 +1097,11 @@ mod tests {
     }
 
     mod connection_task_lifecycle {
+        use std::fs;
         use std::future::pending;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
+        use tempfile::tempdir;
         use tokio::sync::mpsc::UnboundedSender;
         use tokio::time::{Duration, timeout};
 
@@ -1107,7 +1109,7 @@ mod tests {
         use crate::domain::Table;
         use crate::domain::connection::{
             ConnectionConfig, ConnectionId, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
-            PostgresConnectionConfig, SslMode,
+            PostgresConnectionConfig, SqliteConnectionConfig, SslMode,
         };
         use crate::ports::outbound::DbOperationError;
         use crate::update::action::ConnectionTarget;
@@ -1421,6 +1423,75 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn quitting_cancels_sqlite_save_before_blocking_claim() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("app.db");
+            fs::write(&path, b"").unwrap();
+
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let mut store = MockConnectionStore::new();
+            store.expect_save().never();
+            let runner = test_fixtures::make_runner_with_dsn(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(store),
+                TtlCache::new(300),
+                action_tx,
+                Arc::new(test_fixtures::NoopDsnBuilder),
+            );
+            let mut state = AppState::new("test".to_string());
+            let run_id = state.session.begin_connection_save();
+            let run_guard = state.session.connection_save_guard();
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::SaveAndConnect {
+                        id: None,
+                        name: "Local".to_string(),
+                        config: ConnectionConfig::SQLite(
+                            SqliteConnectionConfig::new(path.to_string_lossy().to_string())
+                                .unwrap(),
+                        ),
+                        run_id,
+                        run_guard,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            let shutdown_effects = reduce(
+                &mut state,
+                Action::Quit,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.should_quit);
+            tokio::task::yield_now().await;
+            runner
+                .execute_effects(
+                    shutdown_effects,
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                timeout(Duration::from_millis(100), action_rx.recv())
+                    .await
+                    .is_err()
+            );
         }
 
         #[tokio::test]

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -598,7 +598,7 @@ mod tests {
                 let mut released = released.lock().expect("release lock poisoned");
                 while !*released {
                     let (next, result) = condvar
-                        .wait_timeout(released, StdDuration::from_secs(1))
+                        .wait_timeout(released, StdDuration::from_secs(10))
                         .expect("release wait poisoned");
                     released = next;
                     if result.timed_out() {

--- a/src/app/cmd/sqlite_diagnostics.rs
+++ b/src/app/cmd/sqlite_diagnostics.rs
@@ -19,26 +19,35 @@ impl SqliteDiagnosticsTaskOwner {
     where
         F: std::future::Future<Output = ()> + Send + 'static,
     {
-        Self::cancel_slot(slot).await;
+        if let Some(task) = Self::abort_slot(slot) {
+            let _ = task.await;
+        }
         let task = tokio::spawn(task);
         *slot.lock().expect("SQLite diagnostics task lock poisoned") = Some(task);
     }
 
-    async fn cancel_slot(slot: &std::sync::Mutex<Option<JoinHandle<()>>>) {
+    fn abort_slot(slot: &std::sync::Mutex<Option<JoinHandle<()>>>) -> Option<JoinHandle<()>> {
         let task = {
             slot.lock()
                 .expect("SQLite diagnostics task lock poisoned")
                 .take()
         };
-        if let Some(task) = task {
+        if let Some(task) = &task {
             task.abort();
+        }
+        task
+    }
+
+    pub(crate) async fn cancel(&self) {
+        for task in self.abort() {
             let _ = task.await;
         }
     }
 
-    pub(crate) async fn cancel(&self) {
-        Self::cancel_slot(&self.core).await;
-        Self::cancel_slot(&self.quick_check).await;
+    pub(crate) fn abort(&self) -> Vec<JoinHandle<()>> {
+        let core = Self::abort_slot(&self.core);
+        let quick_check = Self::abort_slot(&self.quick_check);
+        [core, quick_check].into_iter().flatten().collect()
     }
 }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -189,7 +189,7 @@ pub fn reduce_execution(
                     state.session.cancel_connection_save_and_disconnect();
                     state.session.clear_mysql_connection_probe();
                     state.should_quit = true;
-                    vec![Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
+                    vec![Effect::CancelTrackedTasks]
                 }
                 Action::ToggleModal(ModalKind::Help) => {
                     state.ui.help_mut().open(HelpOrigin::CommandLine);
@@ -627,10 +627,7 @@ mod tests {
             assert!(state.should_quit);
             assert!(!state.session.is_current_connection_save(save_run_id));
             assert!(state.session.pending_mysql_connection_probe().is_none());
-            assert!(matches!(
-                effects.as_slice(),
-                [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
-            ));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -201,6 +201,8 @@ pub fn reduce_execution(
 
             DispatchResult::handled_with(match follow_up {
                 Action::Quit => {
+                    state.session.cancel_connection_save_and_disconnect();
+                    state.session.clear_mysql_connection_probe();
                     state.should_quit = true;
                     vec![Effect::CancelTrackedTasks]
                 }
@@ -610,6 +612,14 @@ mod tests {
             let mut state = create_test_state();
             state.modal.push_mode(InputMode::CommandLine);
             state.command_line_input.set_content("q".to_string());
+            let save_run_id = state.session.begin_connection_save();
+            let probe_id = ConnectionId::from_string("pending-probe");
+            let _ = state.session.begin_mysql_connection_probe(
+                &probe_id,
+                "mysql",
+                "mysql://localhost/app",
+                Some("app"),
+            );
 
             let effects = dispatch_query(
                 &mut state,
@@ -621,6 +631,8 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.should_quit);
+            assert!(!state.session.is_current_connection_save(save_run_id));
+            assert!(state.session.pending_mysql_connection_probe().is_none());
             assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -16,12 +16,12 @@ pub(super) fn reduce_connection_error(
     match action {
         Action::CloseConnectionError => {
             if state.session.pending_mysql_connection_probe().is_some() {
-                state.session.clear_mysql_connection_probe();
                 state.connection_error.clear();
             } else {
                 state.connection_error.reset_view();
                 state.connection_error.clear_copied_feedback();
             }
+            state.session.clear_mysql_connection_probe();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
@@ -73,6 +73,7 @@ pub(super) fn reduce_connection_error(
             }
             state.connection_error.clear();
             state.session.cancel_connection_save();
+            state.session.clear_mysql_connection_probe();
             state.session.mark_disconnected();
             state.modal.replace_mode(InputMode::ConnectionSetup);
             DispatchResult::handled_with(vec![Effect::CancelConnectionTask])

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -23,7 +23,7 @@ pub(super) fn reduce_connection_error(
                 state.connection_error.clear_copied_feedback();
             }
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::handled()
+            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
         Action::ToggleConnectionErrorDetails => {
             state.connection_error.toggle_details();
@@ -75,7 +75,7 @@ pub(super) fn reduce_connection_error(
             state.session.cancel_connection_save();
             state.session.mark_disconnected();
             state.modal.replace_mode(InputMode::ConnectionSetup);
-            DispatchResult::handled()
+            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
         Action::RetryConnection => {
             if state.connection_error.is_save_and_connect_failure() {

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -6,6 +6,7 @@ use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::ConnectionTarget;
 use crate::update::action::{Action, ScrollAmount, ScrollDirection, ScrollTarget};
+use crate::update::connection::helpers::cancel_connection_task_effects;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn reduce_connection_error(
@@ -21,9 +22,9 @@ pub(super) fn reduce_connection_error(
                 state.connection_error.reset_view();
                 state.connection_error.clear_copied_feedback();
             }
-            state.session.clear_mysql_connection_probe();
+            let cancel_effects = cancel_connection_task_effects(state);
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
+            DispatchResult::handled_with(cancel_effects)
         }
         Action::ToggleConnectionErrorDetails => {
             state.connection_error.toggle_details();
@@ -73,10 +74,10 @@ pub(super) fn reduce_connection_error(
             }
             state.connection_error.clear();
             state.session.cancel_connection_save();
-            state.session.clear_mysql_connection_probe();
+            let cancel_effects = cancel_connection_task_effects(state);
             state.session.mark_disconnected();
             state.modal.replace_mode(InputMode::ConnectionSetup);
-            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
+            DispatchResult::handled_with(cancel_effects)
         }
         Action::RetryConnection => {
             if state.connection_error.is_save_and_connect_failure() {

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -103,6 +103,27 @@ pub(super) fn save_current_connection_cache(state: &mut AppState) {
     state.connection_caches.save(&current_id, cache);
 }
 
+pub(super) fn cancel_connection_task_effects(state: &mut AppState) -> Vec<Effect> {
+    let table_detail_retry =
+        state
+            .session
+            .retry_table_detail_after_probe_failure()
+            .map(|(dsn, generation, run_id)| Effect::FetchTableDetail {
+                dsn,
+                schema: state.query.pagination.schema().to_string(),
+                table: state.query.pagination.table().to_string(),
+                generation,
+                run_id,
+            });
+    state.session.clear_mysql_connection_probe();
+
+    let mut effects = vec![Effect::CancelConnectionTask];
+    if let Some(table_detail_retry) = table_detail_retry {
+        effects.push(table_detail_retry);
+    }
+    effects
+}
+
 pub(super) fn reset_active_connection_state(state: &mut AppState) {
     let inspector_tab = state.ui.inspector_tab();
     reset_state_before_connection_reconciliation(state);

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -16,8 +16,8 @@ use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, InputTarget, ModalKind,
 };
 use crate::update::connection::helpers::{
-    connection_save_fetch_effects, mysql_connection_completion_effects, reset_for_new_connection,
-    save_current_connection_cache,
+    cancel_connection_task_effects, connection_save_fetch_effects,
+    mysql_connection_completion_effects, reset_for_new_connection, save_current_connection_cache,
 };
 use crate::update::connection::lifecycle::try_connect;
 use crate::update::dispatch_result::DispatchResult;
@@ -32,23 +32,23 @@ pub fn reduce_connection_setup(
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
             state.session.cancel_connection_save_and_disconnect();
-            state.session.clear_mysql_connection_probe();
+            let cancel_effects = cancel_connection_task_effects(state);
             state.connection_setup.reset();
             if !state.connections().is_empty() || state.session.dsn().is_some() {
                 state.connection_setup.set_first_run(false);
             }
             state.modal.set_mode(InputMode::ConnectionSetup);
-            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
+            DispatchResult::handled_with(cancel_effects)
         }
         Action::StartEditConnection(id) => {
             DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
         }
         Action::ConnectionEditLoaded(profile) => {
             state.session.cancel_connection_save_and_disconnect();
-            state.session.clear_mysql_connection_probe();
+            let cancel_effects = cancel_connection_task_effects(state);
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
-            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
+            DispatchResult::handled_with(cancel_effects)
         }
         Action::ConnectionEditLoadFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
@@ -56,9 +56,9 @@ pub fn reduce_connection_setup(
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
             state.session.cancel_connection_save_and_disconnect();
-            state.session.clear_mysql_connection_probe();
+            let cancel_effects = cancel_connection_task_effects(state);
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
+            DispatchResult::handled_with(cancel_effects)
         }
 
         // ===== Clipboard Paste =====
@@ -233,7 +233,7 @@ pub fn reduce_connection_setup(
         }
         Action::ConnectionSetupCancel => {
             state.session.cancel_connection_save_and_disconnect();
-            state.session.clear_mysql_connection_probe();
+            let cancel_effects = cancel_connection_task_effects(state);
             if state.connection_setup.is_first_run() {
                 state.confirm_dialog.open(
                     "Confirm",
@@ -241,10 +241,10 @@ pub fn reduce_connection_setup(
                     ConfirmIntent::QuitNoConnection,
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
-                DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
+                DispatchResult::handled_with(cancel_effects)
             } else {
                 state.modal.set_mode(InputMode::Normal);
-                let mut effects = vec![Effect::CancelConnectionTask];
+                let mut effects = cancel_effects;
                 effects.extend(try_connect(state, now));
                 DispatchResult::handled_with(effects)
             }
@@ -1400,6 +1400,50 @@ mod tests {
             state
         }
 
+        fn state_with_interrupted_table_detail() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            let current_id = ConnectionId::from_string("mysql-current");
+            let target_id = ConnectionId::from_string("mysql-target");
+            state.session.activate_connection_with_target(
+                &current_id,
+                "mysql-current",
+                DatabaseType::MySQL,
+                "mysql://localhost/current",
+                Some("current"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let _ = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let _ = state.session.begin_table_detail_run();
+            let _ = state.session.begin_mysql_connection_probe(
+                &target_id,
+                "mysql-target",
+                "mysql://localhost/target",
+                Some("target"),
+            );
+            state
+        }
+
+        fn assert_table_detail_retry(effects: &[Effect]) {
+            assert!(matches!(
+                effects,
+                [
+                    Effect::CancelConnectionTask,
+                    Effect::FetchTableDetail {
+                        dsn,
+                        schema,
+                        table,
+                        ..
+                    }
+                ] if dsn == "mysql://localhost/current"
+                    && schema == "public"
+                    && table == "users"
+            ));
+        }
+
         #[test]
         fn opening_setup_clears_pending_probe() {
             let mut state = state_with_pending_mysql_probe();
@@ -1413,6 +1457,21 @@ mod tests {
 
             assert!(state.session.pending_mysql_connection_probe().is_none());
             assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
+        }
+
+        #[test]
+        fn opening_setup_retries_interrupted_table_detail() {
+            let mut state = state_with_interrupted_table_detail();
+
+            let effects = reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert_table_detail_retry(&effects);
         }
 
         #[test]
@@ -1431,6 +1490,21 @@ mod tests {
         }
 
         #[test]
+        fn loading_edit_retries_interrupted_table_detail() {
+            let mut state = state_with_interrupted_table_detail();
+
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionEditLoaded(Box::new(create_profile("edited"))),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert_table_detail_retry(&effects);
+        }
+
+        #[test]
         fn closing_setup_clears_pending_probe() {
             let mut state = state_with_pending_mysql_probe();
             state.modal.set_mode(InputMode::ConnectionSetup);
@@ -1444,6 +1518,22 @@ mod tests {
 
             assert!(state.session.pending_mysql_connection_probe().is_none());
             assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
+        }
+
+        #[test]
+        fn closing_setup_retries_interrupted_table_detail() {
+            let mut state = state_with_interrupted_table_detail();
+            state.modal.set_mode(InputMode::ConnectionSetup);
+
+            let effects = reduce(
+                &mut state,
+                &Action::CloseModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert_table_detail_retry(&effects);
         }
     }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -37,7 +37,7 @@ pub fn reduce_connection_setup(
                 state.connection_setup.set_first_run(false);
             }
             state.modal.set_mode(InputMode::ConnectionSetup);
-            DispatchResult::handled()
+            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
         Action::StartEditConnection(id) => {
             DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
@@ -46,7 +46,7 @@ pub fn reduce_connection_setup(
             state.session.cancel_connection_save_and_disconnect();
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
-            DispatchResult::handled()
+            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
         Action::ConnectionEditLoadFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
@@ -55,7 +55,7 @@ pub fn reduce_connection_setup(
         Action::CloseModal(ModalKind::ConnectionSetup) => {
             state.session.cancel_connection_save_and_disconnect();
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::handled()
+            DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
 
         // ===== Clipboard Paste =====
@@ -237,10 +237,12 @@ pub fn reduce_connection_setup(
                     ConfirmIntent::QuitNoConnection,
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
-                DispatchResult::handled()
+                DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
             } else {
                 state.modal.set_mode(InputMode::Normal);
-                DispatchResult::handled_with(try_connect(state, now))
+                let mut effects = vec![Effect::CancelConnectionTask];
+                effects.extend(try_connect(state, now));
+                DispatchResult::handled_with(effects)
             }
         }
         Action::ConnectionSaveCompleted {

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -32,6 +32,7 @@ pub fn reduce_connection_setup(
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
             state.session.cancel_connection_save_and_disconnect();
+            state.session.clear_mysql_connection_probe();
             state.connection_setup.reset();
             if !state.connections().is_empty() || state.session.dsn().is_some() {
                 state.connection_setup.set_first_run(false);
@@ -44,6 +45,7 @@ pub fn reduce_connection_setup(
         }
         Action::ConnectionEditLoaded(profile) => {
             state.session.cancel_connection_save_and_disconnect();
+            state.session.clear_mysql_connection_probe();
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
             DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
@@ -54,6 +56,7 @@ pub fn reduce_connection_setup(
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
             state.session.cancel_connection_save_and_disconnect();
+            state.session.clear_mysql_connection_probe();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled_with(vec![Effect::CancelConnectionTask])
         }
@@ -230,6 +233,7 @@ pub fn reduce_connection_setup(
         }
         Action::ConnectionSetupCancel => {
             state.session.cancel_connection_save_and_disconnect();
+            state.session.clear_mysql_connection_probe();
             if state.connection_setup.is_first_run() {
                 state.confirm_dialog.open(
                     "Confirm",
@@ -1378,6 +1382,68 @@ mod tests {
                     .get(&ConnectionField::Host),
                 Some(&"Must be 255 characters or less".to_string())
             );
+        }
+    }
+
+    mod connection_task_cancellation {
+        use super::*;
+
+        fn state_with_pending_mysql_probe() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql-pending");
+            let _ = state.session.begin_mysql_connection_probe(
+                &id,
+                "mysql",
+                "mysql://localhost/app",
+                Some("app"),
+            );
+            state
+        }
+
+        #[test]
+        fn opening_setup_clears_pending_probe() {
+            let mut state = state_with_pending_mysql_probe();
+
+            let effects = reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
+        }
+
+        #[test]
+        fn loading_edit_clears_pending_probe() {
+            let mut state = state_with_pending_mysql_probe();
+
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionEditLoaded(Box::new(create_profile("edited"))),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
+        }
+
+        #[test]
+        fn closing_setup_clears_pending_probe() {
+            let mut state = state_with_pending_mysql_probe();
+            state.modal.set_mode(InputMode::ConnectionSetup);
+
+            let effects = reduce(
+                &mut state,
+                &Action::CloseModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
         }
     }
 

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -30,10 +30,7 @@ pub(super) fn reduce_confirm_dialog(
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    DispatchResult::handled_with(vec![
-                        Effect::CancelSqliteDiagnostics,
-                        Effect::CancelTrackedTasks,
-                    ])
+                    DispatchResult::handled_with(vec![Effect::CancelTrackedTasks])
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
                     DispatchResult::handled_with(vec![Effect::DeleteConnection { id }])

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -606,10 +606,7 @@ mod tests {
 
                 assert!(state.should_quit);
                 assert!(state.confirm_dialog.intent().is_none());
-                assert!(matches!(
-                    effects.as_slice(),
-                    [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
-                ));
+                assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
             }
 
             #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -81,6 +81,8 @@ fn dispatch_enabled_action(
             vec![]
         }
         Action::Quit => {
+            state.session.cancel_connection_save_and_disconnect();
+            state.session.clear_mysql_connection_probe();
             state.should_quit = true;
             vec![Effect::CancelTrackedTasks]
         }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -84,7 +84,7 @@ fn dispatch_enabled_action(
             state.session.cancel_connection_save_and_disconnect();
             state.session.clear_mysql_connection_probe();
             state.should_quit = true;
-            vec![Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
+            vec![Effect::CancelTrackedTasks]
         }
         Action::Resize(w, h) => {
             state.ui.set_terminal_width(w);
@@ -224,10 +224,7 @@ mod tests {
             let effects = reduce(&mut state, Action::Quit, now, &AppServices::stub());
 
             assert!(state.should_quit);
-            assert!(matches!(
-                effects.as_slice(),
-                [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
-            ));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]
@@ -2155,10 +2152,7 @@ mod tests {
 
             assert!(state.should_quit);
             assert!(state.confirm_dialog.intent().is_none());
-            assert!(matches!(
-                effects.as_slice(),
-                [Effect::CancelSqliteDiagnostics, Effect::CancelTrackedTasks]
-            ));
+            assert!(matches!(effects.as_slice(), [Effect::CancelTrackedTasks]));
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2127,7 +2127,7 @@ mod tests {
                 state.confirm_dialog.intent(),
                 Some(&ConfirmIntent::QuitNoConnection)
             ));
-            assert!(effects.is_empty());
+            assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
         }
 
         #[test]
@@ -2145,7 +2145,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(effects.is_empty());
+            assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
         }
     }
 


### PR DESCRIPTION
## Summary
- Route SQLite, PostgreSQL, and MySQL SaveAndConnect through one connection task owner shared with MySQL probing.
- Publish PostgreSQL metadata cache only after the connection profile is saved successfully.
- Abort and await the connection task at connection lifecycle cancellation boundaries.

## Tests
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-elt009-target cargo test -p sabiql-app cmd::connection --lib
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-elt009-target cargo test -p sabiql-app cmd::runner::tests::connection_task_lifecycle --lib
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-elt009-target cargo check -p sabiql-app --lib
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-elt009-target cargo clippy -p sabiql-app --lib --tests -- -D warnings
- RUSTC_WRAPPER= CARGO_TARGET_DIR= scripts/lint_all.sh