### PR TITLE
fix: gate metadata work during MySQL probes

### DIFF
--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -258,7 +258,10 @@ async fn handle_smart_refresh_cache_and_diff(
     new_metadata: Arc<DatabaseMetadata>,
     signature_snapshot: Arc<TableSignatureSnapshot>,
 ) -> Result<()> {
-    if !state.session.dsn_matches(&dsn) || !state.er_preparation.is_current_run(run_id) {
+    if state.session.pending_mysql_connection_probe().is_some()
+        || !state.session.dsn_matches(&dsn)
+        || !state.er_preparation.is_current_run(run_id)
+    {
         return Ok(());
     }
 
@@ -409,5 +412,37 @@ mod tests {
         };
         assert!(result.added_tables.is_empty());
         assert!(result.missing_in_cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_mysql_probe_drops_smart_refresh_cache_diff() {
+        let dsn = "mysql://user:password@localhost:3306/app";
+        let mut state = state_with_mysql_dsn(dsn);
+        let _ = state.session.begin_mysql_connection_probe(
+            &ConnectionId::from_string("mysql-target"),
+            "mysql-target",
+            "mysql://localhost/target",
+            Some("target"),
+        );
+        let completion_engine = RefCell::new(CompletionEngine::new());
+        let (action_tx, mut action_rx) = mpsc::channel(1);
+
+        handle_smart_refresh_cache_and_diff(
+            &action_tx,
+            &state,
+            &completion_engine,
+            dsn.to_string(),
+            1,
+            Arc::new(DatabaseMetadata::new("app".to_string())),
+            Arc::new(TableSignatureSnapshot {
+                signatures: vec![],
+                prefetched_table_details: vec![table::minimal("app", "items")],
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(!completion_engine.borrow().has_cached_table("app.items"));
+        assert!(action_rx.try_recv().is_err());
     }
 }

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 use super::check_er_completion;
 
@@ -25,9 +26,15 @@ pub(super) fn reduce_er_neighbors(
 ) -> DispatchResult {
     match action {
         Action::ExpandPrefetchWithFkNeighbors { run_id } => {
+            if reject_pending_mysql_connection_probe(state) {
+                return DispatchResult::handled();
+            }
             DispatchResult::handled_with(expand_prefetch_with_fk_neighbors(state, *run_id))
         }
         Action::FkNeighborsDiscovered { run_id, tables } => {
+            if reject_pending_mysql_connection_probe(state) {
+                return DispatchResult::handled();
+            }
             if !state.sql_modal.is_current_prefetch_run(*run_id) {
                 return DispatchResult::handled();
             }

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -1452,6 +1452,26 @@ mod tests {
             );
             assert!(effects.is_empty());
         }
+
+        #[test]
+        fn pending_mysql_probe_rejects_neighbor_expansion() {
+            let mut state = state_with_pending_mysql_probe();
+            let run_id = state.sql_modal.begin_er_prefetch();
+            state.er_preparation.mark_waiting_for_test();
+            state.er_preparation.mark_fk_unexpanded();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ExpandPrefetchWithFkNeighbors { run_id },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("neighbor expansion action should be handled");
+
+            assert!(effects.is_empty());
+            assert!(state.er_preparation.is_waiting());
+            assert!(!state.er_preparation.fk_expanded());
+        }
     }
 
     mod fk_neighbors_discovered {
@@ -1539,6 +1559,35 @@ mod tests {
             assert!(state.er_preparation.pending_tables().is_empty());
             assert!(!state.sql_modal.has_pending_prefetch());
             assert!(effects.is_empty());
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_discovered_neighbors_without_queueing() {
+            let mut state = state_with_pending_mysql_probe();
+            let run_id = state.sql_modal.begin_er_prefetch();
+            state.er_preparation.mark_waiting_for_test();
+            state.er_preparation.mark_fk_unexpanded();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::FkNeighborsDiscovered {
+                    run_id,
+                    tables: vec!["public.posts".to_string()],
+                },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("discovered neighbors action should be handled");
+
+            assert!(effects.is_empty());
+            assert!(!state.er_preparation.fk_expanded());
+            assert!(
+                !state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.posts")
+            );
+            assert!(!state.sql_modal.is_prefetch_queued("public.posts"));
         }
 
         #[test]

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -84,6 +84,24 @@ mod tests {
         state
     }
 
+    fn state_with_pending_mysql_probe() -> AppState {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_target(
+            &ConnectionId::from_string("mysql-current"),
+            "mysql-current",
+            DatabaseType::MySQL,
+            "mysql://localhost/current",
+            Some("current"),
+        );
+        let _ = state.session.begin_mysql_connection_probe(
+            &ConnectionId::from_string("mysql-target"),
+            "mysql-target",
+            "mysql://localhost/target",
+            Some("target"),
+        );
+        state
+    }
+
     fn empty_table(schema: &str, name: &str) -> Box<Table> {
         Box::new(test_support::table::minimal(schema, name))
     }
@@ -471,6 +489,53 @@ mod tests {
             assert!(!state.sql_modal.is_table_prefetching(&qualified));
             assert!(!state.er_preparation.fetching_tables().contains(&qualified));
             assert!(state.er_preparation.pending_tables().contains(&qualified));
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_direct_prefetch_without_starting_it() {
+            let mut state = state_with_pending_mysql_probe();
+            let run_id = state.sql_modal.begin_completion_prefetch();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::PrefetchTableDetail {
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("prefetch action should be handled");
+
+            assert!(effects.is_empty());
+            assert!(!state.sql_modal.is_table_prefetching("public.users"));
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_prefetch_completion_without_cache_mutation() {
+            let mut state = state_with_pending_mysql_probe();
+            let run_id = state.sql_modal.begin_completion_prefetch();
+            state
+                .sql_modal
+                .start_table_prefetch("public.users".to_string());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailCached {
+                    dsn: "mysql://localhost/current".to_string(),
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    detail: empty_table("public", "users"),
+                },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("cached detail action should be handled");
+
+            assert!(effects.is_empty());
+            assert!(state.sql_modal.is_table_prefetching("public.users"));
         }
 
         #[test]
@@ -1079,6 +1144,42 @@ mod tests {
                     .iter()
                     .any(|effect| matches!(effect, Effect::DispatchActions(_)))
             );
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_prefetch_queue_without_dequeuing() {
+            let mut state = state_with_pending_mysql_probe();
+            let run_id = state.sql_modal.begin_completion_prefetch();
+            state
+                .sql_modal
+                .queue_table_prefetch("public.users".to_string());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("prefetch queue action should be handled");
+
+            assert!(effects.is_empty());
+            assert!(state.sql_modal.is_prefetch_queued("public.users"));
+            assert_eq!(state.sql_modal.prefetch_in_flight_count(), 0);
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_prefetch_start_without_queueing() {
+            let mut state = state_with_pending_mysql_probe();
+            state.session.set_metadata(Some(make_metadata(2)));
+
+            let effects =
+                dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now())
+                    .into_effects()
+                    .expect("prefetch action should be handled");
+
+            assert!(effects.is_empty());
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(!state.sql_modal.has_pending_prefetch());
         }
     }
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -7,6 +7,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::FailedPrefetchEntry;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 use super::check_er_completion;
 
@@ -94,6 +95,21 @@ pub(super) fn reduce_prefetch(
     action: &Action,
     now: Instant,
 ) -> DispatchResult {
+    if matches!(
+        action,
+        Action::StartErPrefetchAll
+            | Action::StartErPrefetchScoped { .. }
+            | Action::StartCompletionPrefetch { .. }
+            | Action::ProcessPrefetchQueue { .. }
+            | Action::PrefetchTableDetail { .. }
+            | Action::TableDetailCached { .. }
+            | Action::TableDetailCacheFailed { .. }
+            | Action::TableDetailAlreadyCached { .. }
+    ) && reject_pending_mysql_connection_probe(state)
+    {
+        return DispatchResult::handled();
+    }
+
     match action {
         Action::StartErPrefetchAll => {
             if (state.sql_modal.active_prefetch_run_id().is_none()

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -104,6 +104,7 @@ pub(super) fn save_current_connection_cache(state: &mut AppState) {
 }
 
 pub(super) fn cancel_connection_task_effects(state: &mut AppState) -> Vec<Effect> {
+    let had_pending_probe = state.session.pending_mysql_connection_probe().is_some();
     let table_detail_retry =
         state
             .session
@@ -116,6 +117,10 @@ pub(super) fn cancel_connection_task_effects(state: &mut AppState) -> Vec<Effect
                 run_id,
             });
     state.session.clear_mysql_connection_probe();
+    if had_pending_probe {
+        state.sql_modal.reset_prefetch();
+        state.er_preparation.reset();
+    }
 
     let mut effects = vec![Effect::CancelConnectionTask];
     if let Some(table_detail_retry) = table_detail_retry {

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -4,7 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::{Action, ErDiagramInfo};
 use crate::update::dispatch_result::DispatchResult;
-use crate::update::helpers::require_er_diagram_enabled;
+use crate::update::helpers::{reject_pending_mysql_connection_probe, require_er_diagram_enabled};
 
 pub(super) fn reduce_diagram_lifecycle(
     state: &mut AppState,
@@ -45,6 +45,9 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
+            if reject_pending_mysql_connection_probe(state) {
+                return DispatchResult::handled();
+            }
             if let Some(result) = require_er_diagram_enabled(state) {
                 return result;
             }

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -73,7 +73,7 @@ mod tests {
         state
     }
 
-    fn state_with_pending_mysql_probe() -> AppState {
+    fn state_with_mysql_connection() -> AppState {
         let mut state = AppState::new("test".to_string());
         state.session.activate_connection_with_target(
             &ConnectionId::from_string("mysql-current"),
@@ -82,6 +82,11 @@ mod tests {
             "mysql://localhost/current",
             Some("current"),
         );
+        state
+    }
+
+    fn state_with_pending_mysql_probe() -> AppState {
+        let mut state = state_with_mysql_connection();
         let _ = state.session.begin_mysql_connection_probe(
             &ConnectionId::from_string("mysql-target"),
             "mysql-target",
@@ -112,6 +117,9 @@ mod tests {
     mod er_open_diagram {
         use super::*;
         use crate::ports::outbound::DbOperationError;
+        use crate::services::AppServices;
+        use crate::update::action::ConnectionTarget;
+        use crate::update::reducer;
 
         #[test]
         fn emits_smart_refresh() {
@@ -188,10 +196,17 @@ mod tests {
 
         #[test]
         fn pending_mysql_probe_rejects_er_completions_without_state_mutation() {
-            let mut state = state_with_pending_mysql_probe();
+            let mut state = state_with_mysql_connection();
+            state.session.set_metadata(Some(make_metadata(1)));
             let run_id = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_waiting_for_test();
             let prefetch_run_id = state.sql_modal.begin_er_prefetch();
+            let _ = state.session.begin_mysql_connection_probe(
+                &ConnectionId::from_string("mysql-target"),
+                "mysql-target",
+                "mysql://localhost/target",
+                Some("target"),
+            );
 
             let actions = vec![
                 Action::SmartErRefreshFetched(SmartErRefreshFetched {
@@ -243,6 +258,85 @@ mod tests {
                 state.sql_modal.active_prefetch_run_id(),
                 Some(prefetch_run_id)
             );
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
+        }
+
+        #[test]
+        fn mysql_probe_failure_cleans_er_run_for_retry() {
+            let mut state = state_with_mysql_connection();
+            state.session.set_metadata(Some(make_metadata(1)));
+            let run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_waiting_for_test();
+            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.session.begin_mysql_connection_probe(
+                &ConnectionId::from_string("mysql-target"),
+                "mysql-target",
+                "mysql://localhost/target",
+                Some("target"),
+            );
+
+            let effects = reduce_er(
+                &mut state,
+                &Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id,
+                    path: "diagram.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("ER completion should be handled");
+            assert!(effects.is_empty());
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
+
+            let probe_run_id = state
+                .session
+                .pending_mysql_connection_probe()
+                .expect("probe should still be pending")
+                .run_id;
+            let effects = reducer::reduce(
+                &mut state,
+                Action::MySqlConnectionProbeFailed {
+                    target: ConnectionTarget {
+                        id: ConnectionId::from_string("mysql-target"),
+                        name: "mysql-target".to_string(),
+                        dsn: "mysql://localhost/target".to_string(),
+                        database_type: DatabaseType::MySQL,
+                        database: Some("target".to_string()),
+                    },
+                    run_id: probe_run_id,
+                    error: DbOperationError::Timeout("timed out".to_string()),
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(effects.is_empty());
+            assert!(state.session.pending_mysql_connection_probe().is_some());
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
+
+            let effects = reducer::reduce(
+                &mut state,
+                Action::CloseConnectionError,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+
+            let effects = reducer::reduce(
+                &mut state,
+                Action::ErOpenDiagram,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::SmartErRefresh { run_id: reopened_run_id, .. }]
+                    if *reopened_run_id == run_id + 1
+            ));
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
         }
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -8,8 +8,22 @@ use std::time::Instant;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 pub fn dispatch_er(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+    if matches!(
+        action,
+        Action::ErGenerateFromCache
+            | Action::ErDiagramOpened(_)
+            | Action::ErDiagramFailed { .. }
+            | Action::SmartErRefreshFetched(_)
+            | Action::SmartErRefreshCompleted(_)
+            | Action::SmartErRefreshFailed(_)
+    ) && reject_pending_mysql_connection_probe(state)
+    {
+        return DispatchResult::handled();
+    }
+
     diagram::reduce_diagram_lifecycle(state, action, now)
         .or_else(|| smart_refresh_fetched::reduce_smart_refresh_fetched(state, action))
         .or_else(|| smart_refresh_completed::reduce_smart_refresh_completed(state, action, now))
@@ -97,6 +111,7 @@ mod tests {
 
     mod er_open_diagram {
         use super::*;
+        use crate::ports::outbound::DbOperationError;
 
         #[test]
         fn emits_smart_refresh() {
@@ -169,6 +184,66 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("Connection switch in progress")
             );
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_er_completions_without_state_mutation() {
+            let mut state = state_with_pending_mysql_probe();
+            let run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_waiting_for_test();
+            let prefetch_run_id = state.sql_modal.begin_er_prefetch();
+
+            let actions = vec![
+                Action::SmartErRefreshFetched(SmartErRefreshFetched {
+                    dsn: "mysql://localhost/current".to_string(),
+                    run_id,
+                    new_metadata: make_metadata(1),
+                    signature_snapshot: Arc::new(TableSignatureSnapshot {
+                        signatures: vec![],
+                        prefetched_table_details: vec![],
+                    }),
+                }),
+                Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                    dsn: "mysql://localhost/current".to_string(),
+                    run_id,
+                    new_metadata: make_metadata(1),
+                    stale_tables: vec![],
+                    added_tables: vec![],
+                    removed_tables: vec![],
+                    missing_in_cache: vec![],
+                    new_signatures: HashMap::new(),
+                }),
+                Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "mysql://localhost/current".to_string(),
+                    run_id,
+                    error: DbOperationError::Timeout("timed out".to_string()),
+                    new_metadata: None,
+                }),
+                Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id,
+                    path: "diagram.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                Action::ErDiagramFailed {
+                    run_id,
+                    error: "failed".to_string(),
+                },
+                Action::ErGenerateFromCache,
+            ];
+
+            for action in actions {
+                let effects = reduce_er(&mut state, &action, Instant::now())
+                    .into_effects()
+                    .expect("ER action should be handled");
+                assert!(effects.is_empty());
+            }
+
+            assert_eq!(
+                state.sql_modal.active_prefetch_run_id(),
+                Some(prefetch_run_id)
+            );
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
         }
 
         #[test]

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -59,6 +59,24 @@ mod tests {
         state
     }
 
+    fn state_with_pending_mysql_probe() -> AppState {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_target(
+            &ConnectionId::from_string("mysql-current"),
+            "mysql-current",
+            DatabaseType::MySQL,
+            "mysql://localhost/current",
+            Some("current"),
+        );
+        let _ = state.session.begin_mysql_connection_probe(
+            &ConnectionId::from_string("mysql-target"),
+            "mysql-target",
+            "mysql://localhost/target",
+            Some("target"),
+        );
+        state
+    }
+
     fn set_active_run_id(state: &mut AppState, run_id: u64) {
         for _ in 0..run_id {
             let _ = state.er_preparation.start_waiting_run();
@@ -129,6 +147,28 @@ mod tests {
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
+        }
+
+        #[test]
+        fn pending_mysql_probe_rejects_er_open_before_prefetch_invalidation() {
+            let mut state = state_with_pending_mysql_probe();
+            state.session.set_metadata(Some(make_metadata(1)));
+            let prefetch_run_id = state.sql_modal.begin_er_prefetch();
+
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("ER open action should be handled");
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.sql_modal.active_prefetch_run_id(),
+                Some(prefetch_run_id)
+            );
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("Connection switch in progress")
+            );
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -20,6 +20,7 @@ use crate::model::shared::key_sequence::KeySequenceState;
 use crate::policy::FeaturePolicy;
 use crate::services::AppServices;
 use crate::update::action::{Action, TableTarget};
+use crate::update::helpers::reject_pending_mysql_connection_probe;
 use crate::update::query_context::termination_effects;
 
 pub fn reduce(
@@ -107,7 +108,6 @@ fn dispatch_enabled_action(
                     .copied()
                     .cloned();
                 if let Some(table) = table {
-                    state.modal.set_mode(InputMode::Normal);
                     return select_table(state, &table);
                 }
             } else if state.modal.active_mode() == InputMode::Normal {
@@ -158,6 +158,10 @@ fn dispatch_enabled_action(
 }
 
 fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
+    if reject_pending_mysql_connection_probe(state) {
+        return vec![];
+    }
+    state.modal.set_mode(InputMode::Normal);
     let generation = state
         .session
         .select_table(&table.schema, &table.name, &mut state.query);
@@ -214,6 +218,7 @@ mod tests {
 
     mod pure_actions {
         use super::*;
+        use crate::domain::DatabaseMetadata;
         use rstest::rstest;
 
         #[test]
@@ -322,6 +327,44 @@ mod tests {
                 TableDetailState::Error(message) if message == "No active connection"
             ));
             assert!(matches!(effects.first(), Some(Effect::CancelTrackedTasks)));
+        }
+
+        #[test]
+        fn table_selection_is_rejected_during_pending_mysql_probe() {
+            let mut state = create_test_state();
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://localhost/current");
+            state.session.set_metadata(Some(Arc::new({
+                let mut metadata = DatabaseMetadata::new("test".to_string());
+                metadata.table_summaries = vec![TableSummary::new(
+                    "public".to_string(),
+                    "users".to_string(),
+                    None,
+                    false,
+                )];
+                metadata
+            })));
+            let _ = state.session.begin_mysql_connection_probe(
+                &ConnectionId::from_string("mysql-target"),
+                "mysql-target",
+                "mysql://localhost/target",
+                Some("target"),
+            );
+            state.modal.set_mode(InputMode::TablePicker);
+
+            let effects = reduce(
+                &mut state,
+                Action::ConfirmSelection,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::TablePicker);
+            assert!(state.session.table_detail().is_none());
+            assert_eq!(
+                state.messages.last_error(),
+                Some("Connection switch in progress")
+            );
         }
     }
 


### PR DESCRIPTION
## Problem
Pending MySQL connection probes retain the old session, so detail, prefetch, and ER starts could still target the old DSN and mutate shared state.

## Background
The probe must finish before new work is allowed to use the retained connection state.

## Approach
Reuse the existing probe rejection helper at table selection, prefetch action handling, and ER diagram start before effects, queue changes, or cache completion state changes. Existing PostgreSQL, SQLite, and post-probe flows remain unchanged.