### PR TITLE
refactor: derive EXPLAIN current surface from right plan

### DIFF
--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -21,18 +21,21 @@ impl SlotSource {
 pub struct CompareSlot {
     pub plan: ExplainPlan,
     pub database_type: DatabaseType,
-    pub query_snippet: String,
     pub full_query: String,
     pub source: SlotSource,
 }
 
 #[derive(Debug, Clone, Default)]
+enum ExplainSurface {
+    #[default]
+    Empty,
+    Current,
+    Error(String),
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct ExplainContext {
-    pub(crate) plan_text: Option<String>,
-    pub(crate) plan_query_snippet: Option<String>,
-    pub(crate) error: Option<String>,
-    pub(crate) is_analyze: bool,
-    pub(crate) execution_time_ms: u64,
+    surface: ExplainSurface,
     pub(crate) scroll_offset: usize,
 
     pub(crate) left: Option<CompareSlot>,
@@ -45,27 +48,31 @@ pub struct ExplainContext {
 
 impl ExplainContext {
     pub fn plan_text(&self) -> Option<&str> {
-        self.plan_text.as_deref()
+        self.current_plan().map(|plan| plan.raw_text.as_str())
     }
 
     pub fn plan_query_snippet(&self) -> Option<&str> {
-        self.plan_query_snippet.as_deref()
+        self.current_slot()
+            .map(|slot| slot.full_query.lines().next().unwrap_or(""))
     }
 
     pub fn current_plan(&self) -> Option<&ExplainPlan> {
-        self.right.as_ref().map(|slot| &slot.plan)
+        self.current_slot().map(|slot| &slot.plan)
     }
 
     pub fn error(&self) -> Option<&str> {
-        self.error.as_deref()
+        match &self.surface {
+            ExplainSurface::Error(error) => Some(error),
+            ExplainSurface::Empty | ExplainSurface::Current => None,
+        }
     }
 
     pub fn is_analyze(&self) -> bool {
-        self.is_analyze
+        self.current_plan().is_some_and(|plan| plan.is_analyze)
     }
 
     pub fn execution_time_ms(&self) -> u64 {
-        self.execution_time_ms
+        self.current_plan().map_or(0, |plan| plan.execution_time_ms)
     }
 
     pub fn scroll_offset(&self) -> usize {
@@ -104,13 +111,9 @@ impl ExplainContext {
                 explain_plan::parse_mysql_tree_explain_text(&text, is_analyze, execution_time_ms)
             }
         };
-        let snippet = query.lines().next().unwrap_or("").to_string();
-        let plan_snippet = snippet.clone();
-
         let new_slot = CompareSlot {
             plan: parsed,
             database_type,
-            query_snippet: snippet,
             full_query: query.to_string(),
             source: SlotSource::AutoLatest,
         };
@@ -122,18 +125,13 @@ impl ExplainContext {
         });
         self.right = Some(new_slot);
 
-        self.plan_text = Some(text);
-        self.plan_query_snippet = Some(plan_snippet);
-        self.error = None;
-        self.is_analyze = is_analyze;
-        self.execution_time_ms = execution_time_ms;
+        self.surface = ExplainSurface::Current;
         self.scroll_offset = 0;
         self.compare_scroll_offset = 0;
     }
 
     pub fn set_error(&mut self, error: String) {
-        self.error = Some(error);
-        self.plan_text = None;
+        self.surface = ExplainSurface::Error(error);
         self.scroll_offset = 0;
     }
 
@@ -164,13 +162,9 @@ impl ExplainContext {
     }
 
     pub fn line_count(&self) -> usize {
-        if let Some(ref text) = self.plan_text {
-            text.lines().count()
-        } else if let Some(ref err) = self.error {
-            err.lines().count()
-        } else {
-            0
-        }
+        self.plan_text()
+            .or_else(|| self.error())
+            .map_or(0, |text| text.lines().count())
     }
 
     // blank + verdict + blank + reasons(3) + blank + separator + blank + slot header + detail + thin_sep
@@ -201,6 +195,13 @@ impl ExplainContext {
             .compare_viewport_height
             .map_or_else(|| Self::modal_inner_height(terminal_height), |h| h as usize);
         self.compare_line_count().saturating_sub(viewport)
+    }
+
+    fn current_slot(&self) -> Option<&CompareSlot> {
+        match &self.surface {
+            ExplainSurface::Current => self.right.as_ref(),
+            ExplainSurface::Empty | ExplainSurface::Error(_) => None,
+        }
     }
 }
 
@@ -250,7 +251,13 @@ mod tests {
         assert!(ctx.left().is_none());
         assert!(ctx.right().is_some());
         assert_eq!(ctx.right().unwrap().plan.total_cost, Some(100.0));
-        assert_eq!(ctx.right().unwrap().query_snippet, "SELECT * FROM users");
+        assert_eq!(
+            ctx.plan_text(),
+            Some("Seq Scan  (cost=0.00..100.00 rows=10 width=32)")
+        );
+        assert_eq!(ctx.plan_query_snippet(), Some("SELECT * FROM users"));
+        assert!(!ctx.is_analyze());
+        assert_eq!(ctx.execution_time_ms(), 42);
         assert_eq!(ctx.right().unwrap().source, SlotSource::AutoLatest);
     }
 
@@ -340,6 +347,7 @@ mod tests {
 
         assert!(ctx.plan_text().is_none());
         assert!(ctx.error().is_none());
+        assert!(ctx.current_plan().is_none());
         assert_eq!(ctx.scroll_offset(), 0);
         assert_eq!(ctx.compare_scroll_offset(), 0);
         assert!(ctx.left().is_some());
@@ -390,11 +398,13 @@ mod tests {
 
         ctx.set_error("some error".to_string());
 
+        assert!(ctx.plan_text().is_none());
+        assert!(ctx.current_plan().is_none());
         assert!(ctx.right().is_some());
     }
 
     #[test]
-    fn set_plan_stores_query_snippet_first_line_only() {
+    fn current_surface_derives_query_snippet_from_full_query_first_line() {
         let mut ctx = ExplainContext::default();
 
         ctx.set_plan(
@@ -405,7 +415,7 @@ mod tests {
             "SELECT *\nFROM users\nWHERE id = 1",
         );
 
-        assert_eq!(ctx.right().unwrap().query_snippet, "SELECT *");
+        assert_eq!(ctx.plan_query_snippet(), Some("SELECT *"));
     }
 
     #[test]

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -108,7 +108,7 @@ mod tests {
             let effects = reduce_at_boundary(&mut state, Action::ExplainRequest);
 
             assert!(effects.is_empty());
-            assert!(state.explain.error.is_none());
+            assert!(state.explain.error().is_none());
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
@@ -284,7 +284,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some(
                     "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements",
                 )
@@ -305,7 +305,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("MySQL EXPLAIN does not support MySQL client commands")
             );
         }
@@ -324,7 +324,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("MySQL EXPLAIN does not support multiple statements")
             );
         }
@@ -343,7 +343,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some(
                     "EXPLAIN QUERY PLAN supports SELECT, INSERT, UPDATE, DELETE, or REPLACE statements"
                 )
@@ -365,7 +365,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some(
                     "EXPLAIN QUERY PLAN is added automatically; enter a supported query without EXPLAIN"
                 )
@@ -384,7 +384,7 @@ mod tests {
             let effects = reduce_at_boundary(&mut state, Action::ExplainAnalyzeRequest);
 
             assert!(effects.is_empty());
-            assert!(state.explain.error.is_none());
+            assert!(state.explain.error().is_none());
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
             assert!(!matches!(
                 state.sql_modal.status(),
@@ -408,7 +408,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("EXPLAIN does not support multiple statements")
             );
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
@@ -494,7 +494,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("EXPLAIN ANALYZE does not support multiple statements")
             );
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
@@ -509,7 +509,7 @@ mod tests {
             let effects = reduce_at_boundary(&mut state, Action::ExplainAnalyzeRequest);
 
             assert!(effects.is_empty());
-            assert!(state.explain.error.is_none());
+            assert!(state.explain.error().is_none());
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
@@ -608,7 +608,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some(
                     "MySQL EXPLAIN ANALYZE only supports side-effect-free SELECT or TABLE statements"
                 )
@@ -782,15 +782,8 @@ mod tests {
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
-            assert!(state.explain.error.is_some());
-            assert!(
-                state
-                    .explain
-                    .error
-                    .as_deref()
-                    .unwrap()
-                    .contains("Read-only")
-            );
+            assert!(state.explain.error().is_some());
+            assert!(state.explain.error().unwrap().contains("Read-only"));
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(state.confirm_dialog.intent().is_none());
         }
@@ -810,7 +803,7 @@ mod tests {
                     .into_effects()
                     .expect("reducer should handle action");
 
-            assert!(state.explain.error.is_none());
+            assert!(state.explain.error().is_none());
             assert_eq!(effects.len(), 1);
             assert!(matches!(
                 &effects[0],
@@ -868,14 +861,7 @@ mod tests {
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
-            assert!(
-                state
-                    .explain
-                    .error
-                    .as_deref()
-                    .unwrap()
-                    .contains("Read-only")
-            );
+            assert!(state.explain.error().unwrap().contains("Read-only"));
         }
     }
 
@@ -1015,7 +1001,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.plan_text.as_deref(), Some("Seq Scan"));
+            assert_eq!(state.explain.plan_text(), Some("Seq Scan"));
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(!state.query.is_running());
@@ -1083,11 +1069,8 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.plan_text.as_deref(), Some("Original"));
-            assert_eq!(
-                state.explain.plan_query_snippet.as_deref(),
-                Some("SELECT old")
-            );
+            assert_eq!(state.explain.plan_text(), Some("Original"));
+            assert_eq!(state.explain.plan_query_snippet(), Some("SELECT old"));
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
         }
 
@@ -1161,7 +1144,7 @@ mod tests {
             );
 
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("Query failed: syntax error. Review the database error details and SQL.")
             );
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
@@ -1196,8 +1179,8 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.plan_text.as_deref(), Some("Original"));
-            assert_eq!(state.explain.error, None);
+            assert_eq!(state.explain.plan_text(), Some("Original"));
+            assert_eq!(state.explain.error(), None);
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
         }
 

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -1193,7 +1193,6 @@ mod tests {
                     execution_time_ms: ms,
                 },
                 database_type: DatabaseType::PostgreSQL,
