### PR TITLE
fix(sqlite): fail on malformed explain plans

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -13,7 +13,9 @@ use crate::domain::{
     sqlite_explain_query_plan_text_from_result,
 };
 use crate::model::app_state::AppState;
-use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
+use crate::ports::outbound::{
+    CachedResultExporter, DbOperationError, QueryExecutor, QueryHistoryStore,
+};
 use crate::update::action::{Action, QueryCompletionContext, QueryFailureContext};
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
@@ -141,27 +143,45 @@ pub async fn run(
                 .spawn(async move {
                     match executor.execute_adhoc(&dsn, &query, access_mode).await {
                         Ok(result) => {
-                            let plan_text = match database_type {
-                                DatabaseType::SQLite => {
-                                    sqlite_explain_query_plan_text_from_result(&result)
-                                }
+                            let plan_result = match database_type {
+                                DatabaseType::SQLite => sqlite_explain_query_plan_text_from_result(
+                                    &result,
+                                )
+                                .map_err(|error| DbOperationError::QueryFailed(error.to_string())),
                                 DatabaseType::PostgreSQL => {
-                                    postgres_explain_plan_text_from_result(&result)
+                                    Ok(postgres_explain_plan_text_from_result(&result))
                                 }
-                                DatabaseType::MySQL => mysql_explain_plan_text_from_result(&result),
+                                DatabaseType::MySQL => {
+                                    Ok(mysql_explain_plan_text_from_result(&result))
+                                }
                             };
-                            tx.send(Action::ExplainCompleted {
-                                dsn,
-                                database_type,
-                                database_generation,
-                                run_id,
-                                query: source_query,
-                                plan_text,
-                                is_analyze,
-                                execution_time_ms: result.execution_time_ms,
-                            })
-                            .await
-                            .ok();
+                            match plan_result {
+                                Ok(plan_text) => {
+                                    tx.send(Action::ExplainCompleted {
+                                        dsn,
+                                        database_type,
+                                        database_generation,
+                                        run_id,
+                                        query: source_query,
+                                        plan_text,
+                                        is_analyze,
+                                        execution_time_ms: result.execution_time_ms,
+                                    })
+                                    .await
+                                    .ok();
+                                }
+                                Err(error) => {
+                                    tx.send(Action::ExplainFailed {
+                                        dsn,
+                                        database_generation,
+                                        run_id,
+                                        error,
+                                        is_analyze,
+                                    })
+                                    .await
+                                    .ok();
+                                }
+                            }
                         }
                         Err(e) => {
                             tx.send(Action::ExplainFailed {
@@ -432,7 +452,10 @@ mod tests {
     use crate::update::action::Action;
 
     mod explain_plan_text {
-        use crate::domain::{QueryResult, QuerySource, sqlite_explain_query_plan_text_from_result};
+        use crate::domain::{
+            QueryResult, QuerySource, SqliteExplainPlanError,
+            postgres_explain_plan_text_from_result, sqlite_explain_query_plan_text_from_result,
+        };
 
         #[test]
         fn sqlite_query_plan_uses_detail_column() {
@@ -463,13 +486,97 @@ mod tests {
             );
 
             assert_eq!(
-                sqlite_explain_query_plan_text_from_result(&result),
+                sqlite_explain_query_plan_text_from_result(&result).unwrap(),
                 "SEARCH users USING INDEX idx_users_name\n  - SCAN orders"
             );
         }
 
         #[test]
-        fn non_sqlite_plan_keeps_first_column_fallback() {
+        fn sqlite_query_plan_requires_structured_columns() {
+            for &missing_column in &["id", "parent", "detail"] {
+                let columns = ["id", "parent", "notused", "detail"]
+                    .into_iter()
+                    .filter(|column| *column != missing_column)
+                    .map(str::to_string)
+                    .collect();
+                let result = QueryResult::success(
+                    "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    columns,
+                    vec![],
+                    1,
+                    QuerySource::Adhoc,
+                );
+
+                assert!(matches!(
+                    sqlite_explain_query_plan_text_from_result(&result),
+                    Err(SqliteExplainPlanError::MissingColumn(column))
+                        if column == missing_column
+                ));
+            }
+        }
+
+        #[test]
+        fn sqlite_query_plan_rejects_malformed_structured_values() {
+            for (column, row) in [
+                ("id", vec!["not-an-id", "0", "0", "SCAN users"]),
+                ("parent", vec!["2", "not-a-parent", "0", "SCAN users"]),
+            ] {
+                let result = QueryResult::success(
+                    "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    vec![
+                        "id".to_string(),
+                        "parent".to_string(),
+                        "notused".to_string(),
+                        "detail".to_string(),
+                    ],
+                    vec![row.into_iter().map(str::to_string).collect()],
+                    1,
+                    QuerySource::Adhoc,
+                );
+
+                assert!(matches!(
+                    sqlite_explain_query_plan_text_from_result(&result),
+                    Err(SqliteExplainPlanError::InvalidValue {
+                        row: 0,
+                        column: invalid_column,
+                        ..
+                    }) if invalid_column == column
+                ));
+            }
+        }
+
+        #[test]
+        fn sqlite_query_plan_rejects_missing_row_values() {
+            for (missing_column, row) in [
+                ("id", vec![]),
+                ("parent", vec!["2"]),
+                ("detail", vec!["2", "0", "0"]),
+            ] {
+                let result = QueryResult::success(
+                    "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    vec![
+                        "id".to_string(),
+                        "parent".to_string(),
+                        "notused".to_string(),
+                        "detail".to_string(),
+                    ],
+                    vec![row.into_iter().map(str::to_string).collect()],
+                    1,
+                    QuerySource::Adhoc,
+                );
+
+                assert!(matches!(
+                    sqlite_explain_query_plan_text_from_result(&result),
+                    Err(SqliteExplainPlanError::MissingValue {
+                        row: 0,
+                        column,
+                    }) if column == missing_column
+                ));
+            }
+        }
+
+        #[test]
+        fn postgres_plan_keeps_first_column_fallback() {
             let result = QueryResult::success(
                 "EXPLAIN SELECT * FROM users".to_string(),
                 vec!["QUERY PLAN".to_string()],
@@ -479,7 +586,7 @@ mod tests {
             );
 
             assert_eq!(
-                sqlite_explain_query_plan_text_from_result(&result),
+                postgres_explain_plan_text_from_result(&result),
                 "Seq Scan on users"
             );
         }
@@ -720,7 +827,8 @@ mod tests {
 
     mod execute_access_mode {
         use super::*;
-        use crate::domain::DatabaseType;
+        use crate::domain::{DatabaseType, QueryResult, QuerySource};
+        use crate::ports::outbound::DbOperationError;
 
         async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
             let cache = TtlCache::new(300);
@@ -794,6 +902,93 @@ mod tests {
             .await;
 
             assert!(matches!(action, Action::ExplainCompleted { run_id: 2, .. }));
+        }
+
+        #[tokio::test]
+        async fn sqlite_explain_parse_failure_returns_explain_failed() {
+            let mut executor = MockQueryExecutor::new();
+            executor.expect_execute_adhoc().once().returning(|_, _, _| {
+                Ok(QueryResult::success(
+                    "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    vec!["id".to_string(), "parent".to_string()],
+                    vec![vec!["2".to_string(), "0".to_string()]],
+                    1,
+                    QuerySource::Adhoc,
+                ))
+            });
+
+            let action = run_effect(
+                Effect::ExecuteExplain {
+                    dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database_generation: 0,
+                    run_id: 2,
+                    query: "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    source_query: "SELECT 1".to_string(),
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                },
+                executor,
+            )
+            .await;
+
+            let Action::ExplainFailed { error, run_id, .. } = action else {
+                panic!("expected ExplainFailed action");
+            };
+            assert_eq!(run_id, 2);
+            assert!(matches!(
+                error,
+                DbOperationError::QueryFailed(details)
+                    if details.contains("missing required column: detail")
+            ));
+        }
+
+        #[tokio::test]
+        async fn sqlite_explain_success_returns_explain_completed() {
+            let mut executor = MockQueryExecutor::new();
+            executor.expect_execute_adhoc().once().returning(|_, _, _| {
+                Ok(QueryResult::success(
+                    "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    vec![
+                        "id".to_string(),
+                        "parent".to_string(),
+                        "notused".to_string(),
+                        "detail".to_string(),
+                    ],
+                    vec![vec![
+                        "2".to_string(),
+                        "0".to_string(),
+                        "0".to_string(),
+                        "SCAN users".to_string(),
+                    ]],
+                    1,
+                    QuerySource::Adhoc,
+                ))
+            });
+
+            let action = run_effect(
+                Effect::ExecuteExplain {
+                    dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database_generation: 0,
+                    run_id: 3,
+                    query: "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    source_query: "SELECT 1".to_string(),
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                },
+                executor,
+            )
+            .await;
+
+            assert!(matches!(
+                action,
+                Action::ExplainCompleted {
+                    run_id: 3,
+                    plan_text,
+                    ..
+                } if plan_text == "SCAN users"
+            ));
         }
 
         #[tokio::test]

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -453,7 +453,7 @@ mod tests {
 
     mod explain_plan_text {
         use crate::domain::{
-            QueryResult, QuerySource, SqliteExplainPlanError,
+            QueryResult, QuerySource, QueryValue, SqliteExplainPlanError,
             postgres_explain_plan_text_from_result, sqlite_explain_query_plan_text_from_result,
         };
 
@@ -573,6 +573,36 @@ mod tests {
                     }) if column == missing_column
                 ));
             }
+        }
+
+        #[test]
+        fn sqlite_query_plan_rejects_non_text_structured_values() {
+            let result = QueryResult::success_with_values(
+                "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                vec![
+                    "id".to_string(),
+                    "parent".to_string(),
+                    "notused".to_string(),
+                    "detail".to_string(),
+                ],
+                vec![vec![
+                    QueryValue::text("2"),
+                    QueryValue::text("0"),
+                    QueryValue::text("0"),
+                    QueryValue::Null,
+                ]],
+                1,
+                QuerySource::Adhoc,
+            );
+
+            assert!(matches!(
+                sqlite_explain_query_plan_text_from_result(&result),
+                Err(SqliteExplainPlanError::InvalidValue {
+                    row: 0,
+                    column: "detail",
+                    value,
+                }) if value == "NULL"
+            ));
         }
 
         #[test]
@@ -827,7 +857,7 @@ mod tests {
 
     mod execute_access_mode {
         use super::*;
-        use crate::domain::{DatabaseType, QueryResult, QuerySource};
+        use crate::domain::{DatabaseType, QueryResult, QuerySource, QueryValue};
         use crate::ports::outbound::DbOperationError;
 
         async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
@@ -988,6 +1018,54 @@ mod tests {
                     plan_text,
                     ..
                 } if plan_text == "SCAN users"
+            ));
+        }
+
+        #[tokio::test]
+        async fn sqlite_explain_non_text_detail_returns_explain_failed() {
+            let mut executor = MockQueryExecutor::new();
+            executor.expect_execute_adhoc().once().returning(|_, _, _| {
+                Ok(QueryResult::success_with_values(
+                    "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    vec![
+                        "id".to_string(),
+                        "parent".to_string(),
+                        "notused".to_string(),
+                        "detail".to_string(),
+                    ],
+                    vec![vec![
+                        QueryValue::text("2"),
+                        QueryValue::text("0"),
+                        QueryValue::text("0"),
+                        QueryValue::Null,
+                    ]],
+                    1,
+                    QuerySource::Adhoc,
+                ))
+            });
+
+            let action = run_effect(
+                Effect::ExecuteExplain {
+                    dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database_generation: 0,
+                    run_id: 4,
+                    query: "EXPLAIN QUERY PLAN SELECT 1".to_string(),
+                    source_query: "SELECT 1".to_string(),
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                },
+                executor,
+            )
+            .await;
+
+            assert!(matches!(
+                action,
+                Action::ExplainFailed {
+                    run_id: 4,
+                    error: DbOperationError::QueryFailed(details),
+                    ..
+                } if details.contains("invalid detail value: NULL")
             ));
         }
 

--- a/src/domain/explain_plan.rs
+++ b/src/domain/explain_plan.rs
@@ -23,27 +23,73 @@ struct SqliteExplainPlanRow {
     detail: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SqliteExplainPlanError {
+    #[error("SQLite EXPLAIN QUERY PLAN result is missing required column: {0}")]
+    MissingColumn(&'static str),
+    #[error("SQLite EXPLAIN QUERY PLAN row {row} is missing required value: {column}")]
+    MissingValue { row: usize, column: &'static str },
+    #[error("SQLite EXPLAIN QUERY PLAN row {row} has invalid {column} value: {value}")]
+    InvalidValue {
+        row: usize,
+        column: &'static str,
+        value: String,
+    },
+}
+
 fn column_index(columns: &[String], name: &str) -> Option<usize> {
     columns
         .iter()
         .position(|column| column.eq_ignore_ascii_case(name))
 }
 
-fn sqlite_explain_plan_rows(result: &QueryResult) -> Option<Vec<SqliteExplainPlanRow>> {
-    let id_index = column_index(&result.columns, "id")?;
-    let parent_index = column_index(&result.columns, "parent")?;
-    let detail_index = column_index(&result.columns, "detail")?;
+fn sqlite_explain_plan_rows(
+    result: &QueryResult,
+) -> Result<Vec<SqliteExplainPlanRow>, SqliteExplainPlanError> {
+    let id_index =
+        column_index(&result.columns, "id").ok_or(SqliteExplainPlanError::MissingColumn("id"))?;
+    let parent_index = column_index(&result.columns, "parent")
+        .ok_or(SqliteExplainPlanError::MissingColumn("parent"))?;
+    let detail_index = column_index(&result.columns, "detail")
+        .ok_or(SqliteExplainPlanError::MissingColumn("detail"))?;
 
     (0..result.data_row_count())
         .map(|row_idx| {
-            Some(SqliteExplainPlanRow {
-                id: result.display_value_at(row_idx, id_index)?.parse().ok()?,
-                parent: result
-                    .display_value_at(row_idx, parent_index)?
+            let id_value = result.display_value_at(row_idx, id_index).ok_or(
+                SqliteExplainPlanError::MissingValue {
+                    row: row_idx,
+                    column: "id",
+                },
+            )?;
+            let id = id_value
+                .parse()
+                .map_err(|_| SqliteExplainPlanError::InvalidValue {
+                    row: row_idx,
+                    column: "id",
+                    value: id_value,
+                })?;
+            let parent_value = result.display_value_at(row_idx, parent_index).ok_or(
+                SqliteExplainPlanError::MissingValue {
+                    row: row_idx,
+                    column: "parent",
+                },
+            )?;
+            let parent =
+                parent_value
                     .parse()
-                    .ok()?,
-                detail: result.display_value_at(row_idx, detail_index)?,
-            })
+                    .map_err(|_| SqliteExplainPlanError::InvalidValue {
+                        row: row_idx,
+                        column: "parent",
+                        value: parent_value,
+                    })?;
+            let detail = result.display_value_at(row_idx, detail_index).ok_or(
+                SqliteExplainPlanError::MissingValue {
+                    row: row_idx,
+                    column: "detail",
+                },
+            )?;
+
+            Ok(SqliteExplainPlanRow { id, parent, detail })
         })
         .collect()
 }
@@ -62,35 +108,31 @@ fn sqlite_explain_plan_depth(
     depth
 }
 
-fn sqlite_explain_plan_text(result: &QueryResult) -> Option<String> {
+fn sqlite_explain_plan_text(result: &QueryResult) -> Result<String, SqliteExplainPlanError> {
     let rows = sqlite_explain_plan_rows(result)?;
     let parents_by_id = rows
         .iter()
         .map(|row| (row.id, row.parent))
         .collect::<HashMap<_, _>>();
     let max_depth = rows.len();
-    Some(
-        rows.iter()
-            .map(|row| {
-                let depth = sqlite_explain_plan_depth(row, &parents_by_id, max_depth);
-                if depth == 0 {
-                    row.detail.clone()
-                } else {
-                    format!("{}- {}", "  ".repeat(depth), row.detail)
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-    )
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let depth = sqlite_explain_plan_depth(row, &parents_by_id, max_depth);
+            if depth == 0 {
+                row.detail.clone()
+            } else {
+                format!("{}- {}", "  ".repeat(depth), row.detail)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
-pub fn sqlite_explain_query_plan_text_from_result(result: &QueryResult) -> String {
-    sqlite_explain_plan_text(result).unwrap_or_else(|| {
-        (0..result.data_row_count())
-            .filter_map(|row_idx| result.display_value_at(row_idx, 0))
-            .collect::<Vec<_>>()
-            .join("\n")
-    })
+pub fn sqlite_explain_query_plan_text_from_result(
+    result: &QueryResult,
+) -> Result<String, SqliteExplainPlanError> {
+    sqlite_explain_plan_text(result)
 }
 
 fn first_result_column_text(result: &QueryResult) -> String {

--- a/src/domain/explain_plan.rs
+++ b/src/domain/explain_plan.rs
@@ -43,6 +43,25 @@ fn column_index(columns: &[String], name: &str) -> Option<usize> {
         .position(|column| column.eq_ignore_ascii_case(name))
 }
 
+fn sqlite_explain_plan_value(
+    result: &QueryResult,
+    row: usize,
+    column_index: usize,
+    column: &'static str,
+) -> Result<String, SqliteExplainPlanError> {
+    let value = result
+        .value_at(row, column_index)
+        .ok_or(SqliteExplainPlanError::MissingValue { row, column })?;
+    value
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| SqliteExplainPlanError::InvalidValue {
+            row,
+            column,
+            value: value.display_value(),
+        })
+}
+
 fn sqlite_explain_plan_rows(
     result: &QueryResult,
 ) -> Result<Vec<SqliteExplainPlanRow>, SqliteExplainPlanError> {
@@ -55,12 +74,7 @@ fn sqlite_explain_plan_rows(
 
     (0..result.data_row_count())
         .map(|row_idx| {
-            let id_value = result.display_value_at(row_idx, id_index).ok_or(
-                SqliteExplainPlanError::MissingValue {
-                    row: row_idx,
-                    column: "id",
-                },
-            )?;
+            let id_value = sqlite_explain_plan_value(result, row_idx, id_index, "id")?;
             let id = id_value
                 .parse()
                 .map_err(|_| SqliteExplainPlanError::InvalidValue {
@@ -68,12 +82,7 @@ fn sqlite_explain_plan_rows(
                     column: "id",
                     value: id_value,
                 })?;
-            let parent_value = result.display_value_at(row_idx, parent_index).ok_or(
-                SqliteExplainPlanError::MissingValue {
-                    row: row_idx,
-                    column: "parent",
-                },
-            )?;
+            let parent_value = sqlite_explain_plan_value(result, row_idx, parent_index, "parent")?;
             let parent =
                 parent_value
                     .parse()
@@ -82,12 +91,7 @@ fn sqlite_explain_plan_rows(
                         column: "parent",
                         value: parent_value,
                     })?;
-            let detail = result.display_value_at(row_idx, detail_index).ok_or(
-                SqliteExplainPlanError::MissingValue {
-                    row: row_idx,
-                    column: "detail",
-                },
-            )?;
+            let detail = sqlite_explain_plan_value(result, row_idx, detail_index, "detail")?;
 
             Ok(SqliteExplainPlanRow { id, parent, detail })
         })

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -27,8 +27,8 @@ pub use command_tag::CommandTag;
 pub use diagnostic::{DatabaseDiagnostic, DiagnosticLevel};
 pub use er::ErTableInfo;
 pub use explain_plan::{
-    mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
-    sqlite_explain_query_plan_text_from_result,
+    SqliteExplainPlanError, mysql_explain_plan_text_from_result,
+    postgres_explain_plan_text_from_result, sqlite_explain_query_plan_text_from_result,
 };
 pub use foreign_key::{FkAction, ForeignKey, UNRESOLVED_FK_COLUMN};
 pub use index::{Index, IndexAttributes, IndexType};

--- a/src/infra/adapters/sqlite/executor_adhoc_session_tests.rs
+++ b/src/infra/adapters/sqlite/executor_adhoc_session_tests.rs
@@ -75,7 +75,7 @@ mod query_results {
             .await
             .unwrap();
 
-        let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+        let plan_text = sqlite_explain_query_plan_text_from_result(&result).unwrap();
 
         assert!(!plan_text.trim().is_empty(), "plan text must not be empty");
         assert!(
@@ -105,7 +105,7 @@ mod query_results {
             .await
             .unwrap();
 
-        let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+        let plan_text = sqlite_explain_query_plan_text_from_result(&result).unwrap();
         let operation_lines = explain_plan_operation_lines(&plan_text);
 
         assert!(
@@ -148,7 +148,7 @@ mod query_results {
             .await
             .unwrap();
 
-        let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+        let plan_text = sqlite_explain_query_plan_text_from_result(&result).unwrap();
 
         assert!(
             plan_text.to_ascii_lowercase().contains("users"),


### PR DESCRIPTION
## Problem
SQLite EXPLAIN QUERY PLAN output was treated as successful even when structured columns or row values were malformed.

## Background
Supported SQLite clients return named id, parent, notused, and detail columns, but the parser silently fell back to the first column when that shape was unavailable.

## Approach
Require the SQLite-specific structured fields and surface parsing failures as ExplainFailed; keep PostgreSQL and MySQL plan extraction unchanged.