### PR TITLE
refactor: remove rerunnable CSV row count stage

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -330,38 +330,11 @@ pub async fn run(
                 .await;
         }
 
-        Effect::CountRowsForExport {
-            dsn,
-            run_id,
-            count_query,
-            export_query,
-            file_name,
-        } => {
-            let executor = Arc::clone(query_executor);
-            let tx = action_tx.clone();
-
-            query_tasks
-                .spawn(async move {
-                    let row_count = executor.count_query_rows(&dsn, &count_query).await.ok();
-                    tx.send(Action::CsvExportRowsCounted {
-                        dsn,
-                        run_id,
-                        row_count,
-                        export_query,
-                        file_name,
-                    })
-                    .await
-                    .ok();
-                })
-                .await;
-        }
-
         Effect::ExportCsv {
             dsn,
             run_id,
             query,
             file_name,
-            row_count,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
@@ -378,7 +351,7 @@ pub async fn run(
                                 dsn,
                                 run_id,
                                 path: path.display().to_string(),
-                                row_count,
+                                row_count: None,
                             })
                             .await
                             .ok();

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -100,19 +100,11 @@ pub enum Effect {
     CancelMetadataTasks,
     CancelSqliteDiagnostics,
     CancelTrackedTasks,
-    CountRowsForExport {
-        dsn: String,
-        run_id: u64,
-        count_query: String,
-        export_query: String,
-        file_name: String,
-    },
     ExportCsv {
         dsn: String,
         run_id: u64,
         query: String,
         file_name: String,
-        row_count: Option<usize>,
     },
     ExportCsvFromCache {
         dsn: String,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -297,7 +297,6 @@ impl EffectRunner {
             | Effect::ExecuteAdhoc { .. }
             | Effect::ExecuteExplain { .. }
             | Effect::ExecuteWrite { .. }
-            | Effect::CountRowsForExport { .. }
             | Effect::ExportCsv { .. }
             | Effect::ExportCsvFromCache { .. }) => {
                 cmd_browse::query::run(
@@ -914,14 +913,6 @@ mod tests {
                 _query: &str,
                 _access_mode: AccessMode,
             ) -> Result<WriteExecutionResult, DbOperationError> {
-                unreachable!("test only starts a preview")
-            }
-
-            async fn count_query_rows(
-                &self,
-                _dsn: &str,
-                _query: &str,
-            ) -> Result<usize, DbOperationError> {
                 unreachable!("test only starts a preview")
             }
 

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -20,7 +20,6 @@ pub enum ConfirmIntent {
         run_id: u64,
         export_query: String,
         file_name: String,
-        row_count: Option<usize>,
     },
     CsvExportCached {
         dsn: String,

--- a/src/app/ports/outbound/query_executor.rs
+++ b/src/app/ports/outbound/query_executor.rs
@@ -31,7 +31,6 @@ pub trait QueryExecutor: Send + Sync {
         query: &str,
         access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError>;
-    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError>;
     async fn export_to_csv(
         &self,
         dsn: &str,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -647,13 +647,6 @@ pub enum Action {
 
     // CSV export
     RequestCsvExport,
-    CsvExportRowsCounted {
-        dsn: String,
-        run_id: u64,
-        row_count: Option<usize>,
-        export_query: String,
-        file_name: String,
-    },
     CsvExportSucceeded {
         dsn: String,
         run_id: u64,

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -537,6 +537,16 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
             assert!(state.confirm_dialog.message().contains("unknown"));
+            let Some(ConfirmIntent::CsvExportRerunnable {
+                export_query,
+                file_name,
+                ..
+            }) = state.confirm_dialog.intent()
+            else {
+                panic!("expected rerunnable CSV export confirmation");
+            };
+            assert_eq!(export_query, "SELECT 1");
+            assert_eq!(file_name, "adhoc");
         }
 
         #[rstest]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -2,10 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::{
-    DatabaseType, QuerySource, QueryValue,
-    mysql_sql::{MySqlExportPlan, mysql_export_plan},
-};
+use crate::domain::{DatabaseType, QuerySource, QueryValue, mysql_sql::mysql_export_plan};
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
 use crate::model::shared::input_mode::InputMode;
@@ -73,85 +70,25 @@ fn dispatch_cached_csv_export(
     }
 }
 
-enum RerunnableCsvRowCount {
-    QueryDatabase,
-    Known(usize),
-}
-
-fn dispatch_counted_rerunnable_csv_export(
-    state: &mut AppState,
-    dsn: String,
-    run_id: u64,
-    export_query: String,
-    file_name: String,
-    row_count: Option<usize>,
-) -> DispatchResult {
-    let needs_confirm = match row_count {
-        Some(count) => count > LARGE_EXPORT_THRESHOLD,
-        None => true,
-    };
-    if needs_confirm {
-        let msg = match row_count {
-            Some(n) => format!("Export {n} rows to CSV? This may take a while."),
-            None => "Row count unknown. Export to CSV?".to_string(),
-        };
-        state.confirm_dialog.open(
-            "Confirm CSV Export",
-            msg,
-            ConfirmIntent::CsvExportRerunnable {
-                dsn,
-                run_id,
-                export_query,
-                file_name,
-                row_count,
-            },
-        );
-        state.modal.push_mode(InputMode::ConfirmDialog);
-        DispatchResult::handled()
-    } else {
-        DispatchResult::handled_with(vec![Effect::ExportCsv {
-            dsn,
-            run_id,
-            query: export_query,
-            file_name,
-            row_count,
-        }])
-    }
-}
-
 fn dispatch_rerunnable_csv_export(
     state: &mut AppState,
     dsn: String,
     run_id: u64,
     export_query: String,
     file_name: String,
-    row_count: RerunnableCsvRowCount,
-    count_query_statement: Option<String>,
 ) -> DispatchResult {
-    if let RerunnableCsvRowCount::Known(row_count) = row_count {
-        return dispatch_counted_rerunnable_csv_export(
-            state,
+    state.confirm_dialog.open(
+        "Confirm CSV Export",
+        "Row count unknown. Export to CSV?",
+        ConfirmIntent::CsvExportRerunnable {
             dsn,
             run_id,
             export_query,
             file_name,
-            Some(row_count),
-        );
-    }
-
-    let count_query = if let Some(statement) = count_query_statement {
-        format!("SELECT COUNT(*) FROM (\n{statement}\n) AS _export_count")
-    } else {
-        let stripped = export_query.trim_end().trim_end_matches(';').to_string();
-        format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count")
-    };
-    DispatchResult::handled_with(vec![Effect::CountRowsForExport {
-        dsn,
-        run_id,
-        count_query,
-        export_query,
-        file_name,
-    }])
+        },
+    );
+    state.modal.push_mode(InputMode::ConfirmDialog);
+    DispatchResult::handled()
 }
 
 pub fn reduce_pagination(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -182,13 +119,7 @@ pub fn reduce_pagination(state: &mut AppState, action: &Action, now: Instant) ->
                     SqliteExportPlan::RerunnableQuery { query } => {
                         let run_id = state.query.begin_non_preview_running(now);
                         return dispatch_rerunnable_csv_export(
-                            state,
-                            dsn,
-                            run_id,
-                            query,
-                            file_name,
-                            RerunnableCsvRowCount::QueryDatabase,
-                            None,
+                            state, dsn, run_id, query, file_name,
                         );
                     }
                     SqliteExportPlan::CachedResult { row_count } => {
@@ -212,65 +143,17 @@ pub fn reduce_pagination(state: &mut AppState, action: &Action, now: Instant) ->
                     );
                 }
 
-                let Some(plan) = mysql_export_plan(&result.query) else {
+                if mysql_export_plan(&result.query).is_none() {
                     return DispatchResult::handled();
-                };
+                }
                 let export_query = result.query.clone();
-                let (row_count, count_query_statement) = match plan {
-                    MySqlExportPlan::CountRows { statement } => {
-                        (RerunnableCsvRowCount::QueryDatabase, Some(statement))
-                    }
-                    MySqlExportPlan::UseResultRowCount => {
-                        (RerunnableCsvRowCount::Known(row_count), None)
-                    }
-                };
                 let run_id = state.query.begin_non_preview_running(now);
-                return dispatch_rerunnable_csv_export(
-                    state,
-                    dsn,
-                    run_id,
-                    export_query,
-                    file_name,
-                    row_count,
-                    count_query_statement,
-                );
+                return dispatch_rerunnable_csv_export(state, dsn, run_id, export_query, file_name);
             }
 
             let export_query = result.query.clone();
             let run_id = state.query.begin_non_preview_running(now);
-            dispatch_rerunnable_csv_export(
-                state,
-                dsn,
-                run_id,
-                export_query,
-                file_name,
-                RerunnableCsvRowCount::QueryDatabase,
-                None,
-            )
-        }
-
-        Action::CsvExportRowsCounted {
-            dsn,
-            run_id,
-            row_count,
-            export_query,
-            file_name,
-        } => {
-            if reject_pending_mysql_connection_probe(state) {
-                return DispatchResult::handled();
-            }
-            if state.is_stale_query_run(dsn, *run_id) {
-                return DispatchResult::handled();
-            }
-
-            dispatch_counted_rerunnable_csv_export(
-                state,
-                dsn.clone(),
-                *run_id,
-                export_query.clone(),
-                file_name.clone(),
-                *row_count,
-            )
+            dispatch_rerunnable_csv_export(state, dsn, run_id, export_query, file_name)
         }
 
         Action::CsvExportSucceeded {
@@ -373,22 +256,6 @@ mod tests {
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
     use crate::update::reducer::reduce;
-
-    fn csv_rows_counted_action(
-        state: &mut AppState,
-        row_count: Option<usize>,
-        export_query: &str,
-        file_name: &str,
-    ) -> Action {
-        let run_id = begin_query_run(state);
-        Action::CsvExportRowsCounted {
-            dsn: "postgres://localhost/test".to_string(),
-            run_id,
-            row_count,
-            export_query: export_query.to_string(),
-            file_name: file_name.to_string(),
-        }
-    }
 
     fn csv_succeeded_action(state: &mut AppState, path: &str, row_count: Option<usize>) -> Action {
         let run_id = begin_query_run(state);
@@ -634,7 +501,7 @@ mod tests {
         use rstest::rstest;
 
         #[test]
-        fn delete_success_then_count_export_then_preview_completion_clears_selection() {
+        fn delete_success_then_csv_export_confirmation_then_preview_completion_clears_selection() {
             let mut state = test_fixtures::state_after_delete_success();
             state.query.set_current_result(preview_result(10));
             state.query.pagination.reset_for_table("public", "users");
@@ -647,18 +514,9 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(effects.len(), 1);
-            match &effects[0] {
-                Effect::CountRowsForExport {
-                    export_query,
-                    file_name,
-                    ..
-                } => {
-                    assert_eq!(export_query, "SELECT * FROM users");
-                    assert_eq!(file_name, "users");
-                }
-                other => panic!("expected CountRowsForExport, got {other:?}"),
-            }
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+            assert!(state.confirm_dialog.message().contains("unknown"));
             assert_eq!(
                 state.query.post_delete_row_selection(),
                 PostDeleteRowSelection::Keep
@@ -676,18 +534,9 @@ mod tests {
             let effects =
                 dispatch_query(&mut state, &Action::RequestCsvExport, Instant::now()).unwrap();
 
-            assert_eq!(effects.len(), 1);
-            match &effects[0] {
-                Effect::CountRowsForExport {
-                    export_query,
-                    file_name,
-                    ..
-                } => {
-                    assert_eq!(export_query, "SELECT 1");
-                    assert_eq!(file_name, "adhoc");
-                }
-                other => panic!("expected CountRowsForExport, got {other:?}"),
-            }
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+            assert!(state.confirm_dialog.message().contains("unknown"));
         }
 
         #[rstest]
@@ -725,34 +574,33 @@ mod tests {
         }
 
         #[test]
-        fn rows_counted_below_threshold_emits_export_effect() {
+        fn rerunnable_export_always_confirms_even_when_result_is_small() {
             let mut state = create_test_state();
-            let action = csv_rows_counted_action(&mut state, Some(500), "SELECT 1", "test");
+            state.query.set_current_result(adhoc_result());
 
-            let effects = dispatch_query(&mut state, &action, Instant::now()).unwrap();
-
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::ExportCsv { .. }));
-        }
-
-        #[test]
-        fn rows_counted_above_threshold_opens_confirm_dialog() {
-            let mut state = create_test_state();
-            let action = csv_rows_counted_action(&mut state, Some(200_000), "SELECT 1", "test");
-
-            let effects = dispatch_query(&mut state, &action, Instant::now()).unwrap();
+            let effects =
+                dispatch_query(&mut state, &Action::RequestCsvExport, Instant::now()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
-            assert!(state.confirm_dialog.title().contains("CSV Export"));
+            assert!(state.confirm_dialog.message().contains("unknown"));
         }
 
         #[test]
-        fn rows_counted_none_opens_confirm_dialog() {
+        fn rerunnable_export_always_confirms_even_when_result_is_large() {
             let mut state = create_test_state();
-            let action = csv_rows_counted_action(&mut state, None, "SELECT 1", "test");
+            let result = QueryResult::success(
+                "SELECT 1".to_string(),
+                vec!["value".to_string()],
+                vec![vec!["1".to_string()]],
+                0,
+                QuerySource::Adhoc,
+            )
+            .with_row_count(200_000);
+            state.query.set_current_result(Arc::new(result));
 
-            let effects = dispatch_query(&mut state, &action, Instant::now()).unwrap();
+            let effects =
+                dispatch_query(&mut state, &Action::RequestCsvExport, Instant::now()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
@@ -801,30 +649,6 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("Query failed: psql error. Review the database error details and SQL.")
             );
-        }
-
-        #[test]
-        fn stale_rows_counted_does_not_open_confirm_or_export() {
-            let mut state = create_test_state();
-            let old_run_id = begin_query_run(&mut state);
-            let _ = begin_query_run(&mut state);
-
-            let effects = dispatch_query(
-                &mut state,
-                &Action::CsvExportRowsCounted {
-                    dsn: "postgres://localhost/test".to_string(),
-                    run_id: old_run_id,
-                    row_count: Some(200_000),
-                    export_query: "SELECT 1".to_string(),
-                    file_name: "test".to_string(),
-                },
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert!(effects.is_empty());
-            assert_ne!(state.input_mode(), InputMode::ConfirmDialog);
-            assert!(state.query.is_running());
         }
 
         #[test]
@@ -900,7 +724,7 @@ mod tests {
             }
 
             #[test]
-            fn select_still_uses_count_effect() {
+            fn select_always_asks_for_unknown_row_count() {
                 let mut state = sqlite_state();
                 state
                     .query
@@ -915,8 +739,9 @@ mod tests {
                 let effects =
                     dispatch_query(&mut state, &Action::RequestCsvExport, Instant::now()).unwrap();
 
-                assert_eq!(effects.len(), 1);
-                assert!(matches!(&effects[0], Effect::CountRowsForExport { .. }));
+                assert!(effects.is_empty());
+                assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+                assert!(state.confirm_dialog.message().contains("unknown"));
             }
 
             #[test]
@@ -965,31 +790,19 @@ mod tests {
             }
 
             #[rstest]
-            #[case::select("SELECT 1", true)]
-            #[case::table("TABLE users", false)]
-            #[case::show("SHOW TABLES", false)]
-            #[case::describe("DESCRIBE users", false)]
-            fn uses_count_only_for_mysql_select(#[case] query: &str, #[case] expects_count: bool) {
+            #[case::select("SELECT 1")]
+            #[case::table("TABLE users")]
+            #[case::show("SHOW TABLES")]
+            #[case::describe("DESCRIBE users")]
+            fn supported_rerunnable_queries_ask_for_unknown_row_count(#[case] query: &str) {
                 let mut state = mysql_state(query);
 
                 let effects =
                     dispatch_query(&mut state, &Action::RequestCsvExport, Instant::now()).unwrap();
 
-                assert_eq!(effects.len(), 1);
-                assert_eq!(
-                    matches!(&effects[0], Effect::CountRowsForExport { .. }),
-                    expects_count
-                );
-                assert_eq!(
-                    matches!(
-                        &effects[0],
-                        Effect::ExportCsv {
-                            row_count: Some(1),
-                            ..
-                        }
-                    ),
-                    !expects_count
-                );
+                assert!(effects.is_empty());
+                assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+                assert!(state.confirm_dialog.message().contains("unknown"));
             }
 
             #[test]
@@ -1032,37 +845,6 @@ mod tests {
                 assert_eq!(columns, &["payload", "text_value", "nullable", "text"]);
                 assert_eq!(cached_values, &values);
                 assert_eq!(*row_count, Some(1));
-            }
-
-            #[rstest]
-            #[case::semicolon_comment(
-                "SELECT id FROM users; -- trailing comment",
-                "SELECT id FROM users"
-            )]
-            #[case::dash_comment(
-                "SELECT id FROM users -- trailing comment",
-                "SELECT id FROM users -- trailing comment"
-            )]
-            #[case::hash_comment(
-                "SELECT id FROM users # trailing comment",
-                "SELECT id FROM users # trailing comment"
-            )]
-            fn count_query_wraps_mysql_statement_with_newlines(
-                #[case] query: &str,
-                #[case] normalized_statement: &str,
-            ) {
-                let mut state = mysql_state(query);
-
-                let effects =
-                    dispatch_query(&mut state, &Action::RequestCsvExport, Instant::now()).unwrap();
-
-                let Effect::CountRowsForExport { count_query, .. } = &effects[0] else {
-                    panic!("expected CountRowsForExport effect");
-                };
-                assert_eq!(
-                    count_query,
-                    &format!("SELECT COUNT(*) FROM (\n{normalized_statement}\n) AS _export_count")
-                );
             }
         }
     }

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -73,7 +73,6 @@ pub(super) fn reduce_confirm_dialog(
                     run_id,
                     export_query,
                     file_name,
-                    row_count,
                 }) => {
                     if reject_pending_mysql_connection_probe(state) {
                         return DispatchResult::handled();
@@ -86,7 +85,6 @@ pub(super) fn reduce_confirm_dialog(
                             run_id,
                             query: export_query,
                             file_name,
-                            row_count,
                         }])
                     }
                 }

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -507,7 +507,6 @@ mod tests {
                 run_id,
                 export_query: "SELECT 1".to_string(),
                 file_name: CSV_TEST_FILE.to_string(),
-                row_count: Some(200_000),
             }
         }
 
@@ -740,7 +739,20 @@ mod tests {
 
                 let effects = confirm_effects(&mut state);
                 assert_eq!(effects.len(), 1);
-                assert!(matches!(&effects[0], Effect::ExportCsv { .. }));
+                let Effect::ExportCsv {
+                    dsn,
+                    run_id: effect_run_id,
+                    query,
+                    file_name,
+                } = &effects[0]
+                else {
+                    panic!("expected rerunnable CSV export effect");
+                };
+
+                assert_eq!(dsn, CSV_TEST_DSN);
+                assert_eq!(*effect_run_id, run_id);
+                assert_eq!(query, "SELECT 1");
+                assert_eq!(file_name, CSV_TEST_FILE);
             }
 
             #[test]
@@ -769,7 +781,6 @@ mod tests {
                         run_id: 1,
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
                     },
                 );
 

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -207,14 +207,6 @@ impl QueryExecutor for MySqlAdapter {
         })
     }
 
-    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
-        let target = parse_and_validate_mysql_dsn(dsn)?;
-        validate_mysql_export_query(query, target.database.as_deref())?;
-
-        let result = execute_adhoc_with_target(&target, query, AccessMode::ReadOnly).await?;
-        parse_mysql_count_result(&result)
-    }
-
     async fn export_to_csv(
         &self,
         dsn: &str,
@@ -232,34 +224,15 @@ impl QueryExecutor for MySqlAdapter {
     }
 }
 
