### PR TITLE
refactor(app): flatten metadata reload effects

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -177,9 +177,6 @@ pub enum Effect {
         run_id: u64,
     },
 
-    // Executes effects in order (each awaits before the next),
-    // but spawned async tasks (e.g. FetchMetadata) may complete out of order.
-    Sequence(Vec<Self>),
     DispatchActions(Vec<Action>),
     SwitchConnection {
         connection_index: usize,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -139,34 +139,10 @@ impl EffectRunner {
     ) -> Result<Vec<Action>> {
         let mut dispatched = Vec::new();
         for effect in effects {
-            match effect {
-                Effect::Sequence(seq_effects) => {
-                    for seq_effect in seq_effects {
-                        dispatched.extend(
-                            self.execute_single_effect(
-                                seq_effect,
-                                tui,
-                                state,
-                                completion_engine,
-                                services,
-                            )
-                            .await?,
-                        );
-                    }
-                }
-                single_effect => {
-                    dispatched.extend(
-                        self.execute_single_effect(
-                            single_effect,
-                            tui,
-                            state,
-                            completion_engine,
-                            services,
-                        )
-                        .await?,
-                    );
-                }
-            }
+            dispatched.extend(
+                self.execute_single_effect(effect, tui, state, completion_engine, services)
+                    .await?,
+            );
         }
         Ok(dispatched)
     }
@@ -191,10 +167,6 @@ impl EffectRunner {
                 Ok(vec![])
             }
 
-            Effect::Sequence(_) => {
-                // Handled in execute_effects()
-                Ok(vec![])
-            }
             Effect::DispatchActions(actions) => Ok(actions),
 
             e @ (Effect::CopyToClipboard { .. } | Effect::OpenFolder { .. }) => {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -306,7 +306,11 @@ mod tests {
                 .into_effects()
                 .unwrap();
 
-            assert!(effects.iter().any(contains_fetch_metadata));
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
             assert!(state.messages.last_error().is_none());
         }
 
@@ -386,14 +390,6 @@ mod tests {
                 state.messages.last_error(),
                 Some("Connection switch in progress")
             );
-        }
-
-        fn contains_fetch_metadata(effect: &Effect) -> bool {
-            match effect {
-                Effect::FetchMetadata { .. } => true,
-                Effect::Sequence(effects) => effects.iter().any(contains_fetch_metadata),
-                _ => false,
-            }
         }
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -374,11 +374,7 @@ mod tests {
             );
             assert!(reload_effects.iter().any(|effect| matches!(
                 effect,
-                Effect::Sequence(effects)
-                    if effects.iter().any(|effect| matches!(
-                        effect,
-                        Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
-                    ))
+                Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
             )));
         }
 
@@ -450,11 +446,7 @@ mod tests {
             );
             assert!(reload_effects.iter().any(|effect| matches!(
                 effect,
-                Effect::Sequence(effects)
-                    if effects.iter().any(|effect| matches!(
-                        effect,
-                        Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
-                    ))
+                Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
             )));
         }
 
@@ -1125,10 +1117,7 @@ mod tests {
             let metadata_run_id = effects
                 .iter()
                 .find_map(|effect| match effect {
-                    Effect::Sequence(effects) => effects.iter().find_map(|effect| match effect {
-                        Effect::FetchMetadata { run_id, .. } => Some(*run_id),
-                        _ => None,
-                    }),
+                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
                     _ => None,
                 })
                 .expect("cached MySQL state should start metadata revalidation");

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -36,14 +36,14 @@ pub(crate) fn clipboard_unavailable() -> Action {
 pub(crate) fn metadata_reload_effects(state: &mut AppState, dsn: &str) -> Vec<Effect> {
     let run_id = state.session.begin_reload();
 
-    vec![Effect::Sequence(vec![
+    vec![
         Effect::CancelMetadataTasks,
         Effect::ClearCompletionEngineCache,
         Effect::FetchMetadata {
             dsn: dsn.to_string(),
             run_id,
         },
-    ])]
+    ]
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1260,16 +1260,13 @@ mod tests {
                 Instant::now(),
                 &AppServices::stub(),
             );
-            let reload_run_id = match &reload_effects[0] {
-                Effect::Sequence(effects) => effects
-                    .iter()
-                    .find_map(|effect| match effect {
-                        Effect::FetchMetadata { run_id, .. } => Some(*run_id),
-                        _ => None,
-                    })
-                    .expect("reload should start metadata fetch"),
-                other => panic!("expected reload sequence, got {other:?}"),
-            };
+            let reload_run_id = reload_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("reload should start metadata fetch");
 
             reduce(
                 &mut state,
@@ -1635,7 +1632,7 @@ mod tests {
         use crate::domain::DatabaseMetadata;
 
         #[test]
-        fn reload_metadata_returns_sequence_effect() {
+        fn reload_metadata_returns_effects_in_execution_order() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
@@ -1647,15 +1644,14 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::Sequence(_)));
-
-            if let Effect::Sequence(seq) = &effects[0] {
-                assert_eq!(seq.len(), 3);
-                assert!(matches!(seq[0], Effect::CancelMetadataTasks));
-                assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
-                assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
-            }
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::CancelMetadataTasks,
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata { .. },
+                ]
+            ));
         }
 
         #[test]
@@ -3448,7 +3444,7 @@ mod tests {
         }
 
         #[test]
-        fn confirm_selection_with_reload_emits_sequence_effect() {
+        fn confirm_selection_with_reload_emits_effects_in_order() {
             let mut state = state_in_palette_mode(KeymapPreset::Ide);
             let entry_index = palette_index_of(&state, |a| matches!(a, Action::ReloadMetadata));
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
@@ -3462,10 +3458,14 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(
-                effects.iter().any(|e| matches!(e, Effect::Sequence(_))),
-                "expected Sequence effect for ReloadMetadata, got {effects:?}"
-            );
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::CancelMetadataTasks,
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata { .. },
+                ]
+            ));
         }
 
         #[test]


### PR DESCRIPTION
## Problem
`Effect::Sequence` duplicated the ordered execution already provided by the top-level effect vector.

## Background
Metadata reload was the only production path retaining the redundant wrapper.

## Approach
Remove the wrapper and its runner branches while preserving cancellation, completion-cache invalidation, metadata-fetch ordering, and existing stale-state behavior.