### PR TITLE
fix(postgres): classify missing metadata relations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,10 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
         run: cargo nextest run -p sabiql --run-ignored ignored-only -E 'test(tests::adapter_postgres)' --show-progress=none
+      - name: Run PostgreSQL metadata provider lifecycle test
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
+        run: cargo nextest run -p sabiql-infra --run-ignored ignored-only -E 'test(provider_classifies_full_and_light_missing_relations_without_losing_empty_tables)' --show-progress=none
       - name: Run Oracle MySQL 8.4 integration tests (Tier 2)
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target

--- a/src/infra/adapters/postgres/metadata.rs
+++ b/src/infra/adapters/postgres/metadata.rs
@@ -127,3 +127,278 @@ impl MetadataProvider for PostgresAdapter {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::ports::outbound::{AccessMode, QueryExecutor};
+
+    const DEFAULT_TEST_DSN: &str = "postgres://dev:dev@localhost:5433/testdb";
+
+    fn postgres_test_dsn() -> String {
+        std::env::var("SABIQL_TEST_DSN").unwrap_or_else(|_| DEFAULT_TEST_DSN.to_string())
+    }
+
+    fn unique_schema_name() -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        format!("sabiql_elt024_{}_{}", std::process::id(), nanos)
+    }
+
+    fn assert_object_missing(
+        result: Result<Table, DbOperationError>,
+        context: &str,
+    ) -> Result<(), String> {
+        match result {
+            Err(DbOperationError::ObjectMissing(_)) => Ok(()),
+            other => Err(format!("{context} returned {other:?}")),
+        }
+    }
+
+    fn assert_permission_denied(
+        result: Result<Table, DbOperationError>,
+        context: &str,
+    ) -> Result<(), String> {
+        match result {
+            Err(DbOperationError::PermissionDenied(_)) => Ok(()),
+            other => Err(format!("{context} returned {other:?}")),
+        }
+    }
+
+    fn dsn_with_credentials(
+        dsn: &str,
+        username: &str,
+        password: &str,
+        database: &str,
+    ) -> Result<String, String> {
+        let mut url = url::Url::parse(dsn).map_err(|error| error.to_string())?;
+        url.set_username(username)
+            .map_err(|()| "failed to set PostgreSQL test username".to_string())?;
+        url.set_password(Some(password))
+            .map_err(|()| "failed to set PostgreSQL test password".to_string())?;
+        url.set_path(&format!("/{database}"));
+        Ok(url.to_string())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL"]
+    async fn provider_classifies_full_and_light_missing_relations_without_losing_empty_tables() {
+        let adapter = PostgresAdapter::new();
+        let dsn = postgres_test_dsn();
+        let schema = unique_schema_name();
+        let qualified = |table: &str| format!(r#""{schema}"."{table}""#);
+
+        let setup = format!(
+            r#"
+            CREATE SCHEMA "{schema}";
+            CREATE TABLE {} (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE {} (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE {} ();
+            CREATE TABLE {} (id INTEGER);
+            CREATE TABLE {} (id INTEGER);
+            "#,
+            qualified("existing_full"),
+            qualified("existing_light"),
+            qualified("zero_columns"),
+            qualified("drop_full"),
+            qualified("drop_light"),
+        );
+        let setup_result = adapter
+            .execute_adhoc(&dsn, &setup, AccessMode::ReadWrite)
+            .await
+            .map_err(|error| error.to_string());
+
+        let test_result: Result<(), String> = match setup_result {
+            Ok(_) => {
+                async {
+                    let full = adapter
+                        .fetch_table_detail(&dsn, &schema, "existing_full")
+                        .await
+                        .map_err(|error| format!("full existing fetch failed: {error}"))?;
+                    if full.columns.len() != 2 || full.owner.is_none() || full.rls.is_none() {
+                        return Err(format!("unexpected full existing table: {full:?}"));
+                    }
+
+                    let light = adapter
+                        .fetch_table_columns_and_fks(&dsn, &schema, "existing_light")
+                        .await
+                        .map_err(|error| format!("light existing fetch failed: {error}"))?;
+                    if light.columns.len() != 2 {
+                        return Err(format!("unexpected light existing table: {light:?}"));
+                    }
+
+                    let full_zero = adapter
+                        .fetch_table_detail(&dsn, &schema, "zero_columns")
+                        .await
+                        .map_err(|error| format!("full zero-column fetch failed: {error}"))?;
+                    if !full_zero.columns.is_empty()
+                        || full_zero.owner.is_none()
+                        || full_zero.rls.is_none()
+                    {
+                        return Err(format!("unexpected full zero-column table: {full_zero:?}"));
+                    }
+
+                    let light_zero = adapter
+                        .fetch_table_columns_and_fks(&dsn, &schema, "zero_columns")
+                        .await
+                        .map_err(|error| format!("light zero-column fetch failed: {error}"))?;
+                    if !light_zero.columns.is_empty() {
+                        return Err(format!(
+                            "unexpected light zero-column table: {light_zero:?}"
+                        ));
+                    }
+
+                    assert_object_missing(
+                        adapter
+                            .fetch_table_detail(&dsn, &schema, "missing_full")
+                            .await,
+                        "full missing relation",
+                    )?;
+                    assert_object_missing(
+                        adapter
+                            .fetch_table_columns_and_fks(&dsn, &schema, "missing_light")
+                            .await,
+                        "light missing relation",
+                    )?;
+
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            &format!("DROP TABLE {}", qualified("drop_full")),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("drop full fixture failed: {error}"))?;
+                    assert_object_missing(
+                        adapter.fetch_table_detail(&dsn, &schema, "drop_full").await,
+                        "full relation after drop",
+                    )?;
+
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            &format!("DROP TABLE {}", qualified("drop_light")),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("drop light fixture failed: {error}"))?;
+                assert_object_missing(
+                    adapter
+                        .fetch_table_columns_and_fks(&dsn, &schema, "drop_light")
+                        .await,
+                        "light relation after drop",
+                    )
+                    ?;
+
+                    let permission_role = format!("{schema}_role");
+                    let permission_database = format!("{schema}_db");
+                    let permission_password = "sabiql_elt024_password";
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            &format!(
+                                "CREATE ROLE \"{permission_role}\" LOGIN PASSWORD '{permission_password}'"
+                            ),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("permission role setup failed: {error}"))?;
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            &format!("CREATE DATABASE \"{permission_database}\""),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("permission database setup failed: {error}"))?;
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            &format!(
+                                "REVOKE CONNECT ON DATABASE \"{permission_database}\" FROM PUBLIC"
+                            ),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("permission ACL setup failed: {error}"))?;
+
+                    let permission_dsn = dsn_with_credentials(
+                        &dsn,
+                        &permission_role,
+                        permission_password,
+                        &permission_database,
+                    )?;
+                    assert_permission_denied(
+                        adapter
+                            .fetch_table_detail(&permission_dsn, &schema, "existing_full")
+                            .await,
+                        "full permission failure",
+                    )?;
+                    assert_permission_denied(
+                        adapter
+                            .fetch_table_columns_and_fks(
+                                &permission_dsn,
+                                &schema,
+                                "existing_light",
+                            )
+                            .await,
+                        "light permission failure",
+                    )
+                }
+                .await
+            }
+            Err(error) => Err(error),
+        };
+
+        let cleanup_result = adapter
+            .execute_adhoc(
+                &dsn,
+                &format!("DROP SCHEMA IF EXISTS \"{schema}\" CASCADE"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string());
+        let permission_database = format!("{schema}_db");
+        let permission_role = format!("{schema}_role");
+        let permission_database_cleanup = adapter
+            .execute_adhoc(
+                &dsn,
+                &format!("DROP DATABASE IF EXISTS \"{permission_database}\""),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string());
+        let permission_role_cleanup = adapter
+            .execute_adhoc(
+                &dsn,
+                &format!("DROP ROLE IF EXISTS \"{permission_role}\""),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string());
+
+        match (
+            test_result,
+            cleanup_result,
+            permission_database_cleanup,
+            permission_role_cleanup,
+        ) {
+            (Ok(()), Ok(()), Ok(()), Ok(())) => {}
+            (Err(test_error), Ok(()), Ok(()), Ok(())) => panic!("{test_error}"),
+            (Ok(()), cleanup_schema, cleanup_database, cleanup_role) => {
+                panic!(
+                    "cleanup failed: schema={cleanup_schema:?}; database={cleanup_database:?}; role={cleanup_role:?}"
+                )
+            }
+            (Err(test_error), cleanup_schema, cleanup_database, cleanup_role) => {
+                panic!(
+                    "test failed: {test_error}; cleanup failed: schema={cleanup_schema:?}; database={cleanup_database:?}; role={cleanup_role:?}"
+                )
+            }
+        }
+    }
+}

