### PR TITLE
refactor(app): combine table detail outcomes

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -172,28 +172,18 @@ async fn fetch_table_detail(
 
     table_detail_tasks
         .replace(async move {
-            match provider.fetch_table_detail(&dsn, &schema, &table).await {
-                Ok(detail) => {
-                    tx.send(Action::TableDetailLoaded {
-                        dsn,
-                        run_id,
-                        detail: Box::new(detail),
-                        generation,
-                    })
-                    .await
-                    .ok();
-                }
-                Err(e) => {
-                    tx.send(Action::TableDetailFailed {
-                        dsn,
-                        run_id,
-                        error: e,
-                        generation,
-                    })
-                    .await
-                    .ok();
-                }
-            }
+            let outcome = provider
+                .fetch_table_detail(&dsn, &schema, &table)
+                .await
+                .map(Box::new);
+            tx.send(Action::TableDetailLoaded {
+                dsn,
+                run_id,
+                outcome,
+                generation,
+            })
+            .await
+            .ok();
         })
         .await;
 }
@@ -561,6 +551,7 @@ mod tests {
                         ref dsn,
                         run_id: 9,
                         generation: 1,
+                        outcome: Ok(_),
                         ..
                     } if dsn == "dsn://test"
                 ),

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1504,7 +1504,7 @@ mod tests {
                     &Action::TableDetailLoaded {
                         dsn: "dsn://test".to_string(),
                         run_id,
-                        detail: Box::new(make_table_detail()),
+                        outcome: Ok(Box::new(make_table_detail())),
                         generation,
                     },
                     Instant::now(),

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -470,13 +470,7 @@ pub enum Action {
     TableDetailLoaded {
         dsn: String,
         run_id: u64,
-        detail: Box<Table>,
-        generation: u64,
-    },
-    TableDetailFailed {
-        dsn: String,
-        run_id: u64,
-        error: DbOperationError,
+        outcome: Result<Box<Table>, DbOperationError>,
         generation: u64,
     },
     PrefetchTableDetail {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -156,7 +156,7 @@ mod tests {
                 &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id,
-                    detail: empty_table("public", "users"),
+                    outcome: Ok(empty_table("public", "users")),
                     generation: current_generation,
                 },
                 Instant::now(),
@@ -175,10 +175,10 @@ mod tests {
 
             dispatch_metadata(
                 &mut state,
-                &Action::TableDetailFailed {
+                &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id,
-                    error: DbOperationError::PermissionDenied("denied".to_string()),
+                    outcome: Err(DbOperationError::PermissionDenied("denied".to_string())),
                     generation,
                 },
                 Instant::now(),
@@ -222,7 +222,7 @@ mod tests {
                 &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: detail_run_id,
-                    detail: empty_table("public", "users"),
+                    outcome: Ok(empty_table("public", "users")),
                     generation,
                 },
                 Instant::now(),
@@ -249,10 +249,10 @@ mod tests {
 
             dispatch_metadata(
                 &mut state,
-                &Action::TableDetailFailed {
+                &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: current_run_id,
-                    error: DbOperationError::PermissionDenied("denied".to_string()),
+                    outcome: Err(DbOperationError::PermissionDenied("denied".to_string())),
                     generation: stale_generation,
                 },
                 Instant::now(),

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -14,7 +14,7 @@ pub(super) fn reduce_table_detail(
         Action::TableDetailLoaded {
             dsn,
             run_id,
-            detail,
+            outcome,
             generation,
         } => {
             if !state.session.dsn_matches(dsn)
@@ -23,33 +23,26 @@ pub(super) fn reduce_table_detail(
                 return DispatchResult::handled();
             }
 
-            if state.session.set_table_detail(*detail.clone(), *generation) {
-                state.ui.set_inspector_scroll_offset(0);
-                return DispatchResult::handled_with(reveal_pending_preview(state, *generation));
-            }
-            DispatchResult::handled()
-        }
-        Action::TableDetailFailed {
-            dsn,
-            run_id,
-            error,
-            generation,
-        } => {
-            if !state.session.dsn_matches(dsn)
-                || !state.session.is_current_table_detail_run(*run_id)
-            {
-                return DispatchResult::handled();
-            }
-
-            let message = error.user_message();
-            if state
-                .session
-                .mark_table_detail_failed(*generation, message.clone())
-            {
-                state.messages.set_error(message);
-                return DispatchResult::handled_with(reveal_pending_preview(state, *generation));
-            }
-            DispatchResult::handled()
+            let effects = match outcome {
+                Ok(detail) if state.session.set_table_detail(*detail.clone(), *generation) => {
+                    state.ui.set_inspector_scroll_offset(0);
+                    reveal_pending_preview(state, *generation)
+                }
+                Ok(_) => Vec::new(),
+                Err(error) => {
+                    let message = error.user_message();
+                    if state
+                        .session
+                        .mark_table_detail_failed(*generation, message.clone())
+                    {
+                        state.messages.set_error(message);
+                        reveal_pending_preview(state, *generation)
+                    } else {
+                        Vec::new()
+                    }
+                }
+            };
+            DispatchResult::handled_with(effects)
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -490,17 +490,19 @@ mod tests {
         renderer.frames.clear();
 
         let inspector_action = if inspector_failed {
-            Action::TableDetailFailed {
+            Action::TableDetailLoaded {
                 dsn: active_dsn(&state),
                 run_id: detail_run_id,
-                error: DbOperationError::QueryFailed("inspector failed".to_string()),
+                outcome: Err(DbOperationError::QueryFailed(
+                    "inspector failed".to_string(),
+                )),
                 generation,
             }
         } else {
             Action::TableDetailLoaded {
                 dsn: active_dsn(&state),
                 run_id: detail_run_id,
-                detail: Box::new(users_table_detail()),
+                outcome: Ok(Box::new(users_table_detail())),
                 generation,
             }
         };
@@ -956,7 +958,7 @@ mod tests {
                 &Action::TableDetailLoaded {
                     dsn,
                     run_id: detail_run_id,
-                    detail: Box::new(users_table_detail()),
+                    outcome: Ok(Box::new(users_table_detail())),
                     generation,
                 },
                 now,
@@ -1018,7 +1020,7 @@ mod tests {
                 &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: detail_run_id,
-                    detail: Box::new(users_table_detail()),
+                    outcome: Ok(Box::new(users_table_detail())),
                     generation,
                 },
                 Instant::now(),
@@ -1058,7 +1060,7 @@ mod tests {
                 &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: old_detail_run_id,
-                    detail: Box::new(users_table_detail()),
+                    outcome: Ok(Box::new(users_table_detail())),
                     generation: old_generation,
                 },
                 Instant::now(),
@@ -1088,7 +1090,7 @@ mod tests {
                 &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: new_detail_run_id,
-                    detail: Box::new(users_table_detail()),
+                    outcome: Ok(Box::new(users_table_detail())),
                     generation: new_generation,
                 },
                 Instant::now(),
@@ -1377,10 +1379,12 @@ mod tests {
 
             let effects = dispatch_metadata(
                 &mut state,
-                &Action::TableDetailFailed {
+                &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: detail_run_id,
-                    error: DbOperationError::QueryFailed("inspector failed".to_string()),
+                    outcome: Err(DbOperationError::QueryFailed(
+                        "inspector failed".to_string(),
+                    )),
                     generation,
                 },
                 Instant::now(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -3255,7 +3255,7 @@ mod tests {
                 Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: detail_run_id,
-                    detail: Box::new(test_support::table::minimal("public", "users")),
+                    outcome: Ok(Box::new(test_support::table::minimal("public", "users"))),
                     generation,
                 },
                 now,


### PR DESCRIPTION
## Problem
Foreground table-detail completion uses separate actions for success and failure even though both share the same terminal identity and reducer boundary.

## Background
The separate action shapes duplicate the completion transport and force the reducer to repeat freshness checks.

## Approach
Carry the provider result as a single `Result` outcome while retaining DSN, run, and selection-generation freshness checks, terminal Inspector state transitions, pending-preview reveal, and full-detail payloads. Prefetch actions remain separate.