### PR TITLE
refactor: remove unused ER progress fields

### DIFF
--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -28,8 +28,6 @@ pub struct ErPreparationState {
 pub struct ErPreparationProgress {
     pub cached: usize,
     pub total: usize,
-    pub failed: usize,
-    pub remaining: usize,
 }
 
 impl ErPreparationState {
@@ -48,8 +46,6 @@ impl ErPreparationState {
         ErPreparationProgress {
             cached,
             total: self.total_tables,
-            failed,
-            remaining,
         }
     }
 


### PR DESCRIPTION
## Problem
ErPreparationProgress exposes failed and remaining values that no production caller consumes.

## Background
The values remain necessary as local inputs when deriving cached progress, while failure tracking is still used by ER retry and footer workflows.

## Approach
Keep the local calculations and existing failure lifecycle intact while narrowing the progress DTO to the values rendered by the footer. Footer output and retry/cancel behavior remain unchanged.