### PR TITLE
refactor(sqlite): unify explain output configuration

### DIFF
--- a/src/infra/adapters/sqlite/executor.rs
+++ b/src/infra/adapters/sqlite/executor.rs
@@ -7,7 +7,7 @@ use crate::adapters::csv_export::export_to_downloads;
 use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use crate::domain::{
     CommandTag, QueryResult, QuerySource, RefreshScope, TableKind, TableKindInfo,
-    WriteExecutionResult, sqlite_sql::is_sqlite_explain_query_plan_sql,
+    WriteExecutionResult,
 };
 
 use super::sqlite3::parser::{
@@ -66,7 +66,8 @@ impl QueryExecutor for SqliteAdapter {
         )]
         let start = Instant::now();
         let stdout = self
-            .execute_quote_for_query_plan(path, &execution_query, query, access_mode.is_read_only())
+            .cli
+            .execute_quote(path, &execution_query, access_mode.is_read_only())
             .await?;
         let elapsed = start.elapsed().as_millis() as u64;
         let (stdout, changes) = strip_sqlite_probes(&stdout, &marker)?;
@@ -185,23 +186,6 @@ impl SqliteAdapter {
         let stdout = self.cli.execute_quote(path, query, read_only).await?;
         let elapsed = start.elapsed().as_millis() as u64;
         quoted_to_query_result(query, &stdout, source, elapsed)
-    }
-
-    async fn execute_quote_for_query_plan(
-        &self,
-        path: &str,
-        execution_sql: &str,
-        source_sql: &str,
-        read_only: bool,
-    ) -> Result<String, DbOperationError> {
-        // Detect against source_sql because execution_sql may include probe statements.
-        if is_sqlite_explain_query_plan_sql(source_sql) {
-            self.cli
-                .execute_quote_with_explain_off(path, execution_sql, read_only)
-                .await
-        } else {
-            self.cli.execute_quote(path, execution_sql, read_only).await
-        }
     }
 
     async fn execute_changes_query(

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -80,28 +80,6 @@ impl SqliteCli {
         .await
     }
 
-    pub(in crate::adapters::sqlite) async fn execute_quote_with_explain_off(
-        &self,
-        path: &str,
-        sql: &str,
-        read_only: bool,
-    ) -> Result<String, DbOperationError> {
-        self.execute_text(
-            path,
-            &[
-                "-batch",
-                "-bail",
-                "-quote",
-                "-header",
-                "-cmd",
-                ".explain off",
-            ],
-            sql,
-            read_only,
-        )
-        .await
-    }
-
     async fn execute_text(
         &self,
         path: &str,
@@ -297,6 +275,7 @@ impl SqliteCli {
             cmd.arg("-readonly");
         }
         cmd.arg("-cmd").arg(format!(".timeout {BUSY_TIMEOUT_MS}"));
+        cmd.arg("-cmd").arg(".explain off");
     }
 
     fn apply_initialization_file(cmd: &mut Command) {
@@ -752,7 +731,7 @@ esac
         }
 
         #[test]
-        fn initialization_precedes_safe_read_only_and_timeout() {
+        fn session_options_include_safety_timeout_and_explain_output() {
             let mut cmd = Command::new("sqlite3");
             SqliteCli::apply_session_options(&mut cmd, true);
             let args = cmd
@@ -770,6 +749,8 @@ esac
                     "-readonly",
                     "-cmd",
                     &format!(".timeout {BUSY_TIMEOUT_MS}"),
+                    "-cmd",
+                    ".explain off",
                 ]
             );
         }


### PR DESCRIPTION
## Problem
SQLite CLI EXPLAIN formatting was disabled only for the adhoc query-plan path, leaving other SQLite invocations on a different output configuration.

## Background
A shared output setting keeps CLI output compatible with the existing parsers across query, metadata, write, and export paths.

## Approach
Apply `.explain off` in the common SQLite session options used by every production invocation. Remove the EXPLAIN-specific execution method and branch while preserving quote, CSV, and JSON formats, error classification, read-only/write safety, and database boundaries.