### PR TITLE
refactor(app): use run IDs for terminal actions

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -108,7 +108,6 @@ async fn fetch_metadata(
     {
         action_tx
             .send(Action::MetadataFailed {
-                dsn,
                 run_id,
                 error: to_db_operation_error(&error),
             })
@@ -124,22 +123,14 @@ async fn fetch_metadata(
         match provider.fetch_metadata(&dsn).await {
             Ok(metadata) => {
                 let metadata = Arc::new(metadata);
-                tx.send(Action::MetadataLoaded {
-                    dsn,
-                    run_id,
-                    metadata,
-                })
-                .await
-                .ok();
+                tx.send(Action::MetadataLoaded { run_id, metadata })
+                    .await
+                    .ok();
             }
             Err(e) => {
-                tx.send(Action::MetadataFailed {
-                    dsn,
-                    run_id,
-                    error: e,
-                })
-                .await
-                .ok();
+                tx.send(Action::MetadataFailed { run_id, error: e })
+                    .await
+                    .ok();
             }
         }
     });
@@ -158,7 +149,6 @@ fn fetch_effective_user(
     MetadataTaskRegistry::spawn(metadata_tasks, async move {
         let effective_user = provider.fetch_effective_user(&dsn).await.ok().flatten();
         tx.send(Action::EffectiveUserLoaded {
-            dsn,
             run_id,
             effective_user,
         })
@@ -310,8 +300,6 @@ mod tests {
             let dir = tempdir().unwrap();
             let path = dir.path().join("missing.db");
             let dsn = format!("sqlite://{}", path.display());
-            let expected_dsn = dsn.clone();
-
             let mut mock_provider = MockMetadataProvider::new();
             mock_provider.expect_fetch_metadata().never();
 
@@ -342,12 +330,11 @@ mod tests {
                 matches!(
                     action,
                     Action::MetadataFailed {
-                        ref dsn,
                         run_id: 7,
                         error: DbOperationError::SqlitePath(SqlitePathError::FileNotFound(
                             ref file_path,
                         )),
-                    } if *dsn == expected_dsn && file_path == &path.display().to_string()
+                    } if file_path == &path.display().to_string()
                 ),
                 "expected MetadataFailed, got {action:?}"
             );
@@ -363,8 +350,6 @@ mod tests {
             let path = dir.path().join("app.db");
             fs::write(&path, b"").unwrap();
             let dsn = format!("sqlite://{}", path.display());
-            let expected_dsn = dsn.clone();
-
             let mut mock_provider = MockMetadataProvider::new();
             mock_provider
                 .expect_fetch_metadata()
@@ -395,14 +380,7 @@ mod tests {
 
             let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
-                matches!(
-                    action,
-                    Action::MetadataLoaded {
-                        ref dsn,
-                        run_id: 7,
-                        ..
-                    } if *dsn == expected_dsn
-                ),
+                matches!(action, Action::MetadataLoaded { run_id: 7, .. }),
                 "expected MetadataLoaded, got {action:?}"
             );
         }
@@ -439,14 +417,7 @@ mod tests {
 
             let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
-                matches!(
-                    action,
-                    Action::MetadataLoaded {
-                        ref dsn,
-                        run_id: 7,
-                        ..
-                    } if dsn == "dsn://miss"
-                ),
+                matches!(action, Action::MetadataLoaded { run_id: 7, .. }),
                 "expected MetadataLoaded, got {action:?}"
             );
         }
@@ -484,14 +455,7 @@ mod tests {
 
             let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
-                matches!(
-                    action,
-                    Action::MetadataFailed {
-                        ref dsn,
-                        run_id: 7,
-                        ..
-                    } if dsn == "dsn://err"
-                ),
+                matches!(action, Action::MetadataFailed { run_id: 7, .. }),
                 "expected MetadataFailed, got {action:?}"
             );
         }
@@ -534,10 +498,9 @@ mod tests {
             assert!(matches!(
                 action,
                 Action::EffectiveUserLoaded {
-                    ref dsn,
                     run_id: 7,
                     effective_user: None,
-                } if dsn == "dsn://test"
+                }
             ));
         }
     }

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -164,7 +164,6 @@ pub async fn run(
                             match plan_result {
                                 Ok(plan_text) => {
                                     tx.send(Action::ExplainCompleted {
-                                        dsn,
                                         database_type,
                                         database_generation,
                                         run_id,
@@ -178,7 +177,6 @@ pub async fn run(
                                 }
                                 Err(error) => {
                                     tx.send(Action::ExplainFailed {
-                                        dsn,
                                         database_generation,
                                         run_id,
                                         error,
@@ -191,7 +189,6 @@ pub async fn run(
                         }
                         Err(e) => {
                             tx.send(Action::ExplainFailed {
-                                dsn,
                                 database_generation,
                                 run_id,
                                 error: e,
@@ -298,7 +295,6 @@ pub async fn run(
                                 );
                             }
                             tx.send(Action::ExecuteWriteSucceeded {
-                                dsn,
                                 run_id,
                                 affected_rows: result.affected_rows,
                                 diagnostics: result.diagnostics,
@@ -317,13 +313,9 @@ pub async fn run(
                                     None,
                                 );
                             }
-                            tx.send(Action::ExecuteWriteFailed {
-                                dsn,
-                                run_id,
-                                error: e,
-                            })
-                            .await
-                            .ok();
+                            tx.send(Action::ExecuteWriteFailed { run_id, error: e })
+                                .await
+                                .ok();
                         }
                     }
                 })
@@ -348,7 +340,6 @@ pub async fn run(
                     match result {
                         Ok(path) => {
                             tx.send(Action::CsvExportSucceeded {
-                                dsn,
                                 run_id,
                                 path: path.display().to_string(),
                                 row_count: None,
@@ -357,13 +348,9 @@ pub async fn run(
                             .ok();
                         }
                         Err(e) => {
-                            tx.send(Action::CsvExportFailed {
-                                dsn,
-                                run_id,
-                                error: e,
-                            })
-                            .await
-                            .ok();
+                            tx.send(Action::CsvExportFailed { run_id, error: e })
+                                .await
+                                .ok();
                         }
                     }
                 })
@@ -371,12 +358,12 @@ pub async fn run(
         }
 
         Effect::ExportCsvFromCache {
-            dsn,
             run_id,
             file_name,
             columns,
             values,
             row_count,
+            ..
         } => {
             let tx = action_tx.clone();
             let exporter = Arc::clone(cached_result_exporter);
@@ -390,7 +377,6 @@ pub async fn run(
                     match result {
                         Ok(path) => {
                             tx.send(Action::CsvExportSucceeded {
-                                dsn,
                                 run_id,
                                 path: path.display().to_string(),
                                 row_count,
@@ -399,7 +385,7 @@ pub async fn run(
                             .ok();
                         }
                         Err(error) => {
-                            tx.send(Action::CsvExportFailed { dsn, run_id, error })
+                            tx.send(Action::CsvExportFailed { run_id, error })
                                 .await
                                 .ok();
                         }

--- a/src/app/cmd/sqlite_diagnostics.rs
+++ b/src/app/cmd/sqlite_diagnostics.rs
@@ -44,12 +44,10 @@ pub(crate) async fn run(
                 .replace(async move {
                     let action = match provider.fetch_core_diagnostics(&dsn).await {
                         Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
-                            dsn,
                             run_id,
                             snapshot: Box::new(snapshot),
                         },
                         Err(error) => Action::SqliteDiagnosticsCoreLoaded {
-                            dsn,
                             run_id,
                             snapshot: Box::new(SqliteDiagnosticsSnapshot::core_fetch_failed(
                                 DiagnosticField::err(error.masked_details()),
@@ -69,7 +67,6 @@ pub(crate) async fn run(
                     let quick_check = provider.fetch_quick_check(&dsn).await;
                     let _ = action_tx
                         .send(Action::SqliteDiagnosticsQuickCheckLoaded {
-                            dsn,
                             run_id,
                             quick_check,
                         })

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -459,8 +459,8 @@ impl AppState {
         !self.session.dsn_matches(dsn) || !self.query.is_current_run(run_id)
     }
 
-    pub fn is_stale_explain_run(&self, dsn: &str, database_generation: u64, run_id: u64) -> bool {
-        self.is_stale_query_run(dsn, run_id)
+    pub fn is_stale_explain_run(&self, database_generation: u64, run_id: u64) -> bool {
+        !self.query.is_current_run(run_id)
             || self.session.database_generation() != database_generation
     }
 }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -433,12 +433,10 @@ pub enum Action {
     // SQLite diagnostics
     RunSqliteDiagnosticsQuickCheck,
     SqliteDiagnosticsCoreLoaded {
-        dsn: String,
         run_id: u64,
         snapshot: Box<SqliteDiagnosticsSnapshot>,
     },
     SqliteDiagnosticsQuickCheckLoaded {
-        dsn: String,
         run_id: u64,
         quick_check: DiagnosticField,
     },
@@ -458,17 +456,14 @@ pub enum Action {
     // Database structure
     ReloadMetadata,
     MetadataLoaded {
-        dsn: String,
         run_id: u64,
         metadata: Arc<DatabaseMetadata>,
     },
     MetadataFailed {
-        dsn: String,
         run_id: u64,
         error: DbOperationError,
     },
     EffectiveUserLoaded {
-        dsn: String,
         run_id: u64,
         effective_user: Option<String>,
     },
@@ -564,7 +559,6 @@ pub enum Action {
     ExplainAnalyzeConfirm,
     ExplainAnalyzeCancel,
     ExplainCompleted {
-        dsn: String,
         database_type: DatabaseType,
         database_generation: u64,
         run_id: u64,
@@ -574,7 +568,6 @@ pub enum Action {
         execution_time_ms: u64,
     },
     ExplainFailed {
-        dsn: String,
         database_generation: u64,
         run_id: u64,
         error: DbOperationError,
@@ -599,13 +592,11 @@ pub enum Action {
         generation: u64,
     },
     ExecuteWriteSucceeded {
-        dsn: String,
         run_id: u64,
         affected_rows: usize,
         diagnostics: Vec<DatabaseDiagnostic>,
     },
     ExecuteWriteFailed {
-        dsn: String,
         run_id: u64,
         error: DbOperationError,
     },
@@ -649,13 +640,11 @@ pub enum Action {
     // CSV export
     RequestCsvExport,
     CsvExportSucceeded {
-        dsn: String,
         run_id: u64,
         path: String,
         row_count: Option<usize>,
     },
     CsvExportFailed {
-        dsn: String,
         run_id: u64,
         error: DbOperationError,
     },
@@ -982,7 +971,6 @@ mod tests {
     fn completion_actions_keep_feature_requirements() {
         assert_eq!(
             Action::ExplainCompleted {
-                dsn: "dsn".to_string(),
                 database_type: DatabaseType::PostgreSQL,
                 database_generation: 0,
                 run_id: 1,
@@ -996,7 +984,6 @@ mod tests {
         );
         assert_eq!(
             Action::ExplainFailed {
-                dsn: "dsn".to_string(),
                 database_generation: 0,
                 run_id: 1,
                 error: DbOperationError::QueryFailed("error".to_string()),
@@ -1007,7 +994,6 @@ mod tests {
         );
         assert_eq!(
             Action::SqliteDiagnosticsCoreLoaded {
-                dsn: "sqlite://test.db".to_string(),
                 run_id: 1,
                 snapshot: Box::new(SqliteDiagnosticsSnapshot::default()),
             }

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -18,14 +18,13 @@ pub(super) fn reduce_loading(
     now: Instant,
 ) -> DispatchResult {
     match action {
-        Action::MetadataLoaded {
-            dsn,
-            run_id,
-            metadata,
-        } => {
-            if !state.session.dsn_matches(dsn) || !state.session.is_current_metadata_run(*run_id) {
+        Action::MetadataLoaded { run_id, metadata } => {
+            if !state.session.is_current_metadata_run(*run_id) {
                 return DispatchResult::handled();
             }
+            let Some(dsn) = state.session.dsn().map(String::from) else {
+                return DispatchResult::handled();
+            };
 
             let has_tables = !metadata.table_summaries.is_empty();
             state.session.mark_connected(Arc::clone(metadata));
@@ -58,7 +57,7 @@ pub(super) fn reduce_loading(
                     ));
                     let detail_run_id = state.session.begin_table_detail_run();
                     effects.push(Effect::FetchTableDetail {
-                        dsn: dsn.clone(),
+                        dsn,
                         schema: state.query.pagination.schema().to_string(),
                         table: state.query.pagination.table().to_string(),
                         generation,
@@ -91,13 +90,10 @@ pub(super) fn reduce_loading(
             DispatchResult::handled_with(effects)
         }
         Action::EffectiveUserLoaded {
-            dsn,
             run_id,
             effective_user,
         } => {
-            if !state.session.dsn_matches(dsn)
-                || !state.session.is_current_effective_user_run(*run_id)
-            {
+            if !state.session.is_current_effective_user_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -106,8 +102,8 @@ pub(super) fn reduce_loading(
                 .mark_effective_user_loaded(effective_user.clone());
             DispatchResult::handled()
         }
-        Action::MetadataFailed { dsn, run_id, error } => {
-            if !state.session.dsn_matches(dsn) || !state.session.is_current_metadata_run(*run_id) {
+        Action::MetadataFailed { run_id, error } => {
+            if !state.session.is_current_metadata_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -193,9 +189,8 @@ mod tests {
         (generation, run_id)
     }
 
-    fn metadata_failed(dsn: &str, run_id: u64) -> Action {
+    fn metadata_failed(run_id: u64) -> Action {
         Action::MetadataFailed {
-            dsn: dsn.to_string(),
             run_id,
             error: DbOperationError::PermissionDenied("metadata refresh failed".to_string()),
         }
@@ -205,9 +200,8 @@ mod tests {
     fn metadata_failure_terminates_initial_loading_detail() {
         let mut state = connected_state(DatabaseType::PostgreSQL);
         let (generation, run_id) = loading_detail_and_metadata_run(&mut state);
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
 
-        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+        let effects = reduce_loading(&mut state, &metadata_failed(run_id), Instant::now())
             .into_effects()
             .expect("metadata failure should be handled");
 
@@ -235,7 +229,7 @@ mod tests {
         )));
         let result_generation = state.query.result_generation();
 
-        reduce_loading(&mut state, &metadata_failed(dsn, run_id), Instant::now());
+        reduce_loading(&mut state, &metadata_failed(run_id), Instant::now());
 
         assert!(state.query.current_result().is_none());
         assert_eq!(state.query.result_generation(), result_generation + 1);
@@ -263,9 +257,7 @@ mod tests {
             TableDetailState::Loading
         ));
         let run_id = state.session.begin_metadata_refresh();
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
-
-        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+        let effects = reduce_loading(&mut state, &metadata_failed(run_id), Instant::now())
             .into_effects()
             .expect("metadata failure should be handled");
 
@@ -281,7 +273,6 @@ mod tests {
     fn metadata_failure_reveals_pending_preview_after_terminalizing_detail() {
         let mut state = connected_state(DatabaseType::SQLite);
         let (generation, run_id) = loading_detail_and_metadata_run(&mut state);
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
         state.query.defer_preview(
             Arc::new(QueryResult::error(
                 "SELECT * FROM public.users".to_string(),
@@ -294,7 +285,7 @@ mod tests {
             false,
         );
 
-        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+        let effects = reduce_loading(&mut state, &metadata_failed(run_id), Instant::now())
             .into_effects()
             .expect("metadata failure should be handled");
 
@@ -321,7 +312,6 @@ mod tests {
     fn reload_failure_terminates_detail_owned_by_metadata_refresh() {
         let mut state = connected_state(DatabaseType::PostgreSQL);
         let (generation, _) = loading_detail_and_metadata_run(&mut state);
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
         state.query.defer_preview(
             Arc::new(QueryResult::error(
                 "SELECT * FROM public.users".to_string(),
@@ -339,7 +329,7 @@ mod tests {
             .expect("metadata reload should be handled");
         let run_id = state.session.metadata_generation();
 
-        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+        let effects = reduce_loading(&mut state, &metadata_failed(run_id), Instant::now())
             .into_effects()
             .expect("metadata failure should be handled");
 
@@ -371,9 +361,7 @@ mod tests {
             .into_effects()
             .expect("metadata reload should be handled");
         let run_id = state.session.metadata_generation();
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
-
-        let effects = reduce_loading(&mut state, &metadata_failed(&dsn, run_id), Instant::now())
+        let effects = reduce_loading(&mut state, &metadata_failed(run_id), Instant::now())
             .into_effects()
             .expect("metadata failure should be handled");
 
@@ -399,15 +387,10 @@ mod tests {
         let generation = state
             .session
             .select_table("public", "orders", &mut state.query);
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
 
-        let effects = reduce_loading(
-            &mut state,
-            &metadata_failed(&dsn, stale_run_id),
-            Instant::now(),
-        )
-        .into_effects()
-        .expect("stale metadata failure should be handled");
+        let effects = reduce_loading(&mut state, &metadata_failed(stale_run_id), Instant::now())
+            .into_effects()
+            .expect("stale metadata failure should be handled");
 
         assert!(effects.is_empty());
         assert!(matches!(
@@ -429,15 +412,10 @@ mod tests {
             .select_table("main", "orders", &mut state.query);
         let detail = table::minimal("main", "orders");
         assert!(state.session.set_table_detail(detail, generation));
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
 
-        let effects = reduce_loading(
-            &mut state,
-            &metadata_failed(&dsn, stale_run_id),
-            Instant::now(),
-        )
-        .into_effects()
-        .expect("stale metadata failure should be handled");
+        let effects = reduce_loading(&mut state, &metadata_failed(stale_run_id), Instant::now())
+            .into_effects()
+            .expect("stale metadata failure should be handled");
 
         assert!(effects.is_empty());
         assert!(matches!(
@@ -468,11 +446,10 @@ mod tests {
             .into_effects()
             .expect("metadata reload should be handled");
         let metadata_run_id = state.session.metadata_generation();
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
 
         let effects = reduce_loading(
             &mut state,
-            &metadata_failed(&dsn, metadata_run_id),
+            &metadata_failed(metadata_run_id),
             Instant::now(),
         )
         .into_effects()
@@ -492,15 +469,10 @@ mod tests {
         let mut state = connected_state(DatabaseType::MySQL);
         let (generation, stale_run_id) = loading_detail_and_metadata_run(&mut state);
         let current_run_id = state.session.begin_metadata_refresh();
-        let dsn = state.session.dsn().expect("connected DSN").to_string();
 
-        let effects = reduce_loading(
-            &mut state,
-            &metadata_failed(&dsn, stale_run_id),
-            Instant::now(),
-        )
-        .into_effects()
-        .expect("stale metadata failure should be handled");
+        let effects = reduce_loading(&mut state, &metadata_failed(stale_run_id), Instant::now())
+            .into_effects()
+            .expect("stale metadata failure should be handled");
 
         assert!(effects.is_empty());
         assert!(matches!(

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -127,13 +127,13 @@ mod tests {
         #[test]
         fn stale_metadata_loaded_does_not_replace_current_state() {
             let mut state = state_with_dsn("postgres://localhost/new");
-            let run_id = state.session.begin_metadata_refresh();
+            let stale_run_id = state.session.begin_metadata_refresh();
+            let _current_run_id = state.session.begin_metadata_refresh();
 
             let effects = dispatch_metadata(
                 &mut state,
                 &Action::MetadataLoaded {
-                    dsn: "postgres://localhost/old".to_string(),
-                    run_id,
+                    run_id: stale_run_id,
                     metadata: metadata_with_users(),
                 },
                 Instant::now(),
@@ -206,7 +206,6 @@ mod tests {
             dispatch_metadata(
                 &mut state,
                 &Action::MetadataFailed {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: metadata_run_id,
                     error: DbOperationError::PermissionDenied("denied".to_string()),
                 },
@@ -981,11 +980,7 @@ mod tests {
 
         fn metadata_loaded_action(state: &mut AppState, metadata: Arc<DatabaseMetadata>) -> Action {
             let run_id = state.session.begin_metadata_refresh();
-            Action::MetadataLoaded {
-                dsn: "postgres://localhost/test".to_string(),
-                run_id,
-                metadata,
-            }
+            Action::MetadataLoaded { run_id, metadata }
         }
 
         #[test]
@@ -1020,7 +1015,6 @@ mod tests {
             let effects = dispatch_metadata(
                 &mut state,
                 &Action::MetadataLoaded {
-                    dsn: "sqlite:///tmp/test.db".to_string(),
                     run_id: metadata_run_id,
                     metadata: make_metadata(vec![("public", "orders")]),
                 },

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1805,11 +1805,7 @@ mod tests {
 
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
             let run_id = state.session.begin_metadata_refresh();
-            let action = Action::MetadataLoaded {
-                dsn: "postgres://localhost/test".to_string(),
-                run_id,
-                metadata,
-            };
+            let action = Action::MetadataLoaded { run_id, metadata };
             let meta_effects = dispatch_metadata(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(state.ui.explorer_selected(), 1);
@@ -1842,11 +1838,7 @@ mod tests {
 
             let metadata = make_metadata(vec![("public", "orders")]);
             let run_id = state.session.begin_metadata_refresh();
-            let action = Action::MetadataLoaded {
-                dsn: "postgres://localhost/test".to_string(),
-                run_id,
-                metadata,
-            };
+            let action = Action::MetadataLoaded { run_id, metadata };
             dispatch_metadata(&mut state, &action, Instant::now());
 
             assert!(state.query.pagination.table().is_empty());

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -639,6 +639,32 @@ mod tests {
         }
 
         #[test]
+        fn stale_export_success_after_connection_switch_is_ignored() {
+            let mut state = create_test_state();
+            let stale_run_id = begin_query_run(&mut state);
+
+            state.session.reset(&mut state.query);
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/other");
+            let current_run_id = begin_query_run(&mut state);
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::CsvExportSucceeded {
+                    run_id: stale_run_id,
+                    path: "/tmp/stale-export.csv".to_string(),
+                    row_count: Some(1),
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(stale_run_id < current_run_id);
+            assert!(effects.is_empty());
+            assert!(state.query.is_running());
+            assert!(state.messages.last_success.is_none());
+        }
+
+        #[test]
         fn export_failed_sets_error_message() {
             let mut state = create_test_state();
             let action = csv_failed_action(
@@ -653,6 +679,31 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("Query failed: psql error. Review the database error details and SQL.")
             );
+        }
+
+        #[test]
+        fn stale_export_failure_after_connection_switch_is_ignored() {
+            let mut state = create_test_state();
+            let stale_run_id = begin_query_run(&mut state);
+
+            state.session.reset(&mut state.query);
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/other");
+            let current_run_id = begin_query_run(&mut state);
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::CsvExportFailed {
+                    run_id: stale_run_id,
+                    error: DbOperationError::QueryFailed("stale export".to_string()),
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(stale_run_id < current_run_id);
+            assert!(effects.is_empty());
+            assert!(state.query.is_running());
+            assert!(state.messages.last_error.is_none());
         }
 
         #[test]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -157,12 +157,11 @@ pub fn reduce_pagination(state: &mut AppState, action: &Action, now: Instant) ->
         }
 
         Action::CsvExportSucceeded {
-            dsn,
             run_id,
             path,
             row_count,
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -178,8 +177,8 @@ pub fn reduce_pagination(state: &mut AppState, action: &Action, now: Instant) ->
             DispatchResult::handled_with(vec![Effect::OpenFolder { path: folder }])
         }
 
-        Action::CsvExportFailed { dsn, run_id, error } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+        Action::CsvExportFailed { run_id, error } => {
+            if !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -260,7 +259,6 @@ mod tests {
     fn csv_succeeded_action(state: &mut AppState, path: &str, row_count: Option<usize>) -> Action {
         let run_id = begin_query_run(state);
         Action::CsvExportSucceeded {
-            dsn: "postgres://localhost/test".to_string(),
             run_id,
             path: path.to_string(),
             row_count,
@@ -269,11 +267,7 @@ mod tests {
 
     fn csv_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
         let run_id = begin_query_run(state);
-        Action::CsvExportFailed {
-            dsn: "postgres://localhost/test".to_string(),
-            run_id,
-            error,
-        }
+        Action::CsvExportFailed { run_id, error }
     }
 
     fn preview_result_with_two_columns(row_count: usize) -> Arc<QueryResult> {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1424,6 +1424,41 @@ mod tests {
             assert!(state.messages.last_success.is_none());
             assert!(state.query.is_running());
         }
+
+        #[test]
+        fn stale_write_failure_does_not_change_error_modal_or_refresh_target() {
+            let mut state = editable_state();
+            let target = DeleteRefreshTarget {
+                target_page: 1,
+                target_row: Some(2),
+                expected_delete_count: 1,
+            };
+            state.query.set_delete_refresh_target(
+                target.target_page,
+                target.target_row,
+                target.expected_delete_count,
+            );
+            let stale_run_id = begin_query_run(&mut state);
+            let current_run_id = begin_query_run(&mut state);
+            let input_mode = state.input_mode();
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::ExecuteWriteFailed {
+                    run_id: stale_run_id,
+                    error: DbOperationError::QueryFailed("stale write".to_string()),
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(stale_run_id < current_run_id);
+            assert!(effects.is_empty());
+            assert!(state.query.is_running());
+            assert_eq!(state.input_mode(), input_mode);
+            assert_eq!(state.query.pending_delete_refresh_target(), Some(target));
+            assert!(state.messages.last_error.is_none());
+        }
     }
 
     mod delete_write_flow {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -207,12 +207,11 @@ pub fn reduce_write(state: &mut AppState, action: &Action, now: Instant) -> Disp
         }
 
         Action::ExecuteWriteSucceeded {
-            dsn,
             run_id,
             affected_rows,
             diagnostics,
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -304,8 +303,8 @@ pub fn reduce_write(state: &mut AppState, action: &Action, now: Instant) -> Disp
             }
         }
 
-        Action::ExecuteWriteFailed { dsn, run_id, error } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+        Action::ExecuteWriteFailed { run_id, error } => {
+            if !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -431,13 +430,8 @@ mod tests {
         affected_rows: usize,
         diagnostics: Vec<DatabaseDiagnostic>,
     ) -> Action {
-        let dsn = state
-            .session
-            .dsn()
-            .map_or_else(|| "postgres://localhost/test".to_string(), str::to_string);
         let run_id = begin_query_run(state);
         Action::ExecuteWriteSucceeded {
-            dsn,
             run_id,
             affected_rows,
             diagnostics,
@@ -446,11 +440,7 @@ mod tests {
 
     fn write_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
         let run_id = begin_query_run(state);
-        Action::ExecuteWriteFailed {
-            dsn: "postgres://localhost/test".to_string(),
-            run_id,
-            error,
-        }
+        Action::ExecuteWriteFailed { run_id, error }
     }
 
     mod write_flow {
@@ -1297,7 +1287,6 @@ mod tests {
             let effects = dispatch_query(
                 &mut state,
                 &Action::ExecuteWriteSucceeded {
-                    dsn: "mysql://localhost/test".to_string(),
                     run_id,
                     affected_rows: 0,
                     diagnostics: Vec::new(),
@@ -1423,7 +1412,6 @@ mod tests {
             let effects = dispatch_query(
                 &mut state,
                 &Action::ExecuteWriteSucceeded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: old_run_id,
                     affected_rows: 1,
                     diagnostics: Vec::new(),

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -52,11 +52,7 @@ pub(super) fn connection_save_fetch_effects(
     metadata: Option<Arc<DatabaseMetadata>>,
 ) -> Vec<Effect> {
     let metadata_effect = if let Some(metadata) = metadata {
-        Effect::DispatchActions(vec![Action::MetadataLoaded {
-            dsn: dsn.to_string(),
-            run_id,
-            metadata,
-        }])
+        Effect::DispatchActions(vec![Action::MetadataLoaded { run_id, metadata }])
     } else {
         Effect::FetchMetadata {
             dsn: dsn.to_string(),

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1163,7 +1163,6 @@ mod tests {
             let refresh_effects = reduce_app(
                 &mut state,
                 Action::MetadataLoaded {
-                    dsn: "mysql://user@localhost:3306/app".to_string(),
                     run_id: metadata_run_id,
                     metadata: refreshed_metadata,
                 },
@@ -1279,7 +1278,7 @@ mod tests {
             reduce(
                 &mut state,
                 &Action::MySqlConnectionProbeCompleted {
-                    target: target.clone(),
+                    target,
                     run_id: probe_run_id,
                     lower_case_table_names: 0,
                 },
@@ -1288,7 +1287,6 @@ mod tests {
             reduce_app(
                 &mut state,
                 Action::MetadataLoaded {
-                    dsn: target.dsn,
                     run_id: stale_run_id,
                     metadata: Arc::new(DatabaseMetadata::new("stale".to_string())),
                 },
@@ -1608,7 +1606,7 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 &Action::MySqlConnectionProbeCompleted {
-                    target: target.clone(),
+                    target,
                     run_id: probe_run_id,
                     lower_case_table_names: 0,
                 },
@@ -1635,7 +1633,6 @@ mod tests {
             let error_effects = reduce_app(
                 &mut state,
                 Action::MetadataFailed {
-                    dsn: target.dsn,
                     run_id: metadata_run_id,
                     error: DbOperationError::ConnectionFailed("connection refused".to_string()),
                 },
@@ -1662,8 +1659,7 @@ mod tests {
                 database_type: DatabaseType::PostgreSQL,
                 database: None,
             };
-            let postgres_effects =
-                reduce(&mut state, &Action::SwitchConnection(postgres.clone())).unwrap();
+            let postgres_effects = reduce(&mut state, &Action::SwitchConnection(postgres)).unwrap();
             let postgres_run_id = postgres_effects
                 .iter()
                 .find_map(|effect| match effect {
@@ -1692,7 +1688,6 @@ mod tests {
             reduce(
                 &mut state,
                 &Action::MetadataFailed {
-                    dsn: postgres.dsn,
                     run_id: postgres_run_id,
                     error: DbOperationError::ConnectionFailed("stale postgres".to_string()),
                 },

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -989,7 +989,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
-                    dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
                     database_generation,
                     run_id: 1,
@@ -1018,7 +1017,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
-                    dsn: "mysql://test".to_string(),
                     database_type: DatabaseType::MySQL,
                     database_generation,
                     run_id: 1,
@@ -1040,10 +1038,11 @@ mod tests {
         }
 
         #[test]
-        fn mismatched_dsn_does_not_replace_plan() {
+        fn stale_run_does_not_replace_plan() {
             let mut state = sql_modal_state();
             test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
-            let _ = state.query.begin_running(Instant::now());
+            let stale_run_id = state.query.begin_running(Instant::now());
+            let _current_run_id = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             let database_generation = state.session.database_generation();
             state.explain.set_plan(
@@ -1057,10 +1056,9 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
-                    dsn: "dsn://stale".to_string(),
                     database_type: DatabaseType::PostgreSQL,
                     database_generation,
-                    run_id: 1,
+                    run_id: stale_run_id,
                     query: "SELECT stale".to_string(),
                     plan_text: "Stale".to_string(),
                     is_analyze: false,
@@ -1102,7 +1100,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
-                    dsn: "mysql://test".to_string(),
                     database_type: DatabaseType::MySQL,
                     database_generation,
                     run_id,
@@ -1134,7 +1131,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainFailed {
-                    dsn: "dsn://test".to_string(),
                     database_generation,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
@@ -1153,10 +1149,11 @@ mod tests {
         }
 
         #[test]
-        fn mismatched_dsn_does_not_replace_plan_with_error() {
+        fn stale_run_does_not_replace_plan_with_error() {
             let mut state = sql_modal_state();
             test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
-            let _ = state.query.begin_running(Instant::now());
+            let stale_run_id = state.query.begin_running(Instant::now());
+            let _current_run_id = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             let database_generation = state.session.database_generation();
             state.explain.set_plan(
@@ -1170,9 +1167,8 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainFailed {
-                    dsn: "dsn://stale".to_string(),
                     database_generation,
-                    run_id: 1,
+                    run_id: stale_run_id,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
                     is_analyze: false,
                 },
@@ -1221,7 +1217,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainFailed {
-                    dsn: "mysql://test".to_string(),
                     database_generation,
                     run_id,
                     error: DbOperationError::QueryFailed("stale error".to_string()),
@@ -1287,7 +1282,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
-                    dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
                     database_generation,
                     run_id: 1,
@@ -1308,7 +1302,6 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
-                    dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
                     database_generation,
                     run_id: 2,

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -13,7 +13,6 @@ pub(super) fn reduce_output(
 ) -> DispatchResult {
     match action {
         Action::ExplainCompleted {
-            dsn,
             database_type,
             database_generation,
             run_id,
@@ -22,7 +21,7 @@ pub(super) fn reduce_output(
             is_analyze,
             execution_time_ms,
         } => {
-            if state.is_stale_explain_run(dsn, *database_generation, *run_id) {
+            if state.is_stale_explain_run(*database_generation, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_success(
@@ -37,13 +36,12 @@ pub(super) fn reduce_output(
         }
 
         Action::ExplainFailed {
-            dsn,
             database_generation,
             run_id,
             error,
             ..
         } => {
-            if state.is_stale_explain_run(dsn, *database_generation, *run_id) {
+            if state.is_stale_explain_run(*database_generation, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_error(state, error.user_message());

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -37,13 +37,8 @@ pub(super) fn reduce_sqlite_diagnostics(
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled_with(vec![Effect::CancelSqliteDiagnostics])
         }
-        Action::SqliteDiagnosticsCoreLoaded {
-            dsn,
-            run_id,
-            snapshot,
-        } => {
-            if !state.session.dsn_matches(dsn) || !state.sqlite_diagnostics.is_current_run(*run_id)
-            {
+        Action::SqliteDiagnosticsCoreLoaded { run_id, snapshot } => {
+            if !state.sqlite_diagnostics.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             state
@@ -52,12 +47,10 @@ pub(super) fn reduce_sqlite_diagnostics(
             DispatchResult::handled()
         }
         Action::SqliteDiagnosticsQuickCheckLoaded {
-            dsn,
             run_id,
             quick_check,
         } => {
-            if !state.session.dsn_matches(dsn) || !state.sqlite_diagnostics.is_current_run(*run_id)
-            {
+            if !state.sqlite_diagnostics.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             state
@@ -234,7 +227,6 @@ mod tests {
         reduce_sqlite_diagnostics(
             &mut state,
             &Action::SqliteDiagnosticsQuickCheckLoaded {
-                dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: run_id + 1,
                 quick_check: DiagnosticField::ok("ok"),
             },

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -215,33 +215,51 @@ mod tests {
     fn quick_check_loaded_ignores_stale_run_id() {
         let mut state = AppState::new("test".to_string());
         test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
-        let run_id = state.sqlite_diagnostics.begin_core_fetch();
+        let stale_run_id = state.sqlite_diagnostics.begin_core_fetch();
         state.sqlite_diagnostics.set_core_loaded(
-            run_id,
+            stale_run_id,
             SqliteDiagnosticsSnapshot {
                 quick_check: DiagnosticField::Pending,
                 ..Default::default()
             },
         );
+        let current_run_id = state.sqlite_diagnostics.begin_core_fetch();
 
         reduce_sqlite_diagnostics(
             &mut state,
             &Action::SqliteDiagnosticsQuickCheckLoaded {
-                run_id: run_id + 1,
+                run_id: stale_run_id,
                 quick_check: DiagnosticField::ok("ok"),
             },
             Instant::now(),
         )
         .unwrap();
 
-        assert!(
-            state
-                .sqlite_diagnostics
-                .snapshot()
-                .unwrap()
-                .quick_check
-                .is_pending()
-        );
+        assert!(stale_run_id < current_run_id);
+        assert!(state.sqlite_diagnostics.snapshot().is_none());
+        assert!(state.sqlite_diagnostics.is_loading());
+    }
+
+    #[test]
+    fn core_loaded_ignores_stale_run_id_after_new_fetch() {
+        let mut state = AppState::new("test".to_string());
+        test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        let stale_run_id = state.sqlite_diagnostics.begin_core_fetch();
+        let current_run_id = state.sqlite_diagnostics.begin_core_fetch();
+
+        reduce_sqlite_diagnostics(
+            &mut state,
+            &Action::SqliteDiagnosticsCoreLoaded {
+                run_id: stale_run_id,
+                snapshot: Box::new(SqliteDiagnosticsSnapshot::default()),
+            },
+            Instant::now(),
+        )
+        .unwrap();
+
+        assert!(stale_run_id < current_run_id);
+        assert!(state.sqlite_diagnostics.snapshot().is_none());
+        assert!(state.sqlite_diagnostics.is_loading());
     }
 
     #[test]

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -215,6 +215,7 @@ mod tests {
     fn quick_check_loaded_ignores_stale_run_id() {
         let mut state = AppState::new("test".to_string());
         test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        state.modal.set_mode(InputMode::SqliteDiagnostics);
         let stale_run_id = state.sqlite_diagnostics.begin_core_fetch();
         state.sqlite_diagnostics.set_core_loaded(
             stale_run_id,
@@ -223,12 +224,25 @@ mod tests {
                 ..Default::default()
             },
         );
+        let stale_quick_check_run_id = state
+            .sqlite_diagnostics
+            .begin_quick_check()
+            .expect("loaded diagnostics should start quick check");
+        state.sqlite_diagnostics.clear();
         let current_run_id = state.sqlite_diagnostics.begin_core_fetch();
+        let current_snapshot = SqliteDiagnosticsSnapshot {
+            quick_check: DiagnosticField::ok("current result"),
+            ..Default::default()
+        };
+        state
+            .sqlite_diagnostics
+            .set_core_loaded(current_run_id, current_snapshot.clone());
+        let quick_check_running_before = state.sqlite_diagnostics.is_quick_check_running();
 
         reduce_sqlite_diagnostics(
             &mut state,
             &Action::SqliteDiagnosticsQuickCheckLoaded {
-                run_id: stale_run_id,
+                run_id: stale_quick_check_run_id,
                 quick_check: DiagnosticField::ok("ok"),
             },
             Instant::now(),
@@ -236,15 +250,25 @@ mod tests {
         .unwrap();
 
         assert!(stale_run_id < current_run_id);
-        assert!(state.sqlite_diagnostics.snapshot().is_none());
-        assert!(state.sqlite_diagnostics.is_loading());
+        assert!(stale_quick_check_run_id < current_run_id);
+        assert_eq!(state.sqlite_diagnostics.snapshot(), Some(&current_snapshot));
+        assert_eq!(
+            state.sqlite_diagnostics.is_quick_check_running(),
+            quick_check_running_before
+        );
+        assert_eq!(state.input_mode(), InputMode::SqliteDiagnostics);
     }
 
     #[test]
     fn core_loaded_ignores_stale_run_id_after_new_fetch() {
         let mut state = AppState::new("test".to_string());
         test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        state.modal.set_mode(InputMode::SqliteDiagnostics);
         let stale_run_id = state.sqlite_diagnostics.begin_core_fetch();
+        state
+            .sqlite_diagnostics
+            .set_core_loaded(stale_run_id, SqliteDiagnosticsSnapshot::default());
+        state.sqlite_diagnostics.clear();
         let current_run_id = state.sqlite_diagnostics.begin_core_fetch();
 
         reduce_sqlite_diagnostics(
@@ -260,6 +284,8 @@ mod tests {
         assert!(stale_run_id < current_run_id);
         assert!(state.sqlite_diagnostics.snapshot().is_none());
         assert!(state.sqlite_diagnostics.is_loading());
+        assert!(!state.sqlite_diagnostics.is_quick_check_running());
+        assert_eq!(state.input_mode(), InputMode::SqliteDiagnostics);
     }
 
     #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -491,7 +491,6 @@ mod tests {
             assert_unsupported_action_is_a_noop(
                 &mut explain_state,
                 Action::ExplainCompleted {
-                    dsn: "sqlite://test.db".to_string(),
                     database_type: DatabaseType::SQLite,
                     database_generation: 0,
                     run_id: 1,
@@ -505,7 +504,6 @@ mod tests {
             assert_unsupported_action_is_a_noop(
                 &mut explain_state,
                 Action::ExplainFailed {
-                    dsn: "sqlite://test.db".to_string(),
                     database_generation: 0,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("error".to_string()),
@@ -518,7 +516,6 @@ mod tests {
             assert_unsupported_action_is_a_noop(
                 &mut diagnostics_state,
                 Action::SqliteDiagnosticsCoreLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     snapshot: Box::new(SqliteDiagnosticsSnapshot {
                         quick_check: DiagnosticField::ok("ok"),
@@ -1159,7 +1156,6 @@ mod tests {
             test_fixtures::activate_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
-                dsn: "postgres://localhost/test".to_string(),
                 run_id,
                 metadata: Arc::new(metadata),
             }
@@ -1168,11 +1164,7 @@ mod tests {
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
             test_fixtures::activate_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
-            Action::MetadataFailed {
-                dsn: "postgres://localhost/test".to_string(),
-                run_id,
-                error,
-            }
+            Action::MetadataFailed { run_id, error }
         }
 
         #[test]
@@ -1213,7 +1205,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::EffectiveUserLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     effective_user: Some("postgres".to_string()),
                 },
@@ -1234,7 +1225,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::EffectiveUserLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: old_run_id,
                     effective_user: Some("old_user".to_string()),
                 },
@@ -1284,7 +1274,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::MetadataFailed {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: reload_run_id,
                     error: DbOperationError::ConnectionFailed("reload failed".to_string()),
                 },
@@ -1298,7 +1287,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::EffectiveUserLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: user_run_id,
                     effective_user: Some("postgres".to_string()),
                 },
@@ -1369,7 +1357,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::MetadataFailed {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     error: DbOperationError::ConnectionFailed("connection refused".to_string()),
                 },
@@ -1710,7 +1697,6 @@ mod tests {
             // Metadata loaded
             let metadata = DatabaseMetadata::new("test".to_string());
             let action = Action::MetadataLoaded {
-                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 metadata: Arc::new(metadata),
             };
@@ -1851,7 +1837,6 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
-                dsn: "postgres://localhost/test".to_string(),
                 run_id,
                 error: DbOperationError::ConnectionFailed("connection refused".to_string()),
             };
@@ -2274,7 +2259,6 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::ExecuteWriteSucceeded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     affected_rows: 1,
                     diagnostics: Vec::new(),
@@ -2347,7 +2331,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::ExecuteWriteFailed {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     error: DbOperationError::QueryFailed("connection lost".to_string()),
                 },
@@ -2470,7 +2453,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::MetadataLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     metadata: Arc::new(metadata),
                 },
@@ -2498,7 +2480,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::MetadataFailed {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     error: DbOperationError::ConnectionFailed("connection refused".to_string()),
                 },
@@ -2534,7 +2515,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::MetadataFailed {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     error: DbOperationError::QueryFailed("permission denied".to_string()),
                 },
@@ -2866,7 +2846,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::EffectiveUserLoaded {
-                    dsn: dsn_a.clone(),
                     run_id: old_a_run_id,
                     effective_user: Some("old_a_user".to_string()),
                 },
@@ -2878,7 +2857,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::EffectiveUserLoaded {
-                    dsn: dsn_a,
                     run_id: new_a_run_id,
                     effective_user: Some("a_user".to_string()),
                 },
@@ -2967,7 +2945,6 @@ mod tests {
             test_fixtures::activate_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
-                dsn: "postgres://localhost/test".to_string(),
                 run_id,
                 metadata: sample_metadata(),
             }
@@ -3240,7 +3217,6 @@ mod tests {
             reduce(
                 &mut state,
                 Action::MetadataLoaded {
-                    dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     metadata: Arc::new(metadata),
                 },

--- a/src/app/update/test_fixtures.rs
+++ b/src/app/update/test_fixtures.rs
@@ -84,7 +84,6 @@ pub fn state_after_delete_success() -> AppState {
     let effects = reduce(
         &mut state,
         Action::ExecuteWriteSucceeded {
-            dsn: "postgres://localhost/test".to_string(),
             run_id,
             affected_rows: 1,
             diagnostics: Vec::new(),


### PR DESCRIPTION
## Summary

- Reduce terminal completion Actions to their aggregate run identity for metadata, effective user, SQLite diagnostics, writes, CSV exports, and EXPLAIN.
- Preserve confirmation DSNs and effect-side connection data; EXPLAIN retains database-generation validation.
- Keep TableDetail and prefetch Actions unchanged.

## Verification

- cargo check -p sabiql-app --all-targets
- cargo test -p sabiql-app --lib (3504 passed, 2 ignored)
- cargo clippy -p sabiql-app --all-targets -- -D warnings
- cargo fmt --all -- --check
- env -u RUSTC_WRAPPER -u CARGO_TARGET_DIR bash scripts/lint_all.sh