### PR TITLE
fix(app): clear terminal table detail runs

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -220,6 +220,7 @@ impl BrowseSession {
     pub fn set_table_detail(&mut self, detail: Table, generation: u64) -> bool {
         if generation == self.selection_generation {
             self.table_detail_state = TableDetailState::Loaded(Box::new(detail));
+            self.table_detail_run.clear_active();
             true
         } else {
             false
@@ -251,6 +252,7 @@ impl BrowseSession {
     pub fn mark_table_detail_failed(&mut self, generation: u64, error: String) -> bool {
         if generation == self.selection_generation && self.selected_table_key.is_some() {
             self.table_detail_state = TableDetailState::Error(error);
+            self.table_detail_run.clear_active();
             true
         } else {
             false
@@ -1075,12 +1077,30 @@ mod tests {
             let mut session = BrowseSession::default();
             let mut query = QueryExecution::default();
             let generation = session.select_table("public", "users", &mut query);
+            let run_id = session.begin_table_detail_run();
 
             assert!(session.mark_table_detail_failed(generation, "boom".to_string()));
             assert!(matches!(
                 session.table_detail_state(),
                 TableDetailState::Error(error) if error == "boom"
             ));
+            assert!(!session.is_current_table_detail_run(run_id));
+            assert_eq!(session.begin_table_detail_run(), run_id + 1);
+        }
+
+        #[test]
+        fn accepting_success_clears_active_run_and_preserves_detail() {
+            let mut session = BrowseSession::default();
+            let mut query = QueryExecution::default();
+            let generation = session.select_table("public", "users", &mut query);
+            let run_id = session.begin_table_detail_run();
+
+            assert!(session.set_table_detail(make_table_detail(), generation));
+
+            assert!(!session.is_current_table_detail_run(run_id));
+            assert_eq!(session.selection_generation(), generation);
+            assert!(session.table_detail().is_some());
+            assert_eq!(session.begin_table_detail_run(), run_id + 1);
         }
 
         #[test]
@@ -1186,6 +1206,42 @@ mod tests {
             assert!(matches!(
                 session.table_detail_state(),
                 TableDetailState::Error(error) if error == "connection refused"
+            ));
+        }
+
+        #[test]
+        fn mysql_probe_does_not_snapshot_terminal_detail_run() {
+            let mut session = BrowseSession::default();
+            let id = ConnectionId::from_string("mysql-current");
+            let current_dsn = "mysql://current";
+            session.activate_connection_with_target(
+                &id,
+                "mysql-current",
+                DatabaseType::MySQL,
+                current_dsn,
+                Some("app"),
+            );
+            let mut query = QueryExecution::default();
+            let generation = session.select_table("public", "users", &mut query);
+            let run_id = session.begin_table_detail_run();
+            assert!(session.set_table_detail(make_table_detail(), generation));
+
+            let _ = session.begin_mysql_connection_probe(
+                &id,
+                "mysql-target",
+                "mysql://target",
+                Some("app"),
+            );
+
+            assert!(!session.is_current_table_detail_run(run_id));
+            assert!(
+                session
+                    .pending_mysql_connection_probe()
+                    .is_some_and(|pending| pending.table_detail.is_none())
+            );
+            assert!(matches!(
+                session.table_detail_state(),
+                TableDetailState::Loaded(_)
             ));
         }
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -174,6 +174,50 @@ mod tests {
         }
 
         #[test]
+        fn metadata_failure_rejects_late_detail_completion() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            state
+                .session
+                .mark_connected(Arc::new(DatabaseMetadata::new("test".to_string())));
+            let generation = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let detail_run_id = state.session.begin_table_detail_run();
+            let metadata_run_id = state.session.begin_metadata_refresh();
+
+            dispatch_metadata(
+                &mut state,
+                &Action::MetadataFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: metadata_run_id,
+                    error: DbOperationError::PermissionDenied("denied".to_string()),
+                },
+                Instant::now(),
+            );
+            assert!(matches!(
+                state.session.table_detail_state(),
+                TableDetailState::Error(_)
+            ));
+            assert!(!state.session.is_current_table_detail_run(detail_run_id));
+
+            dispatch_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: detail_run_id,
+                    detail: empty_table("public", "users"),
+                    generation,
+                },
+                Instant::now(),
+            );
+
+            assert!(matches!(
+                state.session.table_detail_state(),
+                TableDetailState::Error(_)
+            ));
+        }
+
+        #[test]
         fn stale_table_detail_failure_does_not_update_current_inspector() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let stale_generation = state


### PR DESCRIPTION
## Problem
A table detail completion could leave its run marked active after the detail reached Loaded or Error. A late completion could then replace an Inspector error, and MySQL probe setup could snapshot an already terminal run.

## Background
Metadata refresh failure terminalizes a loading detail, but the detail run identity remained active.

## Approach
Clear only the active table-detail run when the matching generation is accepted as Loaded or Error. The monotonic last run ID, generation, and detail payload remain available for freshness and probe recovery decisions. Regression tests cover both terminal states, the ELT-069 late completion sequence, and MySQL probe handling.