-                query_snippet: "SELECT 1".to_string(),
                 full_query: "SELECT 1".to_string(),
                 source,
             }
@@ -1233,7 +1232,13 @@ mod tests {
             let mut state = sql_modal_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state.explain.plan_text = Some("Seq Scan on users".to_string());
+            state.explain.set_plan(
+                "Seq Scan on users".to_string(),
+                DatabaseType::PostgreSQL,
+                false,
+                0,
+                "SELECT 1",
+            );
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
                 .into_effects()
@@ -1250,7 +1255,6 @@ mod tests {
             let mut state = sql_modal_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state.explain.plan_text = None;
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
                 .into_effects()
@@ -1264,8 +1268,7 @@ mod tests {
             let mut state = sql_modal_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state.explain.plan_text = None;
-            state.explain.error = Some("syntax error".to_string());
+            state.explain.set_error("syntax error".to_string());
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
                 .into_effects()
@@ -1386,7 +1389,6 @@ mod tests {
                     execution_time_ms: 420,
                 },
                 database_type: DatabaseType::PostgreSQL,
-                query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users".to_string(),
                 source: SlotSource::AutoPrevious,
             });
@@ -1405,7 +1407,6 @@ mod tests {
                     execution_time_ms: 50,
                 },
                 database_type: DatabaseType::PostgreSQL,
-                query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users WHERE id=1".to_string(),
                 source: SlotSource::AutoLatest,
             });

