### PR TITLE
fix(infra): preserve refresh after affected-row parse failure

### DIFF
--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8,7 +9,7 @@ use tokio::time::timeout;
 
 use crate::adapters::csv_export::CsvOutputError;
 use crate::app::ports::outbound::{DbOperationError, ExportIoSource};
-use crate::domain::{CommandTag, QueryResult, QuerySource, WriteExecutionResult};
+use crate::domain::{CommandTag, QueryResult, QuerySource, RefreshScope, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
 use super::error::{classify_cli_spawn_error, classify_query_error};
@@ -408,8 +409,9 @@ impl PostgresAdapter {
         let output = self.run_psql(dsn, &[], query, read_only).await?;
 
         let affected_rows = Self::parse_affected_rows_with_source(&output).map_err(
-            |error: ParseCommandTagError| {
-                DbOperationError::CommandTagParseFailed(error.to_string())
+            |error: ParseCommandTagError| DbOperationError::QueryFailedAfterChange {
+                source: Arc::new(DbOperationError::CommandTagParseFailed(error.to_string())),
+                refresh_scope: RefreshScope::Data,
             },
         )?;
 

--- a/src/infra/adapters/sqlite/executor.rs
+++ b/src/infra/adapters/sqlite/executor.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -5,8 +6,8 @@ use async_trait::async_trait;
 use crate::adapters::csv_export::export_to_downloads;
 use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use crate::domain::{
-    CommandTag, QueryResult, QuerySource, TableKind, TableKindInfo, WriteExecutionResult,
-    sqlite_sql::is_sqlite_explain_query_plan_sql,
+    CommandTag, QueryResult, QuerySource, RefreshScope, TableKind, TableKindInfo,
+    WriteExecutionResult, sqlite_sql::is_sqlite_explain_query_plan_sql,
 };
 
 use super::sqlite3::parser::{
@@ -222,7 +223,10 @@ impl SqliteAdapter {
             .cli
             .execute_csv(path, &append_changes_query_for_plan(plan), read_only)
             .await?;
-        parse_affected_rows(&stdout)
+        parse_affected_rows(&stdout).map_err(|error| DbOperationError::QueryFailedAfterChange {
+            source: Arc::new(error),
+            refresh_scope: RefreshScope::Data,
+        })
     }
 }
 


### PR DESCRIPTION
## Problem
A successful PostgreSQL or SQLite write can still fail while parsing its affected-row count, leaving the preview stale.

## Background
The database CLI has already completed successfully before the affected-row output is parsed, so the data may have changed even when the count cannot be read.

## Approach
Classify only this post-success parse failure as a data-refresh failure while retaining the original parse error and leaving execution failures, timeouts, successful counts, and MySQL behavior unchanged.