### PR TITLE
refactor: share clipboard unavailable action helper

### DIFF
--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -8,10 +8,9 @@ use crate::model::shared::detail_view::DetailDisplayMode;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::preview_cell_text::{CellPresentationPolicy, format_for_cell_detail};
-use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, InputTarget, ModalKind, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
-use crate::update::helpers::find_text_matches;
+use crate::update::helpers::{clipboard_unavailable, find_text_matches};
 
 pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
@@ -56,9 +55,7 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
         Action::CellDetailYankAll => DispatchResult::handled_with(vec![Effect::CopyToClipboard {
             content: state.cell_detail.content().to_string(),
             on_success: Some(Box::new(Action::CellDetailYankSuccess)),
-            on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
-                "Clipboard unavailable".into(),
-            )))),
+            on_failure: Some(Box::new(clipboard_unavailable())),
         }]),
         Action::CellDetailYankSuccess => {
             state.flash_timers.set(FlashId::CellDetail, now);

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -8,11 +8,11 @@ use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::{TextInputEditing, TextInputLike};
 use crate::model::shared::ui_state::DEFAULT_JSON_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::policy::preview_cell_text::CellPresentationPolicy;
-use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{
-    EditGuardrailError, editable_preview_base, ensure_column_writable, find_text_matches,
+    EditGuardrailError, clipboard_unavailable, editable_preview_base, ensure_column_writable,
+    find_text_matches,
 };
 use std::time::Instant;
 
@@ -96,9 +96,7 @@ pub fn reduce_json(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content: json,
                 on_success: Some(Box::new(Action::JsonYankSuccess)),
-                on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
-                    "Clipboard unavailable".into(),
-                )))),
+                on_failure: Some(Box::new(clipboard_unavailable())),
             }])
         }
 

--- a/src/app/update/browse/result/row_detail.rs
+++ b/src/app/update/browse/result/row_detail.rs
@@ -5,9 +5,9 @@ use crate::model::app_state::AppState;
 use crate::model::browse::row_detail::RowDetailState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
-use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::clipboard_unavailable;
 
 pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
@@ -47,9 +47,7 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content,
                 on_success: Some(Box::new(Action::RowDetailYankSuccess)),
-                on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
-                    "Clipboard unavailable".into(),
-                )))),
+                on_failure: Some(Box::new(clipboard_unavailable())),
             }])
         }
 
@@ -58,9 +56,7 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content,
                 on_success: Some(Box::new(Action::RowDetailYankSuccess)),
-                on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
-                    "Clipboard unavailable".into(),
-                )))),
+                on_failure: Some(Box::new(clipboard_unavailable())),
             }])
         }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -6,10 +6,10 @@ use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::model::shared::ui_state::YankFlash;
-use crate::ports::outbound::ClipboardError;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::clipboard_unavailable;
 
 pub fn reduce_yank(
     state: &mut AppState,
@@ -132,10 +132,6 @@ pub fn reduce_yank(
         }
         _ => DispatchResult::pass(),
     }
-}
-
-fn clipboard_unavailable() -> Action {
-    Action::CopyFailed(ClipboardError::Unavailable("Clipboard unavailable".into()))
 }
 
 #[cfg(test)]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -15,7 +15,9 @@ use crate::policy::write::write_guardrails::{
     evaluate_guardrails, preview_writeability_for_result, stable_row_identity_for_preview,
 };
 use crate::policy::{FeaturePolicy, FeatureRequirement};
+use crate::ports::outbound::ClipboardError;
 use crate::services::AppServices;
+use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(crate) fn require_er_diagram_enabled(state: &mut AppState) -> Option<DispatchResult> {
@@ -39,6 +41,10 @@ pub(crate) fn reject_pending_mysql_connection_probe(state: &mut AppState) -> boo
         .messages
         .set_error("Connection switch in progress".to_string());
     true
+}
+
+pub(crate) fn clipboard_unavailable() -> Action {
+    Action::CopyFailed(ClipboardError::Unavailable("Clipboard unavailable".into()))
 }
 
 pub(crate) fn metadata_reload_effects(state: &mut AppState, dsn: &str) -> Vec<Effect> {

--- a/src/app/update/sql_editor/yank.rs
+++ b/src/app/update/sql_editor/yank.rs
@@ -7,9 +7,9 @@ use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalTab;
-use crate::ports::outbound::ClipboardError;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::clipboard_unavailable;
 
 pub(super) fn reduce_yank(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
@@ -67,9 +67,7 @@ pub(super) fn reduce_yank(state: &mut AppState, action: &Action, now: Instant) -
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: c,
                         on_success: Some(Box::new(Action::SqlModalYankSuccess)),
-                        on_failure: Some(Box::new(Action::CopyFailed(
-                            ClipboardError::Unavailable("Clipboard unavailable".into()),
-                        ))),
+                        on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 }
                 _ => DispatchResult::handled(),


### PR DESCRIPTION
## Problem
Clipboard-unavailable failure actions repeat the same construction across eight yank producers.

## Background
Each producer owns a distinct success callback, but the unavailable failure action is identical.

## Approach
Move the existing unavailable-action helper to the shared update helper module and reuse it at each producer while preserving every producer-specific success callback and copy behavior.