### PR TITLE
refactor: inline palette feature predicate

### DIFF
--- a/src/app/update/input/palette.rs
+++ b/src/app/update/input/palette.rs
@@ -72,11 +72,7 @@ pub fn palette_commands(
     let feature_policy = FeaturePolicy::new(engine_feature_profile);
     palette_commands_for(preset)
         .iter()
-        .filter(move |kb| palette_command_supported(kb, &feature_policy))
-}
-
-fn palette_command_supported(kb: &KeyBinding, feature_policy: &FeaturePolicy) -> bool {
-    feature_policy.is_enabled(kb.feature_requirement())
+        .filter(move |kb| feature_policy.is_enabled(kb.feature_requirement()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
The command palette uses a single-use helper to apply an existing feature predicate.

## Background
The helper adds an unnecessary symbol hop without providing a separate abstraction.

## Approach
Apply the existing `FeaturePolicy` predicate directly at the palette filter call site, preserving command visibility for every database profile.