### PR TITLE
refactor(app): unify table prefetch ownership

### DIFF
--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -50,7 +50,7 @@ pub async fn run(
             };
 
             if !missing.is_empty() {
-                if let Some(run_id) = state.sql_modal.active_prefetch_run_id() {
+                if let Some(run_id) = state.table_prefetch.active_prefetch_run_id() {
                     for action in missing.into_iter().filter_map(|qualified_name| {
                         qualified_name.split_once('.').map(|(schema, table)| {
                             Action::PrefetchTableDetail {

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1157,7 +1157,7 @@ mod tests {
         }
     }
 
-    mod sql_modal_lifecycle {
+    mod table_prefetch_lifecycle {
         use super::*;
 
         #[test]

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -29,6 +29,7 @@ use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
 use crate::model::sqlite::diagnostics::SqliteDiagnosticsState;
+use crate::model::table_prefetch::TablePrefetchState;
 use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
@@ -51,6 +52,7 @@ pub struct AppState {
     pub ui: UiState,
     pub query: QueryExecution,
     pub sql_modal: SqlModalContext,
+    pub table_prefetch: TablePrefetchState,
     pub messages: MessageState,
     pub er_preparation: super::er_state::ErPreparationState,
     pub connection_setup: ConnectionSetupState,
@@ -85,6 +87,7 @@ impl AppState {
             ui: UiState::new(),
             query: QueryExecution::default(),
             sql_modal: SqlModalContext::default(),
+            table_prefetch: TablePrefetchState::default(),
             messages: MessageState::default(),
             er_preparation: super::er_state::ErPreparationState::default(),
             connection_setup: ConnectionSetupState::default(),
@@ -482,7 +485,7 @@ mod tests {
         ConfirmPreviewLayout, InspectorLayout, RowDetailLayout,
     };
     use crate::model::shared::viewport::ViewportPlan;
-    use crate::model::sql_editor::modal::FailedPrefetchEntry;
+    use crate::model::table_prefetch::FailedPrefetchEntry;
     use crate::services::AppServices;
     use crate::update::action::Action;
     use crate::update::dispatch_metadata;
@@ -1161,22 +1164,22 @@ mod tests {
         fn prefetch_queue_starts_empty() {
             let state = make_state();
 
-            assert!(!state.sql_modal.has_pending_prefetch());
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(!state.table_prefetch.has_pending_prefetch());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
         }
 
         #[test]
         fn prefetch_queue_is_fifo() {
             let mut state = make_state();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.orders".to_string());
 
-            let first = state.sql_modal.take_next_prefetch();
-            let second = state.sql_modal.take_next_prefetch();
+            let first = state.table_prefetch.take_next_prefetch();
+            let second = state.table_prefetch.take_next_prefetch();
 
             assert_eq!(first, Some("public.users".to_string()));
             assert_eq!(second, Some("public.orders".to_string()));
@@ -1187,11 +1190,11 @@ mod tests {
             let mut state = make_state();
 
             state
-                .sql_modal
+                .table_prefetch
                 .start_table_prefetch("public.users".to_string());
 
-            assert!(state.sql_modal.is_table_prefetching("public.users"));
-            assert!(!state.sql_modal.is_table_prefetching("public.orders"));
+            assert!(state.table_prefetch.is_table_prefetching("public.users"));
+            assert!(!state.table_prefetch.is_table_prefetching("public.orders"));
         }
 
         #[test]
@@ -1199,7 +1202,7 @@ mod tests {
             let mut state = make_state();
             let now = Instant::now();
 
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 "public.users".to_string(),
                 FailedPrefetchEntry {
                     failed_at: now,
@@ -1208,7 +1211,10 @@ mod tests {
                 },
             );
 
-            let entry = state.sql_modal.failed_prefetch("public.users").unwrap();
+            let entry = state
+                .table_prefetch
+                .failed_prefetch("public.users")
+                .unwrap();
             assert_eq!(entry.failed_at, now);
             assert_eq!(entry.error, "connection timeout");
         }
@@ -1220,14 +1226,14 @@ mod tests {
         fn prepare_state_for_reload() -> AppState {
             let mut state = make_state();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
             state
-                .sql_modal
+                .table_prefetch
                 .start_table_prefetch("public.orders".to_string());
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 "public.failed".to_string(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -1244,10 +1250,15 @@ mod tests {
 
             dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
-            assert!(!state.sql_modal.has_pending_prefetch());
-            assert_eq!(state.sql_modal.prefetch_in_flight_count(), 0);
-            assert!(state.sql_modal.failed_prefetch("public.failed").is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
+            assert!(!state.table_prefetch.has_pending_prefetch());
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
+            assert!(
+                state
+                    .table_prefetch
+                    .failed_prefetch("public.failed")
+                    .is_none()
+            );
         }
 
         #[test]

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::model::shared::async_run::AsyncRun;
+use crate::model::table_prefetch::TablePrefetchState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ErStatus {
@@ -12,9 +13,6 @@ pub enum ErStatus {
 
 #[derive(Debug, Clone, Default)]
 pub struct ErPreparationState {
-    pending_tables: HashSet<String>,
-    fetching_tables: HashSet<String>,
-    failed_tables: HashMap<String, String>,
     status: ErStatus,
     total_tables: usize,
     target_tables: Vec<String>,
@@ -39,21 +37,14 @@ impl ErPreparationState {
         self.status == ErStatus::Waiting
     }
 
-    pub fn progress(&self) -> ErPreparationProgress {
-        let failed = self.failed_tables.len();
-        let remaining = self.pending_tables.len() + self.fetching_tables.len();
+    pub fn progress(&self, prefetch: &TablePrefetchState) -> ErPreparationProgress {
+        let failed = prefetch.failed_prefetch_count();
+        let remaining = prefetch.pending_prefetch_count() + prefetch.prefetch_in_flight_count();
         let cached = self.total_tables.saturating_sub(remaining + failed);
         ErPreparationProgress {
             cached,
             total: self.total_tables,
         }
-    }
-
-    pub fn failed_table_errors(&self) -> Vec<(String, String)> {
-        self.failed_tables
-            .iter()
-            .map(|(table, error)| (table.clone(), error.clone()))
-            .collect()
     }
 
     pub fn target_tables(&self) -> &[String] {
@@ -76,61 +67,19 @@ impl ErPreparationState {
         matches!(self.status, ErStatus::Rendering | ErStatus::Waiting)
     }
 
-    pub fn is_complete(&self) -> bool {
-        self.pending_tables.is_empty() && self.fetching_tables.is_empty()
-    }
-
-    pub fn has_failures(&self) -> bool {
-        !self.failed_tables.is_empty()
-    }
-
-    pub fn on_table_cached(&mut self, qualified_name: &str) {
-        self.fetching_tables.remove(qualified_name);
-        self.pending_tables.remove(qualified_name);
-        self.failed_tables.remove(qualified_name);
-    }
-
-    pub fn on_table_failed(&mut self, qualified_name: &str, error: String) {
-        self.fetching_tables.remove(qualified_name);
-        self.pending_tables.remove(qualified_name);
-        self.failed_tables.insert(qualified_name.to_string(), error);
-    }
-
-    pub fn start_fetching(&mut self, qualified_name: &str) {
-        self.pending_tables.remove(qualified_name);
-        self.fetching_tables.insert(qualified_name.to_string());
-    }
-
-    pub fn requeue_for_retry(&mut self, qualified_name: &str) {
-        self.fetching_tables.remove(qualified_name);
-        self.pending_tables.insert(qualified_name.to_string());
-    }
-
     pub fn begin_all_prefetch<I>(&mut self, tables: I)
     where
         I: IntoIterator<Item = String>,
     {
-        self.pending_tables.clear();
-        self.fetching_tables.clear();
-        self.failed_tables.clear();
-        self.total_tables = 0;
+        self.total_tables = tables.into_iter().count();
         self.fk_expanded = true;
-
-        for table in tables {
-            self.pending_tables.insert(table);
-            self.total_tables += 1;
-        }
     }
 
     pub fn begin_scoped_prefetch(&mut self, tables: impl AsRef<[String]>) {
         let tables = tables.as_ref();
-        self.pending_tables.clear();
-        self.fetching_tables.clear();
-        self.failed_tables.clear();
         self.fk_expanded = false;
         self.seed_tables = tables.to_vec();
         self.total_tables = tables.len();
-        self.pending_tables.extend(tables.iter().cloned());
     }
 
     pub fn mark_idle(&mut self) {
@@ -155,9 +104,6 @@ impl ErPreparationState {
     }
 
     pub fn reset(&mut self) {
-        self.pending_tables.clear();
-        self.fetching_tables.clear();
-        self.failed_tables.clear();
         self.status = ErStatus::Idle;
         self.total_tables = 0;
         self.target_tables.clear();
@@ -203,38 +149,13 @@ impl ErPreparationState {
         self.last_signatures.clear();
         self.total_tables = total_tables;
     }
-
-    // Re-queueing a table starts a fresh attempt and clears any prior failure
-    // record for that table.
-    pub fn queue_pending_table(&mut self, table: String) -> bool {
-        self.fetching_tables.remove(&table);
-        self.failed_tables.remove(&table);
-        self.pending_tables.insert(table)
-    }
 }
 
 #[cfg(test)]
 pub mod test_support {
-    use std::collections::{HashMap, HashSet};
-
     use super::{ErPreparationState, ErStatus};
 
     impl ErPreparationState {
-        #[doc(hidden)]
-        pub fn pending_tables(&self) -> &HashSet<String> {
-            &self.pending_tables
-        }
-
-        #[doc(hidden)]
-        pub fn fetching_tables(&self) -> &HashSet<String> {
-            &self.fetching_tables
-        }
-
-        #[doc(hidden)]
-        pub fn failed_tables(&self) -> &HashMap<String, String> {
-            &self.failed_tables
-        }
-
         #[doc(hidden)]
         pub fn total_tables(&self) -> usize {
             self.total_tables
@@ -258,228 +179,55 @@ mod tests {
         state.mark_idle();
     }
 
-    mod is_complete {
-        use super::*;
+    #[test]
+    fn all_prefetch_records_total_and_marks_fk_expanded() {
+        let mut state = ErPreparationState::default();
 
-        #[test]
-        fn empty_state_returns_true() {
-            let state = ErPreparationState::default();
+        state.begin_all_prefetch(vec![
+            "public.users".to_string(),
+            "public.orders".to_string(),
+        ]);
 
-            assert!(state.is_complete());
-        }
-
-        #[test]
-        fn pending_tables_returns_false() {
-            let mut state = ErPreparationState::default();
-            state.pending_tables.insert("public.users".to_string());
-
-            assert!(!state.is_complete());
-        }
-
-        #[test]
-        fn fetching_tables_returns_false() {
-            let mut state = ErPreparationState::default();
-            state.fetching_tables.insert("public.users".to_string());
-
-            assert!(!state.is_complete());
-        }
+        assert_eq!(state.total_tables, 2);
+        assert!(state.fk_expanded);
     }
 
-    mod on_table_cached {
-        use super::*;
+    #[test]
+    fn scoped_prefetch_records_seed_tables_without_prefetch_collections() {
+        let mut state = ErPreparationState {
+            fk_expanded: true,
+            ..Default::default()
+        };
+        let tables = vec!["public.users".to_string(), "public.orders".to_string()];
 
-        #[test]
-        fn removes_from_fetching() {
-            let mut state = ErPreparationState::default();
-            state.fetching_tables.insert("public.users".to_string());
+        state.begin_scoped_prefetch(&tables);
 
-            state.on_table_cached("public.users");
-
-            assert!(!state.fetching_tables.contains("public.users"));
-        }
-
-        #[test]
-        fn removes_from_pending() {
-            let mut state = ErPreparationState::default();
-            state.pending_tables.insert("public.users".to_string());
-
-            state.on_table_cached("public.users");
-
-            assert!(!state.pending_tables.contains("public.users"));
-        }
+        assert_eq!(state.total_tables, 2);
+        assert!(!state.fk_expanded);
+        assert_eq!(state.seed_tables, tables);
     }
 
-    mod on_table_failed {
-        use super::*;
+    #[test]
+    fn reset_clears_er_state_but_preserves_run_counter() {
+        let mut state = ErPreparationState {
+            status: ErStatus::Waiting,
+            total_tables: 3,
+            target_tables: vec!["public.users".to_string()],
+            seed_tables: vec!["public.users".to_string()],
+            fk_expanded: true,
+            last_signatures: HashMap::from([("public.users".to_string(), "sig".to_string())]),
+            ..Default::default()
+        };
+        set_active_run_id(&mut state, 5);
 
-        #[test]
-        fn moves_from_fetching_to_failed() {
-            let mut state = ErPreparationState::default();
-            state.fetching_tables.insert("public.users".to_string());
+        state.reset();
 
-            state.on_table_failed("public.users", "timeout".to_string());
-
-            assert!(!state.fetching_tables.contains("public.users"));
-            assert!(state.failed_tables.contains_key("public.users"));
-        }
-
-        #[test]
-        fn removes_from_pending() {
-            let mut state = ErPreparationState::default();
-            state.pending_tables.insert("public.users".to_string());
-
-            state.on_table_failed("public.users", "timeout".to_string());
-
-            assert!(!state.pending_tables.contains("public.users"));
-        }
-    }
-
-    mod requeue_for_retry {
-        use super::*;
-
-        #[test]
-        fn moves_from_fetching_to_pending_without_failed_state() {
-            let mut state = ErPreparationState::default();
-            state.fetching_tables.insert("public.users".to_string());
-
-            state.requeue_for_retry("public.users");
-
-            assert!(!state.fetching_tables.contains("public.users"));
-            assert!(state.pending_tables.contains("public.users"));
-            assert!(!state.failed_tables.contains_key("public.users"));
-        }
-    }
-
-    mod start_fetching {
-        use super::*;
-
-        #[test]
-        fn moves_from_pending_to_fetching() {
-            let mut state = ErPreparationState::default();
-            state.pending_tables.insert("public.users".to_string());
-
-            state.start_fetching("public.users");
-
-            assert!(!state.pending_tables.contains("public.users"));
-            assert!(state.fetching_tables.contains("public.users"));
-        }
-    }
-
-    mod begin_er_prefetch {
-        use super::*;
-
-        #[test]
-        fn all_prefetch_replaces_progress_and_marks_fk_expanded() {
-            let mut state = ErPreparationState {
-                pending_tables: HashSet::from(["stale.pending".to_string()]),
-                fetching_tables: HashSet::from(["stale.fetching".to_string()]),
-                failed_tables: HashMap::from([("stale.failed".to_string(), "error".to_string())]),
-                fk_expanded: false,
-                ..Default::default()
-            };
-
-            state.begin_all_prefetch(vec![
-                "public.users".to_string(),
-                "public.orders".to_string(),
-            ]);
-
-            assert_eq!(state.total_tables, 2);
-            assert!(state.fk_expanded);
-            assert!(state.fetching_tables.is_empty());
-            assert!(state.failed_tables.is_empty());
-            assert!(state.pending_tables.contains("public.users"));
-            assert!(state.pending_tables.contains("public.orders"));
-        }
-
-        #[test]
-        fn scoped_prefetch_records_seed_tables_and_pending_set() {
-            let mut state = ErPreparationState {
-                fk_expanded: true,
-                ..Default::default()
-            };
-            let tables = vec!["public.users".to_string(), "public.orders".to_string()];
-
-            state.begin_scoped_prefetch(&tables);
-
-            assert_eq!(state.total_tables, 2);
-            assert!(!state.fk_expanded);
-            assert_eq!(state.seed_tables, tables);
-            assert!(state.pending_tables.contains("public.users"));
-            assert!(state.pending_tables.contains("public.orders"));
-        }
-    }
-
-    mod reset {
-        use super::*;
-
-        #[test]
-        fn clears_all_state() {
-            let mut state = ErPreparationState {
-                pending_tables: HashSet::from(["a".to_string()]),
-                fetching_tables: HashSet::from(["b".to_string()]),
-                failed_tables: HashMap::from([("c".to_string(), "err".to_string())]),
-                status: ErStatus::Waiting,
-                total_tables: 3,
-                seed_tables: vec!["a".to_string()],
-                fk_expanded: true,
-                last_signatures: HashMap::from([("a".to_string(), "sig".to_string())]),
-                ..Default::default()
-            };
-            set_active_run_id(&mut state, 5);
-
-            state.reset();
-
-            assert!(state.pending_tables.is_empty());
-            assert!(state.fetching_tables.is_empty());
-            assert!(state.failed_tables.is_empty());
-            assert_eq!(state.status, ErStatus::Idle);
-            assert_eq!(state.total_tables, 0);
-            assert!(state.seed_tables.is_empty());
-            assert!(!state.fk_expanded);
-            assert!(state.last_signatures.is_empty());
-            assert_eq!(state.run_id(), 5);
-        }
-    }
-
-    mod waiting_resolution {
-        use super::*;
-
-        #[test]
-        fn skip_only_completion_becomes_ready() {
-            let mut state = ErPreparationState {
-                pending_tables: HashSet::from(["public.users".to_string()]),
-                fetching_tables: HashSet::new(),
-                failed_tables: HashMap::new(),
-                status: ErStatus::Waiting,
-                total_tables: 1,
-                target_tables: vec![],
-                ..Default::default()
-            };
-
-            // Simulate skip: remove from pending (e.g., already cached)
-            state.pending_tables.remove("public.users");
-
-            assert!(state.is_complete());
-            assert!(!state.has_failures());
-        }
-
-        #[test]
-        fn skip_with_prior_failures_still_complete() {
-            let mut state = ErPreparationState {
-                pending_tables: HashSet::from(["public.orders".to_string()]),
-                fetching_tables: HashSet::new(),
-                failed_tables: HashMap::from([("public.users".to_string(), "timeout".to_string())]),
-                status: ErStatus::Waiting,
-                total_tables: 2,
-                target_tables: vec![],
-                ..Default::default()
-            };
-
-            // Simulate skip: remove last pending (e.g., already cached)
-            state.pending_tables.remove("public.orders");
-
-            assert!(state.is_complete());
-            assert!(state.has_failures());
-        }
+        assert_eq!(state.status, ErStatus::Idle);
+        assert_eq!(state.total_tables, 0);
+        assert!(state.target_tables.is_empty());
+        assert!(state.seed_tables.is_empty());
+        assert!(!state.fk_expanded);
+        assert!(state.last_signatures.is_empty());
+        assert_eq!(state.run_id(), 5);
     }
 }

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -8,3 +8,4 @@ pub mod sql_editor;
 pub mod app_state;
 pub mod runtime_state;
 pub mod sqlite;
+pub mod table_prefetch;

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -1,8 +1,6 @@
-use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
 use crate::domain::{CommandTag, DatabaseDiagnostic};
-use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::multi_line_input::MultiLineInputState;
 use crate::model::shared::text_input::{TextInputLike, TextInputState};
 use crate::policy::write::sql_risk::AcknowledgeReason;
@@ -33,13 +31,6 @@ pub enum SqlModalTab {
     Sql,
     Plan,
     Compare,
-}
-
-#[derive(Debug, Clone)]
-pub struct FailedPrefetchEntry {
-    pub failed_at: Instant,
-    pub error: String,
-    pub retry_count: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,11 +77,6 @@ pub struct SqlModalContext {
     pub(crate) status: SqlModalStatus,
     pub(crate) completion: CompletionState,
     pub(crate) completion_debounce: Option<Instant>,
-    prefetch_queue: VecDeque<String>,
-    prefetching_tables: HashSet<String>,
-    failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
-    prefetch_tracks_er: bool,
-    pub(crate) prefetch_run: AsyncRun,
     active_tab: SqlModalTab,
 }
 
@@ -101,116 +87,6 @@ impl SqlModalContext {
 
     pub fn editor_mut_for_input(&mut self) -> &mut MultiLineInputState {
         &mut self.editor
-    }
-
-    // ── Prefetch lifecycle ──────────────────────────────────────────
-
-    pub fn reset_prefetch(&mut self) {
-        self.prefetch_queue.clear();
-        self.prefetching_tables.clear();
-        self.failed_prefetch_tables.clear();
-        self.prefetch_tracks_er = false;
-        self.prefetch_run.clear_active();
-    }
-
-    #[must_use]
-    pub fn begin_er_prefetch(&mut self) -> u64 {
-        if self.prefetch_run.active_id().is_some() && !self.prefetch_tracks_er {
-            // Responses from the replaced completion run are stale and will be discarded.
-            self.prefetching_tables.clear();
-        }
-        self.prefetch_tracks_er = true;
-        self.prefetch_queue.clear();
-        self.failed_prefetch_tables.clear();
-        self.prefetch_run.begin()
-    }
-
-    #[must_use]
-    pub fn begin_completion_prefetch(&mut self) -> u64 {
-        self.prefetch_tracks_er = false;
-        self.prefetch_queue.clear();
-        self.failed_prefetch_tables.clear();
-        self.prefetch_run.begin()
-    }
-
-    pub fn prefetch_tracks_er(&self) -> bool {
-        self.prefetch_tracks_er
-    }
-
-    pub fn invalidate_prefetch(&mut self) {
-        self.prefetch_tracks_er = false;
-        self.prefetching_tables.clear();
-        self.prefetch_run.clear_active();
-    }
-
-    pub fn has_pending_prefetch(&self) -> bool {
-        !self.prefetch_queue.is_empty()
-    }
-
-    pub fn is_prefetch_queued(&self, table: &str) -> bool {
-        self.prefetch_queue.iter().any(|queued| queued == table)
-    }
-
-    pub fn is_table_prefetching(&self, table: &str) -> bool {
-        self.prefetching_tables.contains(table)
-    }
-
-    pub fn prefetch_in_flight_count(&self) -> usize {
-        self.prefetching_tables.len()
-    }
-
-    pub fn failed_prefetch(&self, table: &str) -> Option<&FailedPrefetchEntry> {
-        self.failed_prefetch_tables.get(table)
-    }
-
-    pub fn queue_table_prefetch(&mut self, table: String) {
-        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
-            return;
-        }
-        self.prefetch_queue.push_back(table);
-    }
-
-    pub fn defer_table_prefetch(&mut self, table: String) {
-        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
-            return;
-        }
-        self.prefetch_queue.push_front(table);
-    }
-
-    pub fn take_next_prefetch(&mut self) -> Option<String> {
-        self.prefetch_queue.pop_front()
-    }
-
-    pub fn start_table_prefetch(&mut self, table: String) {
-        self.prefetch_queue.retain(|queued| queued != &table);
-        self.prefetching_tables.insert(table);
-    }
-
-    pub fn complete_table_prefetch(&mut self, table: &str) {
-        self.prefetch_queue.retain(|queued| queued != table);
-        self.prefetching_tables.remove(table);
-        self.failed_prefetch_tables.remove(table);
-    }
-
-    pub fn fail_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) {
-        self.prefetch_queue.retain(|queued| queued != &table);
-        self.prefetching_tables.remove(&table);
-        self.failed_prefetch_tables.insert(table, entry);
-    }
-
-    pub fn retry_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) -> bool {
-        let had_other_pending_before_requeue = self.has_pending_prefetch();
-        self.fail_table_prefetch(table.clone(), entry);
-        self.queue_table_prefetch(table);
-        had_other_pending_before_requeue
-    }
-
-    pub fn active_prefetch_run_id(&self) -> Option<u64> {
-        self.prefetch_run.active_id()
-    }
-
-    pub fn is_current_prefetch_run(&self, run_id: u64) -> bool {
-        self.prefetch_run.is_current(run_id)
     }
 
     // ── Adhoc status ────────────────────────────────────────────────
@@ -479,7 +355,6 @@ mod tests {
             assert_eq!(ctx.editor.cursor(), 0);
             assert_eq!(ctx.status, SqlModalStatus::Normal);
             assert!(!ctx.completion.visible);
-            assert!(ctx.active_prefetch_run_id().is_none());
         }
 
         #[test]
@@ -499,67 +374,6 @@ mod tests {
             assert_eq!(ctx.editor.cursor(), 0);
             assert!(!ctx.completion.visible);
             assert!(ctx.completion.candidates.is_empty());
-        }
-    }
-
-    mod prefetch {
-        use super::*;
-
-        #[test]
-        fn reset_clears_all_state() {
-            let mut ctx = SqlModalContext::default();
-            let _ = ctx.begin_er_prefetch();
-            ctx.queue_table_prefetch("public.users".to_string());
-            ctx.start_table_prefetch("public.posts".to_string());
-            ctx.fail_table_prefetch(
-                "public.failed".to_string(),
-                FailedPrefetchEntry {
-                    failed_at: Instant::now(),
-                    error: "error".to_string(),
-                    retry_count: 0,
-                },
-            );
-
-            ctx.reset_prefetch();
-
-            assert!(ctx.active_prefetch_run_id().is_none());
-            assert!(!ctx.has_pending_prefetch());
-            assert_eq!(ctx.prefetch_in_flight_count(), 0);
-            assert!(ctx.failed_prefetch("public.failed").is_none());
-        }
-
-        #[test]
-        fn queueing_skips_queued_and_in_flight_tables() {
-            let mut ctx = SqlModalContext::default();
-            ctx.queue_table_prefetch("public.users".to_string());
-            ctx.queue_table_prefetch("public.users".to_string());
-            ctx.start_table_prefetch("public.orders".to_string());
-            ctx.queue_table_prefetch("public.orders".to_string());
-
-            assert!(ctx.has_pending_prefetch());
-            assert!(ctx.is_prefetch_queued("public.users"));
-            assert!(ctx.is_table_prefetching("public.orders"));
-            assert_eq!(ctx.prefetch_in_flight_count(), 1);
-        }
-
-        #[test]
-        fn retry_table_prefetch_preserves_failure_and_requeues_table() {
-            let mut ctx = SqlModalContext::default();
-            let failed_at = Instant::now();
-
-            ctx.start_table_prefetch("public.users".to_string());
-            ctx.retry_table_prefetch(
-                "public.users".to_string(),
-                FailedPrefetchEntry {
-                    failed_at,
-                    error: "timeout".to_string(),
-                    retry_count: 1,
-                },
-            );
-
-            assert!(!ctx.is_table_prefetching("public.users"));
-            assert!(ctx.is_prefetch_queued("public.users"));
-            assert_eq!(ctx.failed_prefetch("public.users").unwrap().retry_count, 1);
         }
     }
 

--- a/src/app/model/table_prefetch.rs
+++ b/src/app/model/table_prefetch.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use crate::model::shared::async_run::AsyncRun;
 
-pub const MAX_PREFETCH_RETRIES: u32 = 3;
+pub(crate) const MAX_PREFETCH_RETRIES: u32 = 3;
 
 #[derive(Debug, Clone)]
 pub struct FailedPrefetchEntry {

--- a/src/app/model/table_prefetch.rs
+++ b/src/app/model/table_prefetch.rs
@@ -1,0 +1,285 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::Instant;
+
+use crate::model::shared::async_run::AsyncRun;
+
+pub const MAX_PREFETCH_RETRIES: u32 = 3;
+
+#[derive(Debug, Clone)]
+pub struct FailedPrefetchEntry {
+    pub failed_at: Instant,
+    pub error: String,
+    pub retry_count: u32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TablePrefetchState {
+    prefetch_queue: VecDeque<String>,
+    prefetching_tables: HashSet<String>,
+    failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
+    prefetch_tracks_er: bool,
+    prefetch_run: AsyncRun,
+}
+
+impl TablePrefetchState {
+    pub fn reset_prefetch(&mut self) {
+        self.prefetch_queue.clear();
+        self.prefetching_tables.clear();
+        self.failed_prefetch_tables.clear();
+        self.prefetch_tracks_er = false;
+        self.prefetch_run.clear_active();
+    }
+
+    #[must_use]
+    pub fn begin_er_prefetch(&mut self) -> u64 {
+        if self.prefetch_run.active_id().is_some() && !self.prefetch_tracks_er {
+            // Responses from the replaced completion run are stale and will be discarded.
+            self.prefetching_tables.clear();
+        }
+        self.prefetch_tracks_er = true;
+        self.prefetch_queue.clear();
+        self.failed_prefetch_tables.clear();
+        self.prefetch_run.begin()
+    }
+
+    #[must_use]
+    pub fn begin_completion_prefetch(&mut self) -> u64 {
+        self.prefetch_tracks_er = false;
+        self.prefetch_queue.clear();
+        self.failed_prefetch_tables.clear();
+        self.prefetch_run.begin()
+    }
+
+    pub fn prefetch_tracks_er(&self) -> bool {
+        self.prefetch_tracks_er
+    }
+
+    pub fn invalidate_prefetch(&mut self) {
+        self.prefetch_tracks_er = false;
+        self.prefetching_tables.clear();
+        self.prefetch_run.clear_active();
+    }
+
+    pub fn has_pending_prefetch(&self) -> bool {
+        !self.prefetch_queue.is_empty()
+    }
+
+    pub fn pending_prefetch_count(&self) -> usize {
+        self.prefetch_queue.len()
+    }
+
+    pub fn is_prefetch_queued(&self, table: &str) -> bool {
+        self.prefetch_queue.iter().any(|queued| queued == table)
+    }
+
+    pub fn is_table_prefetching(&self, table: &str) -> bool {
+        self.prefetching_tables.contains(table)
+    }
+
+    pub fn prefetch_in_flight_count(&self) -> usize {
+        self.prefetching_tables.len()
+    }
+
+    pub fn failed_prefetch(&self, table: &str) -> Option<&FailedPrefetchEntry> {
+        self.failed_prefetch_tables.get(table)
+    }
+
+    pub fn failed_table_errors(&self) -> Vec<(String, String)> {
+        self.failed_prefetch_tables
+            .iter()
+            .filter(|(table, entry)| self.is_permanent_failure(table, entry))
+            .map(|(table, entry)| (table.clone(), entry.error.clone()))
+            .collect()
+    }
+
+    pub fn has_failures(&self) -> bool {
+        self.failed_prefetch_count() > 0
+    }
+
+    pub fn failed_prefetch_count(&self) -> usize {
+        self.failed_prefetch_tables
+            .iter()
+            .filter(|(table, entry)| self.is_permanent_failure(table, entry))
+            .count()
+    }
+
+    pub fn queue_table_prefetch(&mut self, table: String) {
+        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
+            return;
+        }
+        self.prefetch_queue.push_back(table);
+    }
+
+    pub fn queue_pending_table(&mut self, table: String) -> bool {
+        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
+            return false;
+        }
+        self.failed_prefetch_tables.remove(&table);
+        self.prefetch_queue.push_back(table);
+        true
+    }
+
+    pub fn defer_table_prefetch(&mut self, table: String) {
+        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
+            return;
+        }
+        self.prefetch_queue.push_front(table);
+    }
+
+    pub fn take_next_prefetch(&mut self) -> Option<String> {
+        self.prefetch_queue.pop_front()
+    }
+
+    pub fn start_table_prefetch(&mut self, table: String) {
+        self.prefetch_queue.retain(|queued| queued != &table);
+        self.prefetching_tables.insert(table);
+    }
+
+    pub fn complete_table_prefetch(&mut self, table: &str) {
+        self.prefetch_queue.retain(|queued| queued != table);
+        self.prefetching_tables.remove(table);
+        self.failed_prefetch_tables.remove(table);
+    }
+
+    pub fn fail_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) {
+        self.prefetch_queue.retain(|queued| queued != &table);
+        self.prefetching_tables.remove(&table);
+        self.failed_prefetch_tables.insert(table, entry);
+    }
+
+    pub fn retry_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) -> bool {
+        let had_other_pending_before_requeue = self.has_pending_prefetch();
+        self.fail_table_prefetch(table.clone(), entry);
+        self.queue_table_prefetch(table);
+        had_other_pending_before_requeue
+    }
+
+    pub fn active_prefetch_run_id(&self) -> Option<u64> {
+        self.prefetch_run.active_id()
+    }
+
+    pub fn is_current_prefetch_run(&self, run_id: u64) -> bool {
+        self.prefetch_run.is_current(run_id)
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.prefetch_queue.is_empty() && self.prefetching_tables.is_empty()
+    }
+
+    fn is_permanent_failure(&self, table: &str, entry: &FailedPrefetchEntry) -> bool {
+        entry.retry_count >= MAX_PREFETCH_RETRIES
+            && !self.is_prefetch_queued(table)
+            && !self.prefetching_tables.contains(table)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_clears_queue_in_flight_failures_and_run() {
+        let mut state = TablePrefetchState::default();
+        let _ = state.begin_er_prefetch();
+        state.queue_table_prefetch("public.users".to_string());
+        state.start_table_prefetch("public.posts".to_string());
+        state.fail_table_prefetch(
+            "public.failed".to_string(),
+            FailedPrefetchEntry {
+                failed_at: Instant::now(),
+                error: "error".to_string(),
+                retry_count: 0,
+            },
+        );
+
+        state.reset_prefetch();
+
+        assert!(state.active_prefetch_run_id().is_none());
+        assert!(!state.has_pending_prefetch());
+        assert_eq!(state.prefetch_in_flight_count(), 0);
+        assert!(state.failed_prefetch("public.failed").is_none());
+    }
+
+    #[test]
+    fn queueing_skips_queued_and_in_flight_tables() {
+        let mut state = TablePrefetchState::default();
+        state.queue_table_prefetch("public.users".to_string());
+        state.queue_table_prefetch("public.users".to_string());
+        state.start_table_prefetch("public.orders".to_string());
+        state.queue_table_prefetch("public.orders".to_string());
+
+        assert!(state.has_pending_prefetch());
+        assert!(state.is_prefetch_queued("public.users"));
+        assert!(state.is_table_prefetching("public.orders"));
+        assert_eq!(state.prefetch_in_flight_count(), 1);
+    }
+
+    #[test]
+    fn retry_preserves_failure_and_requeues_table() {
+        let mut state = TablePrefetchState::default();
+        let failed_at = Instant::now();
+
+        state.start_table_prefetch("public.users".to_string());
+        state.retry_table_prefetch(
+            "public.users".to_string(),
+            FailedPrefetchEntry {
+                failed_at,
+                error: "timeout".to_string(),
+                retry_count: 1,
+            },
+        );
+
+        assert!(!state.is_table_prefetching("public.users"));
+        assert!(state.is_prefetch_queued("public.users"));
+        assert_eq!(
+            state.failed_prefetch("public.users").unwrap().retry_count,
+            1
+        );
+    }
+
+    #[test]
+    fn completion_ignores_permanent_failures_after_queue_drains() {
+        let mut state = TablePrefetchState::default();
+        state.fail_table_prefetch(
+            "public.users".to_string(),
+            FailedPrefetchEntry {
+                failed_at: Instant::now(),
+                error: "timeout".to_string(),
+                retry_count: 3,
+            },
+        );
+
+        assert!(state.is_complete());
+        assert!(state.has_failures());
+    }
+
+    #[test]
+    fn retry_failure_is_not_counted_until_it_becomes_permanent() {
+        let mut state = TablePrefetchState::default();
+        state.start_table_prefetch("public.users".to_string());
+        state.retry_table_prefetch(
+            "public.users".to_string(),
+            FailedPrefetchEntry {
+                failed_at: Instant::now(),
+                error: "timeout".to_string(),
+                retry_count: 1,
+            },
+        );
+
+        assert_eq!(state.failed_prefetch_count(), 0);
+        assert!(!state.has_failures());
+
+        let _ = state.take_next_prefetch();
+        state.fail_table_prefetch(
+            "public.users".to_string(),
+            FailedPrefetchEntry {
+                failed_at: Instant::now(),
+                error: "timeout".to_string(),
+                retry_count: MAX_PREFETCH_RETRIES,
+            },
+        );
+
+        assert_eq!(state.failed_prefetch_count(), 1);
+        assert!(state.has_failures());
+    }
+}

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -9,7 +9,7 @@ use crate::update::helpers::reject_pending_mysql_connection_probe;
 use super::check_er_completion;
 
 pub(super) fn expand_prefetch_with_fk_neighbors(state: &AppState, run_id: u64) -> Vec<Effect> {
-    if !state.sql_modal.is_current_prefetch_run(run_id) {
+    if !state.table_prefetch.is_current_prefetch_run(run_id) {
         return vec![];
     }
     let seed_tables = state.er_preparation.seed_tables().to_vec();
@@ -35,7 +35,7 @@ pub(super) fn reduce_er_neighbors(
             if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();
             }
-            if !state.sql_modal.is_current_prefetch_run(*run_id) {
+            if !state.table_prefetch.is_current_prefetch_run(*run_id) {
                 return DispatchResult::handled();
             }
             state.er_preparation.mark_fk_expanded();
@@ -46,12 +46,9 @@ pub(super) fn reduce_er_neighbors(
             }
 
             for qualified_name in tables {
-                let is_new_pending = state
-                    .er_preparation
+                state
+                    .table_prefetch
                     .queue_pending_table(qualified_name.clone());
-                if is_new_pending {
-                    state.sql_modal.queue_table_prefetch(qualified_name.clone());
-                }
             }
             DispatchResult::handled_with(vec![Effect::SchedulePrefetchQueueProcessing {
                 run_id: *run_id,

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -146,7 +146,7 @@ pub(super) fn reduce_loading(
                 return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn().map(String::from) {
-                state.sql_modal.reset_prefetch();
+                state.table_prefetch.reset_prefetch();
                 state.er_preparation.reset();
                 state.ui.reset_er_picker_request();
                 state.messages.clear();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -12,24 +12,24 @@ use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
-    if state.er_preparation.status() != ErStatus::Waiting || !state.er_preparation.is_complete() {
+    if state.er_preparation.status() != ErStatus::Waiting || !state.table_prefetch.is_complete() {
         return vec![];
     }
 
     if !state.er_preparation.fk_expanded() {
-        let Some(run_id) = state.sql_modal.active_prefetch_run_id() else {
+        let Some(run_id) = state.table_prefetch.active_prefetch_run_id() else {
             return vec![];
         };
         return er_neighbors::expand_prefetch_with_fk_neighbors(state, run_id);
     }
 
-    if !state.er_preparation.has_failures() {
+    if !state.table_prefetch.has_failures() {
         state.er_preparation.mark_idle();
         return vec![Effect::DispatchActions(vec![Action::ErGenerateFromCache])];
     }
 
     state.er_preparation.mark_idle();
-    let failed_data: Vec<(String, String)> = state.er_preparation.failed_table_errors();
+    let failed_data: Vec<(String, String)> = state.table_prefetch.failed_table_errors();
     state.messages.set_error(format!(
         "ER failed: {} table(s) failed. 'e' to retry.",
         failed_data.len()
@@ -56,7 +56,7 @@ mod tests {
     use crate::model::app_state::AppState;
     use crate::model::browse::session::TableDetailState;
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::sql_editor::modal::FailedPrefetchEntry;
+    use crate::model::table_prefetch::FailedPrefetchEntry;
     use crate::ports::outbound::DbOperationError;
     use crate::update::action::Action;
     use std::sync::Arc;
@@ -270,10 +270,10 @@ mod tests {
         #[test]
         fn stale_prefetch_run_does_not_advance_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let old_run_id = state.sql_modal.begin_er_prefetch();
-            let _ = state.sql_modal.begin_er_prefetch();
+            let old_run_id = state.table_prefetch.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
 
             let effects = dispatch_metadata(
@@ -284,9 +284,9 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.sql_modal.has_pending_prefetch());
-            assert!(state.sql_modal.is_prefetch_queued("public.users"));
-            assert_eq!(state.sql_modal.prefetch_in_flight_count(), 0);
+            assert!(state.table_prefetch.has_pending_prefetch());
+            assert!(state.table_prefetch.is_prefetch_queued("public.users"));
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
         }
 
         #[test]
@@ -405,12 +405,12 @@ mod tests {
         #[test]
         fn backoff_table_requeued_at_tail_with_process_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
             let queued = "public.orders".to_string();
-            state.sql_modal.queue_table_prefetch(queued.clone());
+            state.table_prefetch.queue_table_prefetch(queued.clone());
             // Insert a recently failed entry (retry_count=1, just failed)
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -431,9 +431,9 @@ mod tests {
             .unwrap();
 
             // Should be re-queued at tail
-            assert_eq!(state.sql_modal.take_next_prefetch(), Some(queued));
-            assert_eq!(state.sql_modal.take_next_prefetch(), Some(qualified));
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert_eq!(state.table_prefetch.take_next_prefetch(), Some(queued));
+            assert_eq!(state.table_prefetch.take_next_prefetch(), Some(qualified));
+            assert!(!state.table_prefetch.has_pending_prefetch());
             // Should return DelayedProcessPrefetchQueue (not an immediate busy-loop)
             assert!(
                 effects
@@ -445,11 +445,11 @@ mod tests {
         #[test]
         fn backoff_uses_injected_now() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
             let failed_at = Instant::now();
             let now = failed_at.checked_add(Duration::from_secs(1)).unwrap();
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 qualified,
                 FailedPrefetchEntry {
                     failed_at,
@@ -480,9 +480,9 @@ mod tests {
         #[test]
         fn process_queue_does_not_reprocess_requeued_backoff_table() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -490,7 +490,7 @@ mod tests {
                     retry_count: 1,
                 },
             );
-            state.sql_modal.queue_table_prefetch(qualified.clone());
+            state.table_prefetch.queue_table_prefetch(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -506,16 +506,16 @@ mod tests {
                     .count(),
                 1
             );
-            assert_eq!(state.sql_modal.take_next_prefetch(), Some(qualified));
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert_eq!(state.table_prefetch.take_next_prefetch(), Some(qualified));
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]
         fn no_dsn_requeues_without_marking_in_flight() {
             let mut state = AppState::new("test".to_string());
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
-            state.er_preparation.queue_pending_table(qualified.clone());
+            state.table_prefetch.queue_table_prefetch(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -529,16 +529,14 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.sql_modal.is_prefetch_queued(&qualified));
-            assert!(!state.sql_modal.is_table_prefetching(&qualified));
-            assert!(!state.er_preparation.fetching_tables().contains(&qualified));
-            assert!(state.er_preparation.pending_tables().contains(&qualified));
+            assert!(state.table_prefetch.is_prefetch_queued(&qualified));
+            assert!(!state.table_prefetch.is_table_prefetching(&qualified));
         }
 
         #[test]
         fn pending_mysql_probe_rejects_direct_prefetch_without_starting_it() {
             let mut state = state_with_pending_mysql_probe();
-            let run_id = state.sql_modal.begin_completion_prefetch();
+            let run_id = state.table_prefetch.begin_completion_prefetch();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -553,15 +551,15 @@ mod tests {
             .expect("prefetch action should be handled");
 
             assert!(effects.is_empty());
-            assert!(!state.sql_modal.is_table_prefetching("public.users"));
+            assert!(!state.table_prefetch.is_table_prefetching("public.users"));
         }
 
         #[test]
         fn pending_mysql_probe_rejects_prefetch_completion_without_cache_mutation() {
             let mut state = state_with_pending_mysql_probe();
-            let run_id = state.sql_modal.begin_completion_prefetch();
+            let run_id = state.table_prefetch.begin_completion_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .start_table_prefetch("public.users".to_string());
 
             let effects = dispatch_metadata(
@@ -579,16 +577,16 @@ mod tests {
             .expect("cached detail action should be handled");
 
             assert!(effects.is_empty());
-            assert!(state.sql_modal.is_table_prefetching("public.users"));
+            assert!(state.table_prefetch.is_table_prefetching("public.users"));
         }
 
         #[test]
-        fn retry_limit_exceeded_gives_up_and_calls_on_table_failed() {
+        fn retry_limit_exceeded_gives_up_and_keeps_terminal_failure() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
-            state.er_preparation.queue_pending_table(qualified.clone());
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.queue_table_prefetch(qualified.clone());
+            state.table_prefetch.fail_table_prefetch(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -607,26 +605,20 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(!state.sql_modal.is_prefetch_queued(&qualified));
-            assert!(
-                state
-                    .er_preparation
-                    .failed_tables()
-                    .contains_key(&qualified)
-            );
-            assert!(!state.er_preparation.pending_tables().contains(&qualified));
+            assert!(!state.table_prefetch.is_prefetch_queued(&qualified));
+            assert!(state.table_prefetch.has_failures());
         }
 
         #[test]
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
-            state.er_preparation.queue_pending_table(qualified.clone());
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.queue_table_prefetch(qualified.clone());
+            state.table_prefetch.fail_table_prefetch(
                 qualified,
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -657,16 +649,15 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
             // users exhausted retries; posts still awaiting in queue
-            state.er_preparation.queue_pending_table(failed.clone());
-            state.er_preparation.queue_pending_table(remaining.clone());
-            state.sql_modal.queue_table_prefetch(remaining);
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.queue_table_prefetch(failed.clone());
+            state.table_prefetch.queue_table_prefetch(remaining);
+            state.table_prefetch.fail_table_prefetch(
                 failed,
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -697,10 +688,10 @@ mod tests {
         #[test]
         fn expired_backoff_proceeds_normally() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
             // Failed 10 seconds ago with retry_count=1 (backoff = 2s, already expired)
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now().checked_sub(Duration::from_secs(10)).unwrap(),
@@ -721,7 +712,7 @@ mod tests {
             .unwrap();
 
             // Should proceed to fetching
-            assert!(state.sql_modal.is_table_prefetching(&qualified));
+            assert!(state.table_prefetch.is_table_prefetching(&qualified));
             assert!(
                 effects
                     .iter()
@@ -736,9 +727,9 @@ mod tests {
         #[test]
         fn increments_retry_count() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.fail_table_prefetch(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now().checked_sub(Duration::from_mins(1)).unwrap(),
@@ -746,9 +737,9 @@ mod tests {
                     retry_count: 1,
                 },
             );
-            state.sql_modal.start_table_prefetch(qualified.clone());
+            state.table_prefetch.start_table_prefetch(qualified.clone());
 
-            assert!(state.sql_modal.is_table_prefetching(&qualified));
+            assert!(state.table_prefetch.is_table_prefetching(&qualified));
 
             let now = Instant::now();
             dispatch_metadata(
@@ -763,9 +754,9 @@ mod tests {
                 now,
             );
 
-            let entry = state.sql_modal.failed_prefetch(&qualified).unwrap();
+            let entry = state.table_prefetch.failed_prefetch(&qualified).unwrap();
             assert_eq!(entry.retry_count, 2);
-            assert!(!state.sql_modal.is_table_prefetching(&qualified));
+            assert!(!state.table_prefetch.is_table_prefetching(&qualified));
             assert_eq!(
                 entry.error,
                 "Query failed: new error. Review the database error details and SQL."
@@ -775,9 +766,9 @@ mod tests {
         #[test]
         fn first_failure_sets_retry_count_1() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
-            state.sql_modal.start_table_prefetch(qualified.clone());
+            state.table_prefetch.start_table_prefetch(qualified.clone());
 
             let now = Instant::now();
             dispatch_metadata(
@@ -792,17 +783,16 @@ mod tests {
                 now,
             );
 
-            let entry = state.sql_modal.failed_prefetch(&qualified).unwrap();
+            let entry = state.table_prefetch.failed_prefetch(&qualified).unwrap();
             assert_eq!(entry.retry_count, 1);
         }
 
         #[test]
         fn failure_requeues_table_for_retry_with_delayed_process() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let qualified = "public.users".to_string();
-            state.sql_modal.start_table_prefetch(qualified.clone());
-            state.er_preparation.start_fetching(&qualified);
+            state.table_prefetch.start_table_prefetch(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -817,15 +807,9 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.sql_modal.is_prefetch_queued(&qualified));
-            assert!(state.er_preparation.pending_tables().contains(&qualified));
-            assert!(!state.er_preparation.fetching_tables().contains(&qualified));
-            assert!(
-                !state
-                    .er_preparation
-                    .failed_tables()
-                    .contains_key(&qualified)
-            );
+            assert!(state.table_prefetch.is_prefetch_queued(&qualified));
+            assert!(!state.table_prefetch.is_table_prefetching(&qualified));
+            assert!(state.table_prefetch.failed_prefetch(&qualified).is_some());
             assert!(
                 effects
                     .iter()
@@ -841,12 +825,11 @@ mod tests {
         #[test]
         fn failure_continues_existing_queue_before_retry_delay() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             let failed = "public.users".to_string();
             let queued = "public.posts".to_string();
-            state.sql_modal.start_table_prefetch(failed.clone());
-            state.sql_modal.queue_table_prefetch(queued);
-            state.er_preparation.start_fetching(&failed);
+            state.table_prefetch.start_table_prefetch(failed);
+            state.table_prefetch.queue_table_prefetch(queued);
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -876,12 +859,11 @@ mod tests {
         #[test]
         fn transient_failure_then_success_clears_er_failure_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
-            state.sql_modal.start_table_prefetch(qualified.clone());
-            state.er_preparation.start_fetching(&qualified);
+            state.table_prefetch.start_table_prefetch(qualified.clone());
 
             dispatch_metadata(
                 &mut state,
@@ -894,12 +876,8 @@ mod tests {
                 },
                 Instant::now(),
             );
-            let _ = state.sql_modal.take_next_prefetch();
-            state
-                .er_preparation
-                .on_table_failed(&qualified, "timed out".to_string());
-            assert!(!state.er_preparation.failed_tables().is_empty());
-            state.er_preparation.start_fetching(&qualified);
+            let _ = state.table_prefetch.take_next_prefetch();
+            state.table_prefetch.queue_table_prefetch(qualified);
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -914,7 +892,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.failed_tables().is_empty());
+            assert!(!state.table_prefetch.has_failures());
             assert!(
                 effects
                     .iter()
@@ -1167,7 +1145,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(2)));
             dispatch_metadata(&mut state, &Action::StartErPrefetchAll, Instant::now());
             let run_id = state
-                .sql_modal
+                .table_prefetch
                 .active_prefetch_run_id()
                 .expect("prefetch run");
 
@@ -1194,7 +1172,7 @@ mod tests {
         #[test]
         fn process_empty_queue_returns_handled_without_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1205,17 +1183,17 @@ mod tests {
             .expect("empty prefetch queue should be handled");
 
             assert!(effects.is_empty());
-            assert_eq!(state.sql_modal.active_prefetch_run_id(), Some(run_id));
-            assert!(!state.sql_modal.has_pending_prefetch());
-            assert_eq!(state.sql_modal.prefetch_in_flight_count(), 0);
+            assert_eq!(state.table_prefetch.active_prefetch_run_id(), Some(run_id));
+            assert!(!state.table_prefetch.has_pending_prefetch());
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
         }
 
         #[test]
         fn pending_mysql_probe_rejects_prefetch_queue_without_dequeuing() {
             let mut state = state_with_pending_mysql_probe();
-            let run_id = state.sql_modal.begin_completion_prefetch();
+            let run_id = state.table_prefetch.begin_completion_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
 
             let effects = dispatch_metadata(
@@ -1227,8 +1205,8 @@ mod tests {
             .expect("prefetch queue action should be handled");
 
             assert!(effects.is_empty());
-            assert!(state.sql_modal.is_prefetch_queued("public.users"));
-            assert_eq!(state.sql_modal.prefetch_in_flight_count(), 0);
+            assert!(state.table_prefetch.is_prefetch_queued("public.users"));
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
         }
 
         #[test]
@@ -1242,8 +1220,8 @@ mod tests {
                     .expect("prefetch action should be handled");
 
             assert!(effects.is_empty());
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
     }
 
@@ -1265,10 +1243,10 @@ mod tests {
         #[test]
         fn second_call_while_running_is_ignored() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1280,12 +1258,7 @@ mod tests {
             .unwrap();
 
             // In-progress prefetch must not be silently reset
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.users")
-            );
+            assert!(state.table_prefetch.is_prefetch_queued("public.users"));
             assert!(effects.is_empty());
         }
 
@@ -1303,26 +1276,8 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.sql_modal.is_prefetch_queued("public.users"));
-            assert!(state.sql_modal.is_prefetch_queued("public.orders"));
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.users")
-            );
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.users")
-            );
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.orders")
-            );
+            assert!(state.table_prefetch.is_prefetch_queued("public.users"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.orders"));
             assert!(!state.er_preparation.fk_expanded());
             assert_eq!(state.er_preparation.seed_tables(), tables);
             assert!(
@@ -1371,11 +1326,10 @@ mod tests {
             )
             .expect("completion prefetch should be handled");
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_some());
-            assert!(!state.sql_modal.prefetch_tracks_er());
-            assert!(state.sql_modal.is_prefetch_queued("public.users"));
-            assert!(state.sql_modal.is_prefetch_queued("public.orders"));
-            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_some());
+            assert!(!state.table_prefetch.prefetch_tracks_er());
+            assert!(state.table_prefetch.is_prefetch_queued("public.users"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.orders"));
             assert!(effects.iter().any(|effect| {
                 matches!(effect, Effect::SchedulePrefetchQueueProcessing { .. })
             }));
@@ -1390,9 +1344,9 @@ mod tests {
         fn cached_table_retriggers_sql_completion_without_er_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.modal.set_mode(InputMode::SqlModal);
-            let run_id = state.sql_modal.begin_completion_prefetch();
+            let run_id = state.table_prefetch.begin_completion_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .start_table_prefetch("public.users".to_string());
 
             let effects = dispatch_metadata(
@@ -1408,7 +1362,6 @@ mod tests {
             )
             .expect("cached detail should be handled");
 
-            assert!(state.er_preparation.pending_tables().is_empty());
             assert!(
                 effects
                     .iter()
@@ -1424,9 +1377,9 @@ mod tests {
         #[test]
         fn er_prefetch_replaces_an_active_completion_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let completion_run_id = state.sql_modal.begin_completion_prefetch();
+            let completion_run_id = state.table_prefetch.begin_completion_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .start_table_prefetch("public.users".to_string());
 
             let effects = dispatch_metadata(
@@ -1439,20 +1392,14 @@ mod tests {
             .expect("ER prefetch should be handled");
 
             let er_run_id = state
-                .sql_modal
+                .table_prefetch
                 .active_prefetch_run_id()
                 .expect("ER prefetch should have an active run");
             assert_ne!(completion_run_id, er_run_id);
-            assert!(state.sql_modal.prefetch_tracks_er());
-            assert!(!state.sql_modal.is_table_prefetching("public.users"));
-            assert!(state.sql_modal.is_prefetch_queued("public.orders"));
-            assert!(!state.sql_modal.is_prefetch_queued("public.users"));
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.orders")
-            );
+            assert!(state.table_prefetch.prefetch_tracks_er());
+            assert!(!state.table_prefetch.is_table_prefetching("public.users"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.orders"));
+            assert!(!state.table_prefetch.is_prefetch_queued("public.users"));
             assert!(effects.iter().any(|effect| matches!(
                 effect,
                 Effect::SchedulePrefetchQueueProcessing { run_id } if *run_id == er_run_id
@@ -1466,11 +1413,9 @@ mod tests {
         #[test]
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_unexpanded();
-            // pending and fetching are empty → is_complete() = true
-
             let effects = check_er_completion(&mut state);
 
             assert!(effects.iter().any(|e| matches!(
@@ -1498,8 +1443,8 @@ mod tests {
         #[test]
         fn stale_expand_does_not_start_neighbor_extraction() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let stale_run_id = state.sql_modal.begin_er_prefetch();
-            let current_run_id = state.sql_modal.begin_er_prefetch();
+            let stale_run_id = state.table_prefetch.begin_er_prefetch();
+            let current_run_id = state.table_prefetch.begin_er_prefetch();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1511,7 +1456,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                state.sql_modal.active_prefetch_run_id(),
+                state.table_prefetch.active_prefetch_run_id(),
                 Some(current_run_id)
             );
             assert!(effects.is_empty());
@@ -1520,7 +1465,7 @@ mod tests {
         #[test]
         fn pending_mysql_probe_rejects_neighbor_expansion() {
             let mut state = state_with_pending_mysql_probe();
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_unexpanded();
 
@@ -1545,7 +1490,7 @@ mod tests {
         #[test]
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
@@ -1569,7 +1514,7 @@ mod tests {
         #[test]
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
@@ -1583,20 +1528,8 @@ mod tests {
             .unwrap();
 
             assert!(state.er_preparation.fk_expanded());
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.posts")
-            );
-            assert!(
-                state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.tags")
-            );
-            assert!(state.sql_modal.is_prefetch_queued("public.posts"));
-            assert!(state.sql_modal.is_prefetch_queued("public.tags"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.posts"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.tags"));
             assert!(
                 effects
                     .iter()
@@ -1620,15 +1553,14 @@ mod tests {
             .unwrap();
 
             assert!(!state.er_preparation.fk_expanded());
-            assert!(state.er_preparation.pending_tables().is_empty());
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert!(!state.table_prefetch.has_pending_prefetch());
             assert!(effects.is_empty());
         }
 
         #[test]
         fn pending_mysql_probe_rejects_discovered_neighbors_without_queueing() {
             let mut state = state_with_pending_mysql_probe();
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_unexpanded();
 
@@ -1645,20 +1577,14 @@ mod tests {
 
             assert!(effects.is_empty());
             assert!(!state.er_preparation.fk_expanded());
-            assert!(
-                !state
-                    .er_preparation
-                    .pending_tables()
-                    .contains("public.posts")
-            );
-            assert!(!state.sql_modal.is_prefetch_queued("public.posts"));
+            assert!(!state.table_prefetch.is_prefetch_queued("public.posts"));
         }
 
         #[test]
         fn stale_neighbors_from_previous_run_do_not_mutate_current_run() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let stale_run_id = state.sql_modal.begin_er_prefetch();
-            let current_run_id = state.sql_modal.begin_er_prefetch();
+            let stale_run_id = state.table_prefetch.begin_er_prefetch();
+            let current_run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
@@ -1672,27 +1598,26 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                state.sql_modal.active_prefetch_run_id(),
+                state.table_prefetch.active_prefetch_run_id(),
                 Some(current_run_id)
             );
             assert!(!state.er_preparation.fk_expanded());
-            assert!(state.er_preparation.pending_tables().is_empty());
             assert!(effects.is_empty());
         }
 
         #[test]
         fn duplicate_neighbors_are_not_requeued() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
-                .er_preparation
-                .queue_pending_table("public.posts".to_string());
-            state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.posts".to_string());
             state
-                .sql_modal
+                .table_prefetch
+                .queue_table_prefetch("public.posts".to_string());
+            state
+                .table_prefetch
                 .start_table_prefetch("public.tags".to_string());
 
             dispatch_metadata(
@@ -1708,30 +1633,30 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.sql_modal.is_prefetch_queued("public.posts"));
-            assert!(state.sql_modal.is_prefetch_queued("public.comments"));
-            assert!(!state.sql_modal.is_prefetch_queued("public.tags"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.posts"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.comments"));
+            assert!(!state.table_prefetch.is_prefetch_queued("public.tags"));
             assert_eq!(
-                state.sql_modal.take_next_prefetch(),
+                state.table_prefetch.take_next_prefetch(),
                 Some("public.posts".to_string())
             );
             assert_eq!(
-                state.sql_modal.take_next_prefetch(),
+                state.table_prefetch.take_next_prefetch(),
                 Some("public.comments".to_string())
             );
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]
         fn phase2_table_retry_limit_triggers_completion() {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();
-            state.er_preparation.queue_pending_table(neighbor.clone());
-            state.sql_modal.fail_table_prefetch(
+            state.table_prefetch.queue_table_prefetch(neighbor.clone());
+            state.table_prefetch.fail_table_prefetch(
                 neighbor,
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -686,6 +686,46 @@ mod tests {
         }
 
         #[test]
+        fn process_queue_keeps_later_table_owned_after_terminal_failure() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.table_prefetch.begin_er_prefetch();
+            state.er_preparation.mark_waiting_for_test();
+            state.er_preparation.mark_fk_expanded();
+            let failed = "public.users".to_string();
+            let remaining = "public.posts".to_string();
+            state.table_prefetch.fail_table_prefetch(
+                failed.clone(),
+                FailedPrefetchEntry {
+                    failed_at: Instant::now(),
+                    error: "timeout".to_string(),
+                    retry_count: MAX_PREFETCH_RETRIES,
+                },
+            );
+            state.table_prefetch.queue_table_prefetch(failed);
+            state.table_prefetch.queue_table_prefetch(remaining.clone());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.table_prefetch.is_table_prefetching(&remaining));
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::WriteErFailureLog { .. }))
+            );
+            assert!(!effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DispatchActions(actions)
+                    if actions.iter().any(|action| matches!(action, Action::ErGenerateFromCache))
+            )));
+        }
+
+        #[test]
         fn expired_backoff_proceeds_normally() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
@@ -186,15 +187,22 @@ pub(super) fn reduce_prefetch(
             const MAX_CONCURRENT_PREFETCH: usize = 4;
             let current_in_flight = state.table_prefetch.prefetch_in_flight_count();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
+            let batch_size = available_slots.min(state.table_prefetch.pending_prefetch_count());
+            let mut processed_tables = HashSet::with_capacity(batch_size);
 
-            let queued_tables: Vec<String> = (0..available_slots)
-                .filter_map(|_| state.table_prefetch.take_next_prefetch())
-                .collect();
             let mut effects = Vec::new();
-            for qualified_name in queued_tables {
-                if let Some((schema, table)) = qualified_name.split_once('.') {
-                    effects.extend(prefetch_table_detail(state, *run_id, schema, table, now));
+            for _ in 0..batch_size {
+                let Some(qualified_name) = state.table_prefetch.take_next_prefetch() else {
+                    break;
+                };
+                if !processed_tables.insert(qualified_name.clone()) {
+                    state.table_prefetch.defer_table_prefetch(qualified_name);
+                    break;
                 }
+                let Some((schema, table)) = qualified_name.split_once('.') else {
+                    continue;
+                };
+                effects.extend(prefetch_table_detail(state, *run_id, schema, table, now));
             }
 
             DispatchResult::handled_with(effects)

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -4,7 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::sql_editor::modal::FailedPrefetchEntry;
+use crate::model::table_prefetch::FailedPrefetchEntry;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
@@ -15,7 +15,7 @@ const BASE_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 4;
 const MIN_COMPLETION_CACHE_CAPACITY: usize = 500;
 const MAX_COMPLETION_CACHE_CAPACITY: usize = 10_000;
-pub(super) const MAX_PREFETCH_RETRIES: u32 = 3;
+pub(super) use crate::model::table_prefetch::MAX_PREFETCH_RETRIES;
 
 pub(super) fn backoff_secs_for(retry_count: u32) -> u64 {
     (BASE_BACKOFF_SECS * 2u64.pow(retry_count)).min(MAX_BACKOFF_SECS)
@@ -32,27 +32,24 @@ fn prefetch_table_detail(
     table: &str,
     now: Instant,
 ) -> Vec<Effect> {
-    if !state.sql_modal.is_current_prefetch_run(run_id) {
+    if !state.table_prefetch.is_current_prefetch_run(run_id) {
         return vec![];
     }
     let qualified_name = format!("{schema}.{table}");
 
-    if state.sql_modal.is_table_prefetching(&qualified_name) {
+    if state.table_prefetch.is_table_prefetching(&qualified_name) {
         return vec![];
     }
 
-    if let Some(entry) = state.sql_modal.failed_prefetch(&qualified_name) {
+    if let Some(entry) = state.table_prefetch.failed_prefetch(&qualified_name) {
         if entry.retry_count >= MAX_PREFETCH_RETRIES {
-            let mut effects = if state.sql_modal.prefetch_tracks_er() {
-                state
-                    .er_preparation
-                    .on_table_failed(&qualified_name, entry.error.clone());
+            let mut effects = if state.table_prefetch.prefetch_tracks_er() {
                 check_er_completion(state)
             } else {
                 Vec::new()
             };
             if effects.is_empty()
-                && state.sql_modal.prefetch_tracks_er()
+                && state.table_prefetch.prefetch_tracks_er()
                 && state.er_preparation.is_waiting()
             {
                 effects.push(Effect::SchedulePrefetchQueueProcessing { run_id });
@@ -64,7 +61,7 @@ fn prefetch_table_detail(
         let elapsed = now.saturating_duration_since(entry.failed_at).as_secs();
         if elapsed < backoff_secs {
             let remaining = backoff_secs - elapsed;
-            state.sql_modal.queue_table_prefetch(qualified_name);
+            state.table_prefetch.queue_table_prefetch(qualified_name);
             return vec![Effect::DelayedProcessPrefetchQueue {
                 run_id,
                 delay_secs: remaining,
@@ -73,14 +70,11 @@ fn prefetch_table_detail(
     }
 
     let Some(dsn) = state.session.dsn().map(String::from) else {
-        state.sql_modal.defer_table_prefetch(qualified_name);
+        state.table_prefetch.defer_table_prefetch(qualified_name);
         return vec![];
     };
 
-    state.sql_modal.start_table_prefetch(qualified_name.clone());
-    if state.sql_modal.prefetch_tracks_er() {
-        state.er_preparation.start_fetching(&qualified_name);
-    }
+    state.table_prefetch.start_table_prefetch(qualified_name);
 
     vec![Effect::PrefetchTableColumnsAndFks {
         dsn,
@@ -112,11 +106,11 @@ pub(super) fn reduce_prefetch(
 
     match action {
         Action::StartErPrefetchAll => {
-            if (state.sql_modal.active_prefetch_run_id().is_none()
-                || !state.sql_modal.prefetch_tracks_er())
+            if (state.table_prefetch.active_prefetch_run_id().is_none()
+                || !state.table_prefetch.prefetch_tracks_er())
                 && let Some(metadata) = state.session.metadata()
             {
-                let run_id = state.sql_modal.begin_er_prefetch();
+                let run_id = state.table_prefetch.begin_er_prefetch();
                 let qualified_names: Vec<String> = metadata
                     .table_summaries
                     .iter()
@@ -129,7 +123,7 @@ pub(super) fn reduce_prefetch(
                 let resize_capacity = completion_cache_capacity(metadata.table_summaries.len());
 
                 for qualified_name in qualified_names {
-                    state.sql_modal.queue_table_prefetch(qualified_name);
+                    state.table_prefetch.queue_table_prefetch(qualified_name);
                 }
                 DispatchResult::handled_with(vec![
                     Effect::ResizeCompletionCache {
@@ -143,16 +137,18 @@ pub(super) fn reduce_prefetch(
         }
 
         Action::StartErPrefetchScoped { tables } => {
-            if state.sql_modal.active_prefetch_run_id().is_some()
-                && state.sql_modal.prefetch_tracks_er()
+            if state.table_prefetch.active_prefetch_run_id().is_some()
+                && state.table_prefetch.prefetch_tracks_er()
             {
                 DispatchResult::handled()
             } else {
-                let run_id = state.sql_modal.begin_er_prefetch();
+                let run_id = state.table_prefetch.begin_er_prefetch();
                 state.er_preparation.begin_scoped_prefetch(tables);
 
                 for qualified_name in tables {
-                    state.sql_modal.queue_table_prefetch(qualified_name.clone());
+                    state
+                        .table_prefetch
+                        .queue_table_prefetch(qualified_name.clone());
                 }
                 let mut effects = Vec::with_capacity(2);
                 if let Some(metadata) = state.session.metadata() {
@@ -170,27 +166,29 @@ pub(super) fn reduce_prefetch(
                 return DispatchResult::handled();
             }
 
-            let run_id = if let Some(run_id) = state.sql_modal.active_prefetch_run_id() {
+            let run_id = if let Some(run_id) = state.table_prefetch.active_prefetch_run_id() {
                 run_id
             } else {
-                state.sql_modal.begin_completion_prefetch()
+                state.table_prefetch.begin_completion_prefetch()
             };
             for qualified_name in tables {
-                state.sql_modal.queue_table_prefetch(qualified_name.clone());
+                state
+                    .table_prefetch
+                    .queue_table_prefetch(qualified_name.clone());
             }
             DispatchResult::handled_with(vec![Effect::SchedulePrefetchQueueProcessing { run_id }])
         }
 
         Action::ProcessPrefetchQueue { run_id } => {
-            if !state.sql_modal.is_current_prefetch_run(*run_id) {
+            if !state.table_prefetch.is_current_prefetch_run(*run_id) {
                 return DispatchResult::handled();
             }
             const MAX_CONCURRENT_PREFETCH: usize = 4;
-            let current_in_flight = state.sql_modal.prefetch_in_flight_count();
+            let current_in_flight = state.table_prefetch.prefetch_in_flight_count();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
 
             let queued_tables: Vec<String> = (0..available_slots)
-                .filter_map(|_| state.sql_modal.take_next_prefetch())
+                .filter_map(|_| state.table_prefetch.take_next_prefetch())
                 .collect();
             let mut effects = Vec::new();
             for qualified_name in queued_tables {
@@ -217,26 +215,26 @@ pub(super) fn reduce_prefetch(
             table,
             detail,
         } => {
-            if !state.session.dsn_matches(dsn) || !state.sql_modal.is_current_prefetch_run(*run_id)
+            if !state.session.dsn_matches(dsn)
+                || !state.table_prefetch.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
             let qualified_name = format!("{schema}.{table}");
-            state.sql_modal.complete_table_prefetch(&qualified_name);
-            if state.sql_modal.prefetch_tracks_er() {
-                state.er_preparation.on_table_cached(&qualified_name);
-            }
+            state
+                .table_prefetch
+                .complete_table_prefetch(&qualified_name);
 
             let mut effects = vec![Effect::CacheTableInCompletionEngine {
                 qualified_name,
                 table: detail.clone(),
             }];
 
-            if state.sql_modal.has_pending_prefetch() {
+            if state.table_prefetch.has_pending_prefetch() {
                 effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
             }
 
-            if state.sql_modal.prefetch_tracks_er() {
+            if state.table_prefetch.prefetch_tracks_er() {
                 effects.extend(check_er_completion(state));
             } else if state.modal.active_mode() == InputMode::SqlModal {
                 effects.push(Effect::TriggerCompletion);
@@ -252,28 +250,25 @@ pub(super) fn reduce_prefetch(
             table,
             error,
         } => {
-            if !state.session.dsn_matches(dsn) || !state.sql_modal.is_current_prefetch_run(*run_id)
+            if !state.session.dsn_matches(dsn)
+                || !state.table_prefetch.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
             let qualified_name = format!("{schema}.{table}");
 
             let prev_count = state
-                .sql_modal
+                .table_prefetch
                 .failed_prefetch(&qualified_name)
                 .map_or(0, |e| e.retry_count);
-            let had_other_pending_before_requeue = state.sql_modal.retry_table_prefetch(
-                qualified_name.clone(),
+            let had_other_pending_before_requeue = state.table_prefetch.retry_table_prefetch(
+                qualified_name,
                 FailedPrefetchEntry {
                     failed_at: now,
                     error: error.user_message(),
                     retry_count: prev_count + 1,
                 },
             );
-            if state.sql_modal.prefetch_tracks_er() {
-                state.er_preparation.requeue_for_retry(&qualified_name);
-            }
-
             let mut effects = Vec::new();
 
             if had_other_pending_before_requeue {
@@ -284,7 +279,7 @@ pub(super) fn reduce_prefetch(
                 delay_secs: backoff_secs_for(prev_count + 1),
             });
 
-            if state.sql_modal.prefetch_tracks_er() {
+            if state.table_prefetch.prefetch_tracks_er() {
                 effects.extend(check_er_completion(state));
             }
 
@@ -297,23 +292,23 @@ pub(super) fn reduce_prefetch(
             schema,
             table,
         } => {
-            if !state.session.dsn_matches(dsn) || !state.sql_modal.is_current_prefetch_run(*run_id)
+            if !state.session.dsn_matches(dsn)
+                || !state.table_prefetch.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
             let qualified_name = format!("{schema}.{table}");
-            state.sql_modal.complete_table_prefetch(&qualified_name);
-            if state.sql_modal.prefetch_tracks_er() {
-                state.er_preparation.on_table_cached(&qualified_name);
-            }
+            state
+                .table_prefetch
+                .complete_table_prefetch(&qualified_name);
 
             let mut effects = Vec::new();
 
-            if state.sql_modal.has_pending_prefetch() {
+            if state.table_prefetch.has_pending_prefetch() {
                 effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
             }
 
-            if state.sql_modal.prefetch_tracks_er() {
+            if state.table_prefetch.prefetch_tracks_er() {
                 effects.extend(check_er_completion(state));
             } else if state.modal.active_mode() == InputMode::SqlModal {
                 effects.push(Effect::TriggerCompletion);

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -267,7 +267,7 @@ pub(super) fn refresh_effects_for_scope(
     let mut effects = vec![];
 
     if refresh_scope == RefreshScope::Metadata {
-        state.sql_modal.reset_prefetch();
+        state.table_prefetch.reset_prefetch();
         state.er_preparation.invalidate_run();
         state.session.set_table_detail_raw(None);
         let run_id = state.session.begin_metadata_refresh();
@@ -1635,9 +1635,9 @@ mod tests {
         #[test]
         fn ddl_resets_prefetch_state_and_clears_table_detail() {
             let mut state = state_with_table("public", "users");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
             state
                 .session
@@ -1651,8 +1651,8 @@ mod tests {
 
             dispatch_query(&mut state, &action, Instant::now());
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
+            assert!(!state.table_prefetch.has_pending_prefetch());
             assert!(state.session.table_detail().is_none());
         }
 
@@ -1809,7 +1809,7 @@ mod tests {
 
             let effects = dispatch_query(&mut state, &action, Instant::now()).unwrap();
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
             assert!(
                 effects
                     .iter()

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -9,7 +9,7 @@ use crate::update::query_context::termination_effects;
 fn reset_connection_scoped_state(state: &mut AppState) {
     state.query_history_picker.reset();
     state.sql_modal.reset_completion();
-    state.sql_modal.reset_prefetch();
+    state.table_prefetch.reset_prefetch();
     state.explain.reset_for_connection_change();
     state.er_preparation.reset();
     state.ui.reset_er_picker_request();
@@ -114,7 +114,7 @@ pub(super) fn cancel_connection_task_effects(state: &mut AppState) -> Vec<Effect
             });
     state.session.clear_mysql_connection_probe();
     if had_pending_probe {
-        state.sql_modal.reset_prefetch();
+        state.table_prefetch.reset_prefetch();
         state.er_preparation.reset();
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -818,8 +818,8 @@ mod tests {
             state.ui.set_pending_er_picker(true);
             let _ = state.er_preparation.start_waiting_run();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
         }
 
         fn seed_sqlite_diagnostics(state: &mut AppState) {
@@ -833,7 +833,7 @@ mod tests {
         fn assert_er_state_cleared(state: &AppState) {
             assert!(!state.ui.pending_er_picker());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         fn assert_reconciles_postgres_to_sqlite_feature_state(cached: bool) {
@@ -1499,15 +1499,15 @@ mod tests {
             state.ui.set_pending_er_picker(true);
             let _ = state.er_preparation.start_waiting_run();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
 
             let action = create_postgres_switch_action(&new_id, "fresh_db");
             reduce(&mut state, &action);
 
             assert!(!state.ui.pending_er_picker());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]
@@ -1517,8 +1517,8 @@ mod tests {
             state.ui.set_pending_er_picker(true);
             let _ = state.er_preparation.start_waiting_run();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
             state
                 .connection_caches
                 .save(&target_id, ConnectionCache::default());
@@ -1528,7 +1528,7 @@ mod tests {
 
             assert!(!state.ui.pending_er_picker());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
     }
 
@@ -2456,32 +2456,32 @@ mod tests {
             state
                 .connection_caches
                 .save(&target_id, ConnectionCache::default());
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
 
             let action = create_postgres_switch_action(&target_id, "cached_db");
             reduce(&mut state, &action);
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]
         fn switch_without_cache_resets_sql_prefetch() {
             let mut state = AppState::new("test".to_string());
             let new_id = ConnectionId::new();
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.users".to_string());
 
             let action = create_postgres_switch_action(&new_id, "fresh_db");
             reduce(&mut state, &action);
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
-            assert!(!state.sql_modal.has_pending_prefetch());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -504,8 +504,8 @@ mod tests {
             state.ui.set_pending_er_picker(true);
             let _ = state.er_preparation.start_waiting_run();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
 
             reduce_connection_selector(
                 &mut state,
@@ -530,7 +530,7 @@ mod tests {
             assert_sqlite_diagnostics_cleared(&state);
             assert!(!state.ui.pending_er_picker());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1338,8 +1338,8 @@ mod tests {
             state.ui.set_pending_er_picker(true);
             let _ = state.er_preparation.start_waiting_run();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
             let run_id = state.session.begin_connection_save();
 
             let action = Action::ConnectionSaveCompleted {
@@ -1357,7 +1357,7 @@ mod tests {
 
             assert!(!state.ui.pending_er_picker());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(!state.table_prefetch.has_pending_prefetch());
         }
 
         #[test]

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -23,7 +23,7 @@ pub(super) fn reduce_diagram_lifecycle(
             }
             state.er_preparation.mark_idle();
             // Reset so next ErOpenDiagram re-evaluates target_tables from scratch.
-            state.sql_modal.invalidate_prefetch();
+            state.table_prefetch.invalidate_prefetch();
             state.messages.set_success_at(
                 format!(
                     "✓ Opened {path} ({table_count}/{total_tables} tables) — Stale? Press r to reload"
@@ -63,7 +63,7 @@ pub(super) fn reduce_diagram_lifecycle(
                 return DispatchResult::handled();
             }
 
-            state.sql_modal.invalidate_prefetch();
+            state.table_prefetch.invalidate_prefetch();
             let run_id = state.er_preparation.start_waiting_run();
             state
                 .messages

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -148,14 +148,14 @@ mod tests {
         #[test]
         fn active_prefetch_run_still_resets_and_emits_smart_refresh() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
@@ -165,7 +165,7 @@ mod tests {
         fn pending_mysql_probe_rejects_er_open_before_prefetch_invalidation() {
             let mut state = state_with_pending_mysql_probe();
             state.session.set_metadata(Some(make_metadata(1)));
-            let prefetch_run_id = state.sql_modal.begin_er_prefetch();
+            let prefetch_run_id = state.table_prefetch.begin_er_prefetch();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -173,7 +173,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.sql_modal.active_prefetch_run_id(),
+                state.table_prefetch.active_prefetch_run_id(),
                 Some(prefetch_run_id)
             );
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
@@ -189,7 +189,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(1)));
             let run_id = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_waiting_for_test();
-            let prefetch_run_id = state.sql_modal.begin_er_prefetch();
+            let prefetch_run_id = state.table_prefetch.begin_er_prefetch();
             let _ = state.session.begin_mysql_connection_probe(
                 &ConnectionId::from_string("mysql-target"),
                 "mysql-target",
@@ -244,7 +244,7 @@ mod tests {
             }
 
             assert_eq!(
-                state.sql_modal.active_prefetch_run_id(),
+                state.table_prefetch.active_prefetch_run_id(),
                 Some(prefetch_run_id)
             );
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
@@ -256,7 +256,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(1)));
             let run_id = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_waiting_for_test();
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             let _ = state.session.begin_mysql_connection_probe(
                 &ConnectionId::from_string("mysql-target"),
                 "mysql-target",
@@ -313,7 +313,7 @@ mod tests {
             assert!(matches!(effects.as_slice(), [Effect::CancelConnectionTask]));
             assert!(state.session.pending_mysql_connection_probe().is_none());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
 
             let effects = reducer::reduce(
                 &mut state,
@@ -374,7 +374,7 @@ mod tests {
         #[test]
         fn no_metadata_returns_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1782,16 +1782,16 @@ mod tests {
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
-                .er_preparation
-                .queue_pending_table("public.users".to_string());
+                .table_prefetch
+                .queue_table_prefetch("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
             assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
@@ -1803,12 +1803,12 @@ mod tests {
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
@@ -1833,7 +1833,7 @@ mod tests {
         fn no_metadata_returns_error() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1879,9 +1879,9 @@ mod tests {
         fn emits_cache_effect() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .start_table_prefetch("public.users".to_string());
             let now = Instant::now();
 
@@ -1903,16 +1903,16 @@ mod tests {
                 effects[0],
                 Effect::CacheTableInCompletionEngine { .. }
             ));
-            assert!(!state.sql_modal.is_table_prefetching("public.users"));
+            assert!(!state.table_prefetch.is_table_prefetching("public.users"));
         }
 
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state
-                .sql_modal
+                .table_prefetch
                 .queue_table_prefetch("public.orders".to_string());
             let now = Instant::now();
 
@@ -2889,6 +2889,7 @@ mod tests {
         use super::*;
         use crate::domain::DatabaseMetadata;
         use crate::model::er_state::ErStatus;
+        use crate::model::table_prefetch::FailedPrefetchEntry;
 
         fn state_with_metadata() -> AppState {
             let mut state = create_test_state();
@@ -3084,7 +3085,7 @@ mod tests {
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let _ = state.sql_modal.begin_er_prefetch();
+            let _ = state.table_prefetch.begin_er_prefetch();
             state
                 .er_preparation
                 .set_targets(vec!["public.users".to_string()]);
@@ -3133,8 +3134,8 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(state.sql_modal.is_prefetch_queued("public.users"));
-            assert!(state.sql_modal.is_prefetch_queued("public.posts"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.users"));
+            assert!(state.table_prefetch.is_prefetch_queued("public.posts"));
             assert!(state.er_preparation.fk_expanded());
         }
 
@@ -3142,7 +3143,7 @@ mod tests {
         fn prefetch_complete_dispatches_er_generate() {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation
@@ -3173,17 +3174,21 @@ mod tests {
         fn prefetch_complete_with_failures_does_not_auto_open() {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.sql_modal.begin_er_prefetch();
+            let now = Instant::now();
+            let run_id = state.table_prefetch.begin_er_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation
                 .begin_all_prefetch(["public.posts".to_string(), "public.users".to_string()]);
             state.er_preparation.mark_fk_expanded();
-            state
-                .er_preparation
-                .on_table_failed("public.posts", "timeout".to_string());
-            let now = Instant::now();
-
+            state.table_prefetch.fail_table_prefetch(
+                "public.posts".to_string(),
+                FailedPrefetchEntry {
+                    failed_at: now,
+                    error: "timeout".to_string(),
+                    retry_count: 3,
+                },
+            );
             let effects = reduce(
                 &mut state,
                 Action::TableDetailAlreadyCached {

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -1113,7 +1113,7 @@ mod tests {
             .expect("SQL modal open should be handled");
 
             assert!(effects.is_empty());
-            assert!(state.sql_modal.active_prefetch_run_id().is_none());
+            assert!(state.table_prefetch.active_prefetch_run_id().is_none());
         }
 
         #[test]

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -12,11 +12,12 @@ fn er_waiting_progress() {
         "public.comments".to_string(),
         "public.posts".to_string(),
     ]);
-    state.er_preparation.on_table_cached("public.users");
     state
-        .er_preparation
-        .queue_pending_table("public.comments".to_string());
-    state.er_preparation.start_fetching("public.posts");
+        .table_prefetch
+        .queue_table_prefetch("public.comments".to_string());
+    state
+        .table_prefetch
+        .start_table_prefetch("public.posts".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -69,7 +69,7 @@ impl Footer {
         });
         let spinner = spinner_char(now_ms);
 
-        let progress = state.er_preparation.progress();
+        let progress = state.er_preparation.progress(&state.table_prefetch);
 
         let text = format!(
             "{spinner} Preparing ER... ({}/{})",


### PR DESCRIPTION
## Problem
Table-detail prefetch progress is split between `SqlModalContext` and an `ErPreparationState` mirror, requiring duplicate transitions and reset paths.

## Background
ER completion and footer progress read the mirror while completion prefetch uses the modal owner.

## Approach
Introduce one `AppState.table_prefetch` owner for the existing queue, in-flight, failure, purpose, and run state. Remove the ER mirror and derive completion and progress from the shared owner while preserving freshness guards, retry/backoff, concurrency, cache ordering, and MySQL probe handling.