--- a/src/app/update/sql_editor/yank.rs
+++ b/src/app/update/sql_editor/yank.rs
@@ -19,7 +19,7 @@ pub(super) fn reduce_yank(state: &mut AppState, action: &Action, now: Instant) -
                 .active_engine_feature_profile()
                 .normalize_sql_modal_tab(state.sql_modal.active_tab());
             let content = match active_tab {
-                SqlModalTab::Plan => state.explain.plan_text.clone(),
+                SqlModalTab::Plan => state.explain.plan_text().map(str::to_owned),
                 SqlModalTab::Compare => match (&state.explain.left, &state.explain.right) {
                     (Some(l), Some(r)) => {
                         let result = compare_plans(&l.plan, &r.plan);

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -452,7 +452,6 @@ mod tests {
                 execution_time_ms: 250,
             },
             database_type: DatabaseType::PostgreSQL,
-            query_snippet: "SELECT 1".to_string(),
             full_query: "SELECT 1".to_string(),
             source: label,
         }


### PR DESCRIPTION
## Problem

ExplainContext stores current plan presentation data redundantly alongside the right comparison slot, so the setter must keep duplicate state synchronized.

## Background

The right comparison slot already owns the parsed plan and full query, while new-run and error states must hide current output without discarding comparison history.

## Approach

Keep only a private current-surface discriminator and derive current text, mode, elapsed time, and the first query line from the right slot. Preserve auto-advance, comparison, reset behavior, parsers, scrolling, and yank behavior without changing SQL execution or safety boundaries.