-fn parse_mysql_count_result(result: &QueryResult) -> Result<usize, DbOperationError> {
-    let value = match result.values() {
-        [row] => match row.as_slice() {
-            [value] => value.as_str(),
-            _ => None,
-        },
-        _ => None,
-    }
-    .ok_or_else(|| {
-        DbOperationError::QueryFailed(
-            "MySQL row count query returned an invalid result".to_string(),
-        )
-    })?;
-
-    value.parse::<usize>().map_err(|_| {
-        DbOperationError::QueryFailed("MySQL row count was not an integer".to_string())
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::domain::QueryValue;
 
-    fn count_result(values: Vec<Vec<QueryValue>>) -> QueryResult {
+    fn query_result(values: Vec<Vec<QueryValue>>) -> QueryResult {
         QueryResult::success_with_values(
-            "SELECT COUNT(*)".to_string(),
-            vec!["COUNT(*)".to_string()],
+            "SELECT id FROM users".to_string(),
+            vec!["id".to_string()],
             values,
             0,
             QuerySource::Adhoc,
@@ -267,35 +240,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_a_single_integer_count_result() {
-        assert_eq!(
-            parse_mysql_count_result(&count_result(vec![vec![QueryValue::text("42")]])).unwrap(),
-            42
-        );
-    }
-
-    #[test]
-    fn rejects_an_empty_count_result() {
-        assert!(matches!(
-            parse_mysql_count_result(&count_result(Vec::new())),
-            Err(DbOperationError::QueryFailed(details))
-                if details == "MySQL row count query returned an invalid result"
-        ));
-    }
-
-    #[test]
-    fn rejects_a_non_integer_count_result() {
-        assert!(matches!(
-            parse_mysql_count_result(&count_result(vec![vec![QueryValue::text("unknown")]])),
-            Err(DbOperationError::QueryFailed(details))
-                if details == "MySQL row count was not an integer"
-        ));
-    }
-
-    #[test]
     fn uses_affected_rows_for_a_dml_result_without_payload_rows() {
         let result =
-            with_mysql_command_tag(count_result(Vec::new()), CommandTag::Update(3)).unwrap();
+            with_mysql_command_tag(query_result(Vec::new()), CommandTag::Update(3)).unwrap();
 
         assert_eq!(result.row_count(), 3);
         assert_eq!(result.data_row_count(), 0);
@@ -305,7 +252,7 @@ mod tests {
     #[test]
     fn keeps_payload_row_count_for_a_dml_result() {
         let result = with_mysql_command_tag(
-            count_result(vec![vec![QueryValue::text("row")]]),
+            query_result(vec![vec![QueryValue::text("row")]]),
             CommandTag::Update(3),
         )
         .unwrap();
@@ -317,7 +264,7 @@ mod tests {
     #[test]
     fn keeps_empty_row_count_for_non_dml_command_tags() {
         let result = with_mysql_command_tag(
-            count_result(Vec::new()),
+            query_result(Vec::new()),
             CommandTag::Create("TABLE".to_string()),
         )
         .unwrap();

--- a/src/infra/adapters/postgres/executor.rs
+++ b/src/infra/adapters/postgres/executor.rs
@@ -48,10 +48,6 @@ impl QueryExecutor for PostgresAdapter {
             .await
     }
 
-    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
-        self.count_rows(dsn, query, true).await
-    }
-
     async fn export_to_csv(
         &self,
         dsn: &str,

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -421,18 +421,6 @@ impl PostgresAdapter {
         })
     }
 
-    pub(in crate::adapters::postgres) async fn count_rows(
-        &self,
-        dsn: &str,
-        query: &str,
-        read_only: bool,
-    ) -> Result<usize, DbOperationError> {
-        let output = self.run_psql(dsn, &["-t", "-A"], query, read_only).await?;
-        output.trim().parse::<usize>().map_err(|e| {
-            DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {e}"))
-        })
-    }
-
     pub(in crate::adapters::postgres) async fn export_csv_to_file(
         &self,
         dsn: &str,

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -180,10 +180,6 @@ impl QueryExecutor for DbAdapterRegistry {
             .await
     }
 
-    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
-        self.query_executor(dsn)?.count_query_rows(dsn, query).await
-    }
-
     async fn export_to_csv(
         &self,
         dsn: &str,

--- a/src/infra/adapters/sqlite/executor.rs
+++ b/src/infra/adapters/sqlite/executor.rs
@@ -13,10 +13,10 @@ use crate::domain::{
 use super::sqlite3::parser::{
     SqliteStatementPlan, aggregate_sqlite_command_tag, append_changes_query_for_plan,
     command_tag_result, is_sqlite_rerunnable_export_query, last_sqlite_result_set,
-    parse_affected_rows, parse_count_result, quoted_to_query_result, reject_sqlite_fsdir,
-    sqlite_adhoc_execution_query_for_plan, sqlite_empty_result_sentinel,
-    sqlite_export_not_rerunnable_error, sqlite_probe_marker, sqlite_statement_plan,
-    sqlite_statement_tags, statement_counts_as_select_tag, strip_sqlite_probes,
+    parse_affected_rows, quoted_to_query_result, sqlite_adhoc_execution_query_for_plan,
+    sqlite_empty_result_sentinel, sqlite_export_not_rerunnable_error, sqlite_probe_marker,
+    sqlite_statement_plan, sqlite_statement_tags, statement_counts_as_select_tag,
+    strip_sqlite_probes,
 };
 use super::{SqliteAdapter, sql};
 
@@ -130,15 +130,6 @@ impl QueryExecutor for SqliteAdapter {
             affected_rows,
             diagnostics: Vec::new(),
         })
-    }
-
-    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
-        reject_sqlite_fsdir(query)?;
-        let stdout = self
-            .cli
-            .execute_csv(Self::path_from_dsn(dsn)?, query, true)
-            .await?;
-        parse_count_result(&stdout)
     }
 
     async fn export_to_csv(

--- a/src/infra/adapters/sqlite/executor_export_tests.rs
+++ b/src/infra/adapters/sqlite/executor_export_tests.rs
@@ -1,43 +1,6 @@
 use super::*;
 
 #[tokio::test]
-async fn count_query_rows_parses_count_result() {
-    let (_dir, dsn) = test_support::make_sqlite_db(
-        r"
-            CREATE TABLE users(id INTEGER PRIMARY KEY);
-            INSERT INTO users(id) VALUES (1), (2), (3);
-            ",
-    );
-    let adapter = SqliteAdapter::new();
-
-    let count = adapter
-        .count_query_rows(&dsn, "SELECT COUNT(*) FROM users")
-        .await
-        .unwrap();
-
-    assert_eq!(count, 3);
-}
-
-#[tokio::test]
-async fn count_query_rows_rejects_fsdir_before_execution() {
-    let (_dir, dsn) = test_support::make_sqlite_db("");
-    let adapter = SqliteAdapter::new();
-
-    let result = adapter
-        .count_query_rows(
-            &dsn,
-            "SELECT COUNT(*) FROM (SELECT * FROM fsdir('/tmp')) AS files",
-        )
-        .await;
-
-    assert!(matches!(
-        result,
-        Err(DbOperationError::UnsupportedOperation(details))
-            if details == "SQLite fsdir access is not supported in safe mode"
-    ));
-}
-
-#[tokio::test]
 async fn export_to_csv_writes_rows() {
     let (dir, dsn) = test_support::make_sqlite_db(
         r"
@@ -159,18 +122,6 @@ async fn export_to_csv_missing_table_returns_object_missing_and_removes_file() {
 
     assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
     assert!(!path.exists());
-}
-
-#[tokio::test]
-async fn count_query_rows_missing_table_returns_object_missing() {
-    let (_dir, dsn) = test_support::make_sqlite_db("");
-    let adapter = SqliteAdapter::new();
-
-    let result = adapter
-        .count_query_rows(&dsn, "SELECT COUNT(*) FROM missing")
-        .await;
-
-    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
 }
 
 #[tokio::test]

--- a/src/infra/adapters/sqlite/sqlite3/parser/mod.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/mod.rs
@@ -9,12 +9,11 @@ pub(in crate::adapters::sqlite) use command_tag::{
 };
 pub(in crate::adapters::sqlite) use lexer::{
     is_create_view_prefix, is_create_virtual_table_prefix, is_sqlite_rerunnable_export_query,
-    next_keyword_from, reject_sqlite_fsdir, skip_bracket_quoted, skip_quoted,
-    sqlite_export_not_rerunnable_error, virtual_table_module_name,
+    next_keyword_from, skip_bracket_quoted, skip_quoted, sqlite_export_not_rerunnable_error,
+    virtual_table_module_name,
 };
 pub(in crate::adapters::sqlite) use output::{
-    last_sqlite_result_set, parse_affected_rows, parse_count_result, quoted_to_query_result,
-    strip_sqlite_probes,
+    last_sqlite_result_set, parse_affected_rows, quoted_to_query_result, strip_sqlite_probes,
 };
 pub(in crate::adapters::sqlite) use statement_plan::{
     SqliteStatementPlan, append_changes_query_for_plan, sqlite_adhoc_execution_query_for_plan,

--- a/src/infra/adapters/sqlite/sqlite3/parser/output.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/output.rs
@@ -453,21 +453,6 @@ pub(in crate::adapters::sqlite) fn strip_sqlite_probes(
     Ok((kept.join("\n"), changes))
 }
 
-fn first_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(true)
-        .from_reader(stdout.trim().as_bytes());
-    let mut records = reader.records();
-    let record = records
-        .next()
-        .transpose()?
-        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))?;
-    record
-        .get(0)
-        .map(ToString::to_string)
-        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))
-}
-
 fn last_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
     let line = stdout
         .lines()
@@ -500,22 +485,6 @@ pub(in crate::adapters::sqlite) fn parse_affected_rows(
         })?
         .parse::<usize>()
         .map_err(|error| DbOperationError::CommandTagParseFailed(error.to_string()))
-}
-
-pub(in crate::adapters::sqlite) fn parse_count_result(
-    stdout: &str,
-) -> Result<usize, DbOperationError> {
-    first_csv_cell(stdout)
-        .map_err(|error| match error {
-            DbOperationError::EmptyResponse(_) => {
-                DbOperationError::QueryFailed("Failed to parse COUNT result".to_string())
-            }
-            other => other,
-        })?
-        .parse::<usize>()
-        .map_err(|error| {
-            DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {error}"))
-        })
 }
 
 #[cfg(test)]
@@ -808,11 +777,6 @@ mod tests {
 
             assert_eq!(changes.get(&0), Some(&2));
             assert_eq!(filtered, "'id','name'\n1,'Alice'\n'value'\n42");
-        }
-
-        #[test]
-        fn parse_count_result_reads_first_result_cell() {
-            assert_eq!(parse_count_result("COUNT(*)\n42\n").unwrap(), 42);
         }
     }
 }


### PR DESCRIPTION
## Problem

Rerunnable CSV exports perform an extra database COUNT query before asking for confirmation.

## Background

The exact count adds a process and query even though confirmation is required before the export.

## Approach

Rerunnable exports now open an unknown-row-count confirmation immediately and start the export only after approval. Cached results retain their existing known-count behavior, while stale run/DSN checks, cancellation, read-only handling, result messages, and database-specific export safety remain unchanged.

## Verification

- `cargo test -p sabiql-app csv_export --lib`
- `cargo test -p sabiql-infra export --lib`
- `cargo check -p sabiql-app -p sabiql-infra`
- `cargo clippy -p sabiql-app -p sabiql-infra --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/lint_all.sh`
