### PR TITLE
fix(sqlite): ignore comments in PRAGMA values

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1240,6 +1240,18 @@ mod tests {
             #[case::foreign_keys_unknown_double_quoted_value(
                 "PRAGMA foreign_keys(/* comment */ \"BANANA\")"
             )]
+            #[case::foreign_keys_quoted_negative_after_block_comment(
+                "PRAGMA foreign_keys = /* comment */ '-1'"
+            )]
+            #[case::foreign_keys_quoted_negative_call_after_line_comment(
+                "PRAGMA foreign_keys(\n-- comment\n'-1')"
+            )]
+            #[case::foreign_keys_quoted_spaced_on_after_block_comment(
+                "PRAGMA foreign_keys = /* comment */ ' ON '"
+            )]
+            #[case::foreign_keys_negative_after_block_comment(
+                "PRAGMA foreign_keys = /* comment */ -1"
+            )]
             #[case::quoted_schema_foreign_keys_off("PRAGMA \"main\".\"foreign_keys\" = OFF")]
             #[case::bracket_schema_journal_mode("PRAGMA [main].[journal_mode](WAL)")]
             #[case::journal_mode("PRAGMA journal_mode = WAL")]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -854,9 +854,7 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
 }
 
 fn sqlite_foreign_keys_value_is_dangerous(value: Option<&str>) -> bool {
-    value.is_none()
-        || matches!(value, Some("off" | "no" | "false"))
-        || value.is_some_and(|value| value.starts_with('0'))
+    !matches!(value, Some("on" | "yes" | "true" | "1"))
 }
 
 fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
@@ -1230,6 +1228,18 @@ mod tests {
             #[case::foreign_keys_zero_exponent_after_block_comment(
                 "PRAGMA foreign_keys(/* comment */ 0e0)"
             )]
+            #[case::foreign_keys_unknown_after_block_comment(
+                "PRAGMA foreign_keys = /* comment */ BANANA"
+            )]
+            #[case::foreign_keys_unknown_call_after_line_comment(
+                "PRAGMA foreign_keys(\n-- comment\nBANANA)"
+            )]
+            #[case::foreign_keys_unknown_single_quoted_value(
+                "PRAGMA foreign_keys = /* comment */ 'BANANA'"
+            )]
+            #[case::foreign_keys_unknown_double_quoted_value(
+                "PRAGMA foreign_keys(/* comment */ \"BANANA\")"
+            )]
             #[case::quoted_schema_foreign_keys_off("PRAGMA \"main\".\"foreign_keys\" = OFF")]
             #[case::bracket_schema_journal_mode("PRAGMA [main].[journal_mode](WAL)")]
             #[case::journal_mode("PRAGMA journal_mode = WAL")]
@@ -1259,6 +1269,22 @@ mod tests {
                 let sql = "PRAGMA user_version = 3";
                 let result =
                     evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
+
+                assert_eq!(result.risk_level, RiskLevel::Medium);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[rstest]
+            #[case::on("ON")]
+            #[case::yes("YES")]
+            #[case::true_value("TRUE")]
+            #[case::one("1")]
+            fn sqlite_foreign_keys_enable_values_are_medium_writes(#[case] value: &str) {
+                let sql = format!("PRAGMA foreign_keys = {value}");
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(&sql), &sql)
                         .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::Medium);

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -833,7 +833,7 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
             | "incremental_vacuum"
             | "wal_checkpoint"
     ) || (pragma_name == "foreign_keys"
-        && (value.is_none() || matches!(value, Some("off" | "0" | "false"))));
+        && sqlite_foreign_keys_value_is_dangerous(value));
 
     Some(SqlRiskDecision {
         risk_level: if dangerous {
@@ -851,6 +851,12 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
         },
         read_only_allowed: false,
     })
+}
+
+fn sqlite_foreign_keys_value_is_dangerous(value: Option<&str>) -> bool {
+    value.is_none()
+        || matches!(value, Some("off" | "no" | "false"))
+        || value.is_some_and(|value| value.starts_with('0'))
 }
 
 fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
