### PR TITLE
fix(er): invalidate metadata cache after smart refresh

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -770,5 +770,68 @@ mod tests {
             assert_eq!(run.state.runtime.project_name(), "test");
             assert!(cache.get(&"dsn://target".to_string()).await.is_none());
         }
+
+        #[tokio::test]
+        async fn invalidate_forces_following_metadata_fetch() {
+            let mut mock_provider = MockMetadataProvider::new();
+            mock_provider
+                .expect_fetch_metadata()
+                .once()
+                .returning(|_| Ok(test_fixtures::sample_metadata()));
+
+            let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
+            cache
+                .set(
+                    "dsn://target".to_string(),
+                    Arc::new(DatabaseMetadata::new("old".to_string())),
+                )
+                .await;
+
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(mock_provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                cache.clone(),
+                tx,
+            );
+
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::Sequence(vec![
+                    Effect::CacheInvalidate {
+                        dsn: "dsn://target".to_string(),
+                    },
+                    Effect::FetchMetadata {
+                        dsn: "dsn://target".to_string(),
+                        run_id: 7,
+                    },
+                ]),
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
+
+            let action = run.actions.into_iter().next().expect("action dispatched");
+            assert!(matches!(
+                action,
+                Action::MetadataLoaded {
+                    ref dsn,
+                    run_id: 7,
+                    ref metadata,
+                } if dsn == "dsn://target" && metadata.database_name == "testdb"
+            ));
+            assert_eq!(
+                cache
+                    .get(&"dsn://target".to_string())
+                    .await
+                    .expect("fetched metadata should be cached")
+                    .database_name,
+                "testdb"
+            );
+        }
     }
 }

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -320,6 +320,9 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(
+                matches!(&effects[0], Effect::CacheInvalidate { dsn } if dsn == "postgres://localhost/test")
+            );
+            assert!(
                 effects
                     .iter()
                     .any(|e| matches!(e, Effect::GenerateErDiagramFromCache { .. }))
@@ -614,6 +617,9 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
             );
+            assert!(
+                matches!(&effects[0], Effect::CacheInvalidate { dsn } if dsn == "postgres://localhost/test")
+            );
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
@@ -709,7 +715,9 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(effects.is_empty());
+            assert!(
+                matches!(&effects[..], [Effect::CacheInvalidate { dsn }] if dsn == "postgres://localhost/test")
+            );
             assert!(state.messages.last_error.is_some());
         }
 
@@ -746,6 +754,9 @@ mod tests {
                 effects
                     .iter()
                     .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
+            );
+            assert!(
+                matches!(&effects[0], Effect::CacheInvalidate { dsn } if dsn == "postgres://localhost/test")
             );
             assert!(effects.iter().any(|e| matches!(
                 e,

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -617,9 +617,6 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
             );
-            assert!(
-                matches!(&effects[0], Effect::CacheInvalidate { dsn } if dsn == "postgres://localhost/test")
-            );
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
@@ -715,9 +712,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(
-                matches!(&effects[..], [Effect::CacheInvalidate { dsn }] if dsn == "postgres://localhost/test")
-            );
+            assert!(effects.is_empty());
             assert!(state.messages.last_error.is_some());
         }
 

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -33,7 +33,7 @@ pub(super) fn reduce_smart_refresh_completed(
                 .er_preparation
                 .apply_refresh_metadata(new_signatures.clone(), new_metadata.table_summaries.len());
 
-            let mut effects: Vec<Effect> = Vec::new();
+            let mut effects = vec![Effect::CacheInvalidate { dsn: dsn.clone() }];
 
             if !removed_tables.is_empty() {
                 effects.push(Effect::EvictTablesFromCompletionCache {

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -22,6 +22,8 @@ pub(super) fn reduce_smart_refresh_failed(
                 return DispatchResult::handled();
             }
 
+            let mut effects = vec![Effect::CacheInvalidate { dsn: dsn.clone() }];
+
             if let Some(md) = new_metadata {
                 state.session.set_metadata(Some(Arc::clone(md)));
             }
@@ -31,7 +33,7 @@ pub(super) fn reduce_smart_refresh_failed(
                 state
                     .messages
                     .set_error("Metadata not loaded yet".to_string());
-                return DispatchResult::handled();
+                return DispatchResult::handled_with(effects);
             };
             state
                 .er_preparation
@@ -40,10 +42,11 @@ pub(super) fn reduce_smart_refresh_failed(
             state.messages.set_error(format!(
                 "Smart refresh failed ({error}), falling back to full refresh"
             ));
-            DispatchResult::handled_with(vec![
+            effects.extend([
                 Effect::ClearCompletionEngineCache,
                 Effect::DispatchActions(vec![Action::StartErPrefetchAll]),
-            ])
+            ]);
+            DispatchResult::handled_with(effects)
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -22,10 +22,11 @@ pub(super) fn reduce_smart_refresh_failed(
                 return DispatchResult::handled();
             }
 
-            let mut effects = vec![Effect::CacheInvalidate { dsn: dsn.clone() }];
+            let mut effects = Vec::new();
 
             if let Some(md) = new_metadata {
                 state.session.set_metadata(Some(Arc::clone(md)));
+                effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
             }
 
             let Some(metadata) = &state.session.metadata() else {


### PR DESCRIPTION
## Problem
Smart ER refresh updated session metadata while leaving the TTL metadata cache entry intact. A later metadata fetch could therefore reuse the previous catalog.

## Background
The refresh path reads fresh metadata directly and accepts the result without going through the metadata cache.

## Approach
Accepted Smart ER completion and failure results now emit the existing DSN-scoped cache invalidation effect before their existing ER follow-up effects. Stale DSN/run results remain ignored, and the existing metadata fetch path repopulates the cache on its next miss.