### PR TITLE
refactor(app): combine prefetch success outcomes

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -203,11 +203,12 @@ async fn prefetch_table_detail(
 
     if already_cached {
         action_tx
-            .send(Action::TableDetailAlreadyCached {
+            .send(Action::TableDetailCached {
                 dsn,
                 run_id,
                 schema,
                 table,
+                detail: None,
             })
             .await
             .ok();
@@ -230,7 +231,7 @@ async fn prefetch_table_detail(
                     run_id,
                     schema,
                     table,
-                    detail: Box::new(detail),
+                    detail: Some(Box::new(detail)),
                 })
                 .await
                 .ok();
@@ -594,8 +595,61 @@ mod tests {
 
             let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
-                matches!(action, Action::TableDetailCached { .. }),
+                matches!(
+                    action,
+                    Action::TableDetailCached {
+                        detail: Some(_),
+                        ..
+                    }
+                ),
                 "expected TableDetailCached, got {action:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn cached_table_detail_returns_empty_outcome() {
+            let mut mock_provider = MockMetadataProvider::new();
+            mock_provider.expect_fetch_table_detail().never();
+            mock_provider.expect_fetch_table_columns_and_fks().never();
+
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(mock_provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                tx,
+            );
+            let mut completion_engine = CompletionEngine::new();
+            completion_engine.cache_table_detail("public.users".to_string(), sample_table());
+
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::PrefetchTableColumnsAndFks {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 3,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(completion_engine),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
+
+            let action = run.actions.into_iter().next().expect("action dispatched");
+            assert!(
+                matches!(
+                    action,
+                    Action::TableDetailCached {
+                        ref dsn,
+                        run_id: 3,
+                        detail: None,
+                        ..
+                    } if dsn == "dsn://test"
+                ),
+                "expected cache-hit TableDetailCached, got {action:?}"
             );
         }
     }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -483,7 +483,7 @@ pub enum Action {
         run_id: u64,
         schema: String,
         table: String,
-        detail: Box<Table>,
+        detail: Option<Box<Table>>,
     },
     TableDetailCacheFailed {
         dsn: String,
@@ -491,12 +491,6 @@ pub enum Action {
         schema: String,
         table: String,
         error: DbOperationError,
-    },
-    TableDetailAlreadyCached {
-        dsn: String,
-        run_id: u64,
-        schema: String,
-        table: String,
     },
     StartErPrefetchAll,
     StartErPrefetchScoped {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -568,7 +568,7 @@ mod tests {
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    detail: empty_table("public", "users"),
+                    detail: Some(empty_table("public", "users")),
                 },
                 Instant::now(),
             )
@@ -925,7 +925,7 @@ mod tests {
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    detail: empty_table("public", "users"),
+                    detail: Some(empty_table("public", "users")),
                 },
                 Instant::now(),
             )
@@ -1375,7 +1375,7 @@ mod tests {
         }
 
         #[test]
-        fn cached_table_retriggers_sql_completion_without_er_state() {
+        fn fetched_table_retriggers_sql_completion_without_er_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.modal.set_mode(InputMode::SqlModal);
             let run_id = state.table_prefetch.begin_completion_prefetch();
@@ -1390,7 +1390,7 @@ mod tests {
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    detail: empty_table("public", "users"),
+                    detail: Some(empty_table("public", "users")),
                 },
                 Instant::now(),
             )

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -99,7 +99,6 @@ pub(super) fn reduce_prefetch(
             | Action::PrefetchTableDetail { .. }
             | Action::TableDetailCached { .. }
             | Action::TableDetailCacheFailed { .. }
-            | Action::TableDetailAlreadyCached { .. }
     ) && reject_pending_mysql_connection_probe(state)
     {
         return DispatchResult::handled();
@@ -233,10 +232,13 @@ pub(super) fn reduce_prefetch(
                 .table_prefetch
                 .complete_table_prefetch(&qualified_name);
 
-            let mut effects = vec![Effect::CacheTableInCompletionEngine {
-                qualified_name,
-                table: detail.clone(),
-            }];
+            let mut effects = Vec::new();
+            if let Some(detail) = detail {
+                effects.push(Effect::CacheTableInCompletionEngine {
+                    qualified_name,
+                    table: detail.clone(),
+                });
+            }
 
             if state.table_prefetch.has_pending_prefetch() {
                 effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
@@ -294,36 +296,6 @@ pub(super) fn reduce_prefetch(
             DispatchResult::handled_with(effects)
         }
 
-        Action::TableDetailAlreadyCached {
-            dsn,
-            run_id,
-            schema,
-            table,
-        } => {
-            if !state.session.dsn_matches(dsn)
-                || !state.table_prefetch.is_current_prefetch_run(*run_id)
-            {
-                return DispatchResult::handled();
-            }
-            let qualified_name = format!("{schema}.{table}");
-            state
-                .table_prefetch
-                .complete_table_prefetch(&qualified_name);
-
-            let mut effects = Vec::new();
-
-            if state.table_prefetch.has_pending_prefetch() {
-                effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
-            }
-
-            if state.table_prefetch.prefetch_tracks_er() {
-                effects.extend(check_er_completion(state));
-            } else if state.modal.active_mode() == InputMode::SqlModal {
-                effects.push(Effect::TriggerCompletion);
-            }
-
-            DispatchResult::handled_with(effects)
-        }
         _ => DispatchResult::pass(),
     }
 }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1878,7 +1878,7 @@ mod tests {
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    detail: make_test_table(),
+                    detail: Some(make_test_table()),
                 },
                 now,
                 &AppServices::stub(),
@@ -1909,7 +1909,7 @@ mod tests {
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    detail: make_test_table(),
+                    detail: Some(make_test_table()),
                 },
                 now,
                 &AppServices::stub(),
@@ -3134,17 +3134,23 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::TableDetailAlreadyCached {
+                Action::TableDetailCached {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
+                    detail: None,
                 },
                 now,
                 &AppServices::stub(),
             );
 
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert!(
+                !effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::CacheTableInCompletionEngine { .. }))
+            );
             assert!(effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache)))
@@ -3172,11 +3178,12 @@ mod tests {
             );
             let effects = reduce(
                 &mut state,
-                Action::TableDetailAlreadyCached {
+                Action::TableDetailCached {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
+                    detail: None,
                 },
                 now,
                 &AppServices::stub(),


### PR DESCRIPTION
## Problem
Prefetch fetch success and cache-hit paths use separate actions even though their reducer continuation is the same.

## Background
The duplicate success action keeps the same run, DSN, queue, and ER handling in two places.

## Approach
Represent a fetched detail as `Some` and a cache hit as `None` on one action. Only fetched details emit the completion-cache write effect; failure and retry actions remain unchanged.