### PR TITLE
refactor: remove dead message error timestamp

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1263,9 +1263,7 @@ mod tests {
         #[test]
         fn clears_stale_messages() {
             let mut state = prepare_state_for_reload();
-            state
-                .messages
-                .set_error_at("Old error".to_string(), Instant::now());
+            state.messages.set_error("Old error".to_string());
 
             assert!(state.messages.last_error().is_some());
             assert!(state.messages.expires_at().is_none());

--- a/src/app/model/shared/message.rs
+++ b/src/app/model/shared/message.rs
@@ -22,7 +22,7 @@ impl MessageState {
         self.expires_at
     }
 
-    pub fn set_error_at(&mut self, msg: String, _now: Instant) {
+    pub fn set_error(&mut self, msg: String) {
         self.last_error = Some(msg);
         self.last_success = None;
         self.expires_at = None;
@@ -69,7 +69,7 @@ mod tests {
         state.set_success_at("Success!".to_string(), now);
         assert!(state.last_success().is_some());
 
-        state.set_error_at("Error!".to_string(), now);
+        state.set_error("Error!".to_string());
 
         assert_eq!(state.last_error(), Some("Error!"));
         assert!(state.last_success().is_none());
@@ -79,7 +79,7 @@ mod tests {
     fn set_success_clears_error_message() {
         let now = fixed_instant();
         let mut state = MessageState::default();
-        state.set_error_at("Error!".to_string(), now);
+        state.set_error("Error!".to_string());
         assert!(state.last_error().is_some());
 
         state.set_success_at("Success!".to_string(), now);
@@ -90,11 +90,10 @@ mod tests {
 
     #[test]
     fn set_error_does_not_set_expiration_time() {
-        let now = fixed_instant();
         let mut state = MessageState::default();
         assert!(state.expires_at().is_none());
 
-        state.set_error_at("Error!".to_string(), now);
+        state.set_error("Error!".to_string());
 
         assert!(state.expires_at().is_none());
     }
@@ -103,7 +102,7 @@ mod tests {
     fn clear_expired_at_keeps_error_message() {
         let now = fixed_instant();
         let mut state = MessageState::default();
-        state.set_error_at("Error".to_string(), now);
+        state.set_error("Error".to_string());
 
         state.clear_expired_at(now + Duration::from_mins(1));
 
@@ -129,9 +128,8 @@ mod tests {
 
     #[test]
     fn clear_error_removes_error_message() {
-        let now = fixed_instant();
         let mut state = MessageState::default();
-        state.set_error_at("Error".to_string(), now);
+        state.set_error("Error".to_string());
 
         state.clear_error();
 
@@ -140,9 +138,8 @@ mod tests {
 
     #[test]
     fn clear_removes_all_messages() {
-        let now = fixed_instant();
         let mut state = MessageState::default();
-        state.set_error_at("Error".to_string(), now);
+        state.set_error("Error".to_string());
 
         state.clear();
 

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -21,7 +21,7 @@ pub(super) fn expand_prefetch_with_fk_neighbors(state: &AppState, run_id: u64) -
 pub(super) fn reduce_er_neighbors(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::ExpandPrefetchWithFkNeighbors { run_id } => {
@@ -35,7 +35,7 @@ pub(super) fn reduce_er_neighbors(
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
-                return DispatchResult::handled_with(check_er_completion(state, now));
+                return DispatchResult::handled_with(check_er_completion(state));
             }
 
             for qualified_name in tables {

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -134,7 +134,7 @@ pub(super) fn reduce_loading(
             })
         }
         Action::ReloadMetadata => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn().map(String::from) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -11,7 +11,7 @@ use crate::model::er_state::ErStatus;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn check_er_completion(state: &mut AppState, now: Instant) -> Vec<Effect> {
+pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
     if state.er_preparation.status() != ErStatus::Waiting || !state.er_preparation.is_complete() {
         return vec![];
     }
@@ -30,13 +30,10 @@ pub(super) fn check_er_completion(state: &mut AppState, now: Instant) -> Vec<Eff
 
     state.er_preparation.mark_idle();
     let failed_data: Vec<(String, String)> = state.er_preparation.failed_table_errors();
-    state.messages.set_error_at(
-        format!(
-            "ER failed: {} table(s) failed. 'e' to retry.",
-            failed_data.len()
-        ),
-        now,
-    );
+    state.messages.set_error(format!(
+        "ER failed: {} table(s) failed. 'e' to retry.",
+        failed_data.len()
+    ));
     vec![Effect::WriteErFailureLog {
         failed_tables: failed_data,
     }]
@@ -1309,7 +1306,7 @@ mod tests {
             state.er_preparation.mark_fk_unexpanded();
             // pending and fetching are empty → is_complete() = true
 
-            let effects = check_er_completion(&mut state, Instant::now());
+            let effects = check_er_completion(&mut state);
 
             assert!(effects.iter().any(|e| matches!(
                 e,
@@ -1324,7 +1321,7 @@ mod tests {
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
 
-            let effects = check_er_completion(&mut state, Instant::now());
+            let effects = check_er_completion(&mut state);
 
             assert!(effects.iter().any(|e| matches!(
                 e,

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -46,7 +46,7 @@ fn prefetch_table_detail(
                 state
                     .er_preparation
                     .on_table_failed(&qualified_name, entry.error.clone());
-                check_er_completion(state, now)
+                check_er_completion(state)
             } else {
                 Vec::new()
             };
@@ -225,7 +225,7 @@ pub(super) fn reduce_prefetch(
             }
 
             if state.sql_modal.prefetch_tracks_er() {
-                effects.extend(check_er_completion(state, now));
+                effects.extend(check_er_completion(state));
             } else if state.modal.active_mode() == InputMode::SqlModal {
                 effects.push(Effect::TriggerCompletion);
             }
@@ -273,7 +273,7 @@ pub(super) fn reduce_prefetch(
             });
 
             if state.sql_modal.prefetch_tracks_er() {
-                effects.extend(check_er_completion(state, now));
+                effects.extend(check_er_completion(state));
             }
 
             DispatchResult::handled_with(effects)
@@ -302,7 +302,7 @@ pub(super) fn reduce_prefetch(
             }
 
             if state.sql_modal.prefetch_tracks_er() {
-                effects.extend(check_er_completion(state, now));
+                effects.extend(check_er_completion(state));
             } else if state.modal.active_mode() == InputMode::SqlModal {
                 effects.push(Effect::TriggerCompletion);
             }

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -8,7 +8,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_table_detail(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::TableDetailLoaded {
@@ -46,7 +46,7 @@ pub(super) fn reduce_table_detail(
                 .session
                 .mark_table_detail_failed(*generation, message.clone())
             {
-                state.messages.set_error_at(message, now);
+                state.messages.set_error(message);
                 return DispatchResult::handled_with(reveal_pending_preview(state, *generation));
             }
             DispatchResult::handled()

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -9,7 +9,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub fn reduce_connection_list(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::ListSelect {
@@ -53,10 +53,10 @@ pub fn reduce_connection_list(
                 .set_service_file_path(service_file_path.clone());
 
             if let Some(warning) = profile_load_warning {
-                state.messages.set_error_at(warning.clone(), now);
+                state.messages.set_error(warning.clone());
             }
             if let Some(warning) = service_load_warning {
-                state.messages.set_error_at(warning.clone(), now);
+                state.messages.set_error(warning.clone());
             }
 
             let list_len = state.connection_list_items().len();

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -109,7 +109,7 @@ pub fn reduce_execution(
             let is_preview = matches!(context, QueryFailureContext::Preview { .. });
             if is_preview && matches!(error, DbOperationError::PreviewSizeExceeded(_)) {
                 state.query.mark_idle();
-                state.messages.set_error_at(error.user_message(), now);
+                state.messages.set_error(error.user_message());
                 return DispatchResult::handled();
             }
 
@@ -140,7 +140,7 @@ pub fn reduce_execution(
                     state.query.set_current_result(result);
                 } else {
                     let user_message = error.user_message();
-                    state.messages.set_error_at(user_message.clone(), now);
+                    state.messages.set_error(user_message.clone());
                     state.sql_modal.finish_adhoc_error(user_message);
                 }
             }
@@ -216,7 +216,7 @@ pub fn reduce_execution(
             table,
             generation,
         }) => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if state.session.dsn().is_none() {
@@ -235,7 +235,7 @@ pub fn reduce_execution(
         }
 
         Action::ExecuteAdhoc(query) => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn().map(String::from) {

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -37,7 +37,7 @@ pub(super) fn preview_effect_for_current_table(
     target_page: usize,
     generation: u64,
 ) -> Option<Effect> {
-    if reject_pending_mysql_connection_probe(state, now) {
+    if reject_pending_mysql_connection_probe(state) {
         return None;
     }
     let dsn = state.session.dsn().map(String::from)?;

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -163,7 +163,7 @@ pub fn reduce_pagination(
 ) -> DispatchResult {
     match action {
         Action::RequestCsvExport => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if !state.can_request_csv_export() {
@@ -183,7 +183,7 @@ pub fn reduce_pagination(
             if state.session.active_database_type() == Some(DatabaseType::SQLite) {
                 match sqlite_export_plan(result.source, &export_query, &result.columns, row_count) {
                     SqliteExportPlan::NotExportable { reason } => {
-                        state.messages.set_error_at(reason, now);
+                        state.messages.set_error(reason);
                         return DispatchResult::handled();
                     }
                     SqliteExportPlan::RerunnableQuery { query } => {
@@ -261,7 +261,7 @@ pub fn reduce_pagination(
             export_query,
             file_name,
         } => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if state.is_stale_query_run(dsn, *run_id) {
@@ -306,20 +306,20 @@ pub fn reduce_pagination(
             }
 
             state.query.mark_idle();
-            state.messages.set_error_at(error.user_message(), now);
+            state.messages.set_error(error.user_message());
             DispatchResult::handled()
         }
 
         Action::OpenFolderFailed(error) => {
             state
                 .messages
-                .set_error_at(format!("Failed to open folder: {error}"), now);
+                .set_error(format!("Failed to open folder: {error}"));
 
             DispatchResult::handled()
         }
 
         Action::ResultNextPage => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
@@ -340,7 +340,7 @@ pub fn reduce_pagination(
         }
 
         Action::ResultPrevPage => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if state.query.is_running() || !state.query.can_paginate_visible_result() {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -177,7 +177,7 @@ pub fn reduce_write(
 ) -> DispatchResult {
     match action {
         Action::SubmitCellEditWrite => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             if !state.result_interaction.staged_delete_rows().is_empty() {
@@ -189,27 +189,26 @@ pub fn reduce_write(
                             result.target_row,
                             staged_count,
                         );
-                        return open_write_preview_confirm(state, &result.preview, now);
+                        return open_write_preview_confirm(state, &result.preview);
                     }
                     Err(err) => {
-                        state.messages.set_error_at(err.to_string(), now);
+                        state.messages.set_error(err.to_string());
                         return DispatchResult::handled();
                     }
                 }
             }
 
             if state.query.is_running() {
-                state.messages.set_error_at(
-                    EditGuardrailError::WriteUnavailableWhileQueryRunning.to_string(),
-                    now,
-                );
+                state
+                    .messages
+                    .set_error(EditGuardrailError::WriteUnavailableWhileQueryRunning.to_string());
                 return DispatchResult::handled();
             }
 
             match build_update_preview(state, services) {
-                Ok(preview) => open_write_preview_confirm(state, &preview, now),
+                Ok(preview) => open_write_preview_confirm(state, &preview),
                 Err(err) => {
-                    state.messages.set_error_at(err.to_string(), now);
+                    state.messages.set_error(err.to_string());
                     DispatchResult::handled()
                 }
             }
@@ -242,13 +241,10 @@ pub fn reduce_write(
                             now,
                         );
                     } else {
-                        state.messages.set_error_at(
-                            write_message_with_diagnostics(
-                                format!("UPDATE expected 1 row, but affected {affected_rows} rows"),
-                                diagnostics,
-                            ),
-                            now,
-                        );
+                        state.messages.set_error(write_message_with_diagnostics(
+                            format!("UPDATE expected 1 row, but affected {affected_rows} rows"),
+                            diagnostics,
+                        ));
                     }
 
                     state.result_interaction.clear_cell_edit();
@@ -284,19 +280,16 @@ pub fn reduce_write(
                             now,
                         );
                     } else {
-                        state.messages.set_error_at(
-                            write_message_with_diagnostics(
-                                format!(
-                                    "DELETE expected {} {}, but affected {} {}",
-                                    expected,
-                                    row_word(expected),
-                                    affected_rows,
-                                    row_word(*affected_rows),
-                                ),
-                                diagnostics,
+                        state.messages.set_error(write_message_with_diagnostics(
+                            format!(
+                                "DELETE expected {} {}, but affected {} {}",
+                                expected,
+                                row_word(expected),
+                                affected_rows,
+                                row_word(*affected_rows),
                             ),
-                            now,
-                        );
+                            diagnostics,
+                        ));
                     }
                     state.result_interaction.clear_cell_edit();
                     state.result_interaction.clear_staged_deletes();
@@ -330,7 +323,7 @@ pub fn reduce_write(
                 .unwrap_or(RefreshScope::None);
             let operation = state.result_interaction.complete_write_failure();
             state.query.clear_delete_refresh_target();
-            state.messages.set_error_at(error.user_message(), now);
+            state.messages.set_error(error.user_message());
             if refresh_scope == RefreshScope::None {
                 state.modal.set_mode(match operation {
                     WriteOperation::Update => InputMode::CellEdit,
@@ -370,16 +363,11 @@ fn write_diagnostic_message(diagnostic: &DatabaseDiagnostic) -> String {
     format!("{level} (Code {}): {}", diagnostic.code, diagnostic.message)
 }
 
-fn open_write_preview_confirm(
-    state: &mut AppState,
-    preview: &WritePreview,
-    now: Instant,
-) -> DispatchResult {
+fn open_write_preview_confirm(state: &mut AppState, preview: &WritePreview) -> DispatchResult {
     if state.session.is_read_only() {
-        state.messages.set_error_at(
-            "Read-only mode: write operations are disabled".to_string(),
-            now,
-        );
+        state
+            .messages
+            .set_error("Read-only mode: write operations are disabled".to_string());
         return DispatchResult::handled();
     }
     state.result_interaction.set_write_preview(preview.clone());
@@ -1551,7 +1539,7 @@ mod tests {
             state.modal.set_mode(InputMode::Normal);
             let preview = delete_preview();
 
-            let effects = open_write_preview_confirm(&mut state, &preview, Instant::now())
+            let effects = open_write_preview_confirm(&mut state, &preview)
                 .into_effects()
                 .expect("write preview should be handled");
 
@@ -1571,7 +1559,7 @@ mod tests {
             state.query.set_delete_refresh_target(0, Some(2), 3);
             let preview = delete_preview();
 
-            let effects = open_write_preview_confirm(&mut state, &preview, Instant::now())
+            let effects = open_write_preview_confirm(&mut state, &preview)
                 .into_effects()
                 .expect("write preview should be handled");
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -78,13 +78,13 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     Ok((row_idx, col_idx, cell_value))
 }
 
-pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+pub fn reduce_edit(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::ResultEnterCellEdit => {
             if state.session.is_read_only() {
                 state
                     .messages
-                    .set_error_at("Read-only mode: editing is disabled".to_string(), now);
+                    .set_error("Read-only mode: editing is disabled".to_string());
                 return DispatchResult::handled();
             }
 
@@ -103,7 +103,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
                     DispatchResult::handled()
                 }
                 Err(reason) => {
-                    state.messages.set_error_at(reason.to_string(), now);
+                    state.messages.set_error(reason.to_string());
                     DispatchResult::handled()
                 }
             }

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -68,9 +68,7 @@ pub fn reduce_json(state: &mut AppState, action: &Action, now: Instant) -> Dispa
                     serde_json::to_string_pretty(&value).unwrap_or_else(|_| cell_value.clone())
                 }
                 Err(err) => {
-                    state
-                        .messages
-                        .set_error_at(format!("Invalid JSON: {err}"), now);
+                    state.messages.set_error(format!("Invalid JSON: {err}"));
                     return DispatchResult::handled();
                 }
             };
@@ -113,11 +111,11 @@ pub fn reduce_json(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             if state.session.is_read_only() {
                 state
                     .messages
-                    .set_error_at("Read-only mode: editing is disabled".to_string(), now);
+                    .set_error("Read-only mode: editing is disabled".to_string());
                 return DispatchResult::handled();
             }
             if let Err(reason) = ensure_json_column_writable(state) {
-                state.messages.set_error_at(reason.to_string(), now);
+                state.messages.set_error(reason.to_string());
                 return DispatchResult::handled();
             }
             state.json_detail.enter_edit();
@@ -129,11 +127,11 @@ pub fn reduce_json(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             if state.session.is_read_only() {
                 state
                     .messages
-                    .set_error_at("Read-only mode: editing is disabled".to_string(), now);
+                    .set_error("Read-only mode: editing is disabled".to_string());
                 return DispatchResult::handled();
             }
             if let Err(reason) = ensure_json_column_writable(state) {
-                state.messages.set_error_at(reason.to_string(), now);
+                state.messages.set_error(reason.to_string());
                 return DispatchResult::handled();
             }
             state

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -24,7 +24,7 @@ fn ensure_cell_visible(state: &mut AppState) {
     }
 }
 
-pub fn reduce_selection(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+pub fn reduce_selection(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::ResultActivateCell => {
             let rows = result_row_count(state);
@@ -65,17 +65,15 @@ pub fn reduce_selection(state: &mut AppState, action: &Action, now: Instant) -> 
         }
         Action::StageRowForDelete => {
             if state.session.is_read_only() {
-                state.messages.set_error_at(
-                    "Read-only mode: delete operations are disabled".to_string(),
-                    now,
-                );
+                state
+                    .messages
+                    .set_error("Read-only mode: delete operations are disabled".to_string());
                 return DispatchResult::handled();
             }
             if let Some(reason) = state.visible_preview_target_read_only_reason() {
-                state.messages.set_error_at(
-                    EditGuardrailError::ReadOnlyPreviewTarget(reason).to_string(),
-                    now,
-                );
+                state
+                    .messages
+                    .set_error(EditGuardrailError::ReadOnlyPreviewTarget(reason).to_string());
                 return DispatchResult::handled();
             }
             if let Some(row_idx) = state.result_interaction.selection().row() {

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -42,9 +42,7 @@ pub fn reduce_yank(
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
-                    state
-                        .messages
-                        .set_error_at("Cell index out of bounds".into(), now);
+                    state.messages.set_error("Cell index out of bounds".into());
                     DispatchResult::handled()
                 }
             } else {
@@ -101,9 +99,7 @@ pub fn reduce_yank(
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
-                    state
-                        .messages
-                        .set_error_at("Row index out of bounds".into(), now);
+                    state.messages.set_error("Row index out of bounds".into());
                     DispatchResult::handled()
                 }
             } else {
@@ -131,7 +127,7 @@ pub fn reduce_yank(
             DispatchResult::handled()
         }
         Action::CopyFailed(e) => {
-            state.messages.set_error_at(e.to_string(), now);
+            state.messages.set_error(e.to_string());
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -23,11 +23,11 @@ fn clear_query_confirmation(state: &mut AppState) {
 pub fn reduce_connection_lifecycle(
     state: &mut AppState,
     action: &Action,
-    now: std::time::Instant,
+    _now: std::time::Instant,
     _services: &AppServices,
 ) -> DispatchResult {
     match action {
-        Action::TryConnect => DispatchResult::handled_with(try_connect(state, now)),
+        Action::TryConnect => DispatchResult::handled_with(try_connect(state)),
 
         Action::SwitchConnection(target) => {
             state.session.cancel_connection_save_and_disconnect();
@@ -41,10 +41,9 @@ pub fn reduce_connection_lifecycle(
             } = target;
 
             if *database_type == DatabaseType::MySQL && database.is_none() {
-                state.messages.set_error_at(
-                    "MySQL connection field `database` is required".to_string(),
-                    now,
-                );
+                state
+                    .messages
+                    .set_error("MySQL connection field `database` is required".to_string());
                 return DispatchResult::handled();
             }
 
@@ -196,7 +195,7 @@ pub fn reduce_connection_lifecycle(
     }
 }
 
-pub(super) fn try_connect(state: &mut AppState, now: std::time::Instant) -> Vec<Effect> {
+pub(super) fn try_connect(state: &mut AppState) -> Vec<Effect> {
     state.session.cancel_connection_save_and_disconnect();
     if state.session.connection_state().is_not_connected()
         && state.modal.active_mode() == InputMode::Normal
@@ -204,10 +203,9 @@ pub(super) fn try_connect(state: &mut AppState, now: std::time::Instant) -> Vec<
         if let Some(dsn) = state.session.dsn().map(str::to_string) {
             if state.session.active_database_type() == Some(DatabaseType::MySQL) {
                 if state.session.active_database().is_none() {
-                    state.messages.set_error_at(
-                        "MySQL connection field `database` is required".to_string(),
-                        now,
-                    );
+                    state
+                        .messages
+                        .set_error("MySQL connection field `database` is required".to_string());
                     return vec![];
                 }
                 let target = ConnectionTarget {

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -98,7 +98,7 @@ pub(super) fn reduce_connection_selector(
             })
         }
         Action::ConnectionDeleteFailed(e) => {
-            state.messages.set_error_at(e.to_string(), now);
+            state.messages.set_error(e.to_string());
             DispatchResult::handled()
         }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -27,7 +27,7 @@ use crate::update::query_context::termination_effects;
 pub fn reduce_connection_setup(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
@@ -48,7 +48,7 @@ pub fn reduce_connection_setup(
             DispatchResult::handled_with(cancel_effects)
         }
         Action::ConnectionEditLoadFailed(e) => {
-            state.messages.set_error_at(e.to_string(), now);
+            state.messages.set_error(e.to_string());
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
@@ -242,7 +242,7 @@ pub fn reduce_connection_setup(
             } else {
                 state.modal.set_mode(InputMode::Normal);
                 let mut effects = cancel_effects;
-                effects.extend(try_connect(state, now));
+                effects.extend(try_connect(state));
                 DispatchResult::handled_with(effects)
             }
         }
@@ -316,7 +316,7 @@ pub fn reduce_connection_setup(
                 state.modal.replace_mode(InputMode::ConnectionError);
                 return DispatchResult::handled();
             }
-            state.messages.set_error_at(e.to_string(), now);
+            state.messages.set_error(e.to_string());
             DispatchResult::handled()
         }
 

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -37,15 +37,15 @@ pub(super) fn reduce_diagram_lifecycle(
                 return DispatchResult::handled();
             }
             state.er_preparation.mark_idle();
-            state.messages.set_error_at(error.clone(), now);
+            state.messages.set_error(error.clone());
             DispatchResult::handled()
         }
         Action::ErLogWriteFailed(error) => {
-            state.messages.set_error_at(error.clone(), now);
+            state.messages.set_error(error.clone());
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
-            if let Some(result) = require_er_diagram_enabled(state, now) {
+            if let Some(result) = require_er_diagram_enabled(state) {
                 return result;
             }
             if state.er_preparation.is_busy() {
@@ -53,15 +53,13 @@ pub(super) fn reduce_diagram_lifecycle(
             }
 
             let Some(dsn) = state.session.dsn().map(String::from) else {
-                state
-                    .messages
-                    .set_error_at("No active connection".to_string(), now);
+                state.messages.set_error("No active connection".to_string());
                 return DispatchResult::handled();
             };
             if state.session.metadata().is_none() {
                 state
                     .messages
-                    .set_error_at("Metadata not loaded yet".to_string(), now);
+                    .set_error("Metadata not loaded yet".to_string());
                 return DispatchResult::handled();
             }
 
@@ -74,7 +72,7 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
         }
         Action::ErGenerateFromCache => {
-            if let Some(result) = require_er_diagram_enabled(state, now) {
+            if let Some(result) = require_er_diagram_enabled(state) {
                 return result;
             }
             if !state.er_preparation.can_generate_from_cache() {

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -9,7 +9,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_smart_refresh_failed(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::SmartErRefreshFailed(SmartErRefreshError {
@@ -30,17 +30,16 @@ pub(super) fn reduce_smart_refresh_failed(
                 state.er_preparation.mark_idle();
                 state
                     .messages
-                    .set_error_at("Metadata not loaded yet".to_string(), now);
+                    .set_error("Metadata not loaded yet".to_string());
                 return DispatchResult::handled();
             };
             state
                 .er_preparation
                 .invalidate_refresh_signatures(metadata.table_summaries.len());
 
-            state.messages.set_error_at(
-                format!("Smart refresh failed ({error}), falling back to full refresh"),
-                now,
-            );
+            state.messages.set_error(format!(
+                "Smart refresh failed ({error}), falling back to full refresh"
+            ));
             DispatchResult::handled_with(vec![
                 Effect::ClearCompletionEngineCache,
                 Effect::DispatchActions(vec![Action::StartErPrefetchAll]),

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -28,7 +28,7 @@ pub(super) fn reduce_analyze(
 ) -> DispatchResult {
     match action {
         Action::ExplainAnalyzeRequest => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
@@ -108,7 +108,7 @@ pub(super) fn reduce_analyze(
         }
 
         Action::ExplainAnalyzeConfirm => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 state.sql_modal.cancel_confirmation();
                 return DispatchResult::handled();
             }

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -25,7 +25,7 @@ pub(super) fn reduce_request(
 ) -> DispatchResult {
     match action {
         Action::ExplainRequest => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use unicode_casefold::UnicodeCaseFold;
 
 use crate::cmd::effect::Effect;
@@ -20,30 +18,26 @@ use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::services::AppServices;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(crate) fn require_er_diagram_enabled(
-    state: &mut AppState,
-    now: Instant,
-) -> Option<DispatchResult> {
+pub(crate) fn require_er_diagram_enabled(state: &mut AppState) -> Option<DispatchResult> {
     let feature_policy = FeaturePolicy::new(&state.session.active_engine_feature_profile());
     if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
         return None;
     }
 
-    state.messages.set_error_at(
-        "ER diagrams are not available for this connection".to_string(),
-        now,
-    );
+    state
+        .messages
+        .set_error("ER diagrams are not available for this connection".to_string());
     Some(DispatchResult::handled())
 }
 
-pub(crate) fn reject_pending_mysql_connection_probe(state: &mut AppState, now: Instant) -> bool {
+pub(crate) fn reject_pending_mysql_connection_probe(state: &mut AppState) -> bool {
     if state.session.pending_mysql_connection_probe().is_none() {
         return false;
     }
 
     state
         .messages
-        .set_error_at("Connection switch in progress".to_string(), now);
+        .set_error("Connection switch in progress".to_string());
     true
 }
 

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -44,7 +44,7 @@ pub(super) fn reduce_confirm_dialog(
                     sql,
                     blocked: false,
                 }) => {
-                    if reject_pending_mysql_connection_probe(state, now) {
+                    if reject_pending_mysql_connection_probe(state) {
                         state.result_interaction.clear_write_preview();
                         state.query.clear_delete_refresh_target();
                         return DispatchResult::handled();
@@ -60,9 +60,7 @@ pub(super) fn reduce_confirm_dialog(
                     } else {
                         state.result_interaction.clear_write_preview();
                         state.query.clear_delete_refresh_target();
-                        state
-                            .messages
-                            .set_error_at("No active connection".to_string(), now);
+                        state.messages.set_error("No active connection".to_string());
                         DispatchResult::handled()
                     }
                 }
@@ -77,7 +75,7 @@ pub(super) fn reduce_confirm_dialog(
                     file_name,
                     row_count,
                 }) => {
-                    if reject_pending_mysql_connection_probe(state, now) {
+                    if reject_pending_mysql_connection_probe(state) {
                         return DispatchResult::handled();
                     }
                     if state.is_stale_query_run(&dsn, run_id) {
@@ -99,7 +97,7 @@ pub(super) fn reduce_confirm_dialog(
                     row_count,
                     snapshot,
                 }) => {
-                    if reject_pending_mysql_connection_probe(state, now) {
+                    if reject_pending_mysql_connection_probe(state) {
                         return DispatchResult::handled();
                     }
                     if state.is_stale_query_run(&dsn, run_id) {

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -16,7 +16,7 @@ pub(super) fn reduce_er_picker(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ErTablePicker) => {
-            if let Some(result) = require_er_diagram_enabled(state, now) {
+            if let Some(result) = require_er_diagram_enabled(state) {
                 return result;
             }
             if state.session.metadata().is_none() {
@@ -108,9 +108,7 @@ pub(super) fn reduce_er_picker(
         }
         Action::ErConfirmSelection => {
             if state.ui.er_selected_tables().is_empty() {
-                state
-                    .messages
-                    .set_error_at("No tables selected".to_string(), now);
+                state.messages.set_error("No tables selected".to_string());
                 return DispatchResult::handled();
             }
             state

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -11,7 +11,7 @@ use crate::update::helpers::reject_pending_mysql_connection_probe;
 pub(super) fn reduce_query_history_picker(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::QueryHistoryPicker) => {
@@ -67,7 +67,7 @@ pub(super) fn reduce_query_history_picker(
             if state.session.query_history_scope().as_ref() != Some(scope) {
                 return DispatchResult::handled();
             }
-            state.messages.set_error_at(e.to_string(), now);
+            state.messages.set_error(e.to_string());
             DispatchResult::handled()
         }
         Action::TextInput {
@@ -133,7 +133,7 @@ pub(super) fn reduce_query_history_picker(
             DispatchResult::handled()
         }
         Action::QueryHistoryConfirmSelection => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             let grouped = state.query_history_picker.grouped_filtered_entries();

--- a/src/app/update/modal/settings.rs
+++ b/src/app/update/modal/settings.rs
@@ -120,7 +120,7 @@ pub(super) fn reduce_settings(
         Action::SettingsSaveFailed(error) => {
             state
                 .messages
-                .set_error_at(format!("Failed to save settings: {error}"), now);
+                .set_error(format!("Failed to save settings: {error}"));
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -108,7 +108,7 @@ fn dispatch_enabled_action(
                     .cloned();
                 if let Some(table) = table {
                     state.modal.set_mode(InputMode::Normal);
-                    return select_table(state, &table, now);
+                    return select_table(state, &table);
                 }
             } else if state.modal.active_mode() == InputMode::Normal {
                 if state.connection_error.has_error() {
@@ -120,7 +120,7 @@ fn dispatch_enabled_action(
                 }
                 let table = state.tables().get(state.ui.explorer_selected()).cloned();
                 if let Some(table) = table {
-                    return select_table(state, &table, now);
+                    return select_table(state, &table);
                 }
             } else if state.modal.active_mode() == InputMode::CommandPalette {
                 use crate::update::input::palette::palette_action_for_index;
@@ -157,7 +157,7 @@ fn dispatch_enabled_action(
     }
 }
 
-fn select_table(state: &mut AppState, table: &TableSummary, now: Instant) -> Vec<Effect> {
+fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
     let generation = state
         .session
         .select_table(&table.schema, &table.name, &mut state.query);
@@ -181,7 +181,7 @@ fn select_table(state: &mut AppState, table: &TableSummary, now: Instant) -> Vec
         state
             .session
             .mark_table_detail_failed(generation, message.clone());
-        state.messages.set_error_at(message, now);
+        state.messages.set_error(message);
     }
     effects.push(Effect::DispatchActions(vec![Action::ExecutePreview(
         TableTarget {
@@ -313,10 +313,9 @@ mod tests {
         #[test]
         fn selecting_table_without_connection_does_not_leave_inspector_loading() {
             let mut state = create_test_state();
-            let now = Instant::now();
             let table = TableSummary::new("public".to_string(), "users".to_string(), None, false);
 
-            let effects = select_table(&mut state, &table, now);
+            let effects = select_table(&mut state, &table);
 
             assert!(matches!(
                 state.session.table_detail_state(),

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -11,7 +11,7 @@ pub(super) fn start_adhoc_if_connected(
     query: String,
     now: Instant,
 ) -> DispatchResult {
-    if reject_pending_mysql_connection_probe(state, now) {
+    if reject_pending_mysql_connection_probe(state) {
         return DispatchResult::handled();
     }
 

--- a/src/app/update/sql_editor/high_risk.rs
+++ b/src/app/update/sql_editor/high_risk.rs
@@ -107,7 +107,7 @@ pub(super) fn reduce_high_risk_confirmation(
         }
 
         Action::SqlModalConfirmExecute => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 state.sql_modal.cancel_confirmation();
                 return DispatchResult::handled();
             }

--- a/src/app/update/sql_editor/mode.rs
+++ b/src/app/update/sql_editor/mode.rs
@@ -8,11 +8,11 @@ use crate::update::action::{Action, CursorMove, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
 
-pub(super) fn reduce_mode(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+pub(super) fn reduce_mode(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         // Modal open/submit
         Action::OpenModal(ModalKind::SqlModal) => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             state.modal.set_mode(InputMode::SqlModal);

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -27,7 +27,7 @@ fn into_submit_result<Statement>(
 pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::SqlModalSubmit => {
-            if reject_pending_mysql_connection_probe(state, now) {
+            if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
             let query = state.sql_modal.editor.content().trim().to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,12 +361,7 @@ impl Runtime {
             pending = next;
         }
         if depth >= MAX_DEPTH && !pending.is_empty() {
-            dispatch_overflow_fallback(
-                &mut self.state,
-                self.effect_runner.action_tx(),
-                pending,
-                Instant::now(),
-            );
+            dispatch_overflow_fallback(&mut self.state, self.effect_runner.action_tx(), pending);
             // Render immediately so the overflow error is visible before the next
             // event-loop pass; errors do not have an expiry wake-up anymore.
             self.run_effects(vec![Effect::Render]).await?;
@@ -445,7 +440,6 @@ fn dispatch_overflow_fallback(
     state: &mut AppState,
     action_tx: &mpsc::Sender<Action>,
     pending: Vec<Action>,
-    now: Instant,
 ) {
     let deferred = pending.len();
     let mut dropped = 0usize;
@@ -463,7 +457,7 @@ fn dispatch_overflow_fallback(
             "Internal error: action dispatch depth exceeded ({MAX_DEPTH}); {deferred} actions deferred"
         )
     };
-    state.messages.set_error_at(message, now);
+    state.messages.set_error(message);
 }
 
 fn load_service_entries(state: &mut AppState, reader: &dyn PgServiceEntryReader) {
@@ -474,7 +468,7 @@ fn load_service_entries(state: &mut AppState, reader: &dyn PgServiceEntryReader)
         }
         Ok(_) | Err(ServiceFileError::NotFound(_)) => {}
         Err(e) => {
-            state.messages.set_error_at(e.to_string(), Instant::now());
+            state.messages.set_error(e.to_string());
         }
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -230,8 +230,6 @@ fn disabled_message_contains_version_and_upgrade_guidance() {
 }
 
 mod dispatch_overflow_fallback {
-    use std::time::Instant;
-
     use sabiql_app::model::app_state::AppState;
     use sabiql_app::update::action::Action;
     use tokio::sync::mpsc;
@@ -243,12 +241,7 @@ mod dispatch_overflow_fallback {
         let mut state = AppState::new("test".to_string());
         let (tx, mut rx) = mpsc::channel(8);
 
-        dispatch_overflow_fallback(
-            &mut state,
-            &tx,
-            vec![Action::Render, Action::Render],
-            Instant::now(),
-        );
+        dispatch_overflow_fallback(&mut state, &tx, vec![Action::Render, Action::Render]);
 
         assert!(rx.try_recv().is_ok());
         assert!(rx.try_recv().is_ok());
@@ -265,7 +258,6 @@ mod dispatch_overflow_fallback {
             &mut state,
             &tx,
             vec![Action::Render, Action::Render, Action::Render],
-            Instant::now(),
         );
 
         let error = state.messages.last_error().unwrap();

--- a/src/tests/render_snapshots/table_explorer.rs
+++ b/src/tests/render_snapshots/table_explorer.rs
@@ -52,12 +52,11 @@ fn focus_mode_fullscreen_result() {
 #[test]
 fn error_message_in_footer() {
     let mut state = explorer_selected_state();
-    let now = test_instant();
     let mut terminal = create_test_terminal();
 
     state
         .messages
-        .set_error_at("Connection failed: timeout".to_string(), now);
+        .set_error("Connection failed: timeout".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -67,12 +66,10 @@ fn error_message_in_footer() {
 #[test]
 fn long_error_message_wraps_into_footer_and_command_line() {
     let mut state = explorer_selected_state();
-    let now = test_instant();
     let mut terminal = create_test_terminal();
 
-    state.messages.set_error_at(
+    state.messages.set_error(
         "Connection failed: the database server returned a detailed explanation that should remain visible until the next user operation instead of disappearing from the footer after a short timeout".to_string(),
-        now,
     );
 
     let output = render_to_string(&mut terminal, &mut state);


### PR DESCRIPTION
## Problem
Message errors accept an unused timestamp, making the sticky error path appear time-dependent.

## Background
Only success messages expire; error messages remain until explicitly cleared.

## Approach
Make the error setter time-independent and update all workspace callers while preserving sticky errors, success expiry, and existing database-specific messages.