### PR TITLE
refactor(mysql): classify TLS failures in adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,7 +2811,6 @@ dependencies = [
  "toml",
  "unicode-casefold",
  "unicode-width",
- "url",
  "uuid",
 ]
 

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -23,7 +23,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
-url.workspace = true
 unicode-casefold.workspace = true
 unicode-width.workspace = true
 sabiql-domain.workspace = true

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -4,8 +4,6 @@ use crate::ports::outbound::{
     ConnectionFailureKind, DatabaseCli, DbOperationError, SqliteCompatibilityKind,
     UnsupportedOperationKind,
 };
-use sabiql_domain::connection::MySqlSslMode;
-use url::Url;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConnectionErrorKind {
@@ -117,19 +115,6 @@ impl ConnectionErrorKind {
     }
 }
 
-fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
-    let url = Url::parse(dsn).ok()?;
-    if url.scheme() != "mysql" {
-        return None;
-    }
-    url.query_pairs().find_map(|(key, value)| {
-        if key != "ssl-mode" {
-            return None;
-        }
-        value.parse().ok()
-    })
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionErrorInfo {
     pub kind: ConnectionErrorKind,
@@ -186,35 +171,6 @@ impl ConnectionErrorInfo {
             _ => ConnectionErrorKind::Unknown,
         };
         Self::with_kind(kind, raw_details)
-    }
-
-    pub fn from_db_operation_error_with_dsn(error: &DbOperationError, dsn: &str) -> Self {
-        let mut info = Self::from_db_operation_error(error);
-        info.kind = mysql_ssl_mode_from_dsn(dsn)
-            .and_then(|ssl_mode| match (ssl_mode, error) {
-                (
-                    MySqlSslMode::VerifyCa,
-                    DbOperationError::ConnectionFailedWithKind {
-                        kind: ConnectionFailureKind::TlsCertificateVerification,
-                        ..
-                    },
-                ) => Some(ConnectionErrorKind::MySqlConnectionFailure(
-                    ConnectionFailureKind::TlsCaVerification,
-                )),
-                (
-                    MySqlSslMode::VerifyIdentity,
-                    DbOperationError::ConnectionFailedWithKind {
-                        kind: ConnectionFailureKind::TlsCertificateVerification,
-                        ..
-                    },
-                ) => Some(ConnectionErrorKind::MySqlConnectionFailure(
-                    ConnectionFailureKind::TlsHostnameVerification,
-                )),
-                _ => None,
-            })
-            .unwrap_or(info.kind);
-
-        info
     }
 
     pub fn masked_details(&self) -> &str {
@@ -324,35 +280,6 @@ mod tests {
         }
 
         #[test]
-        fn from_db_operation_error_with_dsn_uses_mysql_tls_mode_for_ambiguous_verification() {
-            let error = DbOperationError::ConnectionFailedWithKind {
-                kind: ConnectionFailureKind::TlsCertificateVerification,
-                details: "certificate verification failed".to_string(),
-            };
-            let ca = ConnectionErrorInfo::from_db_operation_error_with_dsn(
-                &error,
-                "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_CA",
-            );
-            let identity = ConnectionErrorInfo::from_db_operation_error_with_dsn(
-                &error,
-                "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_IDENTITY",
-            );
-
-            assert_eq!(
-                ca.kind,
-                ConnectionErrorKind::MySqlConnectionFailure(
-                    ConnectionFailureKind::TlsCaVerification
-                )
-            );
-            assert_eq!(
-                identity.kind,
-                ConnectionErrorKind::MySqlConnectionFailure(
-                    ConnectionFailureKind::TlsHostnameVerification
-                )
-            );
-        }
-
-        #[test]
         fn from_db_operation_error_preserves_connection_lost_kind() {
             let info = ConnectionErrorInfo::from_db_operation_error(
                 &DbOperationError::ConnectionLost("connection to server was lost".to_string()),
@@ -454,6 +381,12 @@ mod tests {
         #[case(
             ConnectionFailureKind::TlsHandshake,
             ConnectionErrorKind::MySqlConnectionFailure(ConnectionFailureKind::TlsHandshake)
+        )]
+        #[case(
+            ConnectionFailureKind::TlsCertificateVerification,
+            ConnectionErrorKind::MySqlConnectionFailure(
+                ConnectionFailureKind::TlsCertificateVerification
+            )
         )]
         #[case(
             ConnectionFailureKind::TlsCaVerification,

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -112,7 +112,7 @@ pub(super) fn reduce_loading(
                 return DispatchResult::handled();
             }
 
