### PR TITLE
fix(postgres): preserve psql exit status when stderr is empty

### DIFF
--- a/src/infra/adapters/postgres/psql/error.rs
+++ b/src/infra/adapters/postgres/psql/error.rs
@@ -1,3 +1,10 @@
+use std::process::ExitStatus;
+
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+#[cfg(windows)]
+use std::os::windows::process::ExitStatusExt;
+
 use crate::app::ports::outbound::{ConnectionFailureKind, DatabaseCli, DbOperationError};
 
 pub(in crate::adapters::postgres) fn classify_cli_spawn_error(
@@ -13,10 +20,17 @@ pub(in crate::adapters::postgres) fn classify_cli_spawn_error(
     }
 }
 
-pub(in crate::adapters::postgres) fn classify_query_error(stderr: &str) -> DbOperationError {
+pub(in crate::adapters::postgres) fn classify_query_error(
+    stderr: &str,
+    status: ExitStatus,
+) -> DbOperationError {
     let trimmed = stderr.trim();
     let Some(details) = (!trimmed.is_empty()).then_some(trimmed) else {
-        return DbOperationError::QueryFailed(String::new());
+        return DbOperationError::QueryFailed(if status.success() {
+            String::new()
+        } else {
+            exit_status_details(status)
+        });
     };
 
     if let Some(sqlstate) = extract_sqlstate(details) {
@@ -24,6 +38,19 @@ pub(in crate::adapters::postgres) fn classify_query_error(stderr: &str) -> DbOpe
     }
 
     classify_by_stderr(details)
+}
+
+fn exit_status_details(status: ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("psql exited with status code {code}");
+    }
+
+    #[cfg(unix)]
+    if let Some(signal) = status.signal() {
+        return format!("psql terminated by signal {signal}");
+    }
+
+    "psql exited without a status code".to_string()
 }
 
 fn classify_by_sqlstate(sqlstate: &str, details: &str) -> DbOperationError {
@@ -258,6 +285,22 @@ mod tests {
     mod classification {
         use super::*;
 
+        fn exit_status(code: i32) -> ExitStatus {
+            #[cfg(unix)]
+            {
+                ExitStatus::from_raw(code << 8)
+            }
+            #[cfg(windows)]
+            {
+                ExitStatus::from_raw(code as u32)
+            }
+        }
+
+        fn classify(stderr: &str) -> DbOperationError {
+            let status = exit_status(1);
+            classify_query_error(stderr, status)
+        }
+
         fn classification_name(error: DbOperationError) -> &'static str {
             match error {
                 DbOperationError::PermissionDenied(_) => "PermissionDenied",
@@ -313,7 +356,7 @@ mod tests {
         #[case("FATAL:  28P01: opaque authentication failure", "Auth")]
         #[case("FATAL:  3D000: opaque database failure", "DatabaseNotFound")]
         fn classifies_sqlstate_first(#[case] input: &str, #[case] expected: &str) {
-            assert_eq!(classification_name(classify_query_error(input)), expected);
+            assert_eq!(classification_name(classify(input)), expected);
         }
 
         #[rstest]
@@ -337,14 +380,69 @@ mod tests {
             "ConnectionRefused"
         )]
         fn falls_back_to_stderr_matching(#[case] input: &str, #[case] expected: &str) {
-            assert_eq!(classification_name(classify_query_error(input)), expected);
+            assert_eq!(classification_name(classify(input)), expected);
         }
 
         #[test]
         fn unknown_falls_back_safely() {
             assert!(matches!(
-                classify_query_error("some random error"),
+                classify("some random error"),
                 DbOperationError::QueryFailed(_)
+            ));
+        }
+
+        #[test]
+        fn nonzero_empty_stderr_includes_status_code() {
+            let status = exit_status(7);
+
+            assert!(matches!(
+                classify_query_error("", status),
+                DbOperationError::QueryFailed(details)
+                    if details == "psql exited with status code 7"
+            ));
+        }
+
+        #[test]
+        fn whitespace_stderr_includes_status_code() {
+            let status = exit_status(7);
+
+            assert!(matches!(
+                classify_query_error(" \n\t", status),
+                DbOperationError::QueryFailed(details)
+                    if details == "psql exited with status code 7"
+            ));
+        }
+
+        #[test]
+        fn nonzero_stderr_keeps_existing_classification() {
+            let status = exit_status(7);
+
+            assert!(matches!(
+                classify_query_error("ERROR:  42501: permission denied", status),
+                DbOperationError::PermissionDenied(details)
+                    if details == "ERROR:  42501: permission denied"
+            ));
+        }
+
+        #[test]
+        fn zero_status_does_not_create_failure_detail() {
+            let status = exit_status(0);
+
+            assert!(matches!(
+                classify_query_error("", status),
+                DbOperationError::QueryFailed(details) if details.is_empty()
+            ));
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn signal_status_is_reported_without_exit_code() {
+            let status = ExitStatus::from_raw(15);
+
+            assert!(matches!(
+                classify_query_error("", status),
+                DbOperationError::QueryFailed(details)
+                    if details == "psql terminated by signal 15"
             ));
         }
     }

--- a/src/infra/adapters/postgres/psql/error.rs
+++ b/src/infra/adapters/postgres/psql/error.rs
@@ -2,7 +2,7 @@ use std::process::ExitStatus;
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 use std::os::windows::process::ExitStatusExt;
 
 use crate::app::ports::outbound::{ConnectionFailureKind, DatabaseCli, DbOperationError};
@@ -427,7 +427,7 @@ mod tests {
             #[case] expected_summary: &str,
             #[case] expected_hint: &str,
         ) {
-            let error = classify_query_error(input);
+            let error = classify(input);
 
             assert_eq!(error.masked_details(), input);
             assert_eq!(error.summary(), expected_summary);

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -64,9 +64,9 @@ async fn collect_csv_output(
     drop(writer);
     match result {
         Ok(Ok((status, _))) if status.success() => Ok(()),
-        Ok(Ok((_, stderr))) => {
+        Ok(Ok((status, stderr))) => {
             let _ = tokio::fs::remove_file(path).await;
-            Err(classify_query_error(&stderr))
+            Err(classify_query_error(&stderr, status))
         }
         Ok(Err(e)) => {
             let _ = tokio::fs::remove_file(path).await;
@@ -241,7 +241,7 @@ impl PostgresAdapter {
 
         let (status, stdout, stderr) = result;
         if !status.success() {
-            return Err(classify_query_error(&stderr));
+            return Err(classify_query_error(&stderr, status));
         }
         Ok(stdout)
     }
@@ -762,6 +762,95 @@ mod tests {
 
             assert!(matches!(result, Err(DbOperationError::PermissionDenied(_))));
             assert!(!path.exists());
+        }
+
+        #[tokio::test]
+        async fn nonzero_exit_without_stderr_reports_status_and_removes_file() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("export.csv");
+            let child = Command::new("sh")
+                .arg("-c")
+                .arg("exit 7")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+                .unwrap();
+
+            let result = collect_csv_output(child, &path, std::time::Duration::from_secs(2)).await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailed(details))
+                    if details == "psql exited with status code 7"
+            ));
+            assert!(!path.exists());
+        }
+    }
+
+    #[cfg(unix)]
+    mod process_status {
+        use tokio::process::Command;
+
+        use crate::adapters::postgres::PostgresAdapter;
+        use crate::app::ports::outbound::DbOperationError;
+
+        #[tokio::test]
+        async fn nonzero_exit_without_stderr_reports_status() {
+            let mut command = Command::new("sh");
+            command.args(["-c", "exit 7"]);
+
+            let result = PostgresAdapter::collect_output(&mut command, 2).await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailed(details))
+                    if details == "psql exited with status code 7"
+            ));
+        }
+
+        #[tokio::test]
+        async fn nonzero_exit_with_stderr_keeps_existing_classification() {
+            let mut command = Command::new("sh");
+            command.args([
+                "-c",
+                "printf 'ERROR:  42501: permission denied\\n' >&2; exit 7",
+            ]);
+
+            let result = PostgresAdapter::collect_output(&mut command, 2).await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::PermissionDenied(details))
+                    if details == "ERROR:  42501: permission denied"
+            ));
+        }
+
+        #[tokio::test]
+        async fn zero_exit_keeps_empty_stdout_successful() {
+            let mut command = Command::new("sh");
+            command.args(["-c", "exit 0"]);
+
+            assert_eq!(
+                PostgresAdapter::collect_output(&mut command, 2)
+                    .await
+                    .unwrap(),
+                ""
+            );
+        }
+
+        #[tokio::test]
+        async fn signal_exit_reports_signal_status() {
+            let mut command = Command::new("sh");
+            command.args(["-c", "kill -TERM $$"]);
+
+            let result = PostgresAdapter::collect_output(&mut command, 2).await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::QueryFailed(details))
+                    if details == "psql terminated by signal 15"
+            ));
         }
     }
 


### PR DESCRIPTION
## Problem
A nonzero `psql` exit with empty stderr reaches `QueryFailed` without actionable details.

## Background
The executor already collects the process exit status, but the error classifier only received stderr.

## Approach
Pass the collected status into PostgreSQL error classification and use stable code or signal diagnostics only when stderr is empty. Preserve existing stderr classification and successful execution paths.