### PR TITLE
refactor(error): remove CSV export I/O source wrapper

### DIFF
--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -127,7 +127,7 @@ pub enum DbOperationError {
     #[error("Query failed")]
     QueryFailed(String),
     #[error("CSV export failed")]
-    ExportIo(#[source] ExportIoSource),
+    ExportIo(#[source] Arc<std::io::Error>),
     #[error("Preview exceeded its byte budget")]
     PreviewSizeExceeded(String),
     #[error("Query failed after a change")]
@@ -172,29 +172,6 @@ pub enum DbOperationError {
     Timeout(String),
     #[error("Operation canceled")]
     Canceled(String),
-}
-
-#[derive(Clone)]
-pub struct ExportIoSource(Arc<std::io::Error>);
-
-impl ExportIoSource {
-    pub fn new(error: std::io::Error) -> Self {
-        Self(Arc::new(error))
-    }
-}
-
-impl std::ops::Deref for ExportIoSource {
-    type Target = std::io::Error;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
-}
-
-impl fmt::Display for ExportIoSource {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
 }
 
 impl DbOperationError {
@@ -427,7 +404,7 @@ mod tests {
         #[case(DbOperationError::LockTimeout("boom".to_string()))]
         #[case(DbOperationError::ObjectMissing("boom".to_string()))]
         #[case(DbOperationError::QueryFailed("boom".to_string()))]
-        #[case(DbOperationError::ExportIo(ExportIoSource::new(std::io::Error::other("boom"))))]
+        #[case(DbOperationError::ExportIo(Arc::new(std::io::Error::other("boom"))))]
         #[case(DbOperationError::UnsupportedOperation("boom".to_string()))]
         #[case(DbOperationError::UnsupportedOperationWithKind {
             kind: UnsupportedOperationKind::ClientVersion,
@@ -590,7 +567,7 @@ mod tests {
 
         #[test]
         fn export_io_uses_export_guidance_and_preserves_source() {
-            let error = DbOperationError::ExportIo(ExportIoSource::new(std::io::Error::other(
+            let error = DbOperationError::ExportIo(Arc::new(std::io::Error::other(
                 "password=mysecret host=localhost",
             )));
 

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -30,7 +30,7 @@ pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
-    ConnectionFailureKind, DatabaseCli, DbOperationError, ExportIoSource, SqliteCompatibilityKind,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, SqliteCompatibilityKind,
     UnsupportedOperationKind,
 };
 pub use ddl_generator::DdlGenerator;

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
-use sabiql_app::ports::outbound::{DbOperationError, ExportIoSource};
+use sabiql_app::ports::outbound::DbOperationError;
 use tokio::io::{AsyncWriteExt, BufWriter};
 
 pub const CSV_FLUSH_THRESHOLD: usize = 64 * 1024;
@@ -98,7 +99,7 @@ impl From<std::io::Error> for CsvOutputError {
 impl CsvOutputError {
     pub(super) fn into_db_operation_error(self) -> DbOperationError {
         match self {
-            Self::File(error) => DbOperationError::ExportIo(ExportIoSource::new(error)),
+            Self::File(error) => DbOperationError::ExportIo(Arc::new(error)),
             Self::Process(error) => DbOperationError::QueryFailed(error.to_string()),
         }
     }
@@ -135,7 +136,7 @@ impl CsvFileWriter {
     pub(crate) async fn create(path: PathBuf) -> Result<Self, DbOperationError> {
         let file = tokio::fs::File::create(path)
             .await
-            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         Ok(Self {
             file: BufWriter::new(file),
             csv_writer: new_csv_writer(),
@@ -165,11 +166,11 @@ impl CsvFileWriter {
         self.file
             .write_all(&encoded)
             .await
-            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         self.file
             .flush()
             .await
-            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))
     }
 
     async fn flush_buffer(&mut self) -> Result<(), DbOperationError> {
@@ -180,11 +181,11 @@ impl CsvFileWriter {
         self.file
             .write_all(&encoded)
             .await
-            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         self.file
             .flush()
             .await
-            .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
+            .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
         Ok(())
     }
 }
@@ -205,7 +206,7 @@ where
 
     tokio::fs::hard_link(&temporary_path, &final_path)
         .await
-        .map_err(|error| DbOperationError::ExportIo(ExportIoSource::new(error)))?;
+        .map_err(|error| DbOperationError::ExportIo(Arc::new(error)))?;
     let mut published_file = RemoveOnDropGuard::new(final_path.clone());
 
     if cleanup(&temporary_path).is_ok() {
@@ -218,7 +219,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::future::pending;
-    use std::sync::Arc;
 
     use tempfile::tempdir;
     use tokio::sync::Barrier;
@@ -231,7 +231,7 @@ mod tests {
     fn assert_export_io_source(error: &DbOperationError) {
         assert!(matches!(error, DbOperationError::ExportIo(_)));
         let source = std::error::Error::source(error).expect("ExportIo source");
-        assert!(source.downcast_ref::<std::io::Error>().is_some());
+        assert!(source.downcast_ref::<Arc<std::io::Error>>().is_some());
     }
 
     #[cfg(unix)]

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::adapters::csv_export::CsvOutputError;
-use crate::app::ports::outbound::{DbOperationError, ExportIoSource};
+use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{CommandTag, QueryResult, QuerySource, RefreshScope, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
@@ -25,7 +25,7 @@ async fn collect_csv_output(
 
     let file = tokio::fs::File::create(path)
         .await
-        .map_err(|e| DbOperationError::ExportIo(ExportIoSource::new(e)))?;
+        .map_err(|e| DbOperationError::ExportIo(Arc::new(e)))?;
     let mut writer = tokio::io::BufWriter::new(file);
 
     let result = timeout(timeout_duration, async {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::{ExitStatus, Stdio};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::de::DeserializeOwned;
@@ -8,7 +9,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::adapters::csv_export::CsvOutputError;
-use crate::app::ports::outbound::{DbOperationError, ExportIoSource, SqliteCompatibilityKind};
+use crate::app::ports::outbound::{DbOperationError, SqliteCompatibilityKind};
 
 use super::super::path_validation;
 use super::error::{classify_cli_spawn_error, classify_query_error};
@@ -206,7 +207,7 @@ impl SqliteCli {
             Ok(file) => file,
             Err(error) => {
                 kill_and_wait(&mut child).await;
-                return Err(DbOperationError::ExportIo(ExportIoSource::new(error)));
+                return Err(DbOperationError::ExportIo(Arc::new(error)));
             }
         };
         let mut writer = tokio::io::BufWriter::new(file);


### PR DESCRIPTION
## Problem
CSV filesystem failures carry a dedicated wrapper around shared I/O errors at the application boundary.

## Background
The wrapper only preserves Arc ownership and delegates the underlying I/O error behavior.

## Approach
Use Arc<io::Error> directly for the export error source and construct it at each filesystem boundary. This keeps source reporting, shared ownership, masked presentation, and temporary-file cleanup behavior unchanged.

## Validation
Focused application and infrastructure tests, package checks, targeted Clippy, formatting, and lint_all pass.