### PR TITLE
fix(mysql): mask successful diagnostic credentials

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -442,6 +442,30 @@ mod tests {
     use crate::ports::outbound::query_executor::MockQueryExecutor;
     use crate::update::action::Action;
 
+    async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
+        let cache = TtlCache::new(300);
+        let (tx, mut rx) = mpsc::channel(8);
+        let runner = test_fixtures::make_runner(
+            Arc::new(MockMetadataProvider::new()),
+            Arc::new(executor),
+            Arc::new(MockConnectionStore::new()),
+            cache,
+            tx,
+        );
+        let run = test_fixtures::run_one_effect(
+            &runner,
+            effect,
+            AppState::new("test".to_string()),
+            RefCell::new(CompletionEngine::new()),
+            &mut rx,
+            Some(Duration::from_millis(500)),
+        )
+        .await
+        .unwrap();
+
+        run.actions.into_iter().next().expect("action dispatched")
+    }
+
     mod explain_plan_text {
         use crate::domain::{QueryResult, QuerySource, sqlite_explain_query_plan_text_from_result};
 
@@ -776,54 +800,21 @@ mod tests {
                 assert_eq!(diagnostics[0].code, code);
             }
         }
-    }
-
-    mod execute_access_mode {
-        use super::*;
-        use crate::domain::DatabaseType;
-
-        async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
-            let cache = TtlCache::new(300);
-            let (tx, mut rx) = mpsc::channel(8);
-            let runner = test_fixtures::make_runner(
-                Arc::new(MockMetadataProvider::new()),
-                Arc::new(executor),
-                Arc::new(MockConnectionStore::new()),
-                cache,
-                tx,
-            );
-            let run = test_fixtures::run_one_effect(
-                &runner,
-                effect,
-                AppState::new("test".to_string()),
-                RefCell::new(CompletionEngine::new()),
-                &mut rx,
-                Some(Duration::from_millis(500)),
-            )
-            .await
-            .unwrap();
-
-            run.actions.into_iter().next().expect("action dispatched")
-        }
 
         #[tokio::test]
