### PR TITLE
refactor(postgres): clarify executor return names

### DIFF
--- a/src/infra/adapters/postgres/executor.rs
+++ b/src/infra/adapters/postgres/executor.rs
@@ -24,7 +24,7 @@ impl QueryExecutor for PostgresAdapter {
             .await
             .unwrap_or_default();
         let query = Self::build_preview_query(schema, table, &order_columns, limit, offset);
-        self.execute_query_raw(dsn, &query, QuerySource::Preview, true)
+        self.execute_query_result(dsn, &query, QuerySource::Preview, true)
             .await
     }
 
@@ -34,7 +34,7 @@ impl QueryExecutor for PostgresAdapter {
         query: &str,
         access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
-        self.execute_query_raw(dsn, query, QuerySource::Adhoc, access_mode.is_read_only())
+        self.execute_query_result(dsn, query, QuerySource::Adhoc, access_mode.is_read_only())
             .await
     }
 

--- a/src/infra/adapters/postgres/metadata.rs
+++ b/src/infra/adapters/postgres/metadata.rs
@@ -27,8 +27,8 @@ fn postgres_table_not_found(schema: &str, table: &str) -> DbOperationError {
 #[async_trait]
 impl MetadataProvider for PostgresAdapter {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        let schemas_json = self.execute_query(dsn, Self::schemas_query()).await?;
-        let tables_json = self.execute_query(dsn, Self::tables_query()).await?;
+        let schemas_json = self.execute_raw_output(dsn, Self::schemas_query()).await?;
+        let tables_json = self.execute_raw_output(dsn, Self::tables_query()).await?;
 
         let schemas = Self::parse_schemas(&schemas_json)?;
         let tables = Self::parse_tables(&tables_json)?;
@@ -43,7 +43,7 @@ impl MetadataProvider for PostgresAdapter {
 
     async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
         let raw_user = self
-            .execute_query(dsn, Self::effective_user_query())
+            .execute_raw_output(dsn, Self::effective_user_query())
             .await?;
         let user = raw_user.trim();
         Ok((!user.is_empty()).then(|| user.to_string()))
@@ -54,7 +54,7 @@ impl MetadataProvider for PostgresAdapter {
         dsn: &str,
     ) -> Result<TableSignatureSnapshot, DbOperationError> {
         let json = self
-            .execute_query(dsn, Self::table_signatures_query())
+            .execute_raw_output(dsn, Self::table_signatures_query())
             .await?;
         Ok(TableSignatureSnapshot {
             signatures: Self::parse_table_signatures(&json)?,
@@ -69,7 +69,7 @@ impl MetadataProvider for PostgresAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         let query = Self::table_detail_query(schema, table);
-        let json = self.execute_query(dsn, &query).await?;
+        let json = self.execute_raw_output(dsn, &query).await?;
         let (exists, columns, indexes, foreign_keys, rls, triggers, table_info) =
             Self::parse_table_detail_combined(&json)?;
         if !exists {
@@ -102,7 +102,7 @@ impl MetadataProvider for PostgresAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         let query = Self::table_columns_and_fks_query(schema, table);
-        let json = self.execute_query(dsn, &query).await?;
+        let json = self.execute_raw_output(dsn, &query).await?;
         let (exists, columns, foreign_keys) = Self::parse_table_columns_and_fks(&json)?;
         if !exists {
             return Err(postgres_table_not_found(schema, table));

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -246,7 +246,7 @@ impl PostgresAdapter {
         Ok(stdout)
     }
 
-    pub(in crate::adapters::postgres) async fn execute_query(
+    pub(in crate::adapters::postgres) async fn execute_raw_output(
         &self,
         dsn: &str,
         query: &str,
@@ -254,7 +254,7 @@ impl PostgresAdapter {
         self.run_psql(dsn, &["-t", "-A"], query, false).await
     }
 
-    pub(in crate::adapters::postgres) async fn execute_query_raw(
+    pub(in crate::adapters::postgres) async fn execute_query_result(
         &self,
         dsn: &str,
         query: &str,
@@ -461,7 +461,7 @@ impl PostgresAdapter {
         table: &str,
     ) -> Result<Vec<String>, DbOperationError> {
         let query = Self::preview_pk_columns_query(schema, table);
-        let raw = self.execute_query(dsn, &query).await?;
+        let raw = self.execute_raw_output(dsn, &query).await?;
         let trimmed = raw.trim();
         if trimmed.is_empty() || trimmed == "null" {
             return Ok(vec![]);
@@ -807,7 +807,7 @@ mod tests {
         }
     }
 
-    mod execute_query_raw_command_tag {
+    mod execute_query_result_command_tag {
         use crate::adapters::postgres::PostgresAdapter;
         use crate::domain::CommandTag;
 


### PR DESCRIPTION
## Problem
The PostgreSQL adapter executor names do not describe whether they return raw psql text or a parsed `QueryResult`, so callers must inspect definitions to understand the boundary.

## Background
The two execution paths have distinct return contracts.

## Approach
Rename the raw-text entry point to `execute_raw_output` and the parsed-result entry point to `execute_query_result`, updating all PostgreSQL callers without changing execution behavior.