-            let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(error, dsn);
+            let error_info = ConnectionErrorInfo::from_db_operation_error(error);
             state.connection_error.set_error(error_info);
             let was_connected = state.session.connection_state().is_connected();
             state.session.mark_connection_failed();

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -185,9 +185,9 @@ pub fn reduce_connection_lifecycle(
                     .mark_table_detail_probe_failed(&target.dsn, message);
                 state.session.mark_connection_failed();
             }
-            state.connection_error.set_connection_switch_error(
-                ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
-            );
+            state
+                .connection_error
+                .set_connection_switch_error(ConnectionErrorInfo::from_db_operation_error(error));
             state.modal.replace_mode(InputMode::ConnectionError);
             DispatchResult::handled_with(table_detail_retry.into_iter().collect())
         }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -305,9 +305,7 @@ pub fn reduce_connection_setup(
                 ConnectionSaveError::Probe { error, dsn }
                     if *database_type == DatabaseType::MySQL =>
                 {
-                    Some(ConnectionErrorInfo::from_db_operation_error_with_dsn(
-                        error, dsn,
-                    ))
+                    Some(ConnectionErrorInfo::from_db_operation_error(error))
                 }
                 _ => None,
             };
@@ -634,7 +632,6 @@ mod tests {
         use std::sync::Arc;
 
         use super::*;
-        use crate::domain::connection::MySqlSslMode;
         use crate::domain::{
             DatabaseMetadata, MetadataState, QueryResult, QuerySource, TableSummary,
         };
@@ -743,19 +740,17 @@ mod tests {
         }
 
         #[test]
-        fn mysql_probe_failure_uses_tls_mode_to_classify_hostname_verification() {
+        fn mysql_probe_failure_preserves_adapter_tls_classification() {
             let mut state = AppState::new("test".to_string());
             state
                 .connection_setup
                 .set_database_type(DatabaseType::MySQL);
-            state.connection_setup.mysql_ssl_mode = MySqlSslMode::VerifyIdentity;
 
             let error = DbOperationError::ConnectionFailedWithKind {
-                kind: ConnectionFailureKind::TlsCertificateVerification,
+                kind: ConnectionFailureKind::TlsHostnameVerification,
                 details: "certificate verification failed".to_string(),
             };
-            let dsn =
-                "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_IDENTITY".to_string();
+            let dsn = "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED".to_string();
             let run_id = state.session.begin_connection_save();
 
             reduce(

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -13,7 +13,10 @@ use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use tokio::io::{AsyncRead, BufReader, ReadBuf};
 
-use super::super::{dsn::MySqlDsn, option_file::MySqlOptionFile};
+use super::super::{
+    dsn::{MySqlDsn, map_mysql_tls_failure},
+    option_file::MySqlOptionFile,
+};
 use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli_error};
 #[cfg(not(unix))]
 use super::pipe::MySqlExportPipeSource;
@@ -349,13 +352,14 @@ pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
 ) -> Result<(), DbOperationError> {
     let option_file = MySqlOptionFile::create(&target)?;
     let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
-    run_mysql_process_with_timeout(
+    let result = run_mysql_process_with_timeout(
         MYSQL_EXPORT_TIMEOUT,
         &mut process,
         RefreshScope::None,
         async |process| run_mysql_export_process(process, &option_file.path, query, path).await,
     )
-    .await
+    .await;
+    result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
 }
 
 pub(super) async fn run_mysql_export_process(

--- a/src/infra/adapters/mysql/connection.rs
+++ b/src/infra/adapters/mysql/connection.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use super::adapter::MySqlAdapter;
 use super::cli::check_mysql_cli_version;
-use super::dsn::parse_and_validate_mysql_dsn;
+use super::dsn::{map_mysql_tls_failure, parse_and_validate_mysql_dsn};
 use super::option_file::MySqlOptionFile;
 
 #[async_trait]
@@ -17,6 +17,6 @@ impl MySqlConnectionProbe for MySqlAdapter {
         let option_file = MySqlOptionFile::create(&target)?;
         let result = super::cli::probe_mysql_server(&option_file.path).await;
         drop(option_file);
-        result
+        result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
     }
 }

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -1,8 +1,8 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use url::Url;
 
-use crate::app::ports::outbound::{DbOperationError, DsnBuilder};
+use crate::app::ports::outbound::{ConnectionFailureKind, DbOperationError, DsnBuilder};
 use crate::domain::connection::{
     ConnectionProfile, MySqlConnectionConfig, MySqlSslMode, MySqlTransport,
 };
@@ -198,6 +198,35 @@ pub(super) fn parse_and_validate_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOper
     Ok(target)
 }
 
+pub(super) fn map_mysql_tls_failure(
+    error: DbOperationError,
+    ssl_mode: MySqlSslMode,
+) -> DbOperationError {
+    match error {
+        DbOperationError::QueryFailedAfterChange {
+            source,
+            refresh_scope,
+        } => DbOperationError::QueryFailedAfterChange {
+            source: Arc::new(map_mysql_tls_failure((*source).clone(), ssl_mode)),
+            refresh_scope,
+        },
+        DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::TlsCertificateVerification,
+            details,
+        } => {
+            let kind = match ssl_mode {
+                MySqlSslMode::VerifyCa => ConnectionFailureKind::TlsCaVerification,
+                MySqlSslMode::VerifyIdentity => ConnectionFailureKind::TlsHostnameVerification,
+                MySqlSslMode::Disabled | MySqlSslMode::Preferred | MySqlSslMode::Required => {
+                    ConnectionFailureKind::TlsCertificateVerification
+                }
+            };
+            DbOperationError::ConnectionFailedWithKind { kind, details }
+        }
+        error => error,
+    }
+}
+
 pub(super) fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperationError> {
     let values = [
         Some(target.host.as_str()),
@@ -316,6 +345,7 @@ fn decode_url_component(value: &str) -> Result<String, DbOperationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::RefreshScope;
 
     #[test]
     fn builds_and_parses_mysql_dsn_with_encoded_components() {
@@ -348,6 +378,100 @@ mod tests {
             DbOperationError::ConnectionFailed(details)
                 if details == "Invalid MySQL TLS mode" && !details.contains("secret")
         ));
+    }
+
+    #[test]
+    fn maps_ambiguous_tls_certificate_failures_from_the_parsed_ssl_mode() {
+        for (ssl_mode, expected_kind) in [
+            (
+                MySqlSslMode::Preferred,
+                ConnectionFailureKind::TlsCertificateVerification,
+            ),
+            (
+                MySqlSslMode::Required,
+                ConnectionFailureKind::TlsCertificateVerification,
+            ),
+            (
+                MySqlSslMode::VerifyCa,
+                ConnectionFailureKind::TlsCaVerification,
+            ),
+            (
+                MySqlSslMode::VerifyIdentity,
+                ConnectionFailureKind::TlsHostnameVerification,
+            ),
+        ] {
+            let error = map_mysql_tls_failure(
+                DbOperationError::ConnectionFailedWithKind {
+                    kind: ConnectionFailureKind::TlsCertificateVerification,
+                    details: "certificate verification failed".to_string(),
+                },
+                ssl_mode,
+            );
+
+            assert!(matches!(
+                error,
+                DbOperationError::ConnectionFailedWithKind { kind, .. } if kind == expected_kind
+            ));
+        }
+    }
+
+    #[test]
+    fn leaves_non_tls_and_untyped_failures_unchanged() {
+        let error = DbOperationError::ConnectionFailed("hostname mismatch".to_string());
+        assert!(matches!(
+            map_mysql_tls_failure(error, MySqlSslMode::VerifyIdentity),
+            DbOperationError::ConnectionFailed(details) if details == "hostname mismatch"
+        ));
+
+        let error = DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::TlsHandshake,
+            details: "handshake failure".to_string(),
+        };
+        assert!(matches!(
+            map_mysql_tls_failure(error, MySqlSslMode::VerifyCa),
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::TlsHandshake,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn maps_wrapped_tls_failures_for_write_refreshes() {
+        for (ssl_mode, expected_kind) in [
+            (
+                MySqlSslMode::VerifyCa,
+                ConnectionFailureKind::TlsCaVerification,
+            ),
+            (
+                MySqlSslMode::VerifyIdentity,
+                ConnectionFailureKind::TlsHostnameVerification,
+            ),
+        ] {
+            let error = DbOperationError::QueryFailedAfterChange {
+                source: Arc::new(DbOperationError::ConnectionFailedWithKind {
+                    kind: ConnectionFailureKind::TlsCertificateVerification,
+                    details: "certificate verification failed".to_string(),
+                }),
+                refresh_scope: RefreshScope::Data,
+            };
+
+            let mapped = map_mysql_tls_failure(error, ssl_mode);
+            match mapped {
+                DbOperationError::QueryFailedAfterChange {
+                    source,
+                    refresh_scope,
+                } => {
+                    assert_eq!(refresh_scope, RefreshScope::Data);
+                    assert!(matches!(
+                        source.as_ref(),
+                        DbOperationError::ConnectionFailedWithKind { kind, .. }
+                            if *kind == expected_kind
+                    ));
+                }
+                _ => panic!("TLS failure wrapper was not preserved"),
+            }
+        }
     }
 
     #[test]

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -13,7 +13,7 @@ use super::cli::{
     validate_mysql_export_query, validate_mysql_multi_query,
     validate_mysql_multi_query_with_lower_case_table_names,
 };
-use super::dsn::{MySqlDsn, parse_and_validate_mysql_dsn};
+use super::dsn::{MySqlDsn, map_mysql_tls_failure, parse_and_validate_mysql_dsn};
 use super::metadata;
 use super::option_file::MySqlOptionFile;
 
@@ -31,7 +31,7 @@ async fn execute_adhoc_with_target(
         let option_file = MySqlOptionFile::create(target)?;
         let result = run_mysql_single_statement(&option_file.path, query, access_mode).await;
         drop(option_file);
-        let execution = result?;
+        let execution = result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
         let result_set = execution.result_set.ok_or_else(|| {
             DbOperationError::QueryFailed("MySQL TREE EXPLAIN returned no resultset".to_string())
         })?;
@@ -47,7 +47,8 @@ async fn execute_adhoc_with_target(
 
     let option_file = MySqlOptionFile::create(target)?;
     let lower_case_table_names = probe_mysql_server(&option_file.path)
-        .await?
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?
         .lower_case_table_names;
     let statements = validate_mysql_multi_query_with_lower_case_table_names(
         query,
@@ -63,7 +64,7 @@ async fn execute_adhoc_with_target(
     let start = Instant::now();
     let result = run_mysql_adhoc(&option_file.path, &statements, access_mode).await;
     drop(option_file);
-    let execution = result?;
+    let execution = result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
     let elapsed = start.elapsed().as_millis() as u64;
     let mut result = match execution.result_set {
         Some(result_set) => QueryResult::success_with_values(
@@ -160,7 +161,7 @@ impl QueryExecutor for MySqlAdapter {
         let option_file = MySqlOptionFile::create(&target)?;
         let result = run_mysql_adhoc(&option_file.path, &statements, access_mode).await;
         drop(option_file);
-        let execution = result?;
+        let execution = result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
         let affected_rows = execution
             .command_tag
             .and_then(|tag| tag.affected_rows())

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -10,7 +10,7 @@ use crate::domain::{
 
 use super::super::{
     cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
-    dsn::MySqlDsn,
+    dsn::{MySqlDsn, map_mysql_tls_failure},
     option_file::MySqlOptionFile,
     sql::{
         COLUMN_METADATA_BASE_RESULT_COLUMNS, COLUMN_METADATA_RESULT_COLUMNS,
@@ -200,7 +200,10 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
         Ok((lower_case_table_names, results))
     })
     .await;
-    session.resolve_timed_result(result).await
+    session
+        .resolve_timed_result(result)
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
 }
 
 pub(super) fn selected_database(target: &MySqlDsn) -> Result<&str, DbOperationError> {

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -9,7 +9,7 @@ use super::super::{
         MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet,
         validate_mysql_multi_query_with_lower_case_table_names,
     },
-    dsn::parse_and_validate_mysql_dsn,
+    dsn::{map_mysql_tls_failure, parse_and_validate_mysql_dsn},
     option_file::MySqlOptionFile,
     sql::{
         PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, build_preview_query, preview_columns_query,
@@ -77,7 +77,10 @@ async fn execute_preview_with_program(
         execute_preview_with_session(&mut session, database, schema, table, limit, offset),
     )
     .await;
-    session.resolve_timed_result(result).await
+    session
+        .resolve_timed_result(result)
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
 }
 
 async fn execute_preview_with_session(

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -16,7 +16,7 @@ use super::super::sql::{
 };
 use super::super::{
     cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
-    dsn::parse_and_validate_mysql_dsn,
+    dsn::{map_mysql_tls_failure, parse_and_validate_mysql_dsn},
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
@@ -127,7 +127,10 @@ async fn fetch_table_detail_with_program(
         fetch_table_detail_with_session(&mut session, database, schema, table),
     )
     .await;
-    session.resolve_timed_result(result).await
+    session
+        .resolve_timed_result(result)
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
 }
 
 async fn fetch_table_detail_with_session(

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -180,7 +180,7 @@ mod connection {
         let adapter = MySqlAdapter::new();
         let dsn = adapter.build_dsn(&profile);
         let error = adapter.probe(&dsn).await.unwrap_err();
-        let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn);
+        let error_info = ConnectionErrorInfo::from_db_operation_error(&error);
         assert_eq!(
             error_info.kind,
             ConnectionErrorKind::AuthFailed,
@@ -204,7 +204,7 @@ mod connection {
         let dsn = adapter.build_dsn(&profile);
         let error = adapter.probe(&dsn).await.unwrap_err();
         assert_eq!(
-            ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn).kind,
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
             ConnectionErrorKind::MySqlConnectionFailure(ConnectionFailureKind::TlsCaVerification)
         );
     }
@@ -219,7 +219,7 @@ mod connection {
         let adapter = MySqlAdapter::new();
         let dsn = adapter.build_dsn(&profile);
         let error = adapter.probe(&dsn).await.unwrap_err();
-        let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn);
+        let error_info = ConnectionErrorInfo::from_db_operation_error(&error);
         assert_eq!(
             error_info.kind,
             ConnectionErrorKind::MySqlConnectionFailure(
@@ -242,11 +242,7 @@ mod connection {
         let permission_dsn = adapter.build_dsn(&permission_profile);
         let permission_error = adapter.probe(&permission_dsn).await.unwrap_err();
         assert_eq!(
-            ConnectionErrorInfo::from_db_operation_error_with_dsn(
-                &permission_error,
-                &permission_dsn
-            )
-            .kind,
+            ConnectionErrorInfo::from_db_operation_error(&permission_error).kind,
             ConnectionErrorKind::PermissionDenied
         );
 
@@ -258,8 +254,7 @@ mod connection {
         let missing_dsn = adapter.build_dsn(&missing_profile);
         let missing_error = adapter.probe(&missing_dsn).await.unwrap_err();
         assert_eq!(
-            ConnectionErrorInfo::from_db_operation_error_with_dsn(&missing_error, &missing_dsn)
-                .kind,
+            ConnectionErrorInfo::from_db_operation_error(&missing_error).kind,
             ConnectionErrorKind::DatabaseNotFound
         );
 
@@ -268,8 +263,7 @@ mod connection {
         let auth_profile = mysql_profile("mysql-authentication", auth_config);
         let auth_dsn = adapter.build_dsn(&auth_profile);
         let auth_error = adapter.probe(&auth_dsn).await.unwrap_err();
-        let auth_info =
-            ConnectionErrorInfo::from_db_operation_error_with_dsn(&auth_error, &auth_dsn);
+        let auth_info = ConnectionErrorInfo::from_db_operation_error(&auth_error);
         assert_eq!(
             auth_info.kind,
             ConnectionErrorKind::AuthFailed,


### PR DESCRIPTION
## Problem
MySQL TLS verification failures were classified in the app by reparsing the DSN, coupling presentation classification to connection-string parsing.

## Background
The MySQL adapter already owns the parsed SSL mode and is the boundary where CLI failures become typed database-operation errors.

## Approach
Resolve ambiguous TLS certificate failures in the MySQL adapter using the parsed SSL mode, then pass the typed result through the existing app error mapping. Remove the app-side DSN parser while preserving retry, masking, summaries, TLS modes, and non-MySQL classification.