### PR TITLE
refactor(app): remove connection cache store wrapper

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -955,7 +955,7 @@ mod tests {
             let target_id = ConnectionId::new();
             state
                 .connection_caches
-                .save(&target_id, ConnectionCache::default());
+                .insert(target_id.clone(), ConnectionCache::default());
             let run_id = state.query.begin_running(Instant::now());
             let completion_engine = RefCell::new(CompletionEngine::new());
             let mut renderer = NoopRenderer;

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::time::Instant;
 
 use super::explain_context::ExplainContext;
 use super::runtime_state::RuntimeState;
-use crate::domain::connection::{ConnectionProfile, ServiceEntry};
+use crate::domain::connection::{ConnectionId, ConnectionProfile, ServiceEntry};
 use crate::domain::{Column, DatabaseType, TableSummary, mysql_sql::mysql_export_plan};
 use crate::model::browse::inspector_view_model::InspectorViewModel;
 use crate::model::browse::json_detail::JsonDetailState;
@@ -10,7 +11,7 @@ use crate::model::browse::query_execution::{QueryExecution, VisibleResultKind};
 use crate::model::browse::result_interaction::ResultInteraction;
 use crate::model::browse::row_detail::RowDetailState;
 use crate::model::browse::session::BrowseSession;
-use crate::model::connection::cache::ConnectionCacheStore;
+use crate::model::connection::cache::ConnectionCache;
 use crate::model::connection::error_state::ConnectionErrorState;
 use crate::model::connection::list::{self, ConnectionListItem};
 use crate::model::connection::setup::ConnectionSetupState;
@@ -68,7 +69,7 @@ pub struct AppState {
     pub explain: ExplainContext,
     pub modal: ModalState,
     pub flash_timers: FlashTimerStore,
-    pub connection_caches: ConnectionCacheStore,
+    pub connection_caches: HashMap<ConnectionId, ConnectionCache>,
     connections: Vec<ConnectionProfile>,
     service_entries: Vec<ServiceEntry>,
     connection_list_items: Vec<ConnectionListItem>,
@@ -103,7 +104,7 @@ impl AppState {
             explain: ExplainContext::default(),
             modal: ModalState::default(),
             flash_timers: FlashTimerStore::default(),
-            connection_caches: ConnectionCacheStore::default(),
+            connection_caches: HashMap::default(),
             connections: Vec::new(),
             service_entries: Vec::new(),
             connection_list_items: Vec::new(),

--- a/src/app/model/connection/cache.rs
+++ b/src/app/model/connection/cache.rs
@@ -31,10 +31,7 @@ impl ConnectionCache {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
-    use crate::domain::ConnectionId;
 
     #[test]
     fn connection_cache_default_has_empty_fields() {
@@ -56,81 +53,6 @@ mod tests {
     }
 
     #[test]
-    fn store_get_returns_none_for_unknown_id() {
-        let caches = HashMap::<ConnectionId, ConnectionCache>::default();
-        let id = ConnectionId::new();
-
-        assert!(caches.get(&id).is_none());
-    }
-
-    #[test]
-    fn store_save_and_get_returns_saved_cache() {
-        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
-        let id = ConnectionId::new();
-
-        let cache = ConnectionCache {
-            explorer_selected: 42,
-            inspector_tab: InspectorTab::Indexes,
-            ..Default::default()
-        };
-        caches.insert(id.clone(), cache);
-
-        let retrieved = caches.get(&id).unwrap();
-        assert_eq!(retrieved.explorer_selected, 42);
-        assert_eq!(retrieved.inspector_tab, InspectorTab::Indexes);
-    }
-
-    #[test]
-    fn store_remove_returns_and_deletes_cache() {
-        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
-        let id = ConnectionId::new();
-
-        let cache = ConnectionCache {
-            explorer_selected: 99,
-            ..Default::default()
-        };
-        caches.insert(id.clone(), cache);
-
-        let removed = caches.remove(&id);
-        assert!(removed.is_some());
-        assert_eq!(removed.unwrap().explorer_selected, 99);
-        assert!(caches.get(&id).is_none());
-    }
-
-    #[test]
-    fn preserves_metadata_on_save_and_get() {
-        use crate::domain::{DatabaseMetadata, TableSummary};
-
-        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
-        let id = ConnectionId::new();
-
-        let metadata = Arc::new({
-            let mut metadata = DatabaseMetadata::new("test_db".to_string());
-            metadata.table_summaries = vec![TableSummary::new(
-                "public".to_string(),
-                "users".to_string(),
-                Some(100),
-                false,
-            )];
-            metadata
-        });
-
-        let cache = ConnectionCache {
-            metadata: Some(metadata),
-            effective_user: Some("postgres".to_string()),
-            ..Default::default()
-        };
-        caches.insert(id.clone(), cache);
-
-        let retrieved = caches.get(&id).unwrap();
-        assert!(retrieved.metadata.is_some());
-        assert_eq!(retrieved.effective_user.as_deref(), Some("postgres"));
-        let retrieved_metadata = retrieved.metadata.as_ref().unwrap();
-        assert_eq!(retrieved_metadata.database_name, "test_db");
-        assert_eq!(retrieved_metadata.table_summaries.len(), 1);
-    }
-
-    #[test]
     fn mysql_restore_requires_matching_connection_identity() {
         let cache = ConnectionCache {
             connection_dsn: Some("mysql://user@localhost/app".to_string()),
@@ -144,33 +66,5 @@ mod tests {
         assert!(cache.is_valid_mysql_snapshot("mysql://user@localhost/app", Some("app")));
         assert!(!cache.is_valid_mysql_snapshot("mysql://user@localhost/other", Some("app")));
         assert!(!cache.is_valid_mysql_snapshot("mysql://user@localhost/app", Some("other")));
-    }
-
-    #[test]
-    fn preserves_query_result_on_save_and_get() {
-        use crate::domain::{QueryResult, QuerySource};
-
-        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
-        let id = ConnectionId::new();
-
-        let query_result = QueryResult::success(
-            "SELECT * FROM users".to_string(),
-            vec!["id".to_string(), "name".to_string()],
-            vec![vec!["1".to_string(), "Alice".to_string()]],
-            10,
-            QuerySource::Preview,
-        );
-
-        let cache = ConnectionCache {
-            query_result: Some(Arc::new(query_result)),
-            ..Default::default()
-        };
-        caches.insert(id.clone(), cache);
-
-        let retrieved = caches.get(&id).unwrap();
-        assert!(retrieved.query_result.is_some());
-        let retrieved_result = retrieved.query_result.as_ref().unwrap();
-        assert_eq!(retrieved_result.query, "SELECT * FROM users");
-        assert_eq!(retrieved_result.row_count(), 1);
     }
 }

--- a/src/app/model/connection/cache.rs
+++ b/src/app/model/connection/cache.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, Table};
+use crate::domain::{DatabaseMetadata, DatabaseType, QueryResult, Table};
 use crate::model::browse::query_execution::PaginationState;
 use crate::model::shared::inspector_tab::InspectorTab;
 
@@ -30,28 +29,12 @@ impl ConnectionCache {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct ConnectionCacheStore {
-    caches: HashMap<ConnectionId, ConnectionCache>,
-}
-
-impl ConnectionCacheStore {
-    pub fn get(&self, id: &ConnectionId) -> Option<&ConnectionCache> {
-        self.caches.get(id)
-    }
-
-    pub fn save(&mut self, id: &ConnectionId, cache: ConnectionCache) {
-        self.caches.insert(id.clone(), cache);
-    }
-
-    pub fn remove(&mut self, id: &ConnectionId) -> Option<ConnectionCache> {
-        self.caches.remove(id)
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::domain::ConnectionId;
 
     #[test]
     fn connection_cache_default_has_empty_fields() {
@@ -74,15 +57,15 @@ mod tests {
 
     #[test]
     fn store_get_returns_none_for_unknown_id() {
-        let store = ConnectionCacheStore::default();
+        let caches = HashMap::<ConnectionId, ConnectionCache>::default();
         let id = ConnectionId::new();
 
-        assert!(store.get(&id).is_none());
+        assert!(caches.get(&id).is_none());
     }
 
     #[test]
     fn store_save_and_get_returns_saved_cache() {
-        let mut store = ConnectionCacheStore::default();
+        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
         let id = ConnectionId::new();
 
         let cache = ConnectionCache {
@@ -90,35 +73,35 @@ mod tests {
             inspector_tab: InspectorTab::Indexes,
             ..Default::default()
         };
-        store.save(&id, cache);
+        caches.insert(id.clone(), cache);
 
-        let retrieved = store.get(&id).unwrap();
+        let retrieved = caches.get(&id).unwrap();
         assert_eq!(retrieved.explorer_selected, 42);
         assert_eq!(retrieved.inspector_tab, InspectorTab::Indexes);
     }
 
     #[test]
     fn store_remove_returns_and_deletes_cache() {
-        let mut store = ConnectionCacheStore::default();
+        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
         let id = ConnectionId::new();
 
         let cache = ConnectionCache {
             explorer_selected: 99,
             ..Default::default()
         };
-        store.save(&id, cache);
+        caches.insert(id.clone(), cache);
 
-        let removed = store.remove(&id);
+        let removed = caches.remove(&id);
         assert!(removed.is_some());
         assert_eq!(removed.unwrap().explorer_selected, 99);
-        assert!(store.get(&id).is_none());
+        assert!(caches.get(&id).is_none());
     }
 
     #[test]
     fn preserves_metadata_on_save_and_get() {
         use crate::domain::{DatabaseMetadata, TableSummary};
 
-        let mut store = ConnectionCacheStore::default();
+        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
         let id = ConnectionId::new();
 
         let metadata = Arc::new({
@@ -137,9 +120,9 @@ mod tests {
             effective_user: Some("postgres".to_string()),
             ..Default::default()
         };
-        store.save(&id, cache);
+        caches.insert(id.clone(), cache);
 
-        let retrieved = store.get(&id).unwrap();
+        let retrieved = caches.get(&id).unwrap();
         assert!(retrieved.metadata.is_some());
         assert_eq!(retrieved.effective_user.as_deref(), Some("postgres"));
         let retrieved_metadata = retrieved.metadata.as_ref().unwrap();
@@ -167,7 +150,7 @@ mod tests {
     fn preserves_query_result_on_save_and_get() {
         use crate::domain::{QueryResult, QuerySource};
 
-        let mut store = ConnectionCacheStore::default();
+        let mut caches = HashMap::<ConnectionId, ConnectionCache>::default();
         let id = ConnectionId::new();
 
         let query_result = QueryResult::success(
@@ -182,9 +165,9 @@ mod tests {
             query_result: Some(Arc::new(query_result)),
             ..Default::default()
         };
-        store.save(&id, cache);
+        caches.insert(id.clone(), cache);
 
-        let retrieved = store.get(&id).unwrap();
+        let retrieved = caches.get(&id).unwrap();
         assert!(retrieved.query_result.is_some());
         let retrieved_result = retrieved.query_result.as_ref().unwrap();
         assert_eq!(retrieved_result.query, "SELECT * FROM users");

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -90,7 +90,7 @@ pub(super) fn save_current_connection_cache(state: &mut AppState) {
         state.query.current_result().cloned(),
         state.query.pagination.clone(),
     );
-    state.connection_caches.save(&current_id, cache);
+    state.connection_caches.insert(current_id, cache);
 }
 
 pub(super) fn cancel_connection_task_effects(state: &mut AppState) -> Vec<Effect> {

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -700,7 +700,7 @@ mod tests {
                 inspector_tab: InspectorTab::ForeignKeys,
                 ..Default::default()
             };
-            state.connection_caches.save(&target_id, cached);
+            state.connection_caches.insert(target_id.clone(), cached);
 
             let action = create_postgres_switch_action(&target_id, "cached_db");
             reduce(&mut state, &action);
@@ -720,7 +720,7 @@ mod tests {
             let target_id = ConnectionId::new();
             state
                 .connection_caches
-                .save(&target_id, ConnectionCache::default());
+                .insert(target_id.clone(), ConnectionCache::default());
             let stale_run_id = state.query.begin_running(std::time::Instant::now());
 
             let action = create_postgres_switch_action(&target_id, "cached_db");
@@ -739,7 +739,7 @@ mod tests {
                 inspector_tab: InspectorTab::Ddl,
                 ..Default::default()
             };
-            state.connection_caches.save(&target_id, cached);
+            state.connection_caches.insert(target_id.clone(), cached);
 
             let action = Action::SwitchConnection(ConnectionTarget {
                 id: target_id,
@@ -846,8 +846,8 @@ mod tests {
             seed_explain_state(&mut state);
 
             if cached {
-                state.connection_caches.save(
-                    &target_id,
+                state.connection_caches.insert(
+                    target_id.clone(),
                     ConnectionCache {
                         inspector_tab: InspectorTab::Rls,
                         ..Default::default()
@@ -894,7 +894,7 @@ mod tests {
             if cached {
                 state
                     .connection_caches
-                    .save(&target_id, ConnectionCache::default());
+                    .insert(target_id.clone(), ConnectionCache::default());
             }
 
             reduce(
@@ -1079,8 +1079,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let target_id = ConnectionId::from_string("mysql-target");
             let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
-            state.connection_caches.save(
-                &target_id,
+            state.connection_caches.insert(
+                target_id.clone(),
                 valid_mysql_cache(&target.dsn, target.database.as_deref().unwrap()),
             );
 
@@ -1176,9 +1176,10 @@ mod tests {
                 let mut state = AppState::new("test".to_string());
                 let target_id = ConnectionId::from_string("mysql-target");
                 let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
-                state
-                    .connection_caches
-                    .save(&target_id, valid_mysql_cache(cached_dsn, cached_database));
+                state.connection_caches.insert(
+                    target_id.clone(),
+                    valid_mysql_cache(cached_dsn, cached_database),
+                );
 
                 let probe_effects =
                     reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
@@ -1214,8 +1215,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let target_id = ConnectionId::from_string("mysql-target");
             let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
-            state.connection_caches.save(
-                &target_id,
+            state.connection_caches.insert(
+                target_id.clone(),
                 valid_mysql_cache(&target.dsn, target.database.as_deref().unwrap()),
             );
 
@@ -1291,8 +1292,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let target_id = ConnectionId::from_string("mysql-target");
             let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
-            state.connection_caches.save(
-                &target_id,
+            state.connection_caches.insert(
+                target_id.clone(),
                 valid_mysql_cache(&target.dsn, target.database.as_deref().unwrap()),
             );
 
@@ -1328,8 +1329,8 @@ mod tests {
             pagination.reset_for_table("main", "items");
             pagination.set_page_result(1, true);
             state.ui.set_explorer_selected_raw(7);
-            state.connection_caches.save(
-                &target_id,
+            state.connection_caches.insert(
+                target_id.clone(),
                 ConnectionCache {
                     explorer_selected: 42,
                     inspector_tab: InspectorTab::ForeignKeys,
@@ -1400,8 +1401,8 @@ mod tests {
             let mut pagination_b = PaginationState::default();
             pagination_b.reset_for_table("main", "orders");
             pagination_b.set_page_result(5, false);
-            state.connection_caches.save(
-                &connection_b,
+            state.connection_caches.insert(
+                connection_b.clone(),
                 ConnectionCache {
                     selected_table_key: Some("main.orders".to_string()),
                     query_result: Some(Arc::new(QueryResult::success(
@@ -1508,7 +1509,7 @@ mod tests {
                 .queue_table_prefetch("public.users".to_string());
             state
                 .connection_caches
-                .save(&target_id, ConnectionCache::default());
+                .insert(target_id.clone(), ConnectionCache::default());
 
             let action = create_postgres_switch_action(&target_id, "cached_db");
             reduce(&mut state, &action);
@@ -2327,8 +2328,8 @@ mod tests {
                 database: None,
             };
             reduce(&mut state, &Action::SwitchConnection(current.clone())).unwrap();
-            state.connection_caches.save(
-                &current.id,
+            state.connection_caches.insert(
+                current.id.clone(),
                 ConnectionCache {
                     explorer_selected: 7,
                     ..Default::default()
@@ -2421,7 +2422,7 @@ mod tests {
 
             state
                 .connection_caches
-                .save(&target_id, ConnectionCache::default());
+                .insert(target_id.clone(), ConnectionCache::default());
             state.result_interaction.activate_cell(3, 2);
 
             let action = create_postgres_switch_action(&target_id, "cached_db");
@@ -2439,7 +2440,7 @@ mod tests {
             let target_id = ConnectionId::new();
             state
                 .connection_caches
-                .save(&target_id, ConnectionCache::default());
+                .insert(target_id.clone(), ConnectionCache::default());
             let _ = state.table_prefetch.begin_er_prefetch();
             state
                 .table_prefetch

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -568,7 +568,7 @@ mod tests {
             let action = create_postgres_switch_action(&new_id, "new_db");
             reduce(&mut state, &action);
 
-            let saved = state.connection_caches.get(&current_id).unwrap();
+            let saved = &state.connection_caches[&current_id];
             assert_eq!(saved.explorer_selected, 5);
             assert_eq!(saved.inspector_tab, InspectorTab::Indexes);
         }
@@ -678,7 +678,7 @@ mod tests {
                 &create_postgres_switch_action(&ConnectionId::from_string("postgres"), "postgres"),
             );
 
-            let cache = state.connection_caches.get(&current_id).unwrap();
+            let cache = &state.connection_caches[&current_id];
             assert!(
                 cache.is_valid_mysql_snapshot(
                     "mysql://user@localhost:3306/current",
@@ -1080,7 +1080,7 @@ mod tests {
             let target_id = ConnectionId::from_string("mysql-target");
             let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
             state.connection_caches.insert(
-                target_id.clone(),
+                target_id,
                 valid_mysql_cache(&target.dsn, target.database.as_deref().unwrap()),
             );
 
@@ -1206,7 +1206,7 @@ mod tests {
                         .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
                 );
                 assert!(state.session.connection_state().is_connecting());
-                assert!(state.connection_caches.get(&target_id).is_none());
+                assert!(!state.connection_caches.contains_key(&target_id));
             }
         }
 
@@ -1216,7 +1216,7 @@ mod tests {
             let target_id = ConnectionId::from_string("mysql-target");
             let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
             state.connection_caches.insert(
-                target_id.clone(),
+                target_id,
                 valid_mysql_cache(&target.dsn, target.database.as_deref().unwrap()),
             );
 
@@ -1293,7 +1293,7 @@ mod tests {
             let target_id = ConnectionId::from_string("mysql-target");
             let target = mysql_target(&target_id, "mysql://user@localhost:3306/app", "app");
             state.connection_caches.insert(
-                target_id.clone(),
+                target_id,
                 valid_mysql_cache(&target.dsn, target.database.as_deref().unwrap()),
             );
 
@@ -1353,7 +1353,7 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::FetchMetadata { .. }))
             );
-            assert!(state.connection_caches.get(&target_id).is_some());
+            assert!(state.connection_caches.contains_key(&target_id));
             assert_eq!(state.ui.explorer_selected(), 42);
             assert_eq!(state.query.pagination.schema(), "main");
             assert_eq!(state.query.pagination.table(), "items");
@@ -2348,14 +2348,7 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(state.session.active_connection_id(), Some(&current.id));
             assert_eq!(state.session.active_database(), None);
-            assert_eq!(
-                state
-                    .connection_caches
-                    .get(&current.id)
-                    .unwrap()
-                    .explorer_selected,
-                7
-            );
+            assert_eq!(state.connection_caches[&current.id].explorer_selected, 7);
             assert!(state.messages.last_error().is_some_and(|message| {
                 message.contains("MySQL connection field `database` is required")
             }));

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1269,8 +1269,8 @@ mod tests {
         fn save_completed_removes_stale_connection_cache_for_saved_profile() {
             let mut state = AppState::new("test".to_string());
             let saved_id = ConnectionId::new();
-            state.connection_caches.save(
-                &saved_id,
+            state.connection_caches.insert(
+                saved_id.clone(),
                 ConnectionCache {
                     metadata: Some(Arc::new({
                         let mut metadata = DatabaseMetadata::new("stale".to_string());

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1260,7 +1260,7 @@ mod tests {
 
             reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
 
-            let saved = state.connection_caches.get(&current_id).unwrap();
+            let saved = &state.connection_caches[&current_id];
             assert_eq!(saved.explorer_selected, 4);
             assert!(saved.metadata.is_some());
         }
@@ -1301,7 +1301,7 @@ mod tests {
             };
             reduce(&mut state, &action, Instant::now());
 
-            assert!(state.connection_caches.get(&saved_id).is_none());
+            assert!(!state.connection_caches.contains_key(&saved_id));
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2700,7 +2700,7 @@ mod tests {
                 metadata: Some(Arc::new(DatabaseMetadata::new("cached_db".to_string()))),
                 ..Default::default()
             };
-            state.connection_caches.save(&conn_b, cached);
+            state.connection_caches.insert(conn_b.clone(), cached);
             let now = Instant::now();
 
             let effects = reduce(

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2653,15 +2653,8 @@ mod tests {
 
             assert_eq!(state.session.active_connection_id(), Some(&conn_b));
             assert!(state.session.connection_state().is_connecting());
-            assert!(state.connection_caches.get(&conn_a).is_some());
-            assert_eq!(
-                state
-                    .connection_caches
-                    .get(&conn_a)
-                    .unwrap()
-                    .explorer_selected,
-                5
-            );
+            assert!(state.connection_caches.contains_key(&conn_a));
+            assert_eq!(state.connection_caches[&conn_a].explorer_selected, 5);
             assert!(matches!(
                 effects.as_slice(),
                 [


### PR DESCRIPTION
## Problem
`ConnectionCacheStore` only forwards `HashMap` operations while adding no cache policy or ownership behavior.

## Background
The cache policy and connection identity checks already live in `ConnectionCache` and connection lifecycle code.

## Approach
Store per-connection caches directly as `HashMap<ConnectionId, ConnectionCache>` and preserve existing save, restore, removal, and identity-validation behavior.