### PR TITLE
refactor: remove settings save error wrapper

### DIFF
--- a/src/app/cmd/settings.rs
+++ b/src/app/cmd/settings.rs
@@ -16,7 +16,7 @@ pub(crate) async fn run(
     let result = settings_store.save(settings.clone());
     let action = match result {
         Ok(()) => Action::SettingsSaved(settings),
-        Err(error) => Action::SettingsSaveFailed(error),
+        Err(error) => Action::SettingsSaveFailed(error.to_string()),
     };
     let _ = action_tx.send(action).await;
 }
@@ -117,7 +117,7 @@ mod tests {
 
         assert!(matches!(
             rx.recv().await,
-            Some(Action::SettingsSaveFailed(_))
+            Some(Action::SettingsSaveFailed(error)) if error == "I/O error: disk full"
         ));
     }
 }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -15,7 +15,6 @@ use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
 use crate::ports::outbound::query_history::QueryHistoryError;
-use crate::ports::outbound::settings_store::SettingsStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
 
@@ -450,7 +449,7 @@ pub enum Action {
     SettingsApply,
     SettingsCancel,
     SettingsSaved(AppSettings),
-    SettingsSaveFailed(SettingsStoreError),
+    SettingsSaveFailed(String),
 
     // Database structure
     ReloadMetadata,

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -270,7 +270,6 @@ mod tests {
     mod settings {
         use super::*;
         use crate::model::shared::theme_id::ThemeId;
-        use crate::ports::outbound::SettingsStoreError;
 
         mod theme_selection {
             use super::*;
@@ -462,9 +461,7 @@ mod tests {
 
             let effects = super::dispatch_modal(
                 &mut state,
-                &Action::SettingsSaveFailed(SettingsStoreError::Io(std::sync::Arc::new(
-                    std::io::Error::other("disk full"),
-                ))),
+                &Action::SettingsSaveFailed("I/O error: disk full".to_string()),
                 Instant::now(),
             )
             .unwrap();


### PR DESCRIPTION
Convert SettingsStoreError to its display text at the settings save Action boundary while keeping the settings store error type and user-facing failure message unchanged.

Validation:
- cargo test -p sabiql-app cmd::settings::tests::save_settings_dispatches
- cargo test -p sabiql-app update::modal::tests::settings::save_failed_sets_error_message -- --exact
- cargo check and targeted Clippy for sabiql-app
- cargo fmt and scripts/lint_all.sh