### PR TITLE
refactor(mysql): move error classification into infra

### DIFF
--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -5,25 +5,6 @@ use std::sync::Arc;
 use crate::domain::{RefreshScope, SqlitePathError};
 use crate::policy::password_masking::mask_password;
 
-pub const MYSQL_CONNECT_TIMEOUT_ERRNOS: &[&str] = &["(60)", "(110)", "(10060)"];
-
-pub fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
-    let start = lowercase_details.find("error ")? + "error ".len();
-    let digits = &lowercase_details[start..];
-    let end = digits
-        .find(|character: char| !character.is_ascii_digit())
-        .unwrap_or(digits.len());
-    digits[..end].parse().ok()
-}
-
-pub fn is_mysql_connect_timeout_message(value: &str) -> bool {
-    let lowercase = value.to_ascii_lowercase();
-    lowercase.contains("can't connect to mysql server")
-        && MYSQL_CONNECT_TIMEOUT_ERRNOS
-            .iter()
-            .any(|errno| lowercase.contains(errno))
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatabaseCli {
     Psql,
@@ -414,18 +395,6 @@ impl From<csv::Error> for DbOperationError {
 mod tests {
     use super::*;
     use rstest::rstest;
-
-    #[test]
-    fn mysql_connect_timeout_classifier_preserves_errno_and_case_rules() {
-        for errno in MYSQL_CONNECT_TIMEOUT_ERRNOS {
-            assert!(is_mysql_connect_timeout_message(&format!(
-                "Can't connect to MySQL server (host) {errno}"
-            )));
-        }
-        assert!(!is_mysql_connect_timeout_message(
-            "Can't connect to MySQL server (host) (111)"
-        ));
-    }
 
     mod post_change_refresh_scope {
         use super::*;

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -31,9 +31,8 @@ pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, ExportIoSource,
-    MYSQL_CONNECT_TIMEOUT_ERRNOS, SqliteCompatibilityKind, UnsupportedOperationKind,
-    is_mysql_connect_timeout_message, mysql_server_error_code,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, ExportIoSource, SqliteCompatibilityKind,
+    UnsupportedOperationKind,
 };
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -1,11 +1,27 @@
 use std::io::{self, Write};
 
-use crate::app::ports::outbound::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, is_mysql_connect_timeout_message,
-    mysql_server_error_code,
-};
+use crate::app::ports::outbound::{ConnectionFailureKind, DatabaseCli, DbOperationError};
 
 use super::probe::mysql_tls_failure_kind;
+
+const MYSQL_CONNECT_TIMEOUT_ERRNOS: [&str; 3] = ["(60)", "(110)", "(10060)"];
+
+fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
+    let start = lowercase_details.find("error ")? + "error ".len();
+    let digits = &lowercase_details[start..];
+    let end = digits
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(digits.len());
+    digits[..end].parse().ok()
+}
+
+pub(super) fn is_mysql_connect_timeout_message(value: &str) -> bool {
+    let lowercase = value.to_ascii_lowercase();
+    lowercase.contains("can't connect to mysql server")
+        && MYSQL_CONNECT_TIMEOUT_ERRNOS
+            .iter()
+            .any(|errno| lowercase.contains(errno))
+}
 
 pub(super) fn map_mysql_cli_spawn_error(error: io::Error) -> DbOperationError {
     if error.kind() == io::ErrorKind::NotFound {
@@ -84,7 +100,7 @@ pub(super) fn classify_mysql_query_failure_with_packet_limit(
     } else if lower.contains("command denied") {
         DbOperationError::PermissionDenied(details)
     } else if lower.contains("unknown database") {
-        DbOperationError::ConnectionFailed(details)
+        connection_failed_with_kind(ConnectionFailureKind::DatabaseNotFound, details)
     } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
         DbOperationError::ObjectMissing(details)
     } else if lower.contains("access denied") || lower.contains("authentication") {
@@ -136,6 +152,9 @@ fn classify_mysql_server_error(
             ConnectionFailureKind::ConnectionRefused,
             details.to_string(),
         ),
+        2005 => {
+            connection_failed_with_kind(ConnectionFailureKind::HostUnreachable, details.to_string())
+        }
         3024 => error(DbOperationError::Timeout),
         _ => return None,
     })
@@ -272,6 +291,32 @@ mod tests {
     }
 
     #[test]
+    fn classifies_mysql_unknown_host_errno_as_host_unreachable() {
+        let details = "ERROR 2005 (HY000): Unknown MySQL server host 'db.internal' (11001)";
+
+        assert!(matches!(
+            classify_mysql_query_failure(details.as_bytes()),
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::HostUnreachable,
+                details: actual_details,
+            } if actual_details == details
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_unknown_database_without_error_code_as_database_not_found() {
+        let details = "mysql: [ERROR] Unknown database 'missing'";
+
+        assert!(matches!(
+            classify_mysql_query_failure(details.as_bytes()),
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::DatabaseNotFound,
+                details: actual_details,
+            } if actual_details == details
+        ));
+    }
+
+    #[test]
     fn preserves_mysql_query_timeout_code_and_message_in_timeout_details() {
         let details = "ERROR 3024 (HY000): Query execution was interrupted, maximum statement execution time exceeded";
 
@@ -298,6 +343,21 @@ mod tests {
 
         let error = classify_mysql_query_failure(b"ERROR 9999 (HY000): SSL connection error");
         assert!(matches!(error, DbOperationError::QueryFailed(_)));
+
+        let error = classify_mysql_query_failure(b"ERROR 9999 (HY000): Unknown database 'missing'");
+        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+    }
+
+    #[test]
+    fn mysql_connect_timeout_classifier_preserves_errno_and_case_rules() {
+        for errno in MYSQL_CONNECT_TIMEOUT_ERRNOS {
+            assert!(is_mysql_connect_timeout_message(&format!(
+                "Can't connect to MySQL server (host) {errno}"
+            )));
+        }
+        assert!(!is_mysql_connect_timeout_message(
+            "Can't connect to MySQL server (host) (111)"
+        ));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -9,11 +9,12 @@ use tokio::time::timeout;
 
 use crate::app::ports::outbound::{
     ConnectionFailureKind, DbOperationError, MySqlConnectionProbeResult, UnsupportedOperationKind,
-    is_mysql_connect_timeout_message,
 };
 
 use super::args::mysql_connection_args;
-use super::error::{clean_mysql_stderr, map_mysql_cli_spawn_error};
+use super::error::{
+    clean_mysql_stderr, is_mysql_connect_timeout_message, map_mysql_cli_spawn_error,
+};
 use super::sanitize_mysql_command_environment;
 
 const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
@@ -425,6 +426,30 @@ mod probe_tests {
             classify_mysql_probe_failure(
                 "ERROR 1049 (42000): Unknown database 'missing'".to_string()
             ),
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::DatabaseNotFound,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_probe_unknown_host_errno_as_host_unreachable() {
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2005 (HY000): Unknown MySQL server host 'db.internal' (11001)".to_string()
+            ),
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::HostUnreachable,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_probe_unknown_database_without_error_code_as_database_not_found() {
+        assert!(matches!(
+            classify_mysql_probe_failure("mysql: [ERROR] Unknown database 'missing'".to_string()),
             DbOperationError::ConnectionFailedWithKind {
                 kind: ConnectionFailureKind::DatabaseNotFound,
                 ..


### PR DESCRIPTION
## Problem
MySQL CLI errno and timeout parsing lived in the DB-agnostic outbound port, while selected connection failures were not reaching their existing typed kinds.

## Background
The classifier is consumed only by MySQL adapter paths, and unknown server-code wording must remain fail-closed.

## Approach
Keep the shared error carrier and presentation unchanged while moving MySQL-specific parsing into the adapter. Classify only errno 2005 and the existing no-code unknown-database form with their existing connection failure kinds, preserving details and current precedence.