### PR TITLE
refactor: remove query history load error wrapper

### DIFF
--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -27,7 +27,9 @@ pub fn spawn_query_history_load(
                             .ok();
                     }
                     Err(e) => {
-                        tx.send(Action::QueryHistoryLoadFailed(scope, e)).await.ok();
+                        tx.send(Action::QueryHistoryLoadFailed(scope, e.to_string()))
+                            .await
+                            .ok();
                     }
                 }
             });

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -20,18 +20,11 @@ pub fn spawn_query_history_load(
             let tx = action_tx.clone();
 
             tokio::spawn(async move {
-                match store.load(&project_name, &scope).await {
-                    Ok(entries) => {
-                        tx.send(Action::QueryHistoryLoaded(scope, entries))
-                            .await
-                            .ok();
-                    }
-                    Err(e) => {
-                        tx.send(Action::QueryHistoryLoadFailed(scope, e.to_string()))
-                            .await
-                            .ok();
-                    }
-                }
+                let action = match store.load(&project_name, &scope).await {
+                    Ok(entries) => Action::QueryHistoryLoaded(scope, entries),
+                    Err(e) => Action::QueryHistoryLoadFailed(scope, e.to_string()),
+                };
+                tx.send(action).await.ok();
             });
         }
         _ => unreachable!("spawn_query_history_load called with non-query-history effect"),

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -30,3 +30,109 @@ pub fn spawn_query_history_load(
         _ => unreachable!("spawn_query_history_load called with non-query-history effect"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::connection::ConnectionId;
+    use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
+    use crate::ports::outbound::QueryHistoryError;
+
+    struct TestQueryHistoryStore {
+        result: Result<Vec<QueryHistoryEntry>, QueryHistoryError>,
+    }
+
+    #[async_trait::async_trait]
+    impl QueryHistoryStore for TestQueryHistoryStore {
+        async fn append(
+            &self,
+            _project_name: &str,
+            _scope: &QueryHistoryScope,
+            _entry: &QueryHistoryEntry,
+        ) -> Result<(), QueryHistoryError> {
+            Ok(())
+        }
+
+        async fn load(
+            &self,
+            _project_name: &str,
+            _scope: &QueryHistoryScope,
+        ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError> {
+            self.result.clone()
+        }
+    }
+
+    fn scope() -> QueryHistoryScope {
+        QueryHistoryScope::new(ConnectionId::from_string("test-conn"), None)
+    }
+
+    fn entry() -> QueryHistoryEntry {
+        QueryHistoryEntry::new_with_database(
+            "SELECT 1".to_string(),
+            "2026-03-13T12:00:00Z".to_string(),
+            ConnectionId::from_string("test-conn"),
+            None,
+            QueryResultStatus::Success,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn load_success_dispatches_one_loaded_action() {
+        let scope = scope();
+        let entries = vec![entry()];
+        let store: Arc<dyn QueryHistoryStore> = Arc::new(TestQueryHistoryStore {
+            result: Ok(entries.clone()),
+        });
+        let (tx, mut rx) = mpsc::channel(2);
+
+        spawn_query_history_load(
+            Effect::LoadQueryHistory {
+                project_name: "test".to_string(),
+                scope: scope.clone(),
+            },
+            &tx,
+            &store,
+        );
+
+        let action = rx.recv().await.expect("action dispatched");
+        match action {
+            Action::QueryHistoryLoaded(received_scope, received_entries) => {
+                assert_eq!(received_scope, scope);
+                assert_eq!(received_entries, entries);
+            }
+            other => panic!("expected QueryHistoryLoaded, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn load_failure_dispatches_one_display_error_action() {
+        let scope = scope();
+        let store: Arc<dyn QueryHistoryStore> = Arc::new(TestQueryHistoryStore {
+            result: Err(QueryHistoryError::Io(Arc::new(std::io::Error::other(
+                "disk error",
+            )))),
+        });
+        let (tx, mut rx) = mpsc::channel(2);
+
+        spawn_query_history_load(
+            Effect::LoadQueryHistory {
+                project_name: "test".to_string(),
+                scope: scope.clone(),
+            },
+            &tx,
+            &store,
+        );
+
+        let action = rx.recv().await.expect("action dispatched");
+        match action {
+            Action::QueryHistoryLoadFailed(received_scope, error) => {
+                assert_eq!(received_scope, scope);
+                assert_eq!(error, "IO error: disk error");
+            }
+            other => panic!("expected QueryHistoryLoadFailed, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -14,7 +14,6 @@ use crate::model::sql_editor::completion::CompletionCandidate;
 use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
-use crate::ports::outbound::query_history::QueryHistoryError;
 use crate::ports::outbound::settings_store::SettingsStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
@@ -621,7 +620,7 @@ pub enum Action {
 
     // Query history
     QueryHistoryLoaded(QueryHistoryScope, Vec<QueryHistoryEntry>),
-    QueryHistoryLoadFailed(QueryHistoryScope, QueryHistoryError),
+    QueryHistoryLoadFailed(QueryHistoryScope, String),
     QueryHistoryConfirmSelection,
 
     // CSV export

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -28,8 +28,6 @@ pub(crate) fn dispatch_modal(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use crate::cmd::effect::Effect;
     use crate::domain::{ConnectionId, DatabaseType, QueryValue};
@@ -1107,7 +1105,6 @@ mod tests {
             QueryHistoryEntry, QueryHistoryScope, QueryResultStatus,
         };
         use crate::model::shared::text_input::TextInputLike;
-        use crate::ports::outbound::query_history::QueryHistoryError;
 
         fn make_entry(query: &str, conn_id: &ConnectionId) -> QueryHistoryEntry {
             QueryHistoryEntry::new_with_database(
@@ -1353,7 +1350,7 @@ mod tests {
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
                         scope(&ConnectionId::from_string("test-conn"), None),
-                        QueryHistoryError::Io(Arc::new(std::io::Error::other("disk error"))),
+                        "IO error: disk error".to_string(),
                     ),
                     now,
                 )
@@ -1375,7 +1372,7 @@ mod tests {
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
                         scope(&ConnectionId::from_string("test-conn"), None),
-                        QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
+                        "IO error: stale error".to_string(),
                     ),
                     now,
                 )
@@ -1394,7 +1391,7 @@ mod tests {
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
                         scope(&ConnectionId::from_string("old-conn"), None),
-                        QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
+                        "IO error: stale error".to_string(),
                     ),
                     now,
                 )

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -54,14 +54,14 @@ pub(super) fn reduce_query_history_picker(state: &mut AppState, action: &Action)
             state.query_history_picker.replace_entries(entries);
             DispatchResult::handled()
         }
-        Action::QueryHistoryLoadFailed(scope, e) => {
+        Action::QueryHistoryLoadFailed(scope, error) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
             if state.session.query_history_scope().as_ref() != Some(scope) {
                 return DispatchResult::handled();
             }
-            state.messages.set_error(e.to_string());
+            state.messages.set_error(error.clone());
             DispatchResult::handled()
         }
         Action::TextInput {


### PR DESCRIPTION
## Problem
Query history load failures cross into the update layer as a structured error even though the picker only renders their message.

## Background
The load failure action does not inspect the error variants or source chain.

## Approach
Convert the load error to its display string when dispatching the failure action. Keep the query history store error contract unchanged for persistence operations and preserve the existing user-visible message.