### PR TITLE
refactor(app): simplify connection save error

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -98,7 +98,6 @@ pub(crate) async fn run(
             run_id,
             run_guard,
         } => {
-            let database_type = config.database_type();
             let id = id.unwrap_or_else(ConnectionId::new);
             let profile = ConnectionProfile::with_id_and_config(id, name, config);
             let profile = match profile {
@@ -107,7 +106,6 @@ pub(crate) async fn run(
                     action_tx
                         .send(Action::ConnectionSaveFailed {
                             error: e.into(),
-                            database_type,
                             run_id,
                         })
                         .await
@@ -130,7 +128,6 @@ pub(crate) async fn run(
                         action_tx
                             .send(Action::ConnectionSaveFailed {
                                 error: error.into(),
-                                database_type,
                                 run_id,
                             })
                             .await
@@ -140,7 +137,6 @@ pub(crate) async fn run(
                 };
                 let dsn = connection.dsn_builder.build_dsn(&profile);
                 let target = ConnectionTarget::from_profile(&profile, dsn);
-                let database_type = target.database_type;
 
                 connection_task
                     .replace(async move {
@@ -158,7 +154,6 @@ pub(crate) async fn run(
                                 Some(Err(e)) => {
                                     tx.blocking_send(Action::ConnectionSaveFailed {
                                         error: e.into(),
-                                        database_type,
                                         run_id,
                                     })
                                     .ok();
@@ -174,9 +169,8 @@ pub(crate) async fn run(
             }
 
             let dsn = connection.dsn_builder.build_dsn(&profile);
-            let database_type = profile.database_type();
 
-            if database_type == DatabaseType::MySQL {
+            if profile.database_type() == DatabaseType::MySQL {
                 let target = ConnectionTarget::from_profile(&profile, dsn);
                 let probe = Arc::clone(&connection.mysql_connection_probe);
                 connection_task
@@ -204,7 +198,6 @@ pub(crate) async fn run(
                                     Some(Err(e)) => {
                                         tx.send(Action::ConnectionSaveFailed {
                                             error: e.into(),
-                                            database_type,
                                             run_id,
                                         })
                                         .await
@@ -215,11 +208,7 @@ pub(crate) async fn run(
                             }
                             Err(e) => {
                                 tx.send(Action::ConnectionSaveFailed {
-                                    error: ConnectionSaveError::Probe {
-                                        error: e,
-                                        dsn: target.dsn.clone(),
-                                    },
-                                    database_type,
+                                    error: ConnectionSaveError::Probe { error: e },
                                     run_id,
                                 })
                                 .await
@@ -257,7 +246,6 @@ pub(crate) async fn run(
                                 Some(Err(e)) => {
                                     tx.send(Action::ConnectionSaveFailed {
                                         error: e.into(),
-                                        database_type,
                                         run_id,
                                     })
                                     .await
@@ -269,7 +257,6 @@ pub(crate) async fn run(
                         Err(e) => {
                             tx.send(Action::ConnectionSaveFailed {
                                 error: e.into(),
-                                database_type,
                                 run_id,
                             })
                             .await
@@ -629,10 +616,9 @@ mod tests {
             assert!(matches!(
                 action,
                 Action::ConnectionSaveFailed {
-                    error: ConnectionSaveError::Probe { dsn, .. },
-                    database_type: DatabaseType::MySQL,
+                    error: ConnectionSaveError::Probe { .. },
                     run_id: 1,
-                } if dsn == "mysql://user:secret@localhost:3306?ssl-mode=REQUIRED"
+                }
             ));
         }
 
@@ -834,11 +820,7 @@ mod tests {
 
             assert!(matches!(
                 run.actions.into_iter().next(),
-                Some(Action::ConnectionSaveFailed {
-                    database_type: DatabaseType::PostgreSQL,
-                    run_id: 1,
-                    ..
-                })
+                Some(Action::ConnectionSaveFailed { run_id: 1, .. })
             ));
         }
 
@@ -1026,7 +1008,6 @@ mod tests {
                         error: ConnectionSaveError::Validation(ConnectionProfileError::SqlitePath(
                             SqlitePathError::FileNotFound(_)
                         ),),
-                        database_type: DatabaseType::SQLite,
                         run_id: 1,
                     }
                 ),

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -25,7 +25,7 @@ use crate::domain::{
     TableSignatureSnapshot,
 };
 
-#[derive(Clone, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
     #[error("{0}")]
     Validation(#[from] ConnectionProfileError),
@@ -34,25 +34,7 @@ pub enum ConnectionSaveError {
     #[error("{0}")]
     Metadata(#[from] DbOperationError),
     #[error("{error}")]
-    Probe {
-        error: DbOperationError,
-        dsn: String,
-    },
-}
-
-impl fmt::Debug for ConnectionSaveError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Validation(error) => formatter.debug_tuple("Validation").field(error).finish(),
-            Self::Store(error) => formatter.debug_tuple("Store").field(error).finish(),
-            Self::Metadata(error) => formatter.debug_tuple("Metadata").field(error).finish(),
-            Self::Probe { error, dsn } => formatter
-                .debug_struct("Probe")
-                .field("error", error)
-                .field("dsn", &mask_password(dsn))
-                .finish(),
-        }
-    }
+    Probe { error: DbOperationError },
 }
 
 pub use crate::model::shared::cursor::CursorMove;
@@ -402,7 +384,6 @@ pub enum Action {
     },
     ConnectionSaveFailed {
         error: ConnectionSaveError,
-        database_type: DatabaseType,
         run_id: u64,
     },
     MySqlConnectionProbeCompleted {
@@ -914,19 +895,6 @@ mod tests {
         };
 
         let debug = format!("{target:?}");
-
-        assert!(!debug.contains("secret"));
-        assert!(debug.contains("mysql://user:****@localhost"));
-    }
-
-    #[test]
-    fn connection_save_probe_debug_masks_mysql_password() {
-        let error = ConnectionSaveError::Probe {
-            error: DbOperationError::ConnectionFailed("probe failed".to_string()),
-            dsn: "mysql://user:secret@localhost:3306/app".to_string(),
-        };
-
-        let debug = format!("{error:?}");
 
         assert!(!debug.contains("secret"));
         assert!(debug.contains("mysql://user:****@localhost"));

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -284,11 +284,7 @@ pub fn reduce_connection_setup(
                 metadata.clone(),
             ))
         }
-        Action::ConnectionSaveFailed {
-            error: e,
-            database_type,
-            run_id,
-        } => {
+        Action::ConnectionSaveFailed { error: e, run_id } => {
             if !state.session.is_current_connection_save(*run_id) {
                 return DispatchResult::handled();
             }
@@ -302,9 +298,7 @@ pub fn reduce_connection_setup(
                 state.session.mark_disconnected();
             }
             let mysql_error = match e {
-                ConnectionSaveError::Probe { error, dsn }
-                    if *database_type == DatabaseType::MySQL =>
-                {
+                ConnectionSaveError::Probe { error } => {
                     Some(ConnectionErrorInfo::from_db_operation_error(error))
                 }
                 _ => None,
@@ -753,14 +747,12 @@ mod tests {
                 kind: ConnectionFailureKind::TlsHostnameVerification,
                 details: "certificate verification failed".to_string(),
             };
-            let dsn = "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED".to_string();
             let run_id = state.session.begin_connection_save();
 
             reduce(
                 &mut state,
                 &Action::ConnectionSaveFailed {
-                    error: ConnectionSaveError::Probe { error, dsn },
-                    database_type: DatabaseType::MySQL,
+                    error: ConnectionSaveError::Probe { error },
                     run_id,
                 },
                 Instant::now(),
@@ -807,12 +799,7 @@ mod tests {
                 reduce(
                     &mut state,
                     &Action::ConnectionSaveFailed {
-                        error: ConnectionSaveError::Probe {
-                            error,
-                            dsn: "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED"
-                                .to_string(),
-                        },
-                        database_type: DatabaseType::MySQL,
+                        error: ConnectionSaveError::Probe { error },
                         run_id,
                     },
                     Instant::now(),
@@ -972,9 +959,7 @@ mod tests {
                 &Action::ConnectionSaveFailed {
                     error: ConnectionSaveError::Probe {
                         error: DbOperationError::ConnectionFailed("connection refused".to_string()),
-                        dsn: "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string(),
                     },
-                    database_type: DatabaseType::MySQL,
                     run_id,
                 },
                 Instant::now(),
@@ -1017,7 +1002,6 @@ mod tests {
                     &mut state,
                     &Action::ConnectionSaveFailed {
                         error: ConnectionSaveError::Metadata(error),
-                        database_type: DatabaseType::PostgreSQL,
                         run_id,
                     },
                     Instant::now(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2098,7 +2098,6 @@ mod tests {
                     error: ConnectionSaveError::Store(ConnectionStoreError::Io(Arc::new(
                         std::io::Error::other("Write error"),
                     ))),
-                    database_type: DatabaseType::PostgreSQL,
                     run_id,
                 },
                 now,


### PR DESCRIPTION
## Problem

Connection save failures carry a DSN and database type that no longer affect error handling after probe errors are typed.

## Background

Probe failures are produced only by the MySQL save-and-connect path, while the reducer classifies the contained DbOperationError.

## Approach

Keep the typed probe error and run identity, remove the redundant DSN and database-type payloads, and simplify the affected dispatch and reducer paths without changing connection-save state transitions.

## Validation

Focused probe tests, all sabiql-app tests, workspace check, sabiql-app Clippy, format check, and repository lint pass. The workspace suite has one pre-existing sabiql-infra SQLite export failure.