@@ -1216,6 +1222,13 @@ mod tests {
             #[case::foreign_keys_zero_after_line_comment("PRAGMA foreign_keys = -- comment\n0")]
             #[case::foreign_keys_false_after_block_comment(
                 "PRAGMA foreign_keys(/* comment */ false)"
+            )]
+            #[case::foreign_keys_no_after_block_comment("PRAGMA foreign_keys = /* comment */ NO")]
+            #[case::foreign_keys_zero_zero_after_line_comment(
+                "PRAGMA foreign_keys = -- comment\n00"
+            )]
+            #[case::foreign_keys_zero_exponent_after_block_comment(
+                "PRAGMA foreign_keys(/* comment */ 0e0)"
             )]
             #[case::quoted_schema_foreign_keys_off("PRAGMA \"main\".\"foreign_keys\" = OFF")]
             #[case::bracket_schema_journal_mode("PRAGMA [main].[journal_mode](WAL)")]
@@ -1646,6 +1659,28 @@ mod tests {
                 let result = evaluate_multi_statement_for_database(
                     DatabaseType::SQLite,
                     "PRAGMA foreign_keys = /* comment */ OFF; CREATE TABLE users(id INTEGER)",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::TargetNameUnavailable,
+                                ref label,
+                            } if label == "PRAGMA"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn sqlite_foreign_keys_no_in_incompatible_transaction_preserves_high_risk_acknowledgement()
+             {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = ON; PRAGMA foreign_keys = NO; PRAGMA foreign_keys;",
                 );
 
                 match result {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -833,7 +833,7 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
             | "incremental_vacuum"
             | "wal_checkpoint"
     ) || (pragma_name == "foreign_keys"
-        && matches!(value, Some("off" | "0" | "false")));
+        && (value.is_none() || matches!(value, Some("off" | "0" | "false"))));
 
     Some(SqlRiskDecision {
         risk_level: if dangerous {
@@ -1195,11 +1195,28 @@ mod tests {
                 assert!(matches!(result.confirmation, ConfirmationType::Immediate));
             }
 
+            #[test]
+            fn sqlite_allowlisted_pragma_ignores_value_comments() {
+                let sql = "PRAGMA table_info(/* comment */ users)";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
+
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(result.read_only_allowed);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
             #[rstest]
             #[case::writable_schema("PRAGMA writable_schema = ON")]
             #[case::writable_schema_call("PRAGMA writable_schema(ON)")]
             #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
             #[case::foreign_keys_call_off("PRAGMA foreign_keys(OFF)")]
+            #[case::foreign_keys_off_after_block_comment("PRAGMA foreign_keys = /* comment */ OFF")]
+            #[case::foreign_keys_zero_after_line_comment("PRAGMA foreign_keys = -- comment\n0")]
+            #[case::foreign_keys_false_after_block_comment(
+                "PRAGMA foreign_keys(/* comment */ false)"
+            )]
             #[case::quoted_schema_foreign_keys_off("PRAGMA \"main\".\"foreign_keys\" = OFF")]
             #[case::bracket_schema_journal_mode("PRAGMA [main].[journal_mode](WAL)")]
             #[case::journal_mode("PRAGMA journal_mode = WAL")]
@@ -1246,6 +1263,24 @@ mod tests {
                 assert_eq!(result.risk_level, RiskLevel::Medium);
                 assert!(!result.read_only_allowed);
                 assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[test]
+            fn sqlite_unterminated_value_comment_requires_acknowledgment() {
+                let sql = "PRAGMA foreign_keys = /* OFF";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
+
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge {
+                        reason: AcknowledgeReason::TargetNameUnavailable,
+                        ref label,
+                    } if label == "PRAGMA"
+                ));
             }
         }
 
