### PR TITLE
refactor(error): type SQLite compatibility failures

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,8 +1,8 @@
 use crate::policy::password_masking::mask_password;
 use crate::policy::sqlite_path::connection_error_kind;
 use crate::ports::outbound::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
-    SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, SqliteCompatibilityKind,
+    UnsupportedOperationKind,
 };
 use sabiql_domain::connection::MySqlSslMode;
 use url::Url;
@@ -165,12 +165,10 @@ impl ConnectionErrorInfo {
             DbOperationError::UnsupportedOperationWithKind { kind, .. } => {
                 ConnectionErrorKind::MySqlUnsupportedOperation(*kind)
             }
-            DbOperationError::UnsupportedOperation(details)
-                if details.contains(SQLITE_TABLE_LIST_REQUIRED_MARKER)
-                    || details.contains(SQLITE_SAFE_MODE_REQUIRED_MARKER) =>
-            {
-                ConnectionErrorKind::SqliteVersionTooOld
-            }
+            DbOperationError::UnsupportedOperationWithSqliteKind {
+                kind: SqliteCompatibilityKind::SafeMode | SqliteCompatibilityKind::TableList,
+                ..
+            } => ConnectionErrorKind::SqliteVersionTooOld,
             DbOperationError::ConnectionFailedWithKind { kind, .. } => match kind {
                 ConnectionFailureKind::HostUnreachable => ConnectionErrorKind::HostUnreachable,
                 ConnectionFailureKind::Auth => ConnectionErrorKind::AuthFailed,
@@ -552,28 +550,49 @@ mod tests {
         }
 
         #[test]
-        fn from_db_operation_error_classifies_sqlite_table_list_requirement() {
+        fn from_db_operation_error_classifies_typed_sqlite_table_list_requirement() {
             let info = ConnectionErrorInfo::from_db_operation_error(
-                &DbOperationError::UnsupportedOperation(format!(
-                    "{SQLITE_TABLE_LIST_REQUIRED_MARKER}: upgrade sqlite3"
-                )),
+                &DbOperationError::UnsupportedOperationWithSqliteKind {
+                    kind: SqliteCompatibilityKind::TableList,
+                    details: "upgrade sqlite3 to version 3.41.1 or later".to_string(),
+                },
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
             assert_eq!(info.kind.summary(), "SQLite 3.41.1 or later required");
+            assert_eq!(
+                info.masked_details(),
+                "upgrade sqlite3 to version 3.41.1 or later"
+            );
         }
 
         #[test]
-        fn from_db_operation_error_classifies_sqlite_safe_mode_requirement() {
+        fn from_db_operation_error_classifies_typed_sqlite_safe_mode_requirement() {
             let info = ConnectionErrorInfo::from_db_operation_error(
-                &DbOperationError::UnsupportedOperation(format!(
-                    "{SQLITE_SAFE_MODE_REQUIRED_MARKER}: sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)"
-                )),
+                &DbOperationError::UnsupportedOperationWithSqliteKind {
+                    kind: SqliteCompatibilityKind::SafeMode,
+                    details: "sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)".to_string(),
+                },
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
             assert_eq!(info.kind.summary(), "SQLite 3.41.1 or later required");
             assert_eq!(info.kind.hint(), "Upgrade sqlite3 to use SQLite safely");
+            assert_eq!(
+                info.masked_details(),
+                "sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)"
+            );
+        }
+
+        #[test]
+        fn marker_like_unsupported_operation_stays_unknown() {
+            let info = ConnectionErrorInfo::from_db_operation_error(
+                &DbOperationError::UnsupportedOperation(
+                    "SQLITE_SAFE_MODE_REQUIRED: sqlite3 3.41.1".to_string(),
+                ),
+            );
+
+            assert_eq!(info.kind, ConnectionErrorKind::Unknown);
         }
     }
 

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use crate::domain::{RefreshScope, SqlitePathError};
 use crate::policy::password_masking::mask_password;
 
-pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
-pub const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str = "SQLITE_SAFE_MODE_REQUIRED";
 pub const MYSQL_CONNECT_TIMEOUT_ERRNOS: &[&str] = &["(60)", "(110)", "(10060)"];
 
 pub fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
@@ -75,6 +73,12 @@ impl UnsupportedOperationKind {
             ),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqliteCompatibilityKind {
+    SafeMode,
+    TableList,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -156,6 +160,11 @@ pub enum DbOperationError {
     #[error("Unsupported operation")]
     UnsupportedOperationWithKind {
         kind: UnsupportedOperationKind,
+        details: String,
+    },
+    #[error("Unsupported operation")]
+    UnsupportedOperationWithSqliteKind {
+        kind: SqliteCompatibilityKind,
         details: String,
     },
     #[error("Connection failed")]
@@ -254,7 +263,7 @@ impl DbOperationError {
                 "Reduce the preview value size and retry",
             ),
             Self::QueryFailedAfterChange { source, .. } => source.presentation(),
-            Self::UnsupportedOperation(_) => (
+            Self::UnsupportedOperation(_) | Self::UnsupportedOperationWithSqliteKind { .. } => (
                 "Unsupported operation",
                 "Use a supported operation for this database",
             ),
@@ -358,6 +367,7 @@ impl DbOperationError {
             | Self::PreviewSizeExceeded(details)
             | Self::UnsupportedOperation(details)
             | Self::UnsupportedOperationWithKind { details, .. }
+            | Self::UnsupportedOperationWithSqliteKind { details, .. }
             | Self::ConnectionFailedWithKind { details, .. }
             | Self::MetadataParseFailed(details)
             | Self::EmptyResponse(details)
@@ -452,6 +462,10 @@ mod tests {
         #[case(DbOperationError::UnsupportedOperation("boom".to_string()))]
         #[case(DbOperationError::UnsupportedOperationWithKind {
             kind: UnsupportedOperationKind::ClientVersion,
+            details: "boom".to_string(),
+        })]
+        #[case(DbOperationError::UnsupportedOperationWithSqliteKind {
+            kind: SqliteCompatibilityKind::SafeMode,
             details: "boom".to_string(),
         })]
         #[case(DbOperationError::ConnectionFailedWithKind {

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -32,9 +32,8 @@ pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, ExportIoSource,
-    MYSQL_CONNECT_TIMEOUT_ERRNOS, SQLITE_SAFE_MODE_REQUIRED_MARKER,
-    SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind, is_mysql_connect_timeout_message,
-    mysql_server_error_code,
+    MYSQL_CONNECT_TIMEOUT_ERRNOS, SqliteCompatibilityKind, UnsupportedOperationKind,
+    is_mysql_connect_timeout_message, mysql_server_error_code,
 };
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/infra/adapters/sqlite/metadata/catalog_tests.rs
+++ b/src/infra/adapters/sqlite/metadata/catalog_tests.rs
@@ -1,6 +1,4 @@
-use crate::app::ports::outbound::{
-    DbOperationError, MetadataProvider, SQLITE_SAFE_MODE_REQUIRED_MARKER,
-};
+use crate::app::ports::outbound::{DbOperationError, MetadataProvider, SqliteCompatibilityKind};
 use crate::domain::{Schema, SqlitePathError, TableKind, TableKindInfo};
 
 use super::super::super::sqlite3::metadata::RawTable;
@@ -49,8 +47,12 @@ mod metadata {
             std::env::var_os("SABIQL_EXPECT_SQLITE_SAFE_MODE_REJECTION").is_some();
 
         match adapter.fetch_metadata(&dsn).await {
-            Err(DbOperationError::UnsupportedOperation(details)) if expects_rejection => {
-                assert!(details.contains(SQLITE_SAFE_MODE_REQUIRED_MARKER));
+            Err(DbOperationError::UnsupportedOperationWithSqliteKind {
+                kind: SqliteCompatibilityKind::SafeMode,
+                details,
+            }) if expects_rejection => {
+                assert!(details.contains("3.41.1"));
+                assert!(!details.contains("SQLITE_SAFE_MODE_REQUIRED"));
             }
             Ok(_) if !expects_rejection => {}
             result => panic!("unexpected SQLite safe mode connection result: {result:?}"),

--- a/src/infra/adapters/sqlite/sql/metadata.rs
+++ b/src/infra/adapters/sqlite/sql/metadata.rs
@@ -1,4 +1,4 @@
-use crate::app::ports::outbound::{DbOperationError, SQLITE_TABLE_LIST_REQUIRED_MARKER};
+use crate::app::ports::outbound::{DbOperationError, SqliteCompatibilityKind};
 
 use super::literal::{quote_ident, quote_literal};
 
@@ -71,10 +71,12 @@ pub(in crate::adapters::sqlite) fn has_virtual_tables_query() -> &'static str {
 }
 
 pub(in crate::adapters::sqlite) fn table_list_required_error() -> DbOperationError {
-    DbOperationError::UnsupportedOperation(format!(
-        "{SQLITE_TABLE_LIST_REQUIRED_MARKER}: This database contains virtual tables (such as FTS or RTree). \
-         Upgrade sqlite3 to version 3.41.1 or later to browse it safely."
-    ))
+    DbOperationError::UnsupportedOperationWithSqliteKind {
+        kind: SqliteCompatibilityKind::TableList,
+        details: "This database contains virtual tables (such as FTS or RTree). \
+                  Upgrade sqlite3 to version 3.41.1 or later to browse it safely."
+            .to_string(),
+    }
 }
 
 pub(in crate::adapters::sqlite) fn is_table_list_unavailable(error: &str) -> bool {
@@ -303,11 +305,20 @@ mod tests {
         }
 
         #[test]
-        fn table_list_required_error_includes_marker_and_upgrade_guidance() {
+        fn table_list_required_error_keeps_upgrade_guidance_without_marker() {
             let error = table_list_required_error();
             let message = error.user_message();
-            assert!(message.contains(SQLITE_TABLE_LIST_REQUIRED_MARKER));
+            assert_eq!(error.summary(), "Unsupported operation");
+            assert_eq!(error.hint(), "Use a supported operation for this database");
             assert!(message.contains("3.41.1"));
+            assert!(!message.contains("SQLITE_TABLE_LIST_REQUIRED"));
+            assert!(matches!(
+                error,
+                DbOperationError::UnsupportedOperationWithSqliteKind {
+                    kind: SqliteCompatibilityKind::TableList,
+                    ..
+                }
+            ));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -8,9 +8,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::adapters::csv_export::CsvOutputError;
-use crate::app::ports::outbound::{
-    DbOperationError, ExportIoSource, SQLITE_SAFE_MODE_REQUIRED_MARKER,
-};
+use crate::app::ports::outbound::{DbOperationError, ExportIoSource, SqliteCompatibilityKind};
 
 use super::super::path_validation;
 use super::error::{classify_cli_spawn_error, classify_query_error};
@@ -435,9 +433,12 @@ impl SqliteVersion {
 }
 
 fn safe_mode_required_error(details: &str) -> DbOperationError {
-    DbOperationError::UnsupportedOperation(format!(
-        "{SQLITE_SAFE_MODE_REQUIRED_MARKER}: sqlite3 3.41.1 or later is required for safe SQLite execution ({details})"
-    ))
+    DbOperationError::UnsupportedOperationWithSqliteKind {
+        kind: SqliteCompatibilityKind::SafeMode,
+        details: format!(
+            "sqlite3 3.41.1 or later is required for safe SQLite execution ({details})"
+        ),
+    }
 }
 
 async fn write_sql_to_stdin(
@@ -614,6 +615,22 @@ mod tests {
         fn safe_mode_requires_sqlite_3_41_1_or_later() {
             assert!(SqliteVersion::new(3, 41, 0) < SQLITE_SAFE_MODE_MIN_VERSION);
             assert!(SqliteVersion::new(3, 41, 1) >= SQLITE_SAFE_MODE_MIN_VERSION);
+        }
+
+        #[test]
+        fn safe_mode_required_error_keeps_details_without_marker() {
+            let error = safe_mode_required_error("found sqlite3 3.41.0");
+
+            assert!(matches!(
+                &error,
+                DbOperationError::UnsupportedOperationWithSqliteKind {
+                    kind: SqliteCompatibilityKind::SafeMode,
+                    details,
+                    } if details == "sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)"
+            ));
+            assert_eq!(error.summary(), "Unsupported operation");
+            assert_eq!(error.hint(), "Use a supported operation for this database");
+            assert!(!error.user_message().contains("SQLITE_SAFE_MODE_REQUIRED"));
         }
 
         #[test]


### PR DESCRIPTION
## Problem
SQLite compatibility failures encode the client requirement in details and reconstruct it later with substring matching.

## Background
The safe-mode and virtual-table metadata paths need the same SQLite client version requirement, while their reasons and legacy catalog fallback remain distinct.

## Approach
Carry the safe-mode and table-list requirements as typed SQLite compatibility kinds in the existing database operation error carrier. Preserve the existing version requirement, connection presentation, human-readable details, and legacy catalog fallback without exposing marker strings.