### PR TITLE
fix(mysql): preserve Unicode identifiers

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -2079,6 +2079,18 @@ mod mysql_tests {
     }
 
     #[test]
+    fn confirmation_preserves_utf8_target() {
+        let MultiStatementDecision::Allow { risk, .. } = mysql("UPDATE café SET value = 1") else {
+            panic!("expected Allow");
+        };
+
+        assert!(matches!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput { ref target, .. } if target == "café"
+        ));
+    }
+
+    #[test]
     fn aligns_supported_mysql_ddl_risk_and_schema_classification() {
         let cases = [
             (

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -2091,6 +2091,24 @@ mod mysql_tests {
     }
 
     #[test]
+    fn qualified_confirmation_preserves_utf8_target() {
+        let MultiStatementDecision::Allow { risk, .. } =
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                Some("äpp"),
+                "UPDATE äpp.éléments SET value = 1",
+            )
+        else {
+            panic!("expected Allow");
+        };
+
+        assert!(matches!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput { ref target, .. } if target == "éléments"
+        ));
+    }
+
+    #[test]
     fn aligns_supported_mysql_ddl_risk_and_schema_classification() {
         let cases = [
             (

--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -142,8 +142,21 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
             {
                 index += 1;
             }
+            let kind = if !sql[start..index].contains('.')
+                && sql[index..].chars().next().is_some_and(|character| {
+                    !character.is_ascii() && is_mysql_unquoted_identifier_char(character)
+                }) {
+                while let Some(character) = sql[index..].chars().next()
+                    && is_mysql_unquoted_identifier_char(character)
+                {
+                    index += character.len_utf8();
+                }
+                TokenKind::Word(sql[start..index].to_ascii_uppercase())
+            } else {
+                TokenKind::Number
+            };
             tokens.push(Token {
-                kind: TokenKind::Number,
+                kind,
                 depth,
                 text: sql[start..index].to_string(),
             });

--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -138,28 +138,26 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
             let start = index;
             index += 1;
             while index < bytes.len()
-                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'.' | b'_'))
+                && (bytes[index].is_ascii_alphanumeric()
+                    || matches!(bytes[index], b'.' | b'_' | b'$'))
             {
                 index += 1;
             }
-            let kind = if !sql[start..index].contains('.')
-                && sql[index..].chars().next().is_some_and(|character| {
-                    !character.is_ascii() && is_mysql_unquoted_identifier_char(character)
-                }) {
+            let has_dot = sql[start..index].contains('.');
+            if !has_dot {
                 while let Some(character) = sql[index..].chars().next()
                     && is_mysql_unquoted_identifier_char(character)
                 {
                     index += character.len_utf8();
                 }
-                TokenKind::Word(sql[start..index].to_ascii_uppercase())
+            }
+            let text = sql[start..index].to_string();
+            let kind = if !has_dot && text.chars().any(|character| !character.is_ascii_digit()) {
+                TokenKind::Word(text.to_ascii_uppercase())
             } else {
                 TokenKind::Number
             };
-            tokens.push(Token {
-                kind,
-                depth,
-                text: sql[start..index].to_string(),
-            });
+            tokens.push(Token { kind, depth, text });
             continue;
         }
         let kind = TokenKind::Symbol(byte as char);

--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -138,24 +138,29 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
             let start = index;
             index += 1;
             while index < bytes.len()
-                && (bytes[index].is_ascii_alphanumeric()
-                    || matches!(bytes[index], b'.' | b'_' | b'$'))
+                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'_' | b'$'))
             {
                 index += 1;
             }
