### PR TITLE
refactor(app): remove connection store path forwarding

### DIFF
--- a/src/app/ports/outbound/connection_store.rs
+++ b/src/app/ports/outbound/connection_store.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::domain::connection::{ConnectionId, ConnectionProfile, ConnectionProfileError};
@@ -42,8 +41,6 @@ impl From<toml::de::Error> for ConnectionStoreError {
 #[cfg_attr(test, mockall::automock)]
 pub trait ConnectionStore: Send + Sync {
     fn save(&self, profile: &ConnectionProfile) -> Result<(), ConnectionStoreError>;
-
-    fn storage_path(&self) -> PathBuf;
 
     fn load_all(&self) -> Result<Vec<ConnectionProfile>, ConnectionStoreError>;
 

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -16,7 +16,7 @@ pub struct TomlConnectionStore {
 
 impl TomlConnectionStore {
     pub fn new() -> Result<Self, ConnectionStoreError> {
-        let config_dir = get_config_dir()?;
+        let config_dir = app_config_dir()?;
         Ok(Self { config_dir })
     }
 
@@ -24,12 +24,12 @@ impl TomlConnectionStore {
         Self { config_dir }
     }
 
-    fn config_file_path(&self) -> PathBuf {
+    pub fn storage_path(&self) -> PathBuf {
         config_file_path(&self.config_dir)
     }
 
     fn load_config_file(&self) -> Result<Option<ConnectionConfigFile>, ConnectionStoreError> {
-        let path = self.config_file_path();
+        let path = config_file_path(&self.config_dir);
         if !path.exists() {
             return Ok(None);
         }
@@ -114,14 +114,6 @@ impl ConnectionStore for TomlConnectionStore {
 
         self.write_all(&profiles)
     }
-
-    fn storage_path(&self) -> PathBuf {
-        self.config_file_path()
-    }
-}
-
-fn get_config_dir() -> Result<PathBuf, ConnectionStoreError> {
-    Ok(app_config_dir()?)
 }
 
 #[cfg(test)]

--- a/src/infra/adapters/settings_store.rs
+++ b/src/infra/adapters/settings_store.rs
@@ -17,7 +17,7 @@ pub struct TomlSettingsStore {
 
 impl TomlSettingsStore {
     pub fn new() -> Result<Self, SettingsStoreError> {
-        let config_dir = get_config_dir()?;
+        let config_dir = app_config_dir()?;
         Ok(Self { config_dir })
     }
 
@@ -25,12 +25,8 @@ impl TomlSettingsStore {
         Self { config_dir }
     }
 
-    fn config_file_path(&self) -> PathBuf {
-        config_file_path(&self.config_dir)
-    }
-
     fn load_config_file_lenient(&self) -> Result<Option<ConnectionConfigFile>, SettingsStoreError> {
-        let path = self.config_file_path();
+        let path = config_file_path(&self.config_dir);
         if !path.exists() {
             return Ok(None);
         }
@@ -51,7 +47,7 @@ impl TomlSettingsStore {
     }
 
     fn load_config_file_strict(&self) -> Result<Option<ConnectionConfigFile>, SettingsStoreError> {
-        let path = self.config_file_path();
+        let path = config_file_path(&self.config_dir);
         if !path.exists() {
             return Ok(None);
         }
@@ -96,10 +92,6 @@ impl SettingsStore for TomlSettingsStore {
 
         Ok(())
     }
-}
-
-fn get_config_dir() -> Result<PathBuf, SettingsStoreError> {
-    Ok(app_config_dir()?)
 }
 
 fn app_settings(config: ConnectionConfigFile) -> AppSettings {


### PR DESCRIPTION
## Summary\n\n- Remove the connection-store path from the outbound port contract.\n- Keep path ownership inside the settings and connection-store adapters.\n\n## Validation\n\n- git diff --check\n