### PR TITLE
fix(app): terminalize inspector after metadata refresh failure

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -258,7 +258,8 @@ impl BrowseSession {
     }
 
     pub fn mark_metadata_detail_failed(&mut self, error: String) -> bool {
-        if self.metadata_detail_generation != Some(self.selection_generation)
+        let metadata_detail_generation = self.metadata_detail_generation.take();
+        if metadata_detail_generation != Some(self.selection_generation)
             || !matches!(&self.table_detail_state, TableDetailState::Loading)
         {
             return false;
@@ -510,6 +511,7 @@ impl BrowseSession {
         self.metadata_state = MetadataState::Loaded;
         self.metadata = Some(metadata);
         self.metadata_run.clear_active();
+        self.metadata_detail_generation = None;
         self.effective_user = None;
         self.effective_user_run.clear_active();
     }
@@ -519,6 +521,7 @@ impl BrowseSession {
         self.metadata_state = MetadataState::NotLoaded;
         self.metadata = None;
         self.metadata_run.clear_active();
+        self.metadata_detail_generation = None;
         self.effective_user = None;
         self.effective_user_run.clear_active();
     }
@@ -540,7 +543,9 @@ impl BrowseSession {
     pub fn begin_metadata_refresh(&mut self) -> u64 {
         self.clear_mysql_connection_probe();
         self.metadata_state = MetadataState::Loading;
-        self.metadata_detail_generation = Some(self.selection_generation);
+        self.metadata_detail_generation =
+            matches!(&self.table_detail_state, TableDetailState::Loading)
+                .then_some(self.selection_generation);
         self.begin_metadata_run()
     }
 
@@ -558,7 +563,11 @@ impl BrowseSession {
     #[must_use]
     pub fn begin_reload(&mut self) -> u64 {
         self.is_reloading = true;
-        self.metadata_detail_generation = None;
+        if self.metadata_detail_generation != Some(self.selection_generation)
+            || !matches!(&self.table_detail_state, TableDetailState::Loading)
+        {
+            self.metadata_detail_generation = None;
+        }
         self.begin_metadata_run()
     }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -153,7 +153,7 @@ pub struct BrowseSession {
     // -- lifecycle-gated --
     metadata: Option<Arc<DatabaseMetadata>>,
     metadata_run: AsyncRun,
-    metadata_detail_generation: u64,
+    metadata_detail_generation: Option<u64>,
     effective_user: Option<String>,
     effective_user_run: AsyncRun,
     table_detail_run: AsyncRun,
@@ -182,7 +182,7 @@ impl Default for BrowseSession {
             selection_generation: 0,
             metadata: None,
             metadata_run: AsyncRun::default(),
-            metadata_detail_generation: 0,
+            metadata_detail_generation: None,
             effective_user: None,
             effective_user_run: AsyncRun::default(),
             table_detail_run: AsyncRun::default(),
@@ -249,10 +249,7 @@ impl BrowseSession {
     }
 
     pub fn mark_table_detail_failed(&mut self, generation: u64, error: String) -> bool {
-        if generation == self.selection_generation
-            && self.selected_table_key.is_some()
-            && matches!(&self.table_detail_state, TableDetailState::Loading)
-        {
+        if generation == self.selection_generation && self.selected_table_key.is_some() {
             self.table_detail_state = TableDetailState::Error(error);
             true
         } else {
@@ -261,7 +258,9 @@ impl BrowseSession {
     }
 
     pub fn mark_metadata_detail_failed(&mut self, error: String) -> bool {
-        if self.metadata_detail_generation != self.selection_generation {
+        if self.metadata_detail_generation != Some(self.selection_generation)
+            || !matches!(&self.table_detail_state, TableDetailState::Loading)
+        {
             return false;
         }
 
@@ -541,6 +540,7 @@ impl BrowseSession {
     pub fn begin_metadata_refresh(&mut self) -> u64 {
         self.clear_mysql_connection_probe();
         self.metadata_state = MetadataState::Loading;
+        self.metadata_detail_generation = Some(self.selection_generation);
         self.begin_metadata_run()
     }
 
@@ -558,6 +558,7 @@ impl BrowseSession {
     #[must_use]
     pub fn begin_reload(&mut self) -> u64 {
         self.is_reloading = true;
+        self.metadata_detail_generation = None;
         self.begin_metadata_run()
     }
 
@@ -575,7 +576,6 @@ impl BrowseSession {
 
     #[must_use]
     fn begin_metadata_run(&mut self) -> u64 {
-        self.metadata_detail_generation = self.selection_generation;
         self.metadata_run.begin()
     }
 
@@ -652,7 +652,7 @@ impl BrowseSession {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.selection_generation = 0;
-        self.metadata_detail_generation = 0;
+        self.metadata_detail_generation = None;
         self.is_reloading = false;
         self.metadata_run.clear_active();
         self.effective_user_run.clear_active();
@@ -688,7 +688,7 @@ impl BrowseSession {
         self.connection_state = ConnectionState::default();
         self.metadata_state = MetadataState::default();
         self.metadata_run.clear_active();
-        self.metadata_detail_generation = 0;
+        self.metadata_detail_generation = None;
         self.effective_user = None;
         self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -153,6 +153,7 @@ pub struct BrowseSession {
     // -- lifecycle-gated --
     metadata: Option<Arc<DatabaseMetadata>>,
     metadata_run: AsyncRun,
+    metadata_detail_generation: u64,
     effective_user: Option<String>,
     effective_user_run: AsyncRun,
     table_detail_run: AsyncRun,
@@ -181,6 +182,7 @@ impl Default for BrowseSession {
             selection_generation: 0,
             metadata: None,
             metadata_run: AsyncRun::default(),
+            metadata_detail_generation: 0,
             effective_user: None,
             effective_user_run: AsyncRun::default(),
             table_detail_run: AsyncRun::default(),
@@ -247,12 +249,23 @@ impl BrowseSession {
     }
 
     pub fn mark_table_detail_failed(&mut self, generation: u64, error: String) -> bool {
-        if generation == self.selection_generation && self.selected_table_key.is_some() {
+        if generation == self.selection_generation
+            && self.selected_table_key.is_some()
+            && matches!(&self.table_detail_state, TableDetailState::Loading)
+        {
             self.table_detail_state = TableDetailState::Error(error);
             true
         } else {
             false
         }
+    }
+
+    pub fn mark_metadata_detail_failed(&mut self, error: String) -> bool {
+        if self.metadata_detail_generation != self.selection_generation {
+            return false;
+        }
+
+        self.mark_table_detail_failed(self.selection_generation, error)
     }
 
     pub fn mark_table_detail_probe_failed(&mut self, dsn: &str, error: String) -> bool {
@@ -562,6 +575,7 @@ impl BrowseSession {
 
     #[must_use]
     fn begin_metadata_run(&mut self) -> u64 {
+        self.metadata_detail_generation = self.selection_generation;
         self.metadata_run.begin()
     }
 
@@ -638,6 +652,7 @@ impl BrowseSession {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.selection_generation = 0;
+        self.metadata_detail_generation = 0;
         self.is_reloading = false;
         self.metadata_run.clear_active();
         self.effective_user_run.clear_active();
@@ -673,6 +688,7 @@ impl BrowseSession {
         self.connection_state = ConnectionState::default();
         self.metadata_state = MetadataState::default();
         self.metadata_run.clear_active();
+        self.metadata_detail_generation = 0;
         self.effective_user = None;
         self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -389,6 +389,46 @@ mod tests {
     }
 
     #[test]
+    fn reload_failure_during_detail_fetch_preserves_loading_detail_and_pending_preview() {
+        let mut state = connected_state(DatabaseType::MySQL);
+        let generation = state.session.select_table("app", "users", &mut state.query);
+        let detail_run_id = state.session.begin_table_detail_run();
+        state.query.defer_preview(
+            Arc::new(QueryResult::error(
+                "SELECT * FROM app.users".to_string(),
+                "preview failed".to_string(),
+                0,
+                QuerySource::Preview,
+            )),
+            generation,
+            None,
+            false,
+        );
+
+        reduce_loading(&mut state, &Action::ReloadMetadata, Instant::now())
+            .into_effects()
+            .expect("metadata reload should be handled");
+        let metadata_run_id = state.session.metadata_generation();
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(
+            &mut state,
+            &metadata_failed(&dsn, metadata_run_id),
+            Instant::now(),
+        )
+        .into_effects()
+        .expect("metadata failure should be handled");
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Loading
+        ));
+        assert!(state.session.is_current_table_detail_run(detail_run_id));
+        assert!(state.query.has_pending_preview(generation));
+    }
+
+    #[test]
     fn stale_metadata_failure_does_not_terminate_current_detail() {
         let mut state = connected_state(DatabaseType::MySQL);
         let (generation, stale_run_id) = loading_detail_and_metadata_run(&mut state);

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -112,7 +112,6 @@ pub(super) fn reduce_loading(
                 return DispatchResult::handled();
             }
 
-            let detail_generation = state.session.selection_generation();
             let error_info = ConnectionErrorInfo::from_db_operation_error(error);
             state.connection_error.set_error(error_info);
             let was_connected = state.session.connection_state().is_connected();
@@ -131,9 +130,12 @@ pub(super) fn reduce_loading(
             DispatchResult::handled_with(if was_connected {
                 if state
                     .session
-                    .mark_table_detail_failed(detail_generation, error.user_message())
+                    .mark_metadata_detail_failed(error.user_message())
                 {
-                    super::table_detail::reveal_pending_preview(state, detail_generation)
+                    super::table_detail::reveal_pending_preview(
+                        state,
+                        state.session.selection_generation(),
+                    )
                 } else {
                     vec![]
                 }
@@ -295,6 +297,95 @@ mod tests {
         );
         assert!(state.query.current_result().is_some());
         assert!(!state.query.has_pending_preview(generation));
+    }
+
+    #[test]
+    fn reload_failure_preserves_existing_detail_snapshot() {
+        let mut state = connected_state(DatabaseType::PostgreSQL);
+        let generation = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        let detail = table::minimal("public", "users");
+        assert!(state.session.set_table_detail(detail, generation));
+
+        reduce_loading(&mut state, &Action::ReloadMetadata, Instant::now())
+            .into_effects()
+            .expect("metadata reload should be handled");
+        let run_id = state.session.metadata_generation();
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+            .into_effects()
+            .expect("metadata failure should be handled");
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Loaded(_)
+        ));
+        assert!(matches!(
+            state.session.table_detail(),
+            Some(detail) if detail.schema == "public" && detail.name == "users"
+        ));
+        assert!(state.session.is_table_detail_terminal(generation));
+    }
+
+    #[test]
+    fn stale_metadata_failure_does_not_terminate_new_loading_detail() {
+        let mut state = connected_state(DatabaseType::PostgreSQL);
+        let _ = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        let stale_run_id = state.session.begin_metadata_refresh();
+        let generation = state
+            .session
+            .select_table("public", "orders", &mut state.query);
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(
+            &mut state,
+            &metadata_failed(&dsn, stale_run_id),
+            Instant::now(),
+        )
+        .into_effects()
+        .expect("stale metadata failure should be handled");
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Loading
+        ));
+        assert!(!state.session.is_table_detail_terminal(generation));
+    }
+
+    #[test]
+    fn stale_metadata_failure_preserves_new_loaded_detail() {
+        let mut state = connected_state(DatabaseType::SQLite);
+        let _ = state
+            .session
+            .select_table("main", "users", &mut state.query);
+        let stale_run_id = state.session.begin_metadata_refresh();
+        let generation = state
+            .session
+            .select_table("main", "orders", &mut state.query);
+        let detail = table::minimal("main", "orders");
+        assert!(state.session.set_table_detail(detail, generation));
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(
+            &mut state,
+            &metadata_failed(&dsn, stale_run_id),
+            Instant::now(),
+        )
+        .into_effects()
+        .expect("stale metadata failure should be handled");
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            state.session.table_detail(),
+            Some(detail) if detail.schema == "main" && detail.name == "orders"
+        ));
+        assert!(state.session.is_table_detail_terminal(generation));
     }
 
     #[test]

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -112,6 +112,7 @@ pub(super) fn reduce_loading(
                 return DispatchResult::handled();
             }
 
+            let detail_generation = state.session.selection_generation();
             let error_info = ConnectionErrorInfo::from_db_operation_error(error);
             state.connection_error.set_error(error_info);
             let was_connected = state.session.connection_state().is_connected();
@@ -128,7 +129,14 @@ pub(super) fn reduce_loading(
                 state.er_preparation.mark_idle();
             }
             DispatchResult::handled_with(if was_connected {
-                vec![]
+                if state
+                    .session
+                    .mark_table_detail_failed(detail_generation, error.user_message())
+                {
+                    super::table_detail::reveal_pending_preview(state, detail_generation)
+                } else {
+                    vec![]
+                }
             } else {
                 termination_effects(&state.query, vec![])
             })
@@ -149,5 +157,167 @@ pub(super) fn reduce_loading(
             }
         }
         _ => DispatchResult::pass(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource};
+    use crate::model::browse::session::TableDetailState;
+    use crate::ports::outbound::DbOperationError;
+    use crate::services::AppServices;
+    use crate::test_support::table;
+    use crate::update::browse::query::dispatch_query;
+
+    fn connected_state(database_type: DatabaseType) -> AppState {
+        let (name, dsn) = match database_type {
+            DatabaseType::PostgreSQL => ("postgres", "postgres://localhost/test"),
+            DatabaseType::SQLite => ("sqlite", "sqlite:///tmp/test.db"),
+            DatabaseType::MySQL => ("mysql", "mysql://localhost/test"),
+        };
+        let mut state = AppState::new("test".to_string());
+        state
+            .session
+            .activate_connection_with_dsn(&ConnectionId::new(), name, database_type, dsn);
+        state
+            .session
+            .mark_connected(Arc::new(DatabaseMetadata::new("test".to_string())));
+        state
+    }
+
+    fn loading_detail_and_metadata_run(state: &mut AppState) -> (u64, u64) {
+        let generation = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        let run_id = state.session.begin_metadata_refresh();
+        (generation, run_id)
+    }
+
+    fn metadata_failed(dsn: &str, run_id: u64) -> Action {
+        Action::MetadataFailed {
+            dsn: dsn.to_string(),
+            run_id,
+            error: DbOperationError::PermissionDenied("metadata refresh failed".to_string()),
+        }
+    }
+
+    #[test]
+    fn metadata_failure_terminates_initial_loading_detail() {
+        let mut state = connected_state(DatabaseType::PostgreSQL);
+        let (generation, run_id) = loading_detail_and_metadata_run(&mut state);
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+            .into_effects()
+            .expect("metadata failure should be handled");
+
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Error(_)
+        ));
+        assert!(state.session.is_table_detail_terminal(generation));
+        assert!(effects.is_empty());
+    }
+
+    #[rstest::rstest]
+    #[case(DatabaseType::PostgreSQL)]
+    #[case(DatabaseType::SQLite)]
+    #[case(DatabaseType::MySQL)]
+    fn metadata_failure_terminates_existing_detail_for_each_database(
+        #[case] database_type: DatabaseType,
+    ) {
+        let mut state = connected_state(database_type);
+        let generation = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        assert!(
+            state
+                .session
+                .set_table_detail(table::minimal("public", "users"), generation,)
+        );
+        state.session.set_table_detail_raw(None);
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Loading
+        ));
+        let run_id = state.session.begin_metadata_refresh();
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+            .into_effects()
+            .expect("metadata failure should be handled");
+
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Error(_)
+        ));
+        assert!(state.session.is_table_detail_terminal(generation));
+        assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn metadata_failure_reveals_pending_preview_after_terminalizing_detail() {
+        let mut state = connected_state(DatabaseType::SQLite);
+        let (generation, run_id) = loading_detail_and_metadata_run(&mut state);
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+        state.query.defer_preview(
+            Arc::new(QueryResult::error(
+                "SELECT * FROM public.users".to_string(),
+                "preview failed".to_string(),
+                0,
+                QuerySource::Preview,
+            )),
+            generation,
+            None,
+            false,
+        );
+
+        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+            .into_effects()
+            .expect("metadata failure should be handled");
+
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::DispatchActions(actions)]
+                if matches!(
+                    actions.as_slice(),
+                    [Action::RevealPendingPreview { generation: action_generation }]
+                        if *action_generation == generation
+                )
+        ));
+        assert!(state.session.is_table_detail_terminal(generation));
+        dispatch_query(
+            &mut state,
+            &Action::RevealPendingPreview { generation },
+            Instant::now(),
+            &AppServices::stub(),
+        );
+        assert!(state.query.current_result().is_some());
+        assert!(!state.query.has_pending_preview(generation));
+    }
+
+    #[test]
+    fn stale_metadata_failure_does_not_terminate_current_detail() {
+        let mut state = connected_state(DatabaseType::MySQL);
+        let (generation, stale_run_id) = loading_detail_and_metadata_run(&mut state);
+        let current_run_id = state.session.begin_metadata_refresh();
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+
+        let effects = reduce_loading(
+            &mut state,
+            &metadata_failed(&dsn, stale_run_id),
+            Instant::now(),
+        )
+        .into_effects()
+        .expect("stale metadata failure should be handled");
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Loading
+        ));
+        assert!(!state.session.is_table_detail_terminal(generation));
+        assert!(state.session.is_current_metadata_run(current_run_id));
     }
 }

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -300,6 +300,47 @@ mod tests {
     }
 
     #[test]
+    fn reload_failure_terminates_detail_owned_by_metadata_refresh() {
+        let mut state = connected_state(DatabaseType::PostgreSQL);
+        let (generation, _) = loading_detail_and_metadata_run(&mut state);
+        let dsn = state.session.dsn().expect("connected DSN").to_string();
+        state.query.defer_preview(
+            Arc::new(QueryResult::error(
+                "SELECT * FROM public.users".to_string(),
+                "preview failed".to_string(),
+                0,
+                QuerySource::Preview,
+            )),
+            generation,
+            None,
+            false,
+        );
+
+        reduce_loading(&mut state, &Action::ReloadMetadata, Instant::now())
+            .into_effects()
+            .expect("metadata reload should be handled");
+        let run_id = state.session.metadata_generation();
+
+        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+            .into_effects()
+            .expect("metadata failure should be handled");
+
+        assert!(matches!(
+            state.session.table_detail_state(),
+            TableDetailState::Error(_)
+        ));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::DispatchActions(actions)]
+                if matches!(
+                    actions.as_slice(),
+                    [Action::RevealPendingPreview { generation: action_generation }]
+                        if *action_generation == generation
+                )
+        ));
+    }
+
+    #[test]
     fn reload_failure_preserves_existing_detail_snapshot() {
         let mut state = connected_state(DatabaseType::PostgreSQL);
         let generation = state

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -55,7 +55,7 @@ pub(super) fn reduce_table_detail(
     }
 }
 
-fn reveal_pending_preview(state: &AppState, generation: u64) -> Vec<Effect> {
+pub(super) fn reveal_pending_preview(state: &AppState, generation: u64) -> Vec<Effect> {
     if state.query.has_pending_preview(generation) {
         vec![Effect::DispatchActions(vec![
             Action::RevealPendingPreview { generation },


### PR DESCRIPTION
## Problem
When a metadata refresh fails, the Inspector table detail can remain in Loading and block a pending preview from being shown.

## Background
A metadata refresh clears the current table detail while the refresh is in progress, but the connected failure path did not terminalize that detail.

## Approach
On a current connected metadata failure, mark the current Inspector detail as Error with the existing database error message and reuse the existing generation-guarded pending-preview reveal. Stale runs and disconnected connection handling retain their existing behavior.