### PR TITLE
refactor(app): remove unreachable MySQL metadata save arm

### DIFF
--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -309,9 +309,6 @@ pub fn reduce_connection_setup(
                         error, dsn,
                     ))
                 }
-                ConnectionSaveError::Metadata(error) if *database_type == DatabaseType::MySQL => {
-                    Some(ConnectionErrorInfo::from_db_operation_error(error))
-                }
                 _ => None,
             };
             if let Some(error_info) = mysql_error {


### PR DESCRIPTION
## Problem
The setup reducer handles `ConnectionSaveError::Metadata` as a MySQL connection failure even though the MySQL SaveAndConnect path never produces that error variant.

## Background
Metadata save errors are produced by the PostgreSQL metadata path. MySQL uses its dedicated probe path and reports persistence failures as store errors.

## Approach
Remove the unreachable MySQL-only reducer arm while preserving the shared error type, PostgreSQL metadata handling, and all MySQL/SQLite save failure paths.

## Validation
- `cargo test -p sabiql-app update::connection::setup`
- `cargo test -p sabiql-app cmd::connection::tests::save_connection`
- `cargo test -p sabiql-app save_failed_sets_error_message`
- `cargo check -p sabiql-app --all-targets`
- `cargo clippy -p sabiql-app --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR= scripts/lint_all.sh`