### PR TITLE
fix(sqlite): classify CTE REPLACE as write

### DIFF
--- a/src/domain/sqlite_sql/export.rs
+++ b/src/domain/sqlite_sql/export.rs
@@ -17,11 +17,7 @@ mod tests {
 
     #[test]
     fn accepts_read_only_statements() {
-        for sql in [
-            "SELECT id FROM users",
-            "PRAGMA table_info(users)",
-            "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload",
-        ] {
+        for sql in ["SELECT id FROM users", "PRAGMA table_info(users)"] {
             assert!(is_sqlite_rerunnable_export_statement(sql), "{sql}");
         }
     }
@@ -31,6 +27,7 @@ mod tests {
         for sql in [
             "INSERT INTO users(id) VALUES (1)",
             "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload",
+            "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload",
             "PRAGMA foreign_keys = OFF",
             "PRAGMA journal_mode = WAL",
         ] {

--- a/src/domain/sqlite_sql/transaction.rs
+++ b/src/domain/sqlite_sql/transaction.rs
@@ -105,11 +105,8 @@ pub fn sqlite_statement_classification(statement: &str) -> SqliteStatementClassi
         Some("ATTACH" | "DETACH") => SqliteStatementClassification::SessionSideEffect,
         Some(
             "ANALYZE" | "REINDEX" | "INSERT" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP"
-            | "TRUNCATE",
+            | "TRUNCATE" | "REPLACE",
         ) => SqliteStatementClassification::TransactionalWrite,
-        Some("REPLACE") if first_keyword.as_deref() == Some("REPLACE") => {
-            SqliteStatementClassification::TransactionalWrite
-        }
         _ => SqliteStatementClassification::ReadOnly,
     }
 }
@@ -341,7 +338,7 @@ mod tests {
             sqlite_statement_classification(
                 "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload"
             ),
-            SqliteStatementClassification::ReadOnly
+            SqliteStatementClassification::TransactionalWrite
         );
         assert_eq!(
             sqlite_statement_classification("START TRANSACTION"),
@@ -352,6 +349,25 @@ mod tests {
                 "WITH changed AS (UPDATE users SET name = 'a' RETURNING *) SELECT * FROM changed"
             ),
             SqliteStatementClassification::TransactionalWrite
+        );
+    }
+
+    #[test]
+    fn cte_replace_enters_the_automatic_transaction_policy() {
+        let classification = sqlite_statement_classification(
+            "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload",
+        );
+
+        assert_eq!(
+            classification,
+            SqliteStatementClassification::TransactionalWrite
+        );
+        assert_eq!(
+            sqlite_transaction_policy_for_classifications(
+                2,
+                &[classification, SqliteStatementClassification::ReadOnly],
+            ),
+            SqliteTransactionPolicy::AutoWrap
         );
     }
 


### PR DESCRIPTION
## Problem
SQLite treated `WITH ... REPLACE` as read-only, so a data-modifying statement could bypass read-only export handling and transaction planning.

## Background
The existing classification special-cased ordinary `REPLACE` even though the existing keyword extraction already identifies the statement after a CTE.

## Approach
Include `REPLACE` in the established transactional-write classification and preserve the existing confirmation, export, parser, and database-specific behavior for all other statements.