### PR TITLE
fix: cancel stale metadata tasks before refresh

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -26,6 +26,9 @@ pub async fn run(
     completion_engine: &RefCell<CompletionEngine>,
 ) {
     match effect {
+        Effect::CancelMetadataTasks => {
+            metadata_tasks.cancel().await;
+        }
         Effect::FetchMetadata { dsn, run_id } => {
             fetch_metadata(
                 action_tx,

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -97,6 +97,7 @@ pub enum Effect {
         access_mode: AccessMode,
     },
     CancelConnectionTask,
+    CancelMetadataTasks,
     CancelSqliteDiagnostics,
     CancelTrackedTasks,
     CountRowsForExport {

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -266,7 +266,8 @@ impl EffectRunner {
             | Effect::PrefetchTableColumnsAndFks { .. }
             | Effect::SchedulePrefetchQueueProcessing { .. }
             | Effect::DelayedProcessPrefetchQueue { .. }
-            | Effect::CacheInvalidate { .. }) => {
+            | Effect::CacheInvalidate { .. }
+            | Effect::CancelMetadataTasks) => {
                 if matches!(&e, Effect::FetchMetadata { .. }) {
                     self.cancel_metadata_tasks().await;
                     self.smart_er_refresh_task.cancel().await;
@@ -292,11 +293,6 @@ impl EffectRunner {
 
             Effect::CancelSqliteDiagnostics => {
                 self.sqlite_diagnostics_task.cancel().await;
-                Ok(vec![])
-            }
-
-            Effect::CancelMetadataTasks => {
-                self.cancel_metadata_tasks().await;
                 Ok(vec![])
             }
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -295,6 +295,11 @@ impl EffectRunner {
                 Ok(vec![])
             }
 
+            Effect::CancelMetadataTasks => {
+                self.cancel_metadata_tasks().await;
+                Ok(vec![])
+            }
+
             Effect::CancelTrackedTasks => {
                 self.cancel_tracked_tasks().await;
                 Ok(vec![])

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -274,6 +274,7 @@ pub(super) fn refresh_effects_for_scope(
         state.session.set_table_detail_raw(None);
         let run_id = state.session.begin_metadata_refresh();
 
+        effects.push(Effect::CancelMetadataTasks);
         effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
         effects.push(Effect::ClearCompletionEngineCache);
         effects.push(Effect::FetchMetadata { dsn, run_id });
@@ -1559,6 +1560,7 @@ mod tests {
             let effects =
                 dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
+            assert!(matches!(effects[0], Effect::CancelMetadataTasks));
             assert!(
                 effects
                     .iter()
@@ -1655,6 +1657,7 @@ mod tests {
             let effects =
                 dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
+            assert!(matches!(effects[0], Effect::CancelMetadataTasks));
             assert!(
                 effects
                     .iter()

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -45,6 +45,7 @@ pub(crate) fn metadata_reload_effects(state: &mut AppState, dsn: &str) -> Vec<Ef
     let run_id = state.session.begin_reload();
 
     vec![Effect::Sequence(vec![
+        Effect::CancelMetadataTasks,
         Effect::CacheInvalidate {
             dsn: dsn.to_string(),
         },

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1619,10 +1619,11 @@ mod tests {
             assert!(matches!(effects[0], Effect::Sequence(_)));
 
             if let Effect::Sequence(seq) = &effects[0] {
-                assert_eq!(seq.len(), 3);
-                assert!(matches!(seq[0], Effect::CacheInvalidate { .. }));
-                assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
-                assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
+                assert_eq!(seq.len(), 4);
+                assert!(matches!(seq[0], Effect::CancelMetadataTasks));
+                assert!(matches!(seq[1], Effect::CacheInvalidate { .. }));
+                assert!(matches!(seq[2], Effect::ClearCompletionEngineCache));
+                assert!(matches!(seq[3], Effect::FetchMetadata { .. }));
             }
         }
 


### PR DESCRIPTION
## Problem
Metadata refresh invalidates the cache before cancelling older metadata tasks, allowing an older task to repopulate the refreshed cache.

## Background
The metadata task registry already waits for cancelled tasks to finish, but refresh callers did not place that boundary before cache invalidation.

## Approach
Add an explicit metadata-task cancellation effect and run it before cache invalidation for direct reload and metadata refresh paths. Existing metadata fetching, cache keys, database-specific errors, and reload presentation remain unchanged.