--- a/src/infra/adapters/postgres/metadata.rs
+++ b/src/infra/adapters/postgres/metadata.rs
@@ -20,6 +20,10 @@ fn extract_primary_key(columns: &[Column]) -> Option<Vec<String>> {
     }
 }
 
+fn postgres_table_not_found(schema: &str, table: &str) -> DbOperationError {
+    DbOperationError::ObjectMissing(format!("PostgreSQL table not found: {schema}.{table}"))
+}
+
 #[async_trait]
 impl MetadataProvider for PostgresAdapter {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
@@ -66,8 +70,11 @@ impl MetadataProvider for PostgresAdapter {
     ) -> Result<Table, DbOperationError> {
         let query = Self::table_detail_query(schema, table);
         let json = self.execute_query(dsn, &query).await?;
-        let (columns, indexes, foreign_keys, rls, triggers, table_info) =
+        let (exists, columns, indexes, foreign_keys, rls, triggers, table_info) =
             Self::parse_table_detail_combined(&json)?;
+        if !exists {
+            return Err(postgres_table_not_found(schema, table));
+        }
         let primary_key = extract_primary_key(&columns);
 
         Ok(Table {
@@ -96,7 +103,10 @@ impl MetadataProvider for PostgresAdapter {
     ) -> Result<Table, DbOperationError> {
         let query = Self::table_columns_and_fks_query(schema, table);
         let json = self.execute_query(dsn, &query).await?;
-        let (columns, foreign_keys) = Self::parse_table_columns_and_fks(&json)?;
+        let (exists, columns, foreign_keys) = Self::parse_table_columns_and_fks(&json)?;
+        if !exists {
+            return Err(postgres_table_not_found(schema, table));
+        }
         let primary_key = extract_primary_key(&columns);
 
         Ok(Table {

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -7,6 +7,7 @@ use crate::domain::{
 use super::super::super::PostgresAdapter;
 
 pub(in crate::adapters::postgres) type TableDetailCombined = (
+    bool,
     Vec<Column>,
     Vec<Index>,
     Vec<ForeignKey>,
@@ -394,6 +395,7 @@ impl PostgresAdapter {
         #[derive(serde::Deserialize)]
         #[serde(deny_unknown_fields)]
         struct CombinedDetail {
+            exists: bool,
             columns: serde_json::Value,
             indexes: serde_json::Value,
             foreign_keys: serde_json::Value,
@@ -411,12 +413,20 @@ impl PostgresAdapter {
         let triggers = Self::parse_triggers(&combined.triggers.to_string())?;
         let table_info = Self::parse_table_info(&combined.table_info.to_string())?;
 
-        Ok((columns, indexes, foreign_keys, rls, triggers, table_info))
+        Ok((
+            combined.exists,
+            columns,
+            indexes,
+            foreign_keys,
+            rls,
+            triggers,
+            table_info,
+        ))
     }
 
     pub(in crate::adapters::postgres) fn parse_table_columns_and_fks(
         json: &str,
-    ) -> Result<(Vec<Column>, Vec<ForeignKey>), DbOperationError> {
+    ) -> Result<(bool, Vec<Column>, Vec<ForeignKey>), DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
             return Err(DbOperationError::EmptyResponse(
                 "table_columns_and_fks".to_string(),
@@ -426,6 +436,7 @@ impl PostgresAdapter {
         #[derive(serde::Deserialize)]
         #[serde(deny_unknown_fields)]
         struct LightDetail {
+            exists: bool,
             columns: serde_json::Value,
             foreign_keys: serde_json::Value,
         }
@@ -435,7 +446,7 @@ impl PostgresAdapter {
         let columns = Self::parse_columns(&light.columns.to_string())?;
         let foreign_keys = Self::parse_foreign_keys(&light.foreign_keys.to_string())?;
 
-        Ok((columns, foreign_keys))
+        Ok((light.exists, columns, foreign_keys))
     }
 }
 
@@ -1261,6 +1272,7 @@ mod tests {
         use super::*;
 
         fn build_combined_json(
+            exists: bool,
             columns: &str,
             indexes: &str,
             fks: &str,
@@ -1270,6 +1282,7 @@ mod tests {
         ) -> String {
             format!(
                 r#"{{
+                    "exists": {exists},
                     "columns": {columns},
                     "indexes": {indexes},
                     "foreign_keys": {fks},
@@ -1283,6 +1296,7 @@ mod tests {
         #[test]
         fn valid_combined_json_parses_all_categories() {
             let json = build_combined_json(
+                true,
                 r#"[{"name":"id","data_type":"integer","nullable":false,"default":null,"is_primary_key":true,"is_unique":false,"comment":null,"ordinal_position":1}]"#,
                 "null",
                 "null",
@@ -1291,9 +1305,10 @@ mod tests {
                 r#"{"owner":"postgres","comment":null,"row_count_estimate":42}"#,
             );
 
-            let (columns, indexes, fks, rls, triggers, table_info) =
+            let (exists, columns, indexes, fks, rls, triggers, table_info) =
                 PostgresAdapter::parse_table_detail_combined(&json).unwrap();
 
+            assert!(exists);
             assert_eq!(columns.len(), 1);
             assert_eq!(columns[0].name, "id");
             assert!(indexes.is_empty());
@@ -1306,12 +1321,29 @@ mod tests {
         }
 
         #[test]
-        fn all_null_sub_values_parse_to_empty_defaults() {
-            let json = build_combined_json("null", "null", "null", "null", "null", "null");
+        fn existing_zero_column_table_keeps_empty_metadata_distinct_from_missing() {
+            let json = build_combined_json(true, "null", "null", "null", "null", "null", "null");
 
-            let (columns, indexes, fks, rls, triggers, table_info) =
+            let (exists, columns, indexes, fks, rls, triggers, table_info) =
                 PostgresAdapter::parse_table_detail_combined(&json).unwrap();
 
+            assert!(exists);
+            assert!(columns.is_empty());
+            assert!(indexes.is_empty());
+            assert!(fks.is_empty());
+            assert!(rls.is_none());
+            assert!(triggers.is_empty());
+            assert!(table_info.owner.is_none());
+        }
+
+        #[test]
+        fn missing_relation_preserves_false_existence_bit() {
+            let json = build_combined_json(false, "null", "null", "null", "null", "null", "null");
+
+            let (exists, columns, indexes, fks, rls, triggers, table_info) =
+                PostgresAdapter::parse_table_detail_combined(&json).unwrap();
+
+            assert!(!exists);
             assert!(columns.is_empty());
             assert!(indexes.is_empty());
             assert!(fks.is_empty());
@@ -1329,7 +1361,7 @@ mod tests {
 
         #[test]
         fn unknown_key_returns_invalid_json_error() {
-            let json = build_combined_json("null", "null", "null", "null", "null", "null")
+            let json = build_combined_json(true, "null", "null", "null", "null", "null", "null")
                 .replace('}', r#","extra_key": null}"#);
             let result = PostgresAdapter::parse_table_detail_combined(&json);
             assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
@@ -1351,19 +1383,22 @@ mod tests {
     mod table_columns_and_fks_parsing {
         use super::*;
 
-        fn build_light_json(columns: &str, fks: &str) -> String {
-            format!(r#"{{"columns": {columns}, "foreign_keys": {fks}}}"#)
+        fn build_light_json(exists: bool, columns: &str, fks: &str) -> String {
+            format!(r#"{{"exists": {exists}, "columns": {columns}, "foreign_keys": {fks}}}"#)
         }
 
         #[test]
         fn valid_light_json_parses_columns_and_fks() {
             let json = build_light_json(
+                true,
                 r#"[{"name":"id","data_type":"integer","nullable":false,"default":null,"is_primary_key":true,"is_unique":false,"comment":null,"ordinal_position":1}]"#,
                 r#"[{"name":"fk_1","from_schema":"public","from_table":"orders","from_columns":["user_id"],"to_schema":"public","to_table":"users","to_columns":["id"],"on_delete":"c","on_update":"a"}]"#,
             );
 
-            let (columns, fks) = PostgresAdapter::parse_table_columns_and_fks(&json).unwrap();
+            let (exists, columns, fks) =
+                PostgresAdapter::parse_table_columns_and_fks(&json).unwrap();
 
+            assert!(exists);
             assert_eq!(columns.len(), 1);
             assert_eq!(columns[0].name, "id");
             assert_eq!(fks.len(), 1);
@@ -1372,24 +1407,38 @@ mod tests {
 
         #[test]
         fn null_sub_values_parse_to_empty() {
-            let json = build_light_json("null", "null");
+            let json = build_light_json(true, "null", "null");
 
-            let (columns, fks) = PostgresAdapter::parse_table_columns_and_fks(&json).unwrap();
+            let (exists, columns, fks) =
+                PostgresAdapter::parse_table_columns_and_fks(&json).unwrap();
 
+            assert!(exists);
+            assert!(columns.is_empty());
+            assert!(fks.is_empty());
+        }
+
+        #[test]
+        fn missing_relation_preserves_false_existence_bit() {
+            let json = build_light_json(false, "null", "null");
+
+            let (exists, columns, fks) =
+                PostgresAdapter::parse_table_columns_and_fks(&json).unwrap();
+
+            assert!(!exists);
             assert!(columns.is_empty());
             assert!(fks.is_empty());
         }
 
         #[test]
         fn missing_key_returns_error() {
-            let json = r#"{"columns": null}"#;
+            let json = r#"{"exists": true, "columns": null}"#;
             let result = PostgresAdapter::parse_table_columns_and_fks(json);
             assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
         }
 
         #[test]
         fn unknown_key_returns_error() {
-            let json = r#"{"columns": null, "foreign_keys": null, "extra": null}"#;
+            let json = r#"{"exists": true, "columns": null, "foreign_keys": null, "extra": null}"#;
             let result = PostgresAdapter::parse_table_columns_and_fks(json);
             assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
         }

--- a/src/infra/adapters/postgres/sql/query.rs
+++ b/src/infra/adapters/postgres/sql/query.rs
@@ -356,10 +356,19 @@ impl PostgresAdapter {
         format!(
             r"
             SELECT json_build_object(
+                'exists', EXISTS (
+                    SELECT 1
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                    WHERE n.nspname = {schema}
+                      AND c.relname = {table}
+                ),
                 'columns', ({columns}),
                 'foreign_keys', ({fks})
             )
             ",
+            schema = quote_literal(schema),
+            table = quote_literal(table),
             columns = Self::columns_query(schema, table).trim(),
             fks = Self::foreign_keys_query(schema, table).trim(),
         )
@@ -369,6 +378,13 @@ impl PostgresAdapter {
         format!(
             r"
             SELECT json_build_object(
+                'exists', EXISTS (
+                    SELECT 1
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                    WHERE n.nspname = {schema}
+                      AND c.relname = {table}
+                ),
                 'columns', ({columns}),
                 'indexes', ({indexes}),
                 'foreign_keys', ({fks}),
@@ -377,6 +393,8 @@ impl PostgresAdapter {
                 'table_info', ({table_info})
             )
             ",
+            schema = quote_literal(schema),
+            table = quote_literal(table),
             columns = Self::columns_query(schema, table).trim(),
             indexes = Self::indexes_query(schema, table).trim(),
             fks = Self::foreign_keys_query(schema, table).trim(),
@@ -553,11 +571,12 @@ mod tests {
         use super::*;
 
         #[test]
-        fn wraps_all_six_categories_in_json_build_object() {
+        fn wraps_existence_and_all_six_categories_in_json_build_object() {
             let sql = PostgresAdapter::table_detail_query("public", "users");
 
             assert!(sql.contains("json_build_object("));
             for key in [
+                "'exists'",
                 "'columns'",
                 "'indexes'",
                 "'foreign_keys'",
@@ -582,10 +601,11 @@ mod tests {
         use super::*;
 
         #[test]
-        fn wraps_columns_and_fks_only_in_json_build_object() {
+        fn wraps_existence_columns_and_fks_in_json_build_object() {
             let sql = PostgresAdapter::table_columns_and_fks_query("public", "users");
 
             assert!(sql.contains("json_build_object("));
+            assert!(sql.contains("'exists'"));
             assert!(sql.contains("'columns'"));
             assert!(sql.contains("'foreign_keys'"));
             assert!(!sql.contains("'indexes'"));


### PR DESCRIPTION
## Problem
PostgreSQL metadata detail queries return null for every category when a relation disappears, so missing tables become empty successful metadata.

## Background
A valid zero-column table also has an empty columns result, so category emptiness cannot identify a missing relation.

## Approach
Include an unprivileged catalog existence bit in full and light detail payloads. Preserve that bit through parsing and classify only false as ObjectMissing at the metadata provider boundary; CLI permission failures continue through existing error handling.