### PR TITLE
fix(mysql): honor process kill failures

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 #[cfg(unix)]
 use std::io;
 #[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+#[cfg(unix)]
 use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
@@ -229,7 +231,8 @@ async fn finish_mysql_process_stop(
         .wait()
         .await
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-    Ok((status, kill_result.is_ok()))
+    let forcibly_stopped = kill_result.is_ok() && status.signal() == Some(libc::SIGKILL);
+    Ok((status, forcibly_stopped))
 }
 
 pub(super) async fn read_all_bytes<R>(reader: &mut R) -> std::io::Result<Vec<u8>>

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -214,12 +214,12 @@ pub(super) async fn stop_mysql_process(
     {
         return Ok((status, false));
     }
-    let _ = child.kill().await;
+    let kill_result = child.kill().await;
     let status = child
         .wait()
         .await
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-    Ok((status, true))
+    Ok((status, kill_result.is_ok()))
 }
 
 pub(super) async fn read_all_bytes<R>(reader: &mut R) -> std::io::Result<Vec<u8>>

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -3,6 +3,8 @@ use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 #[cfg(unix)]
+use std::io;
+#[cfg(unix)]
 use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
@@ -215,6 +217,14 @@ pub(super) async fn stop_mysql_process(
         return Ok((status, false));
     }
     let kill_result = child.kill().await;
+    finish_mysql_process_stop(child, kill_result).await
+}
+
+#[cfg(unix)]
+async fn finish_mysql_process_stop(
+    child: &mut Child,
+    kill_result: io::Result<()>,
+) -> Result<(ExitStatus, bool), DbOperationError> {
     let status = child
         .wait()
         .await

--- a/src/infra/adapters/mysql/cli/process/process_tests.rs
+++ b/src/infra/adapters/mysql/cli/process/process_tests.rs
@@ -1,7 +1,5 @@
 #[cfg(not(unix))]
 use std::io;
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
 
 use crate::app::ports::outbound::DatabaseCli;
 
@@ -123,6 +121,31 @@ async fn failed_kill_preserves_wait_status_without_forced_stop() {
         finish_mysql_process_stop(&mut child, Err(std::io::Error::other("kill failed")))
             .await
             .unwrap();
+
+    assert_eq!(status.code(), expected_status.code());
+    assert!(!forcibly_stopped);
+    assert!(
+        validate_mysql_session_exit(
+            &MySqlSessionResult {
+                status,
+                forcibly_stopped,
+                error_bytes: Vec::new(),
+            },
+            None,
+        )
+        .is_err()
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn successful_kill_request_does_not_override_normal_exit_status() {
+    let mut child = Command::new("sh")
+        .args(["-c", "exit 7"])
+        .spawn()
+        .expect("spawn exiting process");
+    let expected_status = child.wait().await.unwrap();
+    let (status, forcibly_stopped) = finish_mysql_process_stop(&mut child, Ok(())).await.unwrap();
 
     assert_eq!(status.code(), expected_status.code());
     assert!(!forcibly_stopped);

--- a/src/infra/adapters/mysql/cli/process/process_tests.rs
+++ b/src/infra/adapters/mysql/cli/process/process_tests.rs
@@ -1,4 +1,3 @@
-use std::io;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 
@@ -82,12 +81,6 @@ fn preserves_mysql_session_exit_rules() {
 }
 
 #[cfg(unix)]
-#[test]
-fn rejects_nonzero_wait_status_without_confirmed_forced_stop() {
-    assert!(validate_mysql_session_exit(&session(9, false, b""), None).is_err());
-}
-
-#[cfg(unix)]
 #[tokio::test]
 async fn reports_successful_kill_and_wait_status() {
     let mut child = Command::new("sleep")
@@ -114,6 +107,34 @@ async fn preserves_wait_status_for_normal_exit() {
 
     assert_eq!(status.code(), expected_status.code());
     assert!(!forcibly_stopped);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn failed_kill_preserves_wait_status_without_forced_stop() {
+    let mut child = Command::new("sh")
+        .args(["-c", "exit 7"])
+        .spawn()
+        .expect("spawn exiting process");
+    let expected_status = child.wait().await.unwrap();
+    let (status, forcibly_stopped) =
+        finish_mysql_process_stop(&mut child, Err(std::io::Error::other("kill failed")))
+            .await
+            .unwrap();
+
+    assert_eq!(status.code(), expected_status.code());
+    assert!(!forcibly_stopped);
+    assert!(
+        validate_mysql_session_exit(
+            &MySqlSessionResult {
+                status,
+                forcibly_stopped,
+                error_bytes: Vec::new(),
+            },
+            None,
+        )
+        .is_err()
+    );
 }
 
 #[test]

--- a/src/infra/adapters/mysql/cli/process/process_tests.rs
+++ b/src/infra/adapters/mysql/cli/process/process_tests.rs
@@ -1,3 +1,5 @@
+#[cfg(not(unix))]
+use std::io;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 

--- a/src/infra/adapters/mysql/cli/process/process_tests.rs
+++ b/src/infra/adapters/mysql/cli/process/process_tests.rs
@@ -81,6 +81,41 @@ fn preserves_mysql_session_exit_rules() {
     ));
 }
 
+#[cfg(unix)]
+#[test]
+fn rejects_nonzero_wait_status_without_confirmed_forced_stop() {
+    assert!(validate_mysql_session_exit(&session(9, false, b""), None).is_err());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn reports_successful_kill_and_wait_status() {
+    let mut child = Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("spawn sleep process");
+
+    let (status, forcibly_stopped) = stop_mysql_process(&mut child).await.unwrap();
+
+    assert!(!status.success());
+    assert!(forcibly_stopped);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn preserves_wait_status_for_normal_exit() {
+    let mut child = Command::new("sh")
+        .args(["-c", "exit 7"])
+        .spawn()
+        .expect("spawn exiting process");
+    let expected_status = child.wait().await.unwrap();
+
+    let (status, forcibly_stopped) = stop_mysql_process(&mut child).await.unwrap();
+
+    assert_eq!(status.code(), expected_status.code());
+    assert!(!forcibly_stopped);
+}
+
 #[test]
 fn separates_statements_after_line_comments_with_semicolons() {
     for query in [


### PR DESCRIPTION
## Problem
A failed MySQL child kill is currently treated as a forced stop, allowing a non-success wait status to bypass session-exit validation.

## Background
The session cleanup path must distinguish a successful forced stop from a process that exited without being killed.

## Approach
Preserve the kill result through child reaping and mark the session as forcibly stopped only when the kill succeeds. Add focused Unix coverage for successful kill, normal wait status, and an unconfirmed forced stop.