-            let has_dot = sql[start..index].contains('.');
-            if !has_dot {
-                while let Some(character) = sql[index..].chars().next()
-                    && is_mysql_unquoted_identifier_char(character)
+            while let Some(character) = sql[index..].chars().next()
+                && is_mysql_unquoted_identifier_char(character)
+            {
+                index += character.len_utf8();
+            }
+            let is_digit_only = sql[start..index].bytes().all(|byte| byte.is_ascii_digit());
+            if is_digit_only && bytes.get(index) == Some(&b'.') {
+                while index < bytes.len()
+                    && (bytes[index].is_ascii_alphanumeric()
+                        || matches!(bytes[index], b'.' | b'_' | b'$'))
                 {
-                    index += character.len_utf8();
+                    index += 1;
                 }
             }
             let text = sql[start..index].to_string();
-            let kind = if !has_dot && text.chars().any(|character| !character.is_ascii_digit()) {
-                TokenKind::Word(text.to_ascii_uppercase())
-            } else {
+            let kind = if is_digit_only {
                 TokenKind::Number
+            } else {
+                TokenKind::Word(text.to_ascii_uppercase())
             };
             tokens.push(Token { kind, depth, text });
             continue;

--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -147,7 +147,21 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
             {
                 index += character.len_utf8();
             }
-            let is_digit_only = sql[start..index].bytes().all(|byte| byte.is_ascii_digit());
+            let candidate = &sql[start..index];
+            let is_digit_only = candidate.bytes().all(|byte| byte.is_ascii_digit());
+            let is_exponent_literal = is_mysql_exponent_literal(candidate.as_bytes());
+            let is_hex_or_bit_literal = is_mysql_hex_or_bit_literal(candidate.as_bytes());
+            let is_signed_exponent = is_mysql_exponent_prefix(candidate.as_bytes())
+                && matches!(bytes.get(index), Some(b'+' | b'-'))
+                && bytes.get(index + 1).is_some_and(u8::is_ascii_digit);
+            let is_numeric_literal =
+                is_digit_only || is_exponent_literal || is_hex_or_bit_literal || is_signed_exponent;
+            if is_signed_exponent {
+                index += 1;
+                while index < bytes.len() && bytes[index].is_ascii_digit() {
+                    index += 1;
+                }
+            }
             if is_digit_only && bytes.get(index) == Some(&b'.') {
                 while index < bytes.len()
                     && (bytes[index].is_ascii_alphanumeric()
@@ -157,7 +171,7 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
                 }
             }
             let text = sql[start..index].to_string();
-            let kind = if is_digit_only {
+            let kind = if is_numeric_literal {
                 TokenKind::Number
             } else {
                 TokenKind::Word(text.to_ascii_uppercase())
@@ -187,6 +201,36 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
 
 fn is_mysql_unquoted_identifier_char(character: char) -> bool {
     character.is_ascii_alphanumeric() || matches!(character, '_' | '$' | '\u{0080}'..='\u{FFFF}')
+}
+
+fn is_mysql_exponent_prefix(bytes: &[u8]) -> bool {
+    bytes.len() > 1
+        && matches!(bytes.last(), Some(b'e' | b'E'))
+        && bytes[..bytes.len() - 1].iter().all(u8::is_ascii_digit)
+}
+
+fn is_mysql_exponent_literal(bytes: &[u8]) -> bool {
+    let Some(exponent_index) = bytes.iter().position(|byte| matches!(byte, b'e' | b'E')) else {
+        return false;
+    };
+    let mantissa = &bytes[..exponent_index];
+    let exponent = &bytes[exponent_index + 1..];
+    is_mysql_ascii_digit_sequence(mantissa) && is_mysql_ascii_digit_sequence(exponent)
+}
+
+fn is_mysql_hex_or_bit_literal(bytes: &[u8]) -> bool {
+    if bytes.len() <= 2 || bytes[0] != b'0' {
+        return false;
+    }
+    match bytes[1] {
+        b'x' => bytes[2..].iter().all(u8::is_ascii_hexdigit),
+        b'b' => bytes[2..].iter().all(|byte| matches!(byte, b'0' | b'1')),
+        _ => false,
+    }
+}
+
+fn is_mysql_ascii_digit_sequence(bytes: &[u8]) -> bool {
+    !bytes.is_empty() && bytes.iter().all(u8::is_ascii_digit)
 }
 
 pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexError> {

--- a/src/domain/mysql_sql/lexer.rs
+++ b/src/domain/mysql_sql/lexer.rs
@@ -109,13 +109,17 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
             index = end;
             continue;
         }
-        if byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$' {
+        let character = sql[index..]
+            .chars()
+            .next()
+            .expect("lexer index must remain on a UTF-8 boundary");
+        if is_mysql_unquoted_identifier_char(character) && !character.is_ascii_digit() {
             let start = index;
-            index += 1;
-            while index < bytes.len()
-                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'_' | b'$'))
+            index += character.len_utf8();
+            while let Some(character) = sql[index..].chars().next()
+                && is_mysql_unquoted_identifier_char(character)
             {
-                index += 1;
+                index += character.len_utf8();
             }
             let text = sql[start..index].to_string();
             tokens.push(Token {
@@ -124,6 +128,11 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
                 text,
             });
             continue;
+        }
+        if character.is_control() || !character.is_ascii() {
+            return Err(MySqlLexError(
+                "unsupported MySQL character in statement".to_string(),
+            ));
         }
         if byte.is_ascii_digit() {
             let start = index;
@@ -158,6 +167,10 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError
         index += 1;
     }
     Ok(tokens)
+}
+
+fn is_mysql_unquoted_identifier_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '$' | '\u{0080}'..='\u{FFFF}')
 }
 
 pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexError> {

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -262,11 +262,17 @@ fn mysql_target_key(
         1 | 2 => database.to_lowercase(),
         _ => return None,
     };
-    Some(format!(
-        "{}:{}",
-        database,
-        statement.target.as_deref()?.to_ascii_uppercase()
-    ))
+    let target = statement.target.as_deref()?;
+    let target = match lower_case_table_names {
+        0 => target.to_ascii_uppercase(),
+        1 | 2 => target.to_lowercase(),
+        _ => return None,
+    };
+    Some(format!("{database}:{target}"))
+}
+
+fn mysql_names_equal(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right) || left.to_lowercase() == right.to_lowercase()
 }
 
 fn validate_mysql_submission_state(
@@ -299,7 +305,7 @@ fn validate_mysql_submission_state(
                     .target
                     .as_deref()
                     .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
-                savepoints.retain(|current| !current.eq_ignore_ascii_case(name));
+                savepoints.retain(|current| !mysql_names_equal(current, name));
                 savepoints.push(name.to_string());
             }
             MySqlStatementKind::RollbackToSavepoint => {
@@ -314,7 +320,7 @@ fn validate_mysql_submission_state(
                     .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
                 let Some(index) = savepoints
                     .iter()
-                    .position(|current| current.eq_ignore_ascii_case(name))
+                    .position(|current| mysql_names_equal(current, name))
                 else {
                     return Err("MySQL ROLLBACK TO SAVEPOINT name is unknown".to_string());
                 };
@@ -332,7 +338,7 @@ fn validate_mysql_submission_state(
                     .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
                 let Some(index) = savepoints
                     .iter()
-                    .position(|current| current.eq_ignore_ascii_case(name))
+                    .position(|current| mysql_names_equal(current, name))
                 else {
                     return Err("MySQL RELEASE SAVEPOINT name is unknown".to_string());
                 };
@@ -580,6 +586,8 @@ mod tests {
             );
             assert_eq!(statement.target(), Some(expected_target), "{sql}");
         }
+
+        assert!(classify_mysql_statement("UPDATE 123 SET value = 1").is_err());
     }
 
     #[test]
@@ -587,6 +595,7 @@ mod tests {
         for sql in [
             "UPDATE /* ignored café */ café SET value = 1",
             "UPDATE café -- ignored comment\n SET value = 1",
+            "UPDATE café--x\n SET value = 1",
             "CREATE TABLE café (id INT) /*!40100 DEFAULT CHARSET=utf8mb4 */",
             "DROP TABLE café /*!80000 RESTRICT */",
         ] {
@@ -1098,6 +1107,40 @@ mod tests {
                 0,
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn temporary_mysql_table_keys_follow_unicode_table_case_rules() {
+        assert!(
+            classify_mysql_multi_statement_with_lower_case_table_names(
+                "CREATE TEMPORARY TABLE café (id INT); DROP TEMPORARY TABLE CAFÉ",
+                Some("app"),
+                0,
+            )
+            .is_err()
+        );
+
+        for lower_case_table_names in [1, 2] {
+            assert!(
+                classify_mysql_multi_statement_with_lower_case_table_names(
+                    "CREATE TEMPORARY TABLE café (id INT); DROP TEMPORARY TABLE CAFÉ",
+                    Some("app"),
+                    lower_case_table_names,
+                )
+                .is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn unicode_savepoints_are_case_insensitive_in_transactions() {
+        assert!(
+            classify_mysql_multi_statement(
+                "START TRANSACTION; SAVEPOINT café; ROLLBACK TO SAVEPOINT CAFÉ; COMMIT",
+                Some("app"),
+            )
+            .is_ok()
         );
     }
 

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -264,7 +264,7 @@ fn mysql_target_key(
     };
     let target = statement.target.as_deref()?;
     let target = match lower_case_table_names {
-        0 => target.to_ascii_uppercase(),
+        0 => target.to_string(),
         1 | 2 => target.to_lowercase(),
         _ => return None,
     };
@@ -272,7 +272,7 @@ fn mysql_target_key(
 }
 
 fn mysql_names_equal(left: &str, right: &str) -> bool {
-    left.eq_ignore_ascii_case(right) || left.to_lowercase() == right.to_lowercase()
+    left.to_uppercase() == right.to_uppercase()
 }
 
 fn validate_mysql_submission_state(
@@ -564,6 +564,11 @@ mod tests {
     fn preserves_utf8_unquoted_and_backtick_targets() {
         let cases = [
             ("UPDATE café SET value = 1", None, "café"),
+            ("UPDATE 1é SET value = 1", None, "1é"),
+            ("UPDATE 1abc SET value = 1", None, "1abc"),
+            ("UPDATE 1_foo SET value = 1", None, "1_foo"),
+            ("UPDATE 1$foo SET value = 1", None, "1$foo"),
+            ("UPDATE 1$é SET value = 1", None, "1$é"),
             (
                 "UPDATE café.éléments SET value = 1",
                 Some("café"),
@@ -596,6 +601,7 @@ mod tests {
             "UPDATE /* ignored café */ café SET value = 1",
             "UPDATE café -- ignored comment\n SET value = 1",
             "UPDATE café--x\n SET value = 1",
+            "/*!80000 UPDATE café SET value = 1 */",
             "CREATE TABLE café (id INT) /*!40100 DEFAULT CHARSET=utf8mb4 */",
             "DROP TABLE café /*!80000 RESTRICT */",
         ] {
@@ -1131,6 +1137,15 @@ mod tests {
                 .is_ok()
             );
         }
+
+        assert!(
+            classify_mysql_multi_statement_with_lower_case_table_names(
+                "CREATE TEMPORARY TABLE items (id INT); CREATE TEMPORARY TABLE ITEMS (id INT); DROP TEMPORARY TABLE items; DROP TEMPORARY TABLE ITEMS",
+                Some("app"),
+                0,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
@@ -1138,6 +1153,13 @@ mod tests {
         assert!(
             classify_mysql_multi_statement(
                 "START TRANSACTION; SAVEPOINT café; ROLLBACK TO SAVEPOINT CAFÉ; COMMIT",
+                Some("app"),
+            )
+            .is_ok()
+        );
+        assert!(
+            classify_mysql_multi_statement(
+                "START TRANSACTION; SAVEPOINT ς; ROLLBACK TO SAVEPOINT σ; COMMIT",
                 Some("app"),
             )
             .is_ok()

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -603,6 +603,19 @@ mod tests {
     }
 
     #[test]
+    fn rejects_mysql_numeric_literals_as_mutation_targets() {
+        for sql in [
+            "UPDATE 1e3 SET value = 1",
+            "UPDATE 1e+3 SET value = 1",
+            "UPDATE 1e-3 SET value = 1",
+            "UPDATE 0x01AF SET value = 1",
+            "UPDATE 0b01 SET value = 1",
+        ] {
+            assert!(classify_mysql_statement(sql).is_err(), "{sql}");
+        }
+    }
+
+    #[test]
     fn preserves_utf8_targets_around_comments_and_executable_comments() {
         for sql in [
             "UPDATE /* ignored café */ café SET value = 1",

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -555,6 +555,53 @@ mod tests {
     }
 
     #[test]
+    fn preserves_utf8_unquoted_and_backtick_targets() {
+        let cases = [
+            ("UPDATE café SET value = 1", None, "café"),
+            (
+                "UPDATE café.éléments SET value = 1",
+                Some("café"),
+                "éléments",
+            ),
+            ("UPDATE $items SET value = 1", None, "$items"),
+            (
+                r"UPDATE `café`.`éléments` SET value = 1",
+                Some("café"),
+                "éléments",
+            ),
+        ];
+
+        for (sql, expected_database, expected_target) in cases {
+            let statement = classify_mysql_statement(sql).expect(sql);
+            assert_eq!(
+                statement.target_database.as_deref(),
+                expected_database,
+                "{sql}"
+            );
+            assert_eq!(statement.target(), Some(expected_target), "{sql}");
+        }
+    }
+
+    #[test]
+    fn preserves_utf8_targets_around_comments_and_executable_comments() {
+        for sql in [
+            "UPDATE /* ignored café */ café SET value = 1",
+            "UPDATE café -- ignored comment\n SET value = 1",
+            "CREATE TABLE café (id INT) /*!40100 DEFAULT CHARSET=utf8mb4 */",
+            "DROP TABLE café /*!80000 RESTRICT */",
+        ] {
+            let statement = classify_mysql_statement(sql).expect(sql);
+            assert_eq!(statement.target(), Some("café"), "{sql}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_bmp_backtick_targets_fail_closed() {
+        assert!(classify_mysql_statement("UPDATE `caf😀` SET value = 1").is_err());
+        assert!(classify_mysql_statement("UPDATE caf😀 SET value = 1").is_err());
+    }
+
+    #[test]
     fn classifies_documented_mysql_ddl_forms() {
         let cases = [
             (
@@ -1017,6 +1064,38 @@ mod tests {
                 "UPDATE other.items SET value = 1",
                 Some("app"),
                 1,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn qualified_utf8_mysql_mutations_follow_selected_database_case_rules() {
+        let exact = classify_mysql_multi_statement_with_lower_case_table_names(
+            "UPDATE äpp.éléments SET value = 1",
+            Some("äpp"),
+            0,
+        )
+        .unwrap();
+        assert_eq!(exact[0].target_database.as_deref(), Some("äpp"));
+        assert_eq!(exact[0].target(), Some("éléments"));
+
+        for lower_case_table_names in [1, 2] {
+            let statements = classify_mysql_multi_statement_with_lower_case_table_names(
+                "UPDATE ÄPP.éléments SET value = 1",
+                Some("äpp"),
+                lower_case_table_names,
+            )
+            .unwrap();
+            assert_eq!(statements[0].target_database.as_deref(), Some("ÄPP"));
+            assert_eq!(statements[0].target(), Some("éléments"));
+        }
+
+        assert!(
+            classify_mysql_multi_statement_with_lower_case_table_names(
+                "UPDATE ÄPP.éléments SET value = 1",
+                Some("äpp"),
+                0,
             )
             .is_err()
         );

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -570,6 +570,13 @@ mod tests {
             ("UPDATE 1$foo SET value = 1", None, "1$foo"),
             ("UPDATE 1$é SET value = 1", None, "1$é"),
             (
+                "UPDATE 1abc.éléments SET value = 1",
+                Some("1abc"),
+                "éléments",
+            ),
+            ("UPDATE 1$foo.café SET value = 1", Some("1$foo"), "café"),
+            ("UPDATE 1_foo.items SET value = 1", Some("1_foo"), "items"),
+            (
                 "UPDATE café.éléments SET value = 1",
                 Some("café"),
                 "éléments",

--- a/src/domain/mysql_sql/mod.rs
+++ b/src/domain/mysql_sql/mod.rs
@@ -620,13 +620,19 @@ mod tests {
         for sql in [
             "UPDATE /* ignored café */ café SET value = 1",
             "UPDATE café -- ignored comment\n SET value = 1",
-            "UPDATE café--x\n SET value = 1",
             "/*!80000 UPDATE café SET value = 1 */",
             "CREATE TABLE café (id INT) /*!40100 DEFAULT CHARSET=utf8mb4 */",
             "DROP TABLE café /*!80000 RESTRICT */",
         ] {
             let statement = classify_mysql_statement(sql).expect(sql);
             assert_eq!(statement.target(), Some("café"), "{sql}");
+        }
+
+        for sql in [
+            "UPDATE café--x\n SET value = 1",
+            "UPDATE 1e+foo SET value = 1",
+        ] {
+            assert!(classify_mysql_statement(sql).is_err(), "{sql}");
         }
     }
 

--- a/src/domain/mysql_sql/target.rs
+++ b/src/domain/mysql_sql/target.rs
@@ -86,9 +86,24 @@ pub(super) fn identifier_at(
     ) {
         let second_token = tokens.get(index + 2)?;
         let second = identifier_text(second_token)?;
-        return Some((second, Some(first), index + 3));
+        let next = index + 3;
+        if has_unexpected_identifier_boundary(tokens, next) {
+            return None;
+        }
+        return Some((second, Some(first), next));
     }
-    Some((first, None, index + 1))
+    let next = index + 1;
+    if has_unexpected_identifier_boundary(tokens, next) {
+        return None;
+    }
+    Some((first, None, next))
+}
+
+fn has_unexpected_identifier_boundary(tokens: &[Token], index: usize) -> bool {
+    tokens.get(index).is_some_and(|token| match &token.kind {
+        TokenKind::Symbol(symbol) => !matches!(*symbol, '(' | ';'),
+        _ => false,
+    })
 }
 
 fn identifier_text(token: &Token) -> Option<String> {

--- a/src/domain/mysql_sql/target.rs
+++ b/src/domain/mysql_sql/target.rs
@@ -79,24 +79,30 @@ pub(super) fn identifier_at(
         index += 1;
     }
     let first_token = tokens.get(index)?;
-    let first = match &first_token.kind {
-        TokenKind::Word(_) => first_token.text.clone(),
-        TokenKind::Identifier(identifier) => identifier.clone(),
-        _ => return None,
-    };
+    let first = identifier_text(first_token)?;
     if matches!(
         tokens.get(index + 1).map(|token| &token.kind),
         Some(TokenKind::Symbol('.'))
     ) {
         let second_token = tokens.get(index + 2)?;
-        let second = match &second_token.kind {
-            TokenKind::Word(_) => second_token.text.clone(),
-            TokenKind::Identifier(identifier) => identifier.clone(),
-            _ => return None,
-        };
+        let second = identifier_text(second_token)?;
         return Some((second, Some(first), index + 3));
     }
     Some((first, None, index + 1))
+}
+
+fn identifier_text(token: &Token) -> Option<String> {
+    match &token.kind {
+        TokenKind::Word(_) => Some(token.text.clone()),
+        TokenKind::Identifier(identifier)
+            if identifier
+                .chars()
+                .all(|character| character != '\0' && character <= '\u{FFFF}') =>
+        {
+            Some(identifier.clone())
+        }
+        _ => None,
+    }
 }
 
 pub(super) fn skip_mysql_modifiers(


### PR DESCRIPTION
## Problem
MySQL target lexing truncates unquoted UTF-8 identifiers at their ASCII prefix, so database scope and typed confirmations can diverge from the SQL.

## Background
The lexer advanced byte-by-byte for word tokens, which split multibyte identifier characters into invalid fragments.

## Approach
Scan permitted MySQL unquoted identifier characters on UTF-8 character boundaries while preserving the entered target spelling. Reject unsupported characters and invalid quoted identifier text so target handling fails closed. Cover unqualified and qualified names, `$` names, case rules, comments, executable comments, and typed confirmation.