### PR TITLE
refactor(app): remove unused private reducer dependencies

### DIFF
--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
@@ -19,11 +17,7 @@ pub(super) fn expand_prefetch_with_fk_neighbors(state: &AppState, run_id: u64) -
     }]
 }
 
-pub(super) fn reduce_er_neighbors(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::ExpandPrefetchWithFkNeighbors { run_id } => {
             if reject_pending_mysql_connection_probe(state) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -41,9 +41,9 @@ pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
 
 pub fn dispatch_metadata(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     loading::reduce_loading(state, action, now)
-        .or_else(|| table_detail::reduce_table_detail(state, action, now))
+        .or_else(|| table_detail::reduce_table_detail(state, action))
         .or_else(|| prefetch::reduce_prefetch(state, action, now))
-        .or_else(|| er_neighbors::reduce_er_neighbors(state, action, now))
+        .or_else(|| er_neighbors::reduce_er_neighbors(state, action))
 }
 
 #[cfg(test)]

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -1,15 +1,9 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_table_detail(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::TableDetailLoaded {
             dsn,

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -27,7 +27,7 @@ pub(crate) fn dispatch_er(state: &mut AppState, action: &Action, now: Instant) -
     diagram::reduce_diagram_lifecycle(state, action, now)
         .or_else(|| smart_refresh_fetched::reduce_smart_refresh_fetched(state, action))
         .or_else(|| smart_refresh_completed::reduce_smart_refresh_completed(state, action, now))
-        .or_else(|| smart_refresh_failed::reduce_smart_refresh_failed(state, action, now))
+        .or_else(|| smart_refresh_failed::reduce_smart_refresh_failed(state, action))
 }
 
 #[cfg(test)]

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -1,16 +1,11 @@
 use std::sync::Arc;
-use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::{Action, SmartErRefreshError};
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_smart_refresh_failed(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_smart_refresh_failed(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::SmartErRefreshFailed(SmartErRefreshError {
             dsn,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -14,9 +14,9 @@ use crate::update::dispatch_result::DispatchResult;
 pub fn dispatch_explain(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     request::reduce_request(state, action, now)
         .or_else(|| analyze::reduce_analyze(state, action, now))
-        .or_else(|| output::reduce_output(state, action, now))
-        .or_else(|| scroll::reduce_scroll(state, action, now))
-        .or_else(|| tabs::reduce_tabs(state, action, now))
+        .or_else(|| output::reduce_output(state, action))
+        .or_else(|| scroll::reduce_scroll(state, action))
+        .or_else(|| tabs::reduce_tabs(state, action))
 }
 
 #[cfg(test)]

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -1,16 +1,10 @@
-use std::time::Instant;
-
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{finish_explain_error, finish_explain_success};
 
-pub(super) fn reduce_output(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_output(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::ExplainCompleted {
             database_type,

--- a/src/app/update/explain/scroll.rs
+++ b/src/app/update/explain/scroll.rs
@@ -1,16 +1,10 @@
-use std::time::Instant;
-
 use crate::model::app_state::AppState;
 use crate::model::explain_context::ExplainContext;
 use crate::model::shared::text_input::TextInputLike;
 use crate::update::action::{Action, ScrollAmount, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_scroll(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::Scroll {
             target:

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -1,10 +1,8 @@
-use std::time::Instant;
-
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
+pub(super) fn reduce_tabs(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::CompareEditQuery => {
             if let Some(ref right) = state.explain.right {

--- a/src/app/update/modal/base.rs
+++ b/src/app/update/modal/base.rs
@@ -1,16 +1,10 @@
-use std::time::Instant;
-
 use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_base_lifecycle(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_base_lifecycle(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::TablePicker) => {
             state.modal.set_mode(InputMode::TablePicker);

--- a/src/app/update/modal/help.rs
+++ b/src/app/update/modal/help.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use crate::catalog::HelpDocument;
 use crate::model::app_state::AppState;
 use crate::model::shared::help::HelpOrigin;
@@ -46,7 +44,7 @@ fn close_help(state: &mut AppState) {
     state.ui.help_mut().close();
 }
 
-pub(super) fn reduce_help(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
+pub(super) fn reduce_help(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::ToggleModal(ModalKind::Help) => {
             if state.modal.active_mode() == InputMode::Help {

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -17,13 +17,13 @@ pub(crate) fn dispatch_modal(
     action: &Action,
     now: Instant,
 ) -> DispatchResult {
-    base::reduce_base_lifecycle(state, action, now)
+    base::reduce_base_lifecycle(state, action)
         .or_else(|| settings::reduce_settings(state, action, now))
-        .or_else(|| help::reduce_help(state, action, now))
-        .or_else(|| sqlite_diagnostics::reduce_sqlite_diagnostics(state, action, now))
+        .or_else(|| help::reduce_help(state, action))
+        .or_else(|| sqlite_diagnostics::reduce_sqlite_diagnostics(state, action))
         .or_else(|| confirm_dialog::reduce_confirm_dialog(state, action, now))
         .or_else(|| er_picker::reduce_er_picker(state, action, now))
-        .or_else(|| query_history::reduce_query_history_picker(state, action, now))
+        .or_else(|| query_history::reduce_query_history_picker(state, action))
 }
 
 #[cfg(test)]

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
@@ -8,11 +6,7 @@ use crate::update::action::{Action, InputTarget, ListMotion, ListTarget, ModalKi
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
 
-pub(super) fn reduce_query_history_picker(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_query_history_picker(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::QueryHistoryPicker) => {
             if state.modal.active_mode() == InputMode::QueryHistoryPicker {

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -1,16 +1,10 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_sqlite_diagnostics(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_sqlite_diagnostics(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::SqliteDiagnostics) => {
             let Some(dsn) = state.session.dsn().map(String::from) else {
@@ -80,6 +74,8 @@ pub(super) fn reduce_sqlite_diagnostics(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
     use crate::domain::connection::DatabaseType;
     use crate::domain::{ConnectionId, DiagnosticField, SqliteDiagnosticsSnapshot};
@@ -182,12 +178,8 @@ mod tests {
             "postgres://localhost/db",
         );
 
-        let effects = reduce_sqlite_diagnostics(
-            &mut state,
-            &Action::RunSqliteDiagnosticsQuickCheck,
-            Instant::now(),
-        )
-        .unwrap();
+        let effects =
+            reduce_sqlite_diagnostics(&mut state, &Action::RunSqliteDiagnosticsQuickCheck).unwrap();
 
         assert!(effects.is_empty());
         assert!(!state.sqlite_diagnostics.is_quick_check_running());
@@ -245,7 +237,6 @@ mod tests {
                 run_id: stale_quick_check_run_id,
                 quick_check: DiagnosticField::ok("ok"),
             },
-            Instant::now(),
         )
         .unwrap();
 
@@ -277,7 +268,6 @@ mod tests {
                 run_id: stale_run_id,
                 snapshot: Box::new(SqliteDiagnosticsSnapshot::default()),
             },
-            Instant::now(),
         )
         .unwrap();
 
@@ -301,7 +291,6 @@ mod tests {
                 direction: ScrollDirection::Down,
                 amount: ScrollAmount::Line,
             },
-            Instant::now(),
         )
         .unwrap();
 

--- a/src/app/update/sql_editor/completion.rs
+++ b/src/app/update/sql_editor/completion.rs
@@ -1,16 +1,10 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::sql_editor::modal::sql_modal_visible_rows;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_completion(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_completion(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         // Completion navigation
         Action::CompletionNext => {
@@ -109,7 +103,6 @@ mod tests {
                 database_generation: old_scope.2,
                 metadata_generation: old_scope.3,
             },
-            Instant::now(),
         );
 
         assert!(!state.sql_modal.completion().visible);

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -13,9 +13,9 @@ use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 pub fn dispatch_sql_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
-    completion::reduce_completion(state, action, now)
+    completion::reduce_completion(state, action)
         .or_else(|| editing::reduce_editing(state, action, now))
-        .or_else(|| mode::reduce_mode(state, action, now))
+        .or_else(|| mode::reduce_mode(state, action))
         .or_else(|| submit::reduce_submit(state, action, now))
         .or_else(|| high_risk::reduce_high_risk_confirmation(state, action, now))
         .or_else(|| yank::reduce_yank(state, action, now))

--- a/src/app/update/sql_editor/mode.rs
+++ b/src/app/update/sql_editor/mode.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
@@ -8,7 +6,7 @@ use crate::update::action::{Action, CursorMove, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
 
-pub(super) fn reduce_mode(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
+pub(super) fn reduce_mode(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         // Modal open/submit
         Action::OpenModal(ModalKind::SqlModal) => {


### PR DESCRIPTION
## Problem
Private leaf reducers receive `Instant` even though they do not use time.

## Background
The unused dependency is forwarded through the dispatcher chain despite not being part of these reducers’ behavior.

## Approach
Make each affected private leaf accept only the state and action while preserving time-bearing reducers, routing order, and effect behavior.