### PR TITLE
refactor(app): remove redundant query completion DSN

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -100,7 +100,6 @@ pub async fn run(
                     {
                         Ok(result) => {
                             tx.send(Action::QueryCompleted {
-                                dsn,
                                 run_id,
                                 result: Arc::new(result),
                                 context: QueryCompletionContext::Preview {
@@ -113,7 +112,6 @@ pub async fn run(
                         }
                         Err(e) => {
                             tx.send(Action::QueryFailed {
-                                dsn,
                                 run_id,
                                 error: e,
                                 context: QueryFailureContext::Preview { generation },
@@ -213,7 +211,6 @@ pub async fn run(
                                 );
                             }
                             tx.send(Action::QueryCompleted {
-                                dsn,
                                 run_id,
                                 result: Arc::new(result),
                                 context: QueryCompletionContext::Adhoc,
@@ -233,7 +230,6 @@ pub async fn run(
                                 );
                             }
                             tx.send(Action::QueryFailed {
-                                dsn,
                                 run_id,
                                 error: e,
                                 context: QueryFailureContext::Adhoc,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -585,13 +585,11 @@ pub enum Action {
     ExecutePreview(TableTarget),
     ExecuteAdhoc(String),
     QueryCompleted {
-        dsn: String,
         run_id: u64,
         result: Arc<QueryResult>,
         context: QueryCompletionContext,
     },
     QueryFailed {
-        dsn: String,
         run_id: u64,
         error: DbOperationError,
         context: QueryFailureContext,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -30,12 +30,11 @@ pub fn reduce_execution(
 ) -> DispatchResult {
     match action {
         Action::QueryCompleted {
-            dsn,
             run_id,
             result,
             context,
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             if let QueryCompletionContext::Preview { generation, .. } = context
@@ -99,12 +98,11 @@ pub fn reduce_execution(
             DispatchResult::handled_with(try_adhoc_refresh(state, result, now))
         }
         Action::QueryFailed {
-            dsn,
             run_id,
             error,
             context,
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -566,7 +564,6 @@ mod tests {
     ) -> Action {
         let run_id = begin_query_run(state);
         Action::QueryFailed {
-            dsn: state.session.dsn().unwrap_or_default().to_string(),
             run_id,
             error,
             context: match source {
@@ -1273,7 +1270,6 @@ mod tests {
             dispatch_query(
                 &mut state,
                 &Action::QueryCompleted {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: old_run_id,
                     result: adhoc_result(),
                     context: QueryCompletionContext::Adhoc,
@@ -1282,6 +1278,33 @@ mod tests {
                 &AppServices::stub(),
             );
 
+            assert!(state.query.current_result().is_none());
+            assert!(state.query.is_running());
+        }
+
+        #[test]
+        fn same_dsn_reconnect_rejects_previous_query_completion_by_run_id() {
+            let mut state = create_test_state();
+            let stale_run_id = begin_query_run(&mut state);
+
+            state.session.reset(&mut state.query);
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "postgres",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
+            let current_run_id = begin_query_run(&mut state);
+
+            let action = Action::QueryCompleted {
+                run_id: stale_run_id,
+                result: adhoc_result(),
+                context: QueryCompletionContext::Adhoc,
+            };
+            assert!(!format!("{action:?}").contains("dsn:"));
+            dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub());
+
+            assert!(stale_run_id < current_run_id);
             assert!(state.query.current_result().is_none());
             assert!(state.query.is_running());
         }
@@ -1297,7 +1320,6 @@ mod tests {
             dispatch_query(
                 &mut state,
                 &Action::QueryCompleted {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: stale_run_id,
                     result: adhoc_result(),
                     context: QueryCompletionContext::Adhoc,

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -96,7 +96,6 @@ pub(super) mod tests {
     ) -> Action {
         let run_id = begin_query_run(state);
         Action::QueryCompleted {
-            dsn: active_dsn(state),
             run_id,
             result,
             context: match target_page {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -3176,7 +3176,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::QueryCompleted {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     result,
                     context: QueryCompletionContext::Preview {


### PR DESCRIPTION
## Problem
Query completion and failure actions carry a DSN that duplicates the query run identity used by the reducer.

## Background
Query run IDs are monotonic across connection context resets, so the duplicate DSN does not add freshness information.

## Approach
Use the query-owned run ID as the sole freshness check for completion and failure actions while retaining DSNs on execution effects and all other DSN-scoped response actions.