### PR TITLE
fix(app): clear delete selection before non-preview runs

### DIFF
--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -149,6 +149,13 @@ impl QueryExecution {
         self.run.begin()
     }
 
+    #[must_use]
+    pub fn begin_non_preview_running(&mut self, now: Instant) -> u64 {
+        let run_id = self.begin_running(now);
+        self.post_delete_row_selection = PostDeleteRowSelection::Keep;
+        run_id
+    }
+
     pub fn mark_idle(&mut self) {
         self.start_time = None;
         self.run.clear_active();

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -398,6 +398,7 @@ mod tests {
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
     use crate::update::reducer::reduce;
+    use crate::update::test_fixtures as update_test_fixtures;
     use tokio::sync::mpsc;
 
     #[derive(Debug, PartialEq)]
@@ -792,56 +793,25 @@ mod tests {
         }
 
         #[test]
-        fn preview_start_preserves_post_delete_selection() {
-            let mut state = create_test_state();
-            state
-                .query
-                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
+        fn delete_success_then_adhoc_then_preview_completion_clears_selection() {
+            let mut state = update_test_fixtures::state_after_delete_success();
+            let now = Instant::now();
 
-            let effects = dispatch_query(
+            let effects = reduce(
                 &mut state,
-                &Action::ExecutePreview(TableTarget {
-                    schema: "public".to_string(),
-                    table: "users".to_string(),
-                    generation: 1,
-                }),
-                Instant::now(),
+                Action::ExecuteAdhoc("SELECT 1".to_string()),
+                now,
                 &AppServices::stub(),
-            )
-            .into_effects()
-            .expect("preview should be handled");
-
-            assert!(matches!(
-                effects.as_slice(),
-                [Effect::ExecutePreview { .. }]
-            ));
-            assert_eq!(
-                state.query.post_delete_row_selection(),
-                PostDeleteRowSelection::Select(4)
             );
-        }
-
-        #[test]
-        fn adhoc_start_clears_post_delete_selection() {
-            let mut state = create_test_state();
-            state
-                .query
-                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
-
-            let effects = dispatch_query(
-                &mut state,
-                &Action::ExecuteAdhoc("SELECT 1".to_string()),
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .into_effects()
-            .expect("adhoc should be handled");
 
             assert!(matches!(effects.as_slice(), [Effect::ExecuteAdhoc { .. }]));
             assert_eq!(
                 state.query.post_delete_row_selection(),
                 PostDeleteRowSelection::Keep
             );
+            update_test_fixtures::complete_table_preview(&mut state, now);
+            assert!(state.result_interaction.selection().row().is_none());
+            assert!(state.result_interaction.selection().cell().is_none());
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -239,7 +239,7 @@ pub fn reduce_execution(
                 return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn().map(String::from) {
-                let run_id = state.query.begin_running(now);
+                let run_id = state.query.begin_non_preview_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
                     dsn,
                     run_id,
@@ -789,6 +789,59 @@ mod tests {
             assert!(!state.query.pagination.reached_end());
             assert_eq!(state.query.pagination.schema(), "public");
             assert_eq!(state.query.pagination.table(), "users");
+        }
+
+        #[test]
+        fn preview_start_preserves_post_delete_selection() {
+            let mut state = create_test_state();
+            state
+                .query
+                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::ExecutePreview(TableTarget {
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation: 1,
+                }),
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .into_effects()
+            .expect("preview should be handled");
+
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::ExecutePreview { .. }]
+            ));
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Select(4)
+            );
+        }
+
+        #[test]
+        fn adhoc_start_clears_post_delete_selection() {
+            let mut state = create_test_state();
+            state
+                .query
+                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::ExecuteAdhoc("SELECT 1".to_string()),
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .into_effects()
+            .expect("adhoc should be handled");
+
+            assert!(matches!(effects.as_slice(), [Effect::ExecuteAdhoc { .. }]));
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Keep
+            );
         }
 
         #[test]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -187,7 +187,7 @@ pub fn reduce_pagination(
                         return DispatchResult::handled();
                     }
                     SqliteExportPlan::RerunnableQuery { query } => {
-                        let run_id = state.query.begin_running(now);
+                        let run_id = state.query.begin_non_preview_running(now);
                         return dispatch_rerunnable_csv_export(
                             state,
                             dsn,
@@ -201,7 +201,7 @@ pub fn reduce_pagination(
                     SqliteExportPlan::CachedResult { row_count } => {
                         let columns = result.columns.clone();
                         let values = result.values().to_vec();
-                        let run_id = state.query.begin_running(now);
+                        let run_id = state.query.begin_non_preview_running(now);
                         return dispatch_cached_csv_export(
                             state, dsn, run_id, file_name, columns, values, row_count,
                         );
@@ -213,7 +213,7 @@ pub fn reduce_pagination(
                 if result.source == QuerySource::Preview {
                     let columns = result.columns.clone();
                     let values = result.values().to_vec();
-                    let run_id = state.query.begin_running(now);
+                    let run_id = state.query.begin_non_preview_running(now);
                     return dispatch_cached_csv_export(
                         state, dsn, run_id, file_name, columns, values, row_count,
                     );
@@ -230,7 +230,7 @@ pub fn reduce_pagination(
                         (RerunnableCsvRowCount::Known(row_count), None)
                     }
                 };
-                let run_id = state.query.begin_running(now);
+                let run_id = state.query.begin_non_preview_running(now);
                 return dispatch_rerunnable_csv_export(
                     state,
                     dsn,
@@ -242,7 +242,7 @@ pub fn reduce_pagination(
                 );
             }
 
-            let run_id = state.query.begin_running(now);
+            let run_id = state.query.begin_non_preview_running(now);
             dispatch_rerunnable_csv_export(
                 state,
                 dsn,
@@ -373,7 +373,7 @@ mod tests {
     use crate::update::test_fixtures;
     use std::sync::Arc;
 
-    use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
+    use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSelection};
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
 
@@ -728,6 +728,9 @@ mod tests {
             let mut state = export_test_state();
             state.query.set_current_result(preview_result(10));
             state.query.pagination.reset_for_table("public", "users");
+            state
+                .query
+                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
 
             let effects = dispatch_query(
                 &mut state,
@@ -749,6 +752,10 @@ mod tests {
                 }
                 other => panic!("expected CountRowsForExport, got {other:?}"),
             }
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Keep
+            );
         }
 
         #[test]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -376,6 +376,7 @@ mod tests {
     use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSelection};
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
+    use crate::update::reducer::reduce;
 
     fn csv_rows_counted_action(
         state: &mut AppState,
@@ -717,28 +718,19 @@ mod tests {
         use crate::domain::QueryResult;
         use rstest::rstest;
 
-        fn export_test_state() -> AppState {
-            let mut state = AppState::new("test_project".to_string());
-            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            state
-        }
-
         #[test]
-        fn request_with_preview_result_emits_count_effect() {
-            let mut state = export_test_state();
+        fn delete_success_then_count_export_then_preview_completion_clears_selection() {
+            let mut state = test_fixtures::state_after_delete_success();
             state.query.set_current_result(preview_result(10));
             state.query.pagination.reset_for_table("public", "users");
-            state
-                .query
-                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
 
-            let effects = dispatch_query(
+            let now = Instant::now();
+            let effects = reduce(
                 &mut state,
-                &Action::RequestCsvExport,
-                Instant::now(),
+                Action::RequestCsvExport,
+                now,
                 &AppServices::stub(),
-            )
-            .unwrap();
+            );
 
             assert_eq!(effects.len(), 1);
             match &effects[0] {
@@ -756,6 +748,9 @@ mod tests {
                 state.query.post_delete_row_selection(),
                 PostDeleteRowSelection::Keep
             );
+            test_fixtures::complete_table_preview(&mut state, now);
+            assert!(state.result_interaction.selection().row().is_none());
+            assert!(state.result_interaction.selection().cell().is_none());
         }
 
         #[test]

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -99,7 +99,7 @@ pub(super) fn begin_explain_running(state: &mut AppState, now: Instant) -> u64 {
     state.sql_modal.begin_adhoc_running();
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.explain.reset_for_new_run();
-    state.query.begin_running(now)
+    state.query.begin_non_preview_running(now)
 }
 
 pub(super) fn finish_explain_success(

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -30,6 +30,7 @@ mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
     use crate::domain::DatabaseType;
+    use crate::model::browse::query_execution::PostDeleteRowSelection;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::TextInputLike;
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
@@ -491,6 +492,9 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             activate_postgres_connection(&mut state);
+            state
+                .query
+                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -508,6 +512,10 @@ mod tests {
             ));
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Keep
+            );
         }
     }
 

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -488,17 +488,18 @@ mod tests {
         }
 
         #[test]
-        fn emits_execute_explain_effect() {
-            let mut state = sql_modal_state();
+        fn delete_success_then_explain_then_preview_completion_clears_selection() {
+            let mut state = test_fixtures::state_after_delete_success();
+            state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            activate_postgres_connection(&mut state);
-            state
-                .query
-                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
+            let now = Instant::now();
 
-            let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
-                .into_effects()
-                .expect("reducer should handle action");
+            let effects = reduce(
+                &mut state,
+                Action::ExplainRequest,
+                now,
+                &AppServices::stub(),
+            );
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(
@@ -516,6 +517,9 @@ mod tests {
                 state.query.post_delete_row_selection(),
                 PostDeleteRowSelection::Keep
             );
+            test_fixtures::complete_table_preview(&mut state, now);
+            assert!(state.result_interaction.selection().row().is_none());
+            assert!(state.result_interaction.selection().cell().is_none());
         }
     }
 

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -50,7 +50,7 @@ pub(super) fn reduce_confirm_dialog(
                         return DispatchResult::handled();
                     }
                     if let Some(dsn) = state.session.dsn().map(String::from) {
-                        let run_id = state.query.begin_running(now);
+                        let run_id = state.query.begin_non_preview_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                             dsn,
                             run_id,

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -29,6 +29,7 @@ mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
     use crate::domain::{ConnectionId, DatabaseType, QueryValue};
+    use crate::model::browse::query_execution::PostDeleteRowSelection;
     use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
     use crate::model::shared::help::HelpMode;
     use crate::model::shared::input_mode::InputMode;
@@ -638,6 +639,9 @@ mod tests {
                     &mut state,
                     "postgres://localhost/test",
                 );
+                state
+                    .query
+                    .set_post_delete_selection(PostDeleteRowSelection::Select(4));
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -655,6 +659,10 @@ mod tests {
                 assert_eq!(state.input_mode(), InputMode::CellEdit);
                 assert!(state.query.is_running());
                 assert!(state.query.start_time().is_some());
+                assert_eq!(
+                    state.query.post_delete_row_selection(),
+                    PostDeleteRowSelection::Keep
+                );
                 assert_eq!(effects.len(), 1);
                 assert!(matches!(&effects[0], Effect::ExecuteWrite { .. }));
             }

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -35,10 +35,12 @@ mod tests {
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::settings::KeymapPreset;
     use crate::ports::outbound::AppSettings;
+    use crate::services::AppServices;
     use crate::update::action::{
         CursorMove, InputTarget, ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection,
         ScrollTarget, TextKillDirection,
     };
+    use crate::update::reducer::reduce;
     use crate::update::test_fixtures;
     use std::time::Instant;
 
@@ -632,16 +634,9 @@ mod tests {
             }
 
             #[test]
-            fn execute_write_sets_running_state_and_returns_effect() {
-                let mut state = create_test_state();
+            fn delete_success_then_write_then_preview_completion_clears_selection() {
+                let mut state = test_fixtures::state_after_delete_success();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                test_fixtures::activate_postgres_connection(
-                    &mut state,
-                    "postgres://localhost/test",
-                );
-                state
-                    .query
-                    .set_post_delete_selection(PostDeleteRowSelection::Select(4));
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -652,9 +647,12 @@ mod tests {
                 );
 
                 let now = Instant::now();
-                let effects = super::dispatch_modal(&mut state, &Action::ConfirmDialogConfirm, now)
-                    .into_effects()
-                    .expect("reducer should handle action");
+                let effects = reduce(
+                    &mut state,
+                    Action::ConfirmDialogConfirm,
+                    now,
+                    &AppServices::stub(),
+                );
 
                 assert_eq!(state.input_mode(), InputMode::CellEdit);
                 assert!(state.query.is_running());
@@ -665,6 +663,9 @@ mod tests {
                 );
                 assert_eq!(effects.len(), 1);
                 assert!(matches!(&effects[0], Effect::ExecuteWrite { .. }));
+                test_fixtures::complete_table_preview(&mut state, now);
+                assert!(state.result_interaction.selection().row().is_none());
+                assert!(state.result_interaction.selection().cell().is_none());
             }
 
             #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2129,6 +2129,7 @@ mod tests {
     mod confirm_dialog_transitions {
         use super::*;
         use crate::domain::QueryValue;
+        use crate::model::browse::query_execution::PostDeleteRowSelection;
         use crate::model::shared::confirm_dialog::ConfirmIntent;
         use crate::policy::write::write_guardrails::{
             GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
@@ -2248,6 +2249,10 @@ mod tests {
             );
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::ExecutePreview { .. }));
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Select(499)
+            );
         }
 
         #[test]
@@ -2280,6 +2285,9 @@ mod tests {
                     blocked: false,
                 },
             );
+            state
+                .query
+                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
 
             let now = Instant::now();
             reduce(
@@ -2303,6 +2311,10 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.result_interaction.pending_write_preview().is_none());
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Keep
+            );
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2178,7 +2178,7 @@ mod tests {
         }
 
         #[test]
-        fn confirm_delete_write_then_success_preserves_delete_context() {
+        fn confirm_delete_write_success_sets_delete_preview_selection() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
@@ -2256,7 +2256,7 @@ mod tests {
         }
 
         #[test]
-        fn confirm_delete_write_then_failure_returns_to_normal() {
+        fn confirm_delete_write_failure_clears_delete_preview_selection() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -22,7 +22,7 @@ pub(super) fn start_adhoc_if_connected(
         return DispatchResult::handled();
     };
 
-    let run_id = state.query.begin_running(now);
+    let run_id = state.query.begin_non_preview_running(now);
     state.sql_modal.begin_adhoc_running();
     DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
         dsn,

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -26,6 +26,7 @@ mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
     use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, TableSummary};
+    use crate::model::browse::query_execution::PostDeleteRowSelection;
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -885,6 +886,9 @@ mod tests {
         #[test]
         fn submit_select_executes_immediately() {
             let mut state = modal_state_with_query("SELECT 1");
+            state
+                .query
+                .set_post_delete_selection(PostDeleteRowSelection::Select(4));
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
                 .into_effects()
@@ -896,6 +900,10 @@ mod tests {
                 effects.as_slice(),
                 [Effect::ExecuteAdhoc { run_id: 1, .. }]
             ));
+            assert_eq!(
+                state.query.post_delete_row_selection(),
+                PostDeleteRowSelection::Keep
+            );
         }
 
         #[test]

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -884,7 +884,7 @@ mod tests {
         }
 
         #[test]
-        fn submit_select_executes_immediately() {
+        fn submit_select_clears_delete_selection_before_adhoc_run() {
             let mut state = modal_state_with_query("SELECT 1");
             state
                 .query

--- a/src/app/update/test_fixtures.rs
+++ b/src/app/update/test_fixtures.rs
@@ -1,6 +1,17 @@
 use crate::cmd::effect::Effect;
-use crate::domain::{ConnectionId, DatabaseType};
+use crate::domain::{ConnectionId, DatabaseType, QueryResult, QuerySource, QueryValue};
 use crate::model::app_state::AppState;
+use crate::model::browse::query_execution::PostDeleteRowSelection;
+use crate::model::shared::confirm_dialog::ConfirmIntent;
+use crate::model::shared::input_mode::InputMode;
+use crate::policy::write::write_guardrails::{
+    GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
+};
+use crate::services::AppServices;
+use crate::update::action::{Action, QueryCompletionContext, TableTarget};
+use crate::update::reducer::reduce;
+use std::sync::Arc;
+use std::time::Instant;
 
 pub fn activate_postgres_connection(state: &mut AppState, dsn: &str) {
     state.session.activate_connection_with_dsn(
@@ -26,6 +37,107 @@ pub fn activate_mysql_connection(state: &mut AppState, dsn: &str) {
         "mysql",
         DatabaseType::MySQL,
         dsn,
+    );
+}
+
+pub fn state_after_delete_success() -> AppState {
+    let mut state = AppState::new("test_project".to_string());
+    activate_postgres_connection(&mut state, "postgres://localhost/test");
+    state.modal.set_mode(InputMode::ConfirmDialog);
+    state.result_interaction.set_write_preview(WritePreview {
+        operation: WriteOperation::Delete,
+        sql: "DELETE FROM \"public\".\"users\" WHERE \"id\" = '2';".to_string(),
+        target_summary: TargetSummary {
+            schema: "public".to_string(),
+            table: "users".to_string(),
+            key_values: vec![("id".to_string(), QueryValue::text("2"))],
+        },
+        diff: vec![],
+        guardrail: GuardrailDecision {
+            risk_level: RiskLevel::Low,
+            blocked: false,
+            reason: None,
+            target_summary: None,
+        },
+    });
+    state.query.set_delete_refresh_target(0, Some(499), 1);
+    state.confirm_dialog.open(
+        "",
+        "",
+        ConfirmIntent::ExecuteWrite {
+            sql: "DELETE FROM \"public\".\"users\" WHERE \"id\" = '2';".to_string(),
+            blocked: false,
+        },
+    );
+
+    let now = Instant::now();
+    let effects = reduce(
+        &mut state,
+        Action::ConfirmDialogConfirm,
+        now,
+        &AppServices::stub(),
+    );
+    let run_id = match effects.as_slice() {
+        [Effect::ExecuteWrite { run_id, .. }] => *run_id,
+        other => panic!("expected ExecuteWrite, got {other:?}"),
+    };
+    let effects = reduce(
+        &mut state,
+        Action::ExecuteWriteSucceeded {
+            dsn: "postgres://localhost/test".to_string(),
+            run_id,
+            affected_rows: 1,
+            diagnostics: Vec::new(),
+        },
+        now,
+        &AppServices::stub(),
+    );
+
+    assert!(matches!(
+        effects.as_slice(),
+        [Effect::ExecutePreview { .. }]
+    ));
+    assert_eq!(
+        state.query.post_delete_row_selection(),
+        PostDeleteRowSelection::Select(499)
+    );
+    state
+}
+
+pub fn complete_table_preview(state: &mut AppState, now: Instant) {
+    let generation = state.session.selection_generation();
+    let effects = reduce(
+        state,
+        Action::ExecutePreview(TableTarget {
+            schema: "public".to_string(),
+            table: "users".to_string(),
+            generation,
+        }),
+        now,
+        &AppServices::stub(),
+    );
+    let run_id = match effects.as_slice() {
+        [Effect::ExecutePreview { run_id, .. }] => *run_id,
+        other => panic!("expected ExecutePreview, got {other:?}"),
+    };
+    reduce(
+        state,
+        Action::QueryCompleted {
+            run_id,
+            result: Arc::new(QueryResult::success(
+                "SELECT * FROM users".to_string(),
+                vec!["id".to_string()],
+                vec![vec!["1".to_string()]],
+                1,
+                QuerySource::Preview,
+            )),
+            context: QueryCompletionContext::Preview {
+                generation,
+                target_page: 0,
+            },
+        },
+        now,
+        &AppServices::stub(),
     );
 }
 


### PR DESCRIPTION
## Problem
Delete-after auto-preview selection state could survive a later non-preview query and be applied to an unrelated preview.

## Background
The marker belongs only to the delete-following preview flow; non-preview execution must expire it without changing preview startup behavior.

## Approach
Keep the existing preview-start path unchanged and add a narrow query-run entry point for non-preview work. Route adhoc, explain, write, and CSV export starts through that entry point, with focused coverage for marker retention and expiration.

## Screenshots

## Linear Issue Link (optional)