-        async fn execute_adhoc_forwards_access_mode_and_masks_diagnostics() {
+        async fn execute_adhoc_masks_credentials_before_action() {
             let mut executor = MockQueryExecutor::new();
-            executor
-                .expect_execute_adhoc()
-                .once()
-                .withf(|_, _, access_mode| *access_mode == AccessMode::ReadOnly)
-                .returning(|_, _, _| {
-                    Ok(
-                        test_fixtures::sample_query_result().with_mysql_diagnostics(vec![
-                            DatabaseDiagnostic {
-                                level: DiagnosticLevel::Warning,
-                                code: 1001,
-                                message: "mysql://user:secret@host".to_string(),
-                            },
-                        ]),
-                    )
-                });
+            executor.expect_execute_adhoc().once().returning(|_, _, _| {
+                Ok(
+                    test_fixtures::sample_query_result().with_mysql_diagnostics(vec![
+                        DatabaseDiagnostic {
+                            level: DiagnosticLevel::Warning,
+                            code: 1001,
+                            message: "mysql://user:secret@host".to_string(),
+                        },
+                    ]),
+                )
+            });
 
             let action = run_effect(
                 Effect::ExecuteAdhoc {
@@ -837,9 +828,7 @@ mod tests {
             .await;
 
             match action {
-                Action::QueryCompleted {
-                    run_id: 1, result, ..
-                } => assert_eq!(
+                Action::QueryCompleted { result, .. } => assert_eq!(
                     result.mysql_diagnostics,
                     vec![DatabaseDiagnostic {
                         level: DiagnosticLevel::Warning,
@@ -849,6 +838,72 @@ mod tests {
                 ),
                 action => panic!("unexpected action: {action:?}"),
             }
+        }
+
+        #[tokio::test]
+        async fn execute_write_masks_credentials_before_action() {
+            let mut executor = MockQueryExecutor::new();
+            executor.expect_execute_write().once().returning(|_, _, _| {
+                Ok(WriteExecutionResult {
+                    affected_rows: 1,
+                    diagnostics: vec![DatabaseDiagnostic {
+                        level: DiagnosticLevel::Warning,
+                        code: 1265,
+                        message: "Data truncated password=secret".to_string(),
+                    }],
+                })
+            });
+
+            let action = run_effect(
+                Effect::ExecuteWrite {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 3,
+                    query: "INSERT INTO users VALUES (1)".to_string(),
+                    access_mode: AccessMode::ReadWrite,
+                },
+                executor,
+            )
+            .await;
+
+            match action {
+                Action::ExecuteWriteSucceeded { diagnostics, .. } => assert_eq!(
+                    diagnostics,
+                    vec![DatabaseDiagnostic {
+                        level: DiagnosticLevel::Warning,
+                        code: 1265,
+                        message: "Data truncated password=****".to_string(),
+                    }]
+                ),
+                action => panic!("unexpected action: {action:?}"),
+            }
+        }
+    }
+
+    mod execute_access_mode {
+        use super::*;
+        use crate::domain::DatabaseType;
+
+        #[tokio::test]
+        async fn execute_adhoc_forwards_access_mode() {
+            let mut executor = MockQueryExecutor::new();
+            executor
+                .expect_execute_adhoc()
+                .once()
+                .withf(|_, _, access_mode| *access_mode == AccessMode::ReadOnly)
+                .returning(|_, _, _| Ok(test_fixtures::sample_query_result()));
+
+            let action = run_effect(
+                Effect::ExecuteAdhoc {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 1,
+                    query: "SELECT 1".to_string(),
+                    access_mode: AccessMode::ReadOnly,
+                },
+                executor,
+            )
+            .await;
+
+            assert!(matches!(action, Action::QueryCompleted { run_id: 1, .. }));
         }
 
         #[tokio::test]
@@ -891,7 +946,7 @@ mod tests {
                         diagnostics: vec![DatabaseDiagnostic {
                             level: DiagnosticLevel::Warning,
                             code: 1265,
-                            message: "Data truncated password=secret".to_string(),
+                            message: "Data truncated".to_string(),
                         }],
                     })
                 });
@@ -918,7 +973,7 @@ mod tests {
                     vec![DatabaseDiagnostic {
                         level: DiagnosticLevel::Warning,
                         code: 1265,
-                        message: "Data truncated password=****".to_string(),
+                        message: "Data truncated".to_string(),
                     }]
                 ),
                 action => panic!("unexpected action: {action:?}"),

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -5,16 +5,23 @@ use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
 use crate::cmd::query_task::QueryTaskRegistry;
-use crate::domain::DatabaseType;
 use crate::domain::command_tag::CommandTag;
 use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
+use crate::domain::{DatabaseDiagnostic, DatabaseType};
 use crate::domain::{
     mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
     sqlite_explain_query_plan_text_from_result,
 };
 use crate::model::app_state::AppState;
+use crate::policy::mask_password;
 use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
 use crate::update::action::{Action, QueryCompletionContext, QueryFailureContext};
+
+fn mask_mysql_diagnostics(diagnostics: &mut [DatabaseDiagnostic]) {
+    for diagnostic in diagnostics {
+        diagnostic.message = mask_password(&diagnostic.message);
+    }
+}
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
     // Algorithm from https://howardhinnant.github.io/date_algorithms.html
@@ -196,6 +203,8 @@ pub async fn run(
                     let result = executor.execute_adhoc(&dsn, &query, access_mode).await;
                     match result {
                         Ok(result) => {
+                            let mut result = result;
+                            mask_mysql_diagnostics(&mut result.mysql_diagnostics);
                             if let Some(scope) = &history_scope {
                                 let rows = result
                                     .command_tag
@@ -259,6 +268,8 @@ pub async fn run(
                 .spawn(async move {
                     match executor.execute_write(&dsn, &query, access_mode).await {
                         Ok(result) => {
+                            let mut result = result;
+                            mask_mysql_diagnostics(&mut result.diagnostics);
                             if let Some(scope) = &history_scope {
                                 spawn_query_history_append(
                                     &history_store,
@@ -720,6 +731,7 @@ mod tests {
 
     mod execute_access_mode {
         use super::*;
+        use crate::cmd::browse::query::mask_mysql_diagnostics;
         use crate::domain::DatabaseType;
 
         async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
@@ -746,14 +758,68 @@ mod tests {
             run.actions.into_iter().next().expect("action dispatched")
         }
 
+        #[test]
+        fn masks_credentials_in_success_diagnostic_messages() {
+            let cases = [
+                (
+                    "mysql://user:dsn-secret@host",
+                    "mysql://user:****@host",
+                    DiagnosticLevel::Warning,
+                    1001,
+                ),
+                (
+                    "password=kv-secret",
+                    "password=****",
+                    DiagnosticLevel::Note,
+                    1002,
+                ),
+                (
+                    "MYSQL_PWD=environment-secret",
+                    "MYSQL_PWD=****",
+                    DiagnosticLevel::Warning,
+                    1003,
+                ),
+                (
+                    "Data truncated",
+                    "Data truncated",
+                    DiagnosticLevel::Note,
+                    1004,
+                ),
+            ];
+
+            for (message, expected, level, code) in cases {
+                let mut diagnostics = vec![DatabaseDiagnostic {
+                    level,
+                    code,
+                    message: message.to_string(),
+                }];
+
+                mask_mysql_diagnostics(&mut diagnostics);
+
+                assert_eq!(diagnostics[0].message, expected);
+                assert_eq!(diagnostics[0].level, level);
+                assert_eq!(diagnostics[0].code, code);
+            }
+        }
+
         #[tokio::test]
-        async fn execute_adhoc_forwards_access_mode() {
+        async fn execute_adhoc_forwards_access_mode_and_masks_diagnostics() {
             let mut executor = MockQueryExecutor::new();
             executor
                 .expect_execute_adhoc()
                 .once()
                 .withf(|_, _, access_mode| *access_mode == AccessMode::ReadOnly)
-                .returning(|_, _, _| Ok(test_fixtures::sample_query_result()));
+                .returning(|_, _, _| {
+                    Ok(
+                        test_fixtures::sample_query_result().with_mysql_diagnostics(vec![
+                            DatabaseDiagnostic {
+                                level: DiagnosticLevel::Warning,
+                                code: 1001,
+                                message: "mysql://user:secret@host".to_string(),
+                            },
+                        ]),
+                    )
+                });
 
             let action = run_effect(
                 Effect::ExecuteAdhoc {
@@ -766,7 +832,19 @@ mod tests {
             )
             .await;
 
-            assert!(matches!(action, Action::QueryCompleted { run_id: 1, .. }));
+            match action {
+                Action::QueryCompleted {
+                    run_id: 1, result, ..
+                } => assert_eq!(
+                    result.mysql_diagnostics,
+                    vec![DatabaseDiagnostic {
+                        level: DiagnosticLevel::Warning,
+                        code: 1001,
+                        message: "mysql://user:****@host".to_string(),
+                    }]
+                ),
+                action => panic!("unexpected action: {action:?}"),
+            }
         }
 
         #[tokio::test]
@@ -809,7 +887,7 @@ mod tests {
                         diagnostics: vec![DatabaseDiagnostic {
                             level: DiagnosticLevel::Warning,
                             code: 1265,
-                            message: "Data truncated".to_string(),
+                            message: "Data truncated password=secret".to_string(),
                         }],
                     })
                 });
@@ -836,7 +914,7 @@ mod tests {
                     vec![DatabaseDiagnostic {
                         level: DiagnosticLevel::Warning,
                         code: 1265,
-                        message: "Data truncated".to_string(),
+                        message: "Data truncated password=****".to_string(),
                     }]
                 ),
                 action => panic!("unexpected action: {action:?}"),

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -729,34 +729,9 @@ mod tests {
         }
     }
 
-    mod execute_access_mode {
+    mod diagnostic_masking {
         use super::*;
         use crate::cmd::browse::query::mask_mysql_diagnostics;
-        use crate::domain::DatabaseType;
-
-        async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
-            let cache = TtlCache::new(300);
-            let (tx, mut rx) = mpsc::channel(8);
-            let runner = test_fixtures::make_runner(
-                Arc::new(MockMetadataProvider::new()),
-                Arc::new(executor),
-                Arc::new(MockConnectionStore::new()),
-                cache,
-                tx,
-            );
-            let run = test_fixtures::run_one_effect(
-                &runner,
-                effect,
-                AppState::new("test".to_string()),
-                RefCell::new(CompletionEngine::new()),
-                &mut rx,
-                Some(Duration::from_millis(500)),
-            )
-            .await
-            .unwrap();
-
-            run.actions.into_iter().next().expect("action dispatched")
-        }
 
         #[test]
         fn masks_credentials_in_success_diagnostic_messages() {
@@ -800,6 +775,35 @@ mod tests {
                 assert_eq!(diagnostics[0].level, level);
                 assert_eq!(diagnostics[0].code, code);
             }
+        }
+    }
+
+    mod execute_access_mode {
+        use super::*;
+        use crate::domain::DatabaseType;
+
+        async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
+            let cache = TtlCache::new(300);
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(executor),
+                Arc::new(MockConnectionStore::new()),
+                cache,
+                tx,
+            );
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                effect,
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
+
+            run.actions.into_iter().next().expect("action dispatched")
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem
Successful MySQL Warning/Note diagnostics can contain credential values and are forwarded to success consumers without masking.

## Background
Error payloads already use the shared password-masking policy, but successful diagnostics bypass that path.

## Approach
Apply the existing password-masking policy to diagnostic messages at the Action generation boundary so state, footer, modal, and debug consumers receive the same masked payload while preserving diagnostic shape and success status.