### PR TITLE
refactor: centralize PostgreSQL SSL mode stringification

### DIFF
--- a/src/domain/connection/ssl_mode.rs
+++ b/src/domain/connection/ssl_mode.rs
@@ -26,18 +26,22 @@ impl SslMode {
             Self::VerifyFull,
         ]
     }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disable => "disable",
+            Self::Allow => "allow",
+            Self::Prefer => "prefer",
+            Self::Require => "require",
+            Self::VerifyCa => "verify-ca",
+            Self::VerifyFull => "verify-full",
+        }
+    }
 }
 
 impl fmt::Display for SslMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Disable => write!(f, "disable"),
-            Self::Allow => write!(f, "allow"),
-            Self::Prefer => write!(f, "prefer"),
-            Self::Require => write!(f, "require"),
-            Self::VerifyCa => write!(f, "verify-ca"),
-            Self::VerifyFull => write!(f, "verify-full"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -238,9 +238,7 @@ impl ConnectionSetup {
                 Self::render_dropdown_list(
                     frame,
                     field_area,
-                    SslMode::all_variants()
-                        .iter()
-                        .map(|ssl_mode| ssl_mode_label_text(*ssl_mode)),
+                    SslMode::all_variants().iter().map(SslMode::as_str),
                     form_state.ssl_dropdown().selected_index(),
                     theme,
                 );
@@ -513,23 +511,10 @@ impl ConnectionSetup {
     }
 }
 
-fn ssl_mode_label_text(mode: SslMode) -> &'static str {
-    match mode {
-        SslMode::Disable => "disable",
-        SslMode::Allow => "allow",
-        SslMode::Prefer => "prefer",
-        SslMode::Require => "require",
-        SslMode::VerifyCa => "verify-ca",
-        SslMode::VerifyFull => "verify-full",
-    }
-}
-
 fn ssl_mode_label(state: &ConnectionSetupState) -> String {
     match state.database_type() {
         DatabaseType::MySQL => state.mysql_ssl_mode().to_string(),
-        DatabaseType::PostgreSQL | DatabaseType::SQLite => {
-            ssl_mode_label_text(state.ssl_mode()).to_string()
-        }
+        DatabaseType::PostgreSQL | DatabaseType::SQLite => state.ssl_mode().to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Make `SslMode::as_str` the domain source for PostgreSQL SSL mode strings and delegate `Display` to it.
- Remove the duplicate UI mapping while preserving MySQL TLS handling.

## Tests

- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-dbp-045-target cargo test -p sabiql-domain ssl_mode`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-dbp-045-target cargo test -p sabiql-ui features::connections::setup`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-dbp-045-target cargo test -p sabiql-infra connection_config`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-dbp-045-target cargo test -p sabiql connection_setup_ssl_mode_ide_hint`
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-dbp-045-target cargo clippy -p sabiql-domain -p sabiql-ui --all-targets --all-features -- -D warnings`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR= bash scripts/lint_all.sh`