### PR TITLE
perf(ui): reduce Result rendering allocations

### DIFF
--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -674,13 +674,6 @@ mod tests {
         }
 
         #[test]
-        fn width_limited_display_stops_after_first_overflow() {
-            let value = format!("{}tail", "a".repeat(1024 * 1024));
-
-            assert_eq!(truncate_display_text(&value, false, 4), "a...");
-        }
-
-        #[test]
         fn display_width_handles_large_nul_text_and_blob_without_display_materialization() {
             const SIZE: usize = 1024 * 1024;
             let text = format!("{}\0tail", "a".repeat(SIZE));

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -480,38 +480,41 @@ fn display_width_of_first_line(value: &str, escape_nul: bool) -> usize {
     }
 }
 
+fn display_grapheme_info(value: &str, escape_nul: bool) -> (&str, usize) {
+    if escape_nul && value == "\0" {
+        ("\\0", 2)
+    } else {
+        (value, UnicodeWidthStr::width(value))
+    }
+}
+
 fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> String {
     let first_line = value.split('\n').next().unwrap_or(value);
     let budget = max_width.saturating_sub(3);
-    let is_truncated = display_width_of_first_line(first_line, escape_nul) > max_width;
-    if is_truncated && max_width < 3 {
-        return ".".repeat(max_width);
-    }
-
     let mut display = String::new();
     let mut display_width = 0usize;
-    let mut truncated_width = 0usize;
 
-    for grapheme in first_line.graphemes(true) {
-        let (width, is_nul) = if escape_nul && grapheme == "\0" {
-            (2, true)
-        } else {
-            (UnicodeWidthStr::width(grapheme), false)
-        };
-
+    for (offset, grapheme) in first_line.grapheme_indices(true) {
+        let (display_grapheme, width) = display_grapheme_info(grapheme, escape_nul);
         if display_width.saturating_add(width) > max_width {
-            break;
+            if max_width < 3 {
+                return ".".repeat(max_width);
+            }
+            display.clear();
+            let mut truncated_width = 0usize;
+            for grapheme in first_line[..offset].graphemes(true) {
+                let (display_grapheme, width) = display_grapheme_info(grapheme, escape_nul);
+                if truncated_width.saturating_add(width) <= budget {
+                    display.push_str(display_grapheme);
+                    truncated_width += width;
+                }
+            }
+            display.push_str("...");
+            return display;
         }
 
-        if !is_truncated || truncated_width.saturating_add(width) <= budget {
-            display.push_str(if is_nul { "\\0" } else { grapheme });
-            truncated_width = truncated_width.saturating_add(width);
-        }
+        display.push_str(display_grapheme);
         display_width += width;
-    }
-
-    if is_truncated {
-        display.push_str("...");
     }
 
     display
@@ -657,6 +660,7 @@ mod tests {
         #[case("日本a語", false, 6, "日a...")]
         #[case("ab\u{200b}cde", false, 4, "a\u{200b}...")]
         #[case("日\0abc", true, 6, "日a...")]
+        #[case("لاabc", false, 4, "ل...")]
         fn truncation_preserves_mixed_width_selection(
             #[case] value: &str,
             #[case] escape_nul: bool,
@@ -667,6 +671,13 @@ mod tests {
                 truncate_display_text(value, escape_nul, max_width),
                 expected
             );
+        }
+
+        #[test]
+        fn width_limited_display_stops_after_first_overflow() {
+            let value = format!("{}tail", "a".repeat(1024 * 1024));
+
+            assert_eq!(truncate_display_text(&value, false, 4), "a...");
         }
 
         #[test]

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -483,9 +483,14 @@ fn display_width_of_first_line(value: &str, escape_nul: bool) -> usize {
 fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> String {
     let first_line = value.split('\n').next().unwrap_or(value);
     let budget = max_width.saturating_sub(3);
+    let is_truncated = display_width_of_first_line(first_line, escape_nul) > max_width;
+    if is_truncated && max_width < 3 {
+        return ".".repeat(max_width);
+    }
+
     let mut display = String::new();
     let mut display_width = 0usize;
-    let mut display_prefix_len = 0usize;
+    let mut truncated_width = 0usize;
 
     for grapheme in first_line.graphemes(true) {
         let (width, is_nul) = if escape_nul && grapheme == "\0" {
@@ -495,38 +500,18 @@ fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> Str
         };
 
         if display_width.saturating_add(width) > max_width {
-            if max_width < 3 {
-                return ".".repeat(max_width);
-            }
-            display.clear();
-            let mut truncated_width = 0usize;
-            for grapheme in first_line[..display_prefix_len].graphemes(true) {
-                let (width, is_nul) = if escape_nul && grapheme == "\0" {
-                    (2, true)
-                } else {
-                    (UnicodeWidthStr::width(grapheme), false)
-                };
-
-                if truncated_width.saturating_add(width) <= budget {
-                    if is_nul {
-                        display.push_str("\\0");
-                    } else {
-                        display.push_str(grapheme);
-                    }
-                    truncated_width += width;
-                }
-            }
-            display.push_str("...");
-            return display;
+            break;
         }
 
-        if is_nul {
-            display.push_str("\\0");
-        } else {
-            display.push_str(grapheme);
+        if !is_truncated || truncated_width.saturating_add(width) <= budget {
+            display.push_str(if is_nul { "\\0" } else { grapheme });
+            truncated_width = truncated_width.saturating_add(width);
         }
         display_width += width;
-        display_prefix_len += grapheme.len();
+    }
+
+    if is_truncated {
+        display.push_str("...");
     }
 
     display

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -250,7 +250,7 @@ impl ResultPane {
 
         let header = Row::new(viewport_indices.iter().map(|&idx| {
             let col_name = result.columns.get(idx).map_or("", String::as_str);
-            Cell::from(col_name.to_string())
+            Cell::from(col_name)
         }))
         .style(
             Style::default()
@@ -484,9 +484,8 @@ fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> Str
     let first_line = value.split('\n').next().unwrap_or(value);
     let budget = max_width.saturating_sub(3);
     let mut display = String::new();
-    let mut truncated = String::new();
     let mut display_width = 0usize;
-    let mut truncated_width = 0usize;
+    let mut truncation_len = 0usize;
 
     for grapheme in first_line.graphemes(true) {
         let (width, is_nul) = if escape_nul && grapheme == "\0" {
@@ -499,24 +498,20 @@ fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> Str
             if max_width < 3 {
                 return ".".repeat(max_width);
             }
-            truncated.push_str("...");
-            return truncated;
+            display.truncate(truncation_len);
+            display.push_str("...");
+            return display;
         }
 
         if is_nul {
             display.push_str("\\0");
-            if truncated_width.saturating_add(width) <= budget {
-                truncated.push_str("\\0");
-                truncated_width += width;
-            }
         } else {
             display.push_str(grapheme);
-            if truncated_width.saturating_add(width) <= budget {
-                truncated.push_str(grapheme);
-                truncated_width += width;
-            }
         }
         display_width += width;
+        if display_width <= budget {
+            truncation_len = display.len();
+        }
     }
 
     display

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -485,7 +485,7 @@ fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> Str
     let budget = max_width.saturating_sub(3);
     let mut display = String::new();
     let mut display_width = 0usize;
-    let mut truncation_len = 0usize;
+    let mut display_prefix_len = 0usize;
 
     for grapheme in first_line.graphemes(true) {
         let (width, is_nul) = if escape_nul && grapheme == "\0" {
@@ -498,7 +498,24 @@ fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> Str
             if max_width < 3 {
                 return ".".repeat(max_width);
             }
-            display.truncate(truncation_len);
+            display.clear();
+            let mut truncated_width = 0usize;
+            for grapheme in first_line[..display_prefix_len].graphemes(true) {
+                let (width, is_nul) = if escape_nul && grapheme == "\0" {
+                    (2, true)
+                } else {
+                    (UnicodeWidthStr::width(grapheme), false)
+                };
+
+                if truncated_width.saturating_add(width) <= budget {
+                    if is_nul {
+                        display.push_str("\\0");
+                    } else {
+                        display.push_str(grapheme);
+                    }
+                    truncated_width += width;
+                }
+            }
             display.push_str("...");
             return display;
         }
@@ -509,9 +526,7 @@ fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> Str
             display.push_str(grapheme);
         }
         display_width += width;
-        if display_width <= budget {
-            truncation_len = display.len();
-        }
+        display_prefix_len += grapheme.len();
     }
 
     display
@@ -649,6 +664,24 @@ mod tests {
             let value = QueryValue::text("a\0bcdef");
 
             assert_eq!(query_value_display_at_width(&value, 6), "a\\0...");
+        }
+
+        #[rstest]
+        #[case("日abc", false, 4, "a...")]
+        #[case("👨‍👩‍👧‍👦abc", false, 4, "a...")]
+        #[case("日本a語", false, 6, "日a...")]
+        #[case("ab\u{200b}cde", false, 4, "a\u{200b}...")]
+        #[case("日\0abc", true, 6, "日a...")]
+        fn truncation_preserves_mixed_width_selection(
+            #[case] value: &str,
+            #[case] escape_nul: bool,
+            #[case] max_width: usize,
+            #[case] expected: &str,
+        ) {
+            assert_eq!(
+                truncate_display_text(value, escape_nul, max_width),
+                expected
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Problem

Result rendering allocates a second `String` for truncated cell text and owns a copy of every visible header name on each frame.

## Background

This is the A12-02 ownership reduction at fixed base `e122e8c4e8e788de074e02a06ca0557db8827964`.

## Approach

Build the visible cell text once while recording the last byte boundary that fits before the ellipsis, then truncate that same buffer when needed. Pass header names to Ratatui as borrowed strings while preserving the existing display, width, and NUL escaping behavior.
