### PR TITLE
refactor(app): remove folder open error wrapper

### DIFF
--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -23,10 +23,10 @@ use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
     AppSettings, CachedResultExporter, ClipboardError, ClipboardWriter, ConfigWriter,
     ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter,
-    FolderOpenError, FolderOpener, MetadataProvider, MySqlConnectionProbe,
-    MySqlConnectionProbeResult, PgServiceEntryReader, QueryExecutor, QueryHistoryError,
-    QueryHistoryStore, RenderOutput, RenderResult, Renderer, ServiceFileError, SettingsStore,
-    SettingsStoreError, SqliteDiagnosticsProvider, SqlitePathValidator,
+    FolderOpener, MetadataProvider, MySqlConnectionProbe, MySqlConnectionProbeResult,
+    PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore, RenderOutput,
+    RenderResult, Renderer, ServiceFileError, SettingsStore, SettingsStoreError,
+    SqliteDiagnosticsProvider, SqlitePathValidator,
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -156,7 +156,7 @@ impl ClipboardWriter for NoopClipboardWriter {
 
 pub struct NoopFolderOpener;
 impl FolderOpener for NoopFolderOpener {
-    fn open(&self, _path: &Path) -> Result<(), FolderOpenError> {
+    fn open(&self, _path: &Path) -> Result<(), std::io::Error> {
         Ok(())
     }
 }

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -37,7 +37,10 @@ pub(crate) async fn run(
         }
         Effect::OpenFolder { path } => {
             if let Err(e) = folder_opener.open(&path) {
-                action_tx.send(Action::OpenFolderFailed(e)).await.ok();
+                action_tx
+                    .send(Action::OpenFolderFailed(Arc::new(e)))
+                    .await
+                    .ok();
             }
         }
         _ => unreachable!("utility::run called with non-utility effect"),
@@ -51,7 +54,6 @@ mod tests {
     use std::sync::Mutex;
 
     use crate::ports::outbound::clipboard::ClipboardError;
-    use crate::ports::outbound::folder_opener::FolderOpenError;
 
     struct MockClipboard {
         result: Result<(), ClipboardError>,
@@ -65,7 +67,7 @@ mod tests {
 
     struct MockFolderOpener {
         opened: Mutex<Vec<PathBuf>>,
-        result: Result<(), FolderOpenError>,
+        result: Result<(), String>,
     }
 
     impl MockFolderOpener {
@@ -79,17 +81,18 @@ mod tests {
         fn failing(error: &str) -> Self {
             Self {
                 opened: Mutex::new(vec![]),
-                result: Err(FolderOpenError::Spawn(Arc::new(std::io::Error::other(
-                    error,
-                )))),
+                result: Err(error.to_owned()),
             }
         }
     }
 
     impl FolderOpener for MockFolderOpener {
-        fn open(&self, path: &Path) -> Result<(), FolderOpenError> {
+        fn open(&self, path: &Path) -> Result<(), std::io::Error> {
             self.opened.lock().unwrap().push(path.to_path_buf());
-            self.result.clone()
+            match &self.result {
+                Ok(()) => Ok(()),
+                Err(error) => Err(std::io::Error::other(error.as_str())),
+            }
         }
     }
 

--- a/src/app/ports/outbound/folder_opener.rs
+++ b/src/app/ports/outbound/folder_opener.rs
@@ -1,18 +1,5 @@
 use std::path::Path;
-use std::sync::Arc;
-
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum FolderOpenError {
-    #[error("{0}")]
-    Spawn(#[source] Arc<std::io::Error>),
-}
-
-impl From<std::io::Error> for FolderOpenError {
-    fn from(e: std::io::Error) -> Self {
-        Self::Spawn(Arc::new(e))
-    }
-}
 
 pub trait FolderOpener: Send + Sync {
-    fn open(&self, path: &Path) -> Result<(), FolderOpenError>;
+    fn open(&self, path: &Path) -> Result<(), std::io::Error>;
 }

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -37,7 +37,7 @@ pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;
 pub use er_exporter::{ErDiagramExporter, ErExportError, ErExportResult};
 pub use er_log_writer::ErLogWriter;
-pub use folder_opener::{FolderOpenError, FolderOpener};
+pub use folder_opener::FolderOpener;
 pub use metadata::MetadataProvider;
 pub use mysql_connection_probe::{MySqlConnectionProbe, MySqlConnectionProbeResult};
 pub use query_executor::QueryExecutor;

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -14,7 +14,6 @@ use crate::model::sql_editor::completion::CompletionCandidate;
 use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
-use crate::ports::outbound::folder_opener::FolderOpenError;
 use crate::ports::outbound::query_history::QueryHistoryError;
 use crate::ports::outbound::settings_store::SettingsStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
@@ -616,7 +615,7 @@ pub enum Action {
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
     CopyFailed(ClipboardError),
-    OpenFolderFailed(FolderOpenError),
+    OpenFolderFailed(Arc<std::io::Error>),
     ToggleFocus,
     ToggleReadOnly,
 

--- a/src/infra/adapters/folder_opener.rs
+++ b/src/infra/adapters/folder_opener.rs
@@ -44,5 +44,7 @@ fn spawn_folder_opener(program: &str, args: &[&str], path: &Path) -> Result<(), 
     target_os = "windows"
 )))]
 fn open_folder(_path: &Path) -> Result<(), std::io::Error> {
-    Err(std::io::Error::other("Opening folders is unsupported on this platform").into())
+    Err(std::io::Error::other(
+        "Opening folders is unsupported on this platform",
+    ))
 }

--- a/src/infra/adapters/folder_opener.rs
+++ b/src/infra/adapters/folder_opener.rs
@@ -1,28 +1,28 @@
 use std::path::Path;
 use std::process::Command;
 
-use crate::app::ports::outbound::folder_opener::{FolderOpenError, FolderOpener};
+use crate::app::ports::outbound::folder_opener::FolderOpener;
 
 pub struct NativeFolderOpener;
 
 impl FolderOpener for NativeFolderOpener {
-    fn open(&self, path: &Path) -> Result<(), FolderOpenError> {
+    fn open(&self, path: &Path) -> Result<(), std::io::Error> {
         open_folder(path)
     }
 }
 
 #[cfg(target_os = "macos")]
-fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
+fn open_folder(path: &Path) -> Result<(), std::io::Error> {
     spawn_folder_opener("open", &[], path)
 }
 
 #[cfg(any(target_os = "freebsd", target_os = "linux"))]
-fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
+fn open_folder(path: &Path) -> Result<(), std::io::Error> {
     spawn_folder_opener("xdg-open", &[], path)
 }
 
 #[cfg(target_os = "windows")]
-fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
+fn open_folder(path: &Path) -> Result<(), std::io::Error> {
     spawn_folder_opener("explorer", &[], path)
 }
 
@@ -32,7 +32,7 @@ fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
     target_os = "linux",
     target_os = "windows"
 ))]
-fn spawn_folder_opener(program: &str, args: &[&str], path: &Path) -> Result<(), FolderOpenError> {
+fn spawn_folder_opener(program: &str, args: &[&str], path: &Path) -> Result<(), std::io::Error> {
     Command::new(program).args(args).arg(path).spawn()?;
     Ok(())
 }
@@ -43,6 +43,6 @@ fn spawn_folder_opener(program: &str, args: &[&str], path: &Path) -> Result<(), 
     target_os = "linux",
     target_os = "windows"
 )))]
-fn open_folder(_path: &Path) -> Result<(), FolderOpenError> {
+fn open_folder(_path: &Path) -> Result<(), std::io::Error> {
     Err(std::io::Error::other("Opening folders is unsupported on this platform").into())
 }


### PR DESCRIPTION
## Problem\n\nFolder opening exposed an adapter-specific error wrapper across the application boundary.\n\n## Approach\n\nUse the standard I/O error at the folder opener boundary and preserve the existing failure action and user-facing behavior.\n