### PR TITLE
refactor(app): require clipboard success callbacks

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -151,7 +151,7 @@ pub enum Effect {
 
     CopyToClipboard {
         content: String,
-        on_success: Option<Box<Action>>,
+        on_success: Box<Action>,
         on_failure: Option<Box<Action>>,
     },
     OpenFolder {

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -133,7 +133,7 @@ mod tests {
             run(
                 Effect::CopyToClipboard {
                     content: "hello".to_string(),
-                    on_success: Box::new(Action::Render),
+                    on_success: Box::new(Action::None),
                     on_failure: Some(Box::new(Action::Render)),
                 },
                 &tx,

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -22,9 +22,7 @@ pub(crate) async fn run(
             let tx = action_tx.clone();
             tokio::task::spawn_blocking(move || match clipboard.copy_text(&content) {
                 Ok(()) => {
-                    if let Some(action) = on_success {
-                        tx.blocking_send(*action).ok();
-                    }
+                    tx.blocking_send(*on_success).ok();
                 }
                 Err(e) => {
                     if let Some(action) = on_failure {
@@ -108,7 +106,7 @@ mod tests {
             run(
                 Effect::CopyToClipboard {
                     content: "hello".to_string(),
-                    on_success: Some(Box::new(Action::Render)),
+                    on_success: Box::new(Action::Render),
                     on_failure: None,
                 },
                 &tx,
@@ -135,7 +133,7 @@ mod tests {
             run(
                 Effect::CopyToClipboard {
                     content: "hello".to_string(),
-                    on_success: None,
+                    on_success: Box::new(Action::Render),
                     on_failure: Some(Box::new(Action::Render)),
                 },
                 &tx,
@@ -162,7 +160,7 @@ mod tests {
             run(
                 Effect::CopyToClipboard {
                     content: "hello".to_string(),
-                    on_success: None,
+                    on_success: Box::new(Action::Render),
                     on_failure: None,
                 },
                 &tx,

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -53,7 +53,7 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
         }
         Action::CellDetailYankAll => DispatchResult::handled_with(vec![Effect::CopyToClipboard {
             content: state.cell_detail.content().to_string(),
-            on_success: Some(Box::new(Action::CellDetailYankSuccess)),
+            on_success: Box::new(Action::CellDetailYankSuccess),
             on_failure: Some(Box::new(clipboard_unavailable())),
         }]),
         Action::CellDetailYankSuccess => {

--- a/src/app/update/browse/result/json.rs
+++ b/src/app/update/browse/result/json.rs
@@ -95,7 +95,7 @@ pub fn reduce_json(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             let json = state.json_detail.current_json_for_yank();
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content: json,
-                on_success: Some(Box::new(Action::JsonYankSuccess)),
+                on_success: Box::new(Action::JsonYankSuccess),
                 on_failure: Some(Box::new(clipboard_unavailable())),
             }])
         }
@@ -1085,10 +1085,7 @@ mod tests {
                     ..
                 } => {
                     assert!(content.contains("theme"));
-                    assert!(matches!(
-                        on_success.as_deref(),
-                        Some(Action::JsonYankSuccess)
-                    ));
+                    assert!(matches!(on_success.as_ref(), Action::JsonYankSuccess));
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }

--- a/src/app/update/browse/result/row_detail.rs
+++ b/src/app/update/browse/result/row_detail.rs
@@ -46,7 +46,7 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
             let content = state.row_detail.content_for_yank();
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content,
-                on_success: Some(Box::new(Action::RowDetailYankSuccess)),
+                on_success: Box::new(Action::RowDetailYankSuccess),
                 on_failure: Some(Box::new(clipboard_unavailable())),
             }])
         }
@@ -55,7 +55,7 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
             let content = state.row_detail.json_for_yank();
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content,
-                on_success: Some(Box::new(Action::RowDetailYankSuccess)),
+                on_success: Box::new(Action::RowDetailYankSuccess),
                 on_failure: Some(Box::new(clipboard_unavailable())),
             }])
         }
@@ -279,7 +279,7 @@ mod tests {
         assert!(matches!(
             &effects[0],
             Effect::CopyToClipboard { content, on_success, .. }
-            if content.contains("id\n  1") && matches!(on_success.as_deref(), Some(Action::RowDetailYankSuccess))
+            if content.contains("id\n  1") && matches!(on_success.as_ref(), Action::RowDetailYankSuccess)
         ));
     }
 
@@ -295,7 +295,7 @@ mod tests {
         assert!(matches!(
             &effects[0],
             Effect::CopyToClipboard { content, on_success, .. }
-            if content.contains("\"name\": \"alice\"") && matches!(on_success.as_deref(), Some(Action::RowDetailYankSuccess))
+            if content.contains("\"name\": \"alice\"") && matches!(on_success.as_ref(), Action::RowDetailYankSuccess)
         ));
     }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -35,10 +35,10 @@ pub fn reduce_yank(
                 if let Some(value) = content {
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: value,
-                        on_success: Some(Box::new(Action::ResultCellYankSuccess {
+                        on_success: Box::new(Action::ResultCellYankSuccess {
                             row: row_idx,
                             col: col_idx,
-                        })),
+                        }),
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
@@ -62,7 +62,7 @@ pub fn reduce_yank(
                     .generate_ddl(state.session.active_database_type_or_default(), table);
                 return DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: ddl,
-                    on_success: Some(Box::new(Action::DdlYankSuccess)),
+                    on_success: Box::new(Action::DdlYankSuccess),
                     on_failure: Some(Box::new(clipboard_unavailable())),
                 }]);
             }
@@ -95,7 +95,7 @@ pub fn reduce_yank(
                 if let Some(tsv) = content {
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: tsv,
-                        on_success: Some(Box::new(Action::ResultRowYankSuccess { row: row_idx })),
+                        on_success: Box::new(Action::ResultRowYankSuccess { row: row_idx }),
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
@@ -223,8 +223,8 @@ mod tests {
                 } => {
                     assert_eq!(content, "r1c2");
                     assert!(matches!(
-                        on_success.as_deref(),
-                        Some(Action::ResultCellYankSuccess { row: 1, col: 2 })
+                        on_success.as_ref(),
+                        Action::ResultCellYankSuccess { row: 1, col: 2 }
                     ));
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
@@ -352,8 +352,8 @@ mod tests {
                 } => {
                     assert_eq!(content, "v0\tv1\tv2");
                     assert!(matches!(
-                        on_success.as_deref(),
-                        Some(Action::ResultRowYankSuccess { row: 0 })
+                        on_success.as_ref(),
+                        Action::ResultRowYankSuccess { row: 0 }
                     ));
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
@@ -541,10 +541,7 @@ mod tests {
                     ..
                 } => {
                     assert!(content.contains("CREATE TABLE"));
-                    assert!(matches!(
-                        on_success.as_deref(),
-                        Some(Action::DdlYankSuccess)
-                    ));
+                    assert!(matches!(on_success.as_ref(), Action::DdlYankSuccess));
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -54,7 +54,7 @@ pub(super) fn reduce_connection_error(
             if let Some(content) = state.connection_error.masked_details() {
                 DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: content.to_string(),
-                    on_success: Some(Box::new(Action::ConnectionErrorCopied)),
+                    on_success: Box::new(Action::ConnectionErrorCopied),
                     on_failure: None,
                 }])
             } else {

--- a/src/app/update/sql_editor/yank.rs
+++ b/src/app/update/sql_editor/yank.rs
@@ -66,7 +66,7 @@ pub(super) fn reduce_yank(state: &mut AppState, action: &Action, now: Instant) -
                 Some(c) if !c.is_empty() => {
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: c,
-                        on_success: Some(Box::new(Action::SqlModalYankSuccess)),
+                        on_success: Box::new(Action::SqlModalYankSuccess),
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 }


### PR DESCRIPTION
## Problem

Clipboard copy effects allowed a missing success callback even though every production copy path expects success feedback.

## Approach

Require the success action in the effect payload and preserve the existing success and failure notifications for all copy flows.