### PR TITLE
refactor: simplify connection switch cancellation

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -568,6 +568,9 @@ mod tests {
         use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
 
+        use crate::domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
+        use crate::ports::outbound::DbOperationError;
+
         use super::*;
 
         struct BlockingDropState {
@@ -623,40 +626,24 @@ mod tests {
             }
         }
 
-        struct PendingDiagnosticsProvider {
+        struct BlockingDiagnosticsProvider {
             started: Arc<tokio::sync::Notify>,
-            allow_action: Mutex<Option<oneshot::Receiver<()>>>,
-            dropped: Arc<std::sync::atomic::AtomicBool>,
-        }
-
-        impl Drop for PendingDiagnosticsProvider {
-            fn drop(&mut self) {
-                self.dropped
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
-            }
+            drop_state: Arc<BlockingDropState>,
         }
 
         #[async_trait::async_trait]
-        impl SqliteDiagnosticsProvider for PendingDiagnosticsProvider {
+        impl SqliteDiagnosticsProvider for BlockingDiagnosticsProvider {
             async fn fetch_core_diagnostics(
                 &self,
                 _dsn: &str,
-            ) -> Result<
-                crate::domain::SqliteDiagnosticsSnapshot,
-                crate::ports::outbound::DbOperationError,
-            > {
-                let allow_action = self
-                    .allow_action
-                    .lock()
-                    .expect("diagnostics action lock poisoned")
-                    .take()
-                    .expect("diagnostics action receiver should be available");
+            ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
+                let _drop_signal = BlockingDrop(Arc::clone(&self.drop_state));
                 self.started.notify_one();
-                allow_action.await.ok();
-                Ok(crate::domain::SqliteDiagnosticsSnapshot::default())
+                pending().await
             }
 
-            async fn fetch_quick_check(&self, _dsn: &str) -> crate::domain::DiagnosticField {
+            async fn fetch_quick_check(&self, _dsn: &str) -> DiagnosticField {
+                let _drop_signal = BlockingDrop(Arc::clone(&self.drop_state));
                 self.started.notify_one();
                 pending().await
             }
@@ -723,12 +710,14 @@ mod tests {
                 .expect("connection task should start");
 
             let diagnostics_started = Arc::new(tokio::sync::Notify::new());
-            let diagnostics_dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
-            let (allow_diagnostics_action_tx, allow_diagnostics_action_rx) = oneshot::channel();
-            let diagnostics_provider = Arc::new(PendingDiagnosticsProvider {
+            let (diagnostics_drop_tx, mut diagnostics_drop_rx) = oneshot::channel();
+            let diagnostics_drop_state = Arc::new(BlockingDropState {
+                entered: Mutex::new(Some(diagnostics_drop_tx)),
+                released: (Mutex::new(false), Condvar::new()),
+            });
+            let diagnostics_provider = Arc::new(BlockingDiagnosticsProvider {
                 started: Arc::clone(&diagnostics_started),
-                allow_action: Mutex::new(Some(allow_diagnostics_action_rx)),
-                dropped: Arc::clone(&diagnostics_dropped),
+                drop_state: Arc::clone(&diagnostics_drop_state),
             }) as Arc<dyn SqliteDiagnosticsProvider>;
             sqlite_diagnostics::run(
                 Effect::FetchSqliteDiagnosticsCore {
@@ -744,35 +733,57 @@ mod tests {
                 .await
                 .expect("SQLite diagnostics task should start");
 
-            let cancel = runner.cancel_tracked_tasks();
-            tokio::pin!(cancel);
-            let connection_aborted = tokio::select! {
-                result = &mut connection_drop_rx => result.is_ok(),
-                () = &mut cancel => false,
-                () = tokio::time::sleep(Duration::from_secs(1)) => false,
-            };
-
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = test_fixtures::NoopRenderer;
+            let services = AppServices::stub();
+            let mut follow_up = Box::pin(runner.execute_effects(
+                vec![
+                    Effect::CancelTrackedTasks,
+                    Effect::DispatchActions(vec![Action::Render]),
+                ],
+                &mut renderer,
+                &mut state,
+                &completion_engine,
+                &services,
+            ));
+            timeout(Duration::from_secs(1), async {
+                tokio::select! {
+                    _ = &mut follow_up => {
+                        panic!("follow-up ran before SQLite diagnostics task joined")
+                    }
+                    result = &mut diagnostics_drop_rx => {
+                        result.expect("SQLite diagnostics drop signal should be sent");
+                    }
+                }
+            })
+            .await
+            .expect("SQLite diagnostics task should enter its drop gate");
+            assert!(
+                timeout(Duration::from_millis(50), &mut follow_up)
+                    .await
+                    .is_err(),
+                "follow-up ran before SQLite diagnostics task joined"
+            );
+            diagnostics_drop_state.release();
             query_drop_state.release();
+            let actions = timeout(Duration::from_secs(1), follow_up)
+                .await
+                .expect("cancellation and follow-up should finish")
+                .expect("effect execution should succeed");
             let query_dropped = timeout(Duration::from_secs(1), &mut query_drop_rx)
                 .await
                 .is_ok();
             let table_dropped = timeout(Duration::from_secs(1), &mut table_drop_rx)
                 .await
                 .is_ok();
-            let cancellation_finished = timeout(Duration::from_secs(1), cancel).await.is_ok();
-            assert!(connection_aborted, "connection task was not aborted first");
-            drop(diagnostics_provider);
-            assert!(
-                diagnostics_dropped.load(std::sync::atomic::Ordering::SeqCst),
-                "SQLite diagnostics task was not aborted"
-            );
+            let connection_aborted = timeout(Duration::from_secs(1), &mut connection_drop_rx)
+                .await
+                .is_ok();
+            assert!(connection_aborted, "connection task was not aborted");
             assert!(query_dropped, "query task was not aborted");
             assert!(table_dropped, "table detail task was not aborted");
-            assert!(cancellation_finished, "cancellation did not finish");
-            assert!(
-                allow_diagnostics_action_tx.send(()).is_err(),
-                "SQLite diagnostics task was still awaiting a follow-up"
-            );
+            assert!(matches!(actions.as_slice(), [Action::Render]));
             assert!(
                 rx.try_recv().is_err(),
                 "SQLite diagnostics task emitted a late action"

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -576,6 +576,7 @@ mod tests {
         struct BlockingDropState {
             entered: Mutex<Option<oneshot::Sender<()>>>,
             released: (Mutex<bool>, Condvar),
+            finished: Mutex<Option<oneshot::Sender<()>>>,
         }
 
         impl BlockingDropState {
@@ -608,6 +609,15 @@ mod tests {
                     if result.timed_out() {
                         break;
                     }
+                }
+                let finished_sender = self
+                    .0
+                    .finished
+                    .lock()
+                    .expect("finished signal lock poisoned")
+                    .take();
+                if let Some(sender) = finished_sender {
+                    sender.send(()).ok();
                 }
             }
         }
@@ -662,9 +672,11 @@ mod tests {
 
             let (query_started_tx, query_started_rx) = oneshot::channel();
             let (query_drop_tx, mut query_drop_rx) = oneshot::channel();
+            let (query_finished_tx, mut query_finished_rx) = oneshot::channel();
             let query_drop_state = Arc::new(BlockingDropState {
                 entered: Mutex::new(Some(query_drop_tx)),
                 released: (Mutex::new(false), Condvar::new()),
+                finished: Mutex::new(Some(query_finished_tx)),
             });
             runner
                 .query_tasks
@@ -714,6 +726,7 @@ mod tests {
             let diagnostics_drop_state = Arc::new(BlockingDropState {
                 entered: Mutex::new(Some(diagnostics_drop_tx)),
                 released: (Mutex::new(false), Condvar::new()),
+                finished: Mutex::new(None),
             });
             let diagnostics_provider = Arc::new(BlockingDiagnosticsProvider {
                 started: Arc::clone(&diagnostics_started),
@@ -750,6 +763,23 @@ mod tests {
             timeout(Duration::from_secs(1), async {
                 tokio::select! {
                     _ = &mut follow_up => {
+                        panic!("follow-up ran before query task joined")
+                    }
+                    result = &mut query_drop_rx => {
+                        result.expect("query drop signal should be sent");
+                    }
+                }
+            })
+            .await
+            .expect("query task should enter its drop gate");
+            query_drop_state.release();
+            timeout(Duration::from_secs(1), &mut query_finished_rx)
+                .await
+                .expect("query task should leave its drop gate")
+                .expect("query finished signal should be sent");
+            timeout(Duration::from_secs(1), async {
+                tokio::select! {
+                    _ = &mut follow_up => {
                         panic!("follow-up ran before SQLite diagnostics task joined")
                     }
                     result = &mut diagnostics_drop_rx => {
@@ -766,14 +796,10 @@ mod tests {
                 "follow-up ran before SQLite diagnostics task joined"
             );
             diagnostics_drop_state.release();
-            query_drop_state.release();
             let actions = timeout(Duration::from_secs(1), follow_up)
                 .await
                 .expect("cancellation and follow-up should finish")
                 .expect("effect execution should succeed");
-            let query_dropped = timeout(Duration::from_secs(1), &mut query_drop_rx)
-                .await
-                .is_ok();
             let table_dropped = timeout(Duration::from_secs(1), &mut table_drop_rx)
                 .await
                 .is_ok();
@@ -781,7 +807,6 @@ mod tests {
                 .await
                 .is_ok();
             assert!(connection_aborted, "connection task was not aborted");
-            assert!(query_dropped, "query task was not aborted");
             assert!(table_dropped, "table detail task was not aborted");
             assert!(matches!(actions.as_slice(), [Action::Render]));
             assert!(

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -623,9 +623,48 @@ mod tests {
             }
         }
 
+        struct PendingDiagnosticsProvider {
+            started: Arc<tokio::sync::Notify>,
+            allow_action: Mutex<Option<oneshot::Receiver<()>>>,
+            dropped: Arc<std::sync::atomic::AtomicBool>,
+        }
+
+        impl Drop for PendingDiagnosticsProvider {
+            fn drop(&mut self) {
+                self.dropped
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl SqliteDiagnosticsProvider for PendingDiagnosticsProvider {
+            async fn fetch_core_diagnostics(
+                &self,
+                _dsn: &str,
+            ) -> Result<
+                crate::domain::SqliteDiagnosticsSnapshot,
+                crate::ports::outbound::DbOperationError,
+            > {
+                let allow_action = self
+                    .allow_action
+                    .lock()
+                    .expect("diagnostics action lock poisoned")
+                    .take()
+                    .expect("diagnostics action receiver should be available");
+                self.started.notify_one();
+                allow_action.await.ok();
+                Ok(crate::domain::SqliteDiagnosticsSnapshot::default())
+            }
+
+            async fn fetch_quick_check(&self, _dsn: &str) -> crate::domain::DiagnosticField {
+                self.started.notify_one();
+                pending().await
+            }
+        }
+
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn cancel_tracked_tasks_aborts_all_groups_before_joining() {
-            let (tx, _rx) = mpsc::channel(8);
+            let (tx, mut rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
@@ -683,6 +722,28 @@ mod tests {
                 .await
                 .expect("connection task should start");
 
+            let diagnostics_started = Arc::new(tokio::sync::Notify::new());
+            let diagnostics_dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let (allow_diagnostics_action_tx, allow_diagnostics_action_rx) = oneshot::channel();
+            let diagnostics_provider = Arc::new(PendingDiagnosticsProvider {
+                started: Arc::clone(&diagnostics_started),
+                allow_action: Mutex::new(Some(allow_diagnostics_action_rx)),
+                dropped: Arc::clone(&diagnostics_dropped),
+            }) as Arc<dyn SqliteDiagnosticsProvider>;
+            sqlite_diagnostics::run(
+                Effect::FetchSqliteDiagnosticsCore {
+                    dsn: "sqlite:///tmp/app.db".to_string(),
+                    run_id: 1,
+                },
+                &runner.action_tx,
+                &diagnostics_provider,
+                &runner.sqlite_diagnostics_task,
+            )
+            .await;
+            timeout(Duration::from_secs(1), diagnostics_started.notified())
+                .await
+                .expect("SQLite diagnostics task should start");
+
             let cancel = runner.cancel_tracked_tasks();
             tokio::pin!(cancel);
             let connection_aborted = tokio::select! {
@@ -700,9 +761,22 @@ mod tests {
                 .is_ok();
             let cancellation_finished = timeout(Duration::from_secs(1), cancel).await.is_ok();
             assert!(connection_aborted, "connection task was not aborted first");
+            drop(diagnostics_provider);
+            assert!(
+                diagnostics_dropped.load(std::sync::atomic::Ordering::SeqCst),
+                "SQLite diagnostics task was not aborted"
+            );
             assert!(query_dropped, "query task was not aborted");
             assert!(table_dropped, "table detail task was not aborted");
             assert!(cancellation_finished, "cancellation did not finish");
+            assert!(
+                allow_diagnostics_action_tx.send(()).is_err(),
+                "SQLite diagnostics task was still awaiting a follow-up"
+            );
+            assert!(
+                rx.try_recv().is_err(),
+                "SQLite diagnostics task emitted a late action"
+            );
         }
     }
 

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -85,21 +85,17 @@ pub(super) fn mysql_connection_completion_effects(state: &mut AppState, dsn: &st
     termination_effects(&state.query, effects)
 }
 
-pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
-    state.session.to_cache(
-        state.ui.explorer_selected(),
-        state.ui.inspector_tab(),
-        state.query.current_result().cloned(),
-        state.query.pagination.clone(),
-    )
-}
-
 pub(super) fn save_current_connection_cache(state: &mut AppState) {
     let Some(current_id) = state.session.active_connection_id().cloned() else {
         return;
     };
 
-    let cache = save_current_cache(state);
+    let cache = state.session.to_cache(
+        state.ui.explorer_selected(),
+        state.ui.inspector_tab(),
+        state.query.current_result().cloned(),
+        state.query.pagination.clone(),
+    );
     state.connection_caches.save(&current_id, cache);
 }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -58,13 +58,10 @@ pub fn reduce_connection_lifecycle(
                 state.query.reset_for_context_change();
                 return DispatchResult::handled_with(termination_effects(
                     &state.query,
-                    vec![
-                        Effect::CancelSqliteDiagnostics,
-                        Effect::ProbeMySqlConnection {
-                            target: target.clone(),
-                            run_id,
-                        },
-                    ],
+                    vec![Effect::ProbeMySqlConnection {
+                        target: target.clone(),
+                        run_id,
+                    }],
                 ));
             }
 
@@ -72,10 +69,7 @@ pub fn reduce_connection_lifecycle(
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, target);
-                let mut effects = vec![
-                    Effect::CancelSqliteDiagnostics,
-                    Effect::ClearCompletionEngineCache,
-                ];
+                let mut effects = vec![Effect::ClearCompletionEngineCache];
                 if state.session.effective_user().is_none() {
                     let run_id = state.session.begin_effective_user_fetch();
                     effects.push(Effect::FetchEffectiveUser {
@@ -91,7 +85,6 @@ pub fn reduce_connection_lifecycle(
                 DispatchResult::handled_with(termination_effects(
                     &state.query,
                     vec![
-                        Effect::CancelSqliteDiagnostics,
                         Effect::ClearCompletionEngineCache,
                         Effect::FetchMetadata {
                             dsn: dsn.clone(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2682,7 +2682,19 @@ mod tests {
                     .explorer_selected,
                 5
             );
-            assert_eq!(effects.len(), 3);
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::CancelTrackedTasks,
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata { .. }
+                ]
+            ));
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::CancelSqliteDiagnostics))
+            );
         }
 
         #[test]
@@ -2732,16 +2744,61 @@ mod tests {
                 state.session.metadata().as_ref().unwrap().database_name,
                 "cached_db"
             );
-            assert_eq!(effects.len(), 3);
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::CancelTrackedTasks,
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchEffectiveUser { .. }
+                ]
+            ));
             assert!(
-                effects
+                !effects
                     .iter()
-                    .any(|effect| matches!(effect, Effect::CancelTrackedTasks))
+                    .any(|effect| matches!(effect, Effect::CancelSqliteDiagnostics))
             );
+        }
+
+        #[test]
+        fn switch_mysql_connection_probes_after_tracked_task_cancellation() {
+            let mut state = create_test_state();
+            let conn_a = ConnectionId::new();
+
+            state.session.activate_connection_with_dsn(
+                &conn_a,
+                "conn-a",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/a",
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://localhost/other".to_string(),
+                name: "Other".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("other".to_string()),
+            };
+
+            let effects = reduce(
+                &mut state,
+                Action::SwitchConnection(target),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::CancelTrackedTasks,
+                    Effect::ProbeMySqlConnection { .. }
+                ]
+            ));
             assert!(
-                effects
+                !effects
                     .iter()
-                    .any(|effect| matches!(effect, Effect::FetchEffectiveUser { .. }))
+                    .any(|effect| matches!(effect, Effect::CancelSqliteDiagnostics))
             );
         }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2682,7 +2682,7 @@ mod tests {
                     .explorer_selected,
                 5
             );
-            assert_eq!(effects.len(), 4);
+            assert_eq!(effects.len(), 3);
         }
 
         #[test]
@@ -2732,7 +2732,7 @@ mod tests {
                 state.session.metadata().as_ref().unwrap().database_name,
                 "cached_db"
             );
-            assert_eq!(effects.len(), 4);
+            assert_eq!(effects.len(), 3);
             assert!(
                 effects
                     .iter()


### PR DESCRIPTION
## Problem
Connection switches cancel SQLite diagnostics through both the tracked-task owner and a dedicated effect, while cache construction adds a private forwarding hop.

## Approach
Make the connection-cache snapshot at its only save site and rely on CancelTrackedTasks to abort and await the diagnostics owner before switch follow-up effects. Keep the dedicated cancellation effect for standalone diagnostics-modal closure.