### PR TITLE
refactor(app): consolidate edit selection errors

### DIFF
--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -37,12 +37,12 @@ fn build_update_preview(state: &AppState) -> Result<WritePreview, EditGuardrailE
         .result_interaction
         .cell_edit()
         .row()
-        .ok_or(EditGuardrailError::NoRowSelectedForEdit)?;
+        .ok_or(EditGuardrailError::NoActiveRow)?;
     let col_idx = state
         .result_interaction
         .cell_edit()
         .col()
-        .ok_or(EditGuardrailError::NoColumnSelectedForEdit)?;
+        .ok_or(EditGuardrailError::NoActiveCell)?;
 
     let row_values = result
         .values()

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -76,10 +76,6 @@ pub enum EditGuardrailError {
     StableKeyColumnsMissing,
     #[error("No active cell edit session")]
     NoActiveCellEditSession,
-    #[error("No row selected for edit")]
-    NoRowSelectedForEdit,
-    #[error("No column selected for edit")]
-    NoColumnSelectedForEdit,
     #[error("Row index out of bounds")]
     RowIndexOutOfBounds,
     #[error("Column index out of bounds")]


### PR DESCRIPTION
## Problem
Duplicate edit-selection failure variants represent the same unreachable cell-edit state.

## Background
CellEditState::is_active requires both row and column selection, so the write-path-specific variants cannot be observed.

## Approach
Reuse the existing active-selection errors and remove the duplicate variants while preserving reachable behavior.

## Screenshots

## Linear Issue Link (optional)