@@ -1590,6 +1625,27 @@ mod tests {
                 let result = evaluate_multi_statement_for_database(
                     DatabaseType::SQLite,
                     "PRAGMA foreign_keys = OFF; CREATE TABLE users(id INTEGER)",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::TargetNameUnavailable,
+                                ref label,
+                            } if label == "PRAGMA"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn sqlite_incompatible_transaction_preserves_commented_high_risk_acknowledgement() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = /* comment */ OFF; CREATE TABLE users(id INTEGER)",
                 );
 
                 match result {

--- a/src/domain/sqlite_sql/transaction.rs
+++ b/src/domain/sqlite_sql/transaction.rs
@@ -278,21 +278,18 @@ fn pragma_value(tail: &str) -> Option<String> {
             let next = pragma_quoted_value_end(&chars, i, ch)?;
             let content_start = chars.get(i + 1)?.0;
             let content_end = chars.get(next.checked_sub(1)?)?.0;
-            if let Some(part) = value[content_start..content_end]
-                .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
-                .find(|part| !part.is_empty())
-            {
-                return Some(part.to_ascii_lowercase());
-            }
-            i = next;
-            continue;
+            return Some(value[content_start..content_end].to_ascii_lowercase());
         }
         if stop_at_close && ch == ')' {
             return None;
         }
-        if ch.is_alphanumeric() || ch == '_' {
+        let has_numeric_sign = matches!(ch, '+' | '-')
+            && chars
+                .get(i + 1)
+                .is_some_and(|(_, next)| next.is_ascii_digit());
+        if has_numeric_sign || ch.is_alphanumeric() || ch == '_' {
             let start = byte_pos;
-            let mut end = i + 1;
+            let mut end = if has_numeric_sign { i + 2 } else { i + 1 };
             while end < chars.len() && (chars[end].1.is_alphanumeric() || chars[end].1 == '_') {
                 end += 1;
             }
@@ -310,9 +307,13 @@ fn pragma_quoted_value_end(chars: &[(usize, char)], i: usize, ch: char) -> Optio
             let mut in_string = false;
             let mut cursor = i;
             while cursor < chars.len() {
-                cursor = advance_single_quote(chars, cursor, chars[cursor].1, &mut in_string)?;
-                if !in_string {
-                    return Some(cursor);
+                if chars[cursor].1 == '\'' {
+                    cursor = advance_single_quote(chars, cursor, chars[cursor].1, &mut in_string)?;
+                    if !in_string {
+                        return Some(cursor);
+                    }
+                } else {
+                    cursor += 1;
                 }
             }
             return None;
@@ -475,6 +476,18 @@ mod tests {
                 "PRAGMA \"main\".\"foreign_keys\"(/* comment */ OFF)",
                 Some("off"),
             ),
+        ] {
+            let pragma = parse_sqlite_pragma(sql).unwrap();
+            assert_eq!(pragma.value.as_deref(), expected, "{sql}");
+        }
+    }
+
+    #[test]
+    fn preserves_quoted_and_signed_pragma_values() {
+        for (sql, expected) in [
+            ("PRAGMA foreign_keys = /* comment */ '-1'", Some("-1")),
+            ("PRAGMA foreign_keys = -- comment\n' ON '", Some(" on ")),
+            ("PRAGMA foreign_keys(/* comment */ -1)", Some("-1")),
         ] {
             let pragma = parse_sqlite_pragma(sql).unwrap();
             assert_eq!(pragma.value.as_deref(), expected, "{sql}");

--- a/src/domain/sqlite_sql/transaction.rs
+++ b/src/domain/sqlite_sql/transaction.rs
@@ -1,6 +1,10 @@
 use super::splitter::{
     first_sqlite_keyword, keywords_with_depth, statement_keyword, top_level_keywords,
 };
+use crate::sql_lex::{
+    advance_single_quote, skip_block_comment, skip_double_quoted_identifier, skip_line_comment,
+    skip_sqlite_quoted_identifier,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqliteStatementClassification {
@@ -249,16 +253,77 @@ pub fn parse_sqlite_pragma(statement: &str) -> Option<SqlitePragma> {
 }
 
 fn pragma_value(tail: &str) -> Option<String> {
-    let value = if let Some(value) = tail.strip_prefix('=') {
-        value
+    let (value, stop_at_close) = if let Some(value) = tail.strip_prefix('=') {
+        (value, false)
     } else {
         let value = tail.strip_prefix('(')?;
-        &value[..value.find(')')?]
+        (value, true)
     };
-    value
-        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
-        .find(|part| !part.is_empty())
-        .map(str::to_ascii_lowercase)
+    let chars: Vec<(usize, char)> = value.char_indices().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+        if let Some(next) = skip_line_comment(&chars, i, ch) {
+            i = next;
+            continue;
+        }
+        if let Some(next) = skip_block_comment(&chars, i, ch) {
+            if next > chars.len() {
+                return None;
+            }
+            i = next;
+            continue;
+        }
+        if matches!(ch, '\'' | '"' | '`' | '[') {
+            let next = pragma_quoted_value_end(&chars, i, ch)?;
+            let content_start = chars.get(i + 1)?.0;
+            let content_end = chars.get(next.checked_sub(1)?)?.0;
+            if let Some(part) = value[content_start..content_end]
+                .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+                .find(|part| !part.is_empty())
+            {
+                return Some(part.to_ascii_lowercase());
+            }
+            i = next;
+            continue;
+        }
+        if stop_at_close && ch == ')' {
+            return None;
+        }
+        if ch.is_alphanumeric() || ch == '_' {
+            let start = byte_pos;
+            let mut end = i + 1;
+            while end < chars.len() && (chars[end].1.is_alphanumeric() || chars[end].1 == '_') {
+                end += 1;
+            }
+            let end_byte = chars.get(end).map_or(value.len(), |(pos, _)| *pos);
+            return Some(value[start..end_byte].to_ascii_lowercase());
+        }
+        i += 1;
+    }
+    None
+}
+
+fn pragma_quoted_value_end(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
+    let end = match ch {
+        '\'' => {
+            let mut in_string = false;
+            let mut cursor = i;
+            while cursor < chars.len() {
+                cursor = advance_single_quote(chars, cursor, chars[cursor].1, &mut in_string)?;
+                if !in_string {
+                    return Some(cursor);
+                }
+            }
+            return None;
+        }
+        '"' => skip_double_quoted_identifier(chars, i, ch)?,
+        '`' | '[' => skip_sqlite_quoted_identifier(chars, i, ch)?,
+        _ => return None,
+    };
+    let close = if ch == '[' { ']' } else { ch };
+    (end <= chars.len() && end > i && chars.get(end - 1).is_some_and(|(_, last)| *last == close))
+        .then_some(end)
 }
 
 fn pragma_identifier_and_tail(sql: &str) -> Option<(&str, &str)> {
@@ -298,6 +363,18 @@ mod tests {
         );
         assert_eq!(
             sqlite_statement_classification("PRAGMA user_version = 42"),
+            SqliteStatementClassification::TransactionalWrite
+        );
+    }
+
+    #[test]
+    fn preserves_pragma_classification_after_value_comments() {
+        assert_eq!(
+            sqlite_statement_classification("PRAGMA journal_mode = /* comment */ WAL"),
+            SqliteStatementClassification::TransactionIncompatible
+        );
+        assert_eq!(
+            sqlite_statement_classification("PRAGMA application_id(/* comment */ 7)"),
             SqliteStatementClassification::TransactionalWrite
         );
     }
@@ -386,5 +463,28 @@ mod tests {
         assert_eq!(pragma.name, "application_id");
         assert!(pragma.has_value);
         assert_eq!(pragma.value.as_deref(), Some("7"));
+    }
+
+    #[test]
+    fn skips_comments_before_pragma_values() {
+        for (sql, expected) in [
+            ("PRAGMA foreign_keys = /* comment */ OFF", Some("off")),
+            ("PRAGMA foreign_keys = -- comment\n0", Some("0")),
+            ("PRAGMA foreign_keys(/* comment */ false)", Some("false")),
+            (
+                "PRAGMA \"main\".\"foreign_keys\"(/* comment */ OFF)",
+                Some("off"),
+            ),
+        ] {
+            let pragma = parse_sqlite_pragma(sql).unwrap();
+            assert_eq!(pragma.value.as_deref(), expected, "{sql}");
+        }
+    }
+
+    #[test]
+    fn does_not_extract_unterminated_block_comment_as_pragma_value() {
+        let pragma = parse_sqlite_pragma("PRAGMA foreign_keys = /* OFF").unwrap();
+
+        assert_eq!(pragma.value, None);
     }
 }


### PR DESCRIPTION
## Problem
SQLite PRAGMA risk parsing can treat a word in a comment immediately before the value as the semantic value.
For example, a commented foreign_keys = OFF can lose its high-risk acknowledgement.\n\n## Background\nThe PRAGMA value parser previously split the raw tail without applying SQLite comment boundaries.

## Approach
Use the existing SQLite lexical helpers to skip line and block comments while extracting the next PRAGMA value, preserving assignment and call forms. Unterminated block comments produce no value and keep the risk decision conservative. Focused coverage preserves dangerous PRAGMA acknowledgement, read-only rejection, transaction classification, and allowlisted reads.