### PR TITLE
refactor(mysql): centralize single-row marker validation

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -362,16 +362,18 @@ pub(super) fn validate_mysql_session_marker(
     result: &MySqlResultSet,
     marker: &str,
 ) -> Result<(), DbOperationError> {
-    if result.columns != [MYSQL_SESSION_MARKER_COLUMN]
-        || result.values.len() != 1
-        || result.values[0].len() != 1
-        || result.values[0][0].as_str() != Some(marker)
-    {
+    if !is_mysql_single_marker(result, MYSQL_SESSION_MARKER_COLUMN, marker) {
         return Err(DbOperationError::QueryFailed(
             "mysql read-only session marker did not match".to_string(),
         ));
     }
     Ok(())
+}
+
+pub(super) fn is_mysql_single_marker(result: &MySqlResultSet, column: &str, marker: &str) -> bool {
+    result.columns == [column]
+        && result.values.len() == 1
+        && matches!(result.values[0].as_slice(), [value] if value.as_str() == Some(marker))
 }
 
 pub(super) fn validate_mysql_session(
@@ -621,6 +623,68 @@ mod tests {
             validate_mysql_session(&mismatched_marker, "marker"),
             Err(DbOperationError::QueryFailed(details))
                 if details == "mysql read-only session marker did not match"
+        ));
+    }
+
+    #[test]
+    fn one_column_one_row_marker_requires_exact_shape_and_value() {
+        let make_result = |columns: &[&str], values: Vec<Vec<QueryValue>>| MySqlResultSet {
+            columns: columns.iter().map(|column| (*column).to_string()).collect(),
+            values,
+        };
+        let marker_value = || QueryValue::Text("marker".to_string());
+
+        assert!(is_mysql_single_marker(
+            &make_result(&["marker_column"], vec![vec![marker_value()]]),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(&[], vec![vec![marker_value()]]),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(
+                &["marker_column", "extra"],
+                vec![vec![marker_value(), marker_value()]],
+            ),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(&["marker_column"], vec![]),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(
+                &["marker_column"],
+                vec![vec![marker_value()], vec![marker_value()]],
+            ),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(&["marker_column"], vec![vec![]]),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(
+                &["marker_column"],
+                vec![vec![marker_value(), marker_value()]]
+            ),
+            "marker_column",
+            "marker",
+        ));
+        assert!(!is_mysql_single_marker(
+            &make_result(
+                &["marker_column"],
+                vec![vec![QueryValue::Text("other".to_string())]],
+            ),
+            "marker_column",
+            "marker",
         ));
     }
 

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -15,9 +15,9 @@ use crate::domain::{
 };
 
 use super::super::policy::{
-    MySqlExecutionResult, mysql_command_tag, mysql_metadata_fallback_has_unsupported_session_state,
-    mysql_possible_refresh_scope, mysql_refresh_scope, mysql_row_count_marker,
-    query_failed_after_change,
+    MySqlExecutionResult, is_mysql_single_marker, mysql_command_tag,
+    mysql_metadata_fallback_has_unsupported_session_state, mysql_possible_refresh_scope,
+    mysql_refresh_scope, mysql_row_count_marker, query_failed_after_change,
 };
 use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns_with_diagnostics;
@@ -289,11 +289,7 @@ async fn run_mysql_adhoc_process(
             last_result_set.as_ref(),
         ))
     } else {
-        if marker_result.columns != ["__sabiql_marker"]
-            || marker_result.values.len() != 1
-            || marker_result.values[0].len() != 1
-            || marker_result.values[0][0].as_str() != Some(marker.as_str())
-        {
+        if !is_mysql_single_marker(&marker_result, "__sabiql_marker", &marker) {
             return Err(query_failed_after_change(
                 DbOperationError::QueryFailed(
                     "mysql adhoc completion marker did not match".to_string(),

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -6,6 +6,7 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
 use super::super::super::option_file::MySqlOptionFile;
 use super::super::args::{mysql_metadata_session_args, mysql_query_args};
+use super::super::policy::is_mysql_single_marker;
 use super::super::probe::validate_lower_case_table_names;
 use super::super::xml::{MySqlResultSet, parse_mysql_preview_xml, parse_mysql_xml};
 use super::{
@@ -104,11 +105,11 @@ impl MySqlMetadataSession {
         normalize_empty_result_columns(&mut source_result, expected_columns);
         let marker_xml = read_one_mysql_resultset(&mut self.process).await?;
         let marker_result = parse_mysql_xml(&marker_xml)?;
-        if marker_result.columns != [MYSQL_INSPECTOR_COMPLETION_MARKER_COLUMN]
-            || marker_result.values.len() != 1
-            || marker_result.values[0].len() != 1
-            || marker_result.values[0][0].as_str() != Some(marker.as_str())
-        {
+        if !is_mysql_single_marker(
+            &marker_result,
+            MYSQL_INSPECTOR_COMPLETION_MARKER_COLUMN,
+            &marker,
+        ) {
             return Err(DbOperationError::QueryFailed(
                 "mysql inspector completion marker did not match".to_string(),
             ));
@@ -133,11 +134,11 @@ impl MySqlMetadataSession {
                 "SELECT '{marker}' AS {MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN}"
             ))
             .await?;
-        if marker_result.columns != [MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN]
-            || marker_result.values.len() != 1
-            || marker_result.values[0].len() != 1
-            || marker_result.values[0][0].as_str() != Some(marker.as_str())
-        {
+        if !is_mysql_single_marker(
+            &marker_result,
+            MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN,
+            &marker,
+        ) {
             return Err(DbOperationError::QueryFailed(
                 "mysql preview completion marker did not match".to_string(),
             ));


### PR DESCRIPTION
## Problem
MySQL marker frames repeat the same one-column, one-row, and value-match invariant across adhoc, session, and policy paths.

## Background
Each copy can drift while the surrounding callers need to retain their marker-specific diagnostics and error-stage handling.

## Approach
Centralize only the shared result-shape and marker-value predicate in the MySQL CLI policy layer, leaving marker names, diagnostics, and result-processing decisions at their callers. Add boundary coverage for empty, single, and multiple columns or rows, row-width mismatches, and marker mismatches.