### PR TITLE
refactor: make text input methods inherent

### DIFF
--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -3,7 +3,6 @@ use std::cell::RefCell;
 use crate::cmd::completion_engine::{CompletionDatabaseScope, CompletionEngine};
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::model::shared::text_input::TextInputLike;
 use crate::update::action::Action;
 
 pub fn run(

--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -1,5 +1,5 @@
 use crate::model::shared::cursor::CursorMove;
-use crate::model::shared::text_input::{TextInputEditing, TextInputState, TextKillDirection};
+use crate::model::shared::text_input::{TextInputState, TextKillDirection};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CellEditState {

--- a/src/app/model/browse/json_detail.rs
+++ b/src/app/model/browse/json_detail.rs
@@ -1,7 +1,5 @@
 use crate::model::shared::detail_view::{DetailContentState, DetailSearchState};
 use crate::model::shared::multi_line_input::MultiLineInputState;
-use crate::model::shared::text_input::TextInputLike;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum JsonDetailMode {
     #[default]
@@ -165,7 +163,6 @@ mod test_support {
 #[cfg(test)]
 mod tests {
     use super::{JsonDetailMode, JsonDetailState};
-    use crate::model::shared::text_input::TextInputLike;
 
     #[test]
     fn open_prettifies_valid_json_into_editor() {

--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -1,9 +1,8 @@
 use crate::model::shared::cursor::CursorMove;
 
 use super::text_input::{
-    TextInputEditing, TextInputLike, TextInputState, TextKillDirection, char_to_byte_index,
-    next_word_start, previous_word_start, readline_forward_word_end,
-    readline_previous_whitespace_boundary, readline_previous_word_start,
+    TextInputState, TextKillDirection, char_to_byte_index, next_word_start, previous_word_start,
+    readline_forward_word_end, readline_previous_whitespace_boundary, readline_previous_word_start,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -41,6 +40,18 @@ impl MultiLineInputState {
 
     pub fn scroll_row(&self) -> usize {
         self.scroll_row
+    }
+
+    pub fn content(&self) -> &str {
+        self.inner.content()
+    }
+
+    pub fn cursor(&self) -> usize {
+        self.inner.cursor()
+    }
+
+    pub fn char_count(&self) -> usize {
+        self.inner.char_count()
     }
 
     pub fn set_cursor(&mut self, pos: usize) {
@@ -111,6 +122,19 @@ impl MultiLineInputState {
             readline_previous_whitespace_boundary(self.content(), self.cursor()),
             self.cursor(),
         )
+    }
+
+    pub fn kill(&mut self, direction: TextKillDirection) -> String {
+        match direction {
+            TextKillDirection::ToLineEnd => self.kill_to_line_end(),
+            TextKillDirection::ToLineStart => self.kill_to_line_start(),
+            TextKillDirection::ReadlineWordEnd => self.kill_next_word(),
+            TextKillDirection::ReadlinePreviousWhitespace => self.kill_previous_word(),
+        }
+    }
+
+    pub fn yank(&mut self, text: &str) {
+        self.insert_str(text);
     }
 
     pub fn set_content(&mut self, s: String) {
@@ -329,27 +353,6 @@ impl MultiLineInputState {
         let (row, col) = find_cursor_position(self.line_spans(), self.cursor());
         self.derived.cursor_row = row;
         self.derived.cursor_col = col;
-    }
-}
-
-impl TextInputLike for MultiLineInputState {
-    fn text_input(&self) -> &TextInputState {
-        &self.inner
-    }
-}
-
-impl TextInputEditing for MultiLineInputState {
-    fn kill(&mut self, direction: TextKillDirection) -> String {
-        match direction {
-            TextKillDirection::ToLineEnd => self.kill_to_line_end(),
-            TextKillDirection::ToLineStart => self.kill_to_line_start(),
-            TextKillDirection::ReadlineWordEnd => self.kill_next_word(),
-            TextKillDirection::ReadlinePreviousWhitespace => self.kill_previous_word(),
-        }
-    }
-
-    fn yank(&mut self, text: &str) {
-        self.insert_str(text);
     }
 }
 

--- a/src/app/model/shared/text_input.rs
+++ b/src/app/model/shared/text_input.rs
@@ -8,33 +8,12 @@ pub struct TextInputState {
     viewport_offset: usize,
 }
 
-pub trait TextInputLike {
-    fn text_input(&self) -> &TextInputState;
-
-    fn content(&self) -> &str {
-        self.text_input().content()
-    }
-
-    fn cursor(&self) -> usize {
-        self.text_input().cursor()
-    }
-
-    fn char_count(&self) -> usize {
-        self.text_input().char_count()
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextKillDirection {
     ToLineEnd,
     ToLineStart,
     ReadlineWordEnd,
     ReadlinePreviousWhitespace,
-}
-
-pub trait TextInputEditing {
-    fn kill(&mut self, direction: TextKillDirection) -> String;
-    fn yank(&mut self, text: &str);
 }
 
 impl TextInputState {
@@ -140,6 +119,19 @@ impl TextInputState {
         )
     }
 
+    pub fn kill(&mut self, direction: TextKillDirection) -> String {
+        match direction {
+            TextKillDirection::ToLineEnd => self.kill_to_line_end(),
+            TextKillDirection::ToLineStart => self.kill_to_line_start(),
+            TextKillDirection::ReadlineWordEnd => self.kill_next_word(),
+            TextKillDirection::ReadlinePreviousWhitespace => self.kill_previous_word(),
+        }
+    }
+
+    pub fn yank(&mut self, text: &str) {
+        self.insert_str(text);
+    }
+
     pub fn move_cursor(&mut self, movement: CursorMove) {
         match movement {
             CursorMove::Left => {
@@ -241,27 +233,6 @@ impl TextInputState {
         self.cursor = start;
         self.viewport_offset = 0;
         removed
-    }
-}
-
-impl TextInputLike for TextInputState {
-    fn text_input(&self) -> &TextInputState {
-        self
-    }
-}
-
-impl TextInputEditing for TextInputState {
-    fn kill(&mut self, direction: TextKillDirection) -> String {
-        match direction {
-            TextKillDirection::ToLineEnd => self.kill_to_line_end(),
-            TextKillDirection::ToLineStart => self.kill_to_line_start(),
-            TextKillDirection::ReadlineWordEnd => self.kill_next_word(),
-            TextKillDirection::ReadlinePreviousWhitespace => self.kill_previous_word(),
-        }
-    }
-
-    fn yank(&mut self, text: &str) {
-        self.insert_str(text);
     }
 }
 

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use crate::domain::{CommandTag, DatabaseDiagnostic};
 use crate::model::shared::multi_line_input::MultiLineInputState;
-use crate::model::shared::text_input::{TextInputLike, TextInputState};
+use crate::model::shared::text_input::TextInputState;
 use crate::policy::write::sql_risk::AcknowledgeReason;
 use crate::policy::write::write_guardrails::AdhocRiskDecision;
 

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -1,6 +1,6 @@
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::shared::text_input::{TextInputEditing, TextInputState};
+use crate::model::shared::text_input::TextInputState;
 use crate::update::action::{Action, InputTarget, ListMotion, ListTarget};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::palette::palette_command_count;

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -5,7 +5,6 @@ use crate::model::browse::json_detail::{JsonDetailMode, JsonDetailState};
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::KeySequenceState;
-use crate::model::shared::text_input::{TextInputEditing, TextInputLike};
 use crate::model::shared::ui_state::DEFAULT_JSON_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -11,7 +11,6 @@ use crate::model::connection::setup::{
 use crate::model::connection::state::ConnectionState;
 use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::shared::text_input::TextInputEditing;
 use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, InputTarget, ModalKind,
 };

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
-use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -26,7 +26,6 @@ mod tests {
     use crate::domain::DatabaseType;
     use crate::model::browse::query_execution::PostDeleteRowSelection;
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::shared::text_input::TextInputLike;
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
     use crate::policy::write::sql_risk::AcknowledgeReason;
     use crate::ports::outbound::AccessMode;

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::{DatabaseType, mysql_sql::mysql_explain_rejection_message};
 use crate::model::app_state::AppState;
-use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::AccessMode;

--- a/src/app/update/explain/scroll.rs
+++ b/src/app/update/explain/scroll.rs
@@ -1,6 +1,5 @@
 use crate::model::app_state::AppState;
 use crate::model::explain_context::ExplainContext;
-use crate::model::shared::text_input::TextInputLike;
 use crate::update::action::{Action, ScrollAmount, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -4,7 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::shared::text_input::{TextInputEditing, TextInputState};
+use crate::model::shared::text_input::TextInputState;
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 

--- a/src/app/update/modal/help.rs
+++ b/src/app/update/modal/help.rs
@@ -2,7 +2,7 @@ use crate::catalog::HelpDocument;
 use crate::model::app_state::AppState;
 use crate::model::shared::help::HelpOrigin;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::shared::text_input::{TextInputEditing, TextInputState};
+use crate::model::shared::text_input::TextInputState;
 use crate::update::action::{
     Action, InputTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
 };

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -1106,7 +1106,6 @@ mod tests {
         use crate::domain::query_history::{
             QueryHistoryEntry, QueryHistoryScope, QueryResultStatus,
         };
-        use crate::model::shared::text_input::TextInputLike;
         use crate::ports::outbound::query_history::QueryHistoryError;
 
         fn make_entry(query: &str, conn_id: &ConnectionId) -> QueryHistoryEntry {

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -1,7 +1,7 @@
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::shared::text_input::{TextInputEditing, TextInputState};
+use crate::model::shared::text_input::TextInputState;
 use crate::update::action::{Action, InputTarget, ListMotion, ListTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;

--- a/src/app/update/modal/settings.rs
+++ b/src/app/update/modal/settings.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::shared::text_input::TextInputEditing;
 use crate::ports::outbound::AppSettings;
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -374,7 +374,6 @@ mod tests {
         use crate::model::er_state::ErStatus;
         use crate::model::shared::flash_timer::FlashId;
         use crate::model::shared::key_sequence::Prefix;
-        use crate::model::shared::text_input::TextInputLike;
         use crate::update::action::{ErDiagramInfo, ScrollAmount, ScrollDirection, ScrollTarget};
 
         fn sqlite_state() -> AppState {
@@ -976,7 +975,6 @@ mod tests {
 
     mod sql_modal_debounce {
         use super::*;
-        use crate::model::shared::text_input::TextInputLike;
         use crate::model::sql_editor::modal::SqlModalStatus;
         use std::time::Duration;
 
@@ -1070,7 +1068,6 @@ mod tests {
 
     mod completion_ui {
         use super::*;
-        use crate::model::shared::text_input::TextInputLike;
         use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 
         fn make_candidate(text: &str) -> CompletionCandidate {

--- a/src/app/update/sql_editor/editing.rs
+++ b/src/app/update/sql_editor/editing.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::KeySequenceState;
-use crate::model::shared::text_input::TextInputEditing;
 use crate::model::sql_editor::modal::{SqlModalStatus, sql_modal_visible_rows};
 use crate::update::action::{Action, CursorMove, InputTarget};
 use crate::update::dispatch_result::DispatchResult;

--- a/src/app/update/sql_editor/high_risk.rs
+++ b/src/app/update/sql_editor/high_risk.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use crate::model::app_state::AppState;
 use crate::model::shared::key_sequence::KeySequenceState;
-use crate::model::shared::text_input::{TextInputEditing, TextInputLike, TextInputState};
+use crate::model::shared::text_input::TextInputState;
 use crate::model::sql_editor::modal::{
     HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalContext, SqlModalStatus,
 };

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -29,7 +29,7 @@ mod tests {
     use crate::model::browse::query_execution::PostDeleteRowSelection;
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::shared::text_input::{TextInputLike, TextInputState};
+    use crate::model::shared::text_input::TextInputState;
     use crate::model::sql_editor::modal::{AdhocSuccessSnapshot, SqlModalStatus, SqlModalTab};
     use crate::policy::write::sql_risk::AcknowledgeReason;
     use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel};

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -2,7 +2,6 @@ use std::time::Instant;
 
 use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
-use crate::model::shared::text_input::TextInputLike;
 use crate::policy::write::sql_risk::{
     ConfirmationType, MultiStatementDecision, SqlRiskDecision,
     evaluate_multi_statement_for_database_with_context,

--- a/src/app/update/sql_editor/yank.rs
+++ b/src/app/update/sql_editor/yank.rs
@@ -5,7 +5,6 @@ use crate::cmd::effect::Effect;
 use crate::domain::explain_plan::{ComparisonVerdict, compare_plans};
 use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
-use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalTab;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;

--- a/src/ui/features/browse/json_detail.rs
+++ b/src/ui/features/browse/json_detail.rs
@@ -8,7 +8,6 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::browse::json_detail::JsonDetailMode;
 use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::render_output::JsonDetailLayout;
-use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::policy::{FeaturePolicy, FeatureRequirement};
 use crate::features::browse::detail_view::render_detail_search;
 use crate::primitives::atoms::scroll_indicator::{

--- a/src/ui/features/sql_modal/editor.rs
+++ b/src/ui/features/sql_modal/editor.rs
@@ -8,7 +8,6 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::flash_timer::FlashId;
-use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
 use crate::primitives::atoms::{
     CursorKind, ModalTextSurface, apply_yank_flash, build_modal_text_surface_lines,


### PR DESCRIPTION
## Summary

- Remove the internal TextInputLike and TextInputEditing traits.
- Keep the existing text access and editing behavior as inherent methods on TextInputState and MultiLineInputState.
- Update all workspace callers to use the concrete methods.

## Validation

- cargo test -p sabiql-app text_input --lib
- cargo test -p sabiql-app multi_line_input --lib
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- bash scripts/lint_all.sh