### PR TITLE
refactor(mysql): require configured pipe handles

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -142,15 +142,9 @@ impl MySqlProcess {
                 .kill_on_drop(true);
             sanitize_mysql_command_environment(&mut command);
             let mut child = command.spawn().map_err(map_mysql_cli_spawn_error)?;
-            let stdin = child.stdin.take().ok_or_else(|| {
-                DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
-            })?;
-            let stdout = child.stdout.take().ok_or_else(|| {
-                DbOperationError::QueryFailed("mysql stdout was not piped".to_string())
-            })?;
-            let stderr = child.stderr.take().ok_or_else(|| {
-                DbOperationError::QueryFailed("mysql stderr was not piped".to_string())
-            })?;
+            let stdin = child.stdin.take().expect("piped mysql stdin");
+            let stdout = child.stdout.take().expect("piped mysql stdout");
+            let stderr = child.stderr.take().expect("piped mysql stderr");
             Ok(Self {
                 child,
                 client_packet_limit_bytes,

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -138,15 +138,9 @@ impl MySqlMetadataProcess {
             .kill_on_drop(true);
         sanitize_mysql_command_environment(&mut command);
         let mut child = command.spawn().map_err(map_mysql_cli_spawn_error)?;
-        let stdin = child.stdin.take().ok_or_else(|| {
-            DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
-        })?;
-        let stdout = child.stdout.take().ok_or_else(|| {
-            DbOperationError::QueryFailed("mysql stdout was not piped".to_string())
-        })?;
-        let stderr = child.stderr.take().ok_or_else(|| {
-            DbOperationError::QueryFailed("mysql stderr was not piped".to_string())
-        })?;
+        let stdin = child.stdin.take().expect("piped mysql stdin");
+        let stdout = child.stdout.take().expect("piped mysql stdout");
+        let stderr = child.stderr.take().expect("piped mysql stderr");
         Ok(Self {
             child,
             stdin: Some(stdin),


### PR DESCRIPTION
## Problem
The non-Unix MySQL CLI path treats pipe handles configured by the spawn command as recoverable product errors.

## Background
These handles are required by the process setup, while the stdin lifecycle remains optional so cleanup can explicitly close the Windows pipe before draining output.

## Approach
Treat the six spawn-time pipe extractions as configuration invariants and preserve the existing spawn, write, shutdown, drain, and cleanup error paths.