### PR TITLE
refactor(app): narrow CLI SQLite API

### DIFF
--- a/src/app/cmd/cli_sqlite.rs
+++ b/src/app/cmd/cli_sqlite.rs
@@ -43,34 +43,30 @@ pub enum CliSqliteActivateError {
 }
 
 impl CliSqliteTarget {
-    pub fn parse_cli_argument(input: &str) -> Result<Self, CliSqliteTargetError> {
+    fn parse_cli_argument(input: &str) -> Result<Self, CliSqliteTargetError> {
         let path = parse_cli_path(input)?;
         Ok(Self {
             config: SqliteConnectionConfig::new(path)?,
         })
     }
 
-    pub fn path(&self) -> &str {
+    fn path(&self) -> &str {
         self.config.path()
     }
 
-    pub fn dsn(&self) -> String {
-        format!("sqlite://{}", self.config.path())
-    }
-
-    pub fn display_name(&self) -> String {
+    fn display_name(&self) -> String {
         Path::new(self.config.path())
             .file_name()
             .and_then(|name| name.to_str())
             .map_or_else(|| self.config.path().to_string(), str::to_owned)
     }
 
-    pub fn path_for_validation(&self) -> &Path {
+    fn path_for_validation(&self) -> &Path {
         Path::new(self.config.path())
     }
 }
 
-pub fn connection_id_for_path(path: &str) -> ConnectionId {
+fn connection_id_for_path(path: &str) -> ConnectionId {
     let derived = Uuid::new_v5(&CLI_SQLITE_CONNECTION_NAMESPACE, path.as_bytes());
     ConnectionId::from_string(format!("cli-sqlite-{}", derived.as_simple()))
 }
@@ -150,7 +146,6 @@ mod tests {
             let target = CliSqliteTarget::parse_cli_argument("sqlite:///tmp/app.db").unwrap();
 
             assert_eq!(target.path(), "/tmp/app.db");
-            assert_eq!(target.dsn(), "sqlite:///tmp/app.db");
         }
 
         #[rstest]

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -1886,11 +1886,9 @@ mod tests {
 
         #[test]
         fn is_ephemeral_connection_detects_cli_connection() {
-            use crate::cmd::cli_sqlite::connection_id_for_path;
-
             let mut session = BrowseSession::default();
             session.activate_cli_ephemeral_connection(
-                &connection_id_for_path("/tmp/app.db"),
+                &ConnectionId::from_string("cli-sqlite-test"),
                 "app.db",
                 "sqlite:///tmp/app.db",
             );

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -224,11 +224,11 @@ mod tests {
 
         #[test]
         fn blocked_for_cli_ephemeral_connection() {
-            use crate::cmd::cli_sqlite::connection_id_for_path;
+            use crate::domain::ConnectionId;
 
             let mut state = AppState::new("test".to_string());
             state.session.activate_cli_ephemeral_connection(
-                &connection_id_for_path("/tmp/app.db"),
+                &ConnectionId::from_string("cli-sqlite-test"),
                 "app.db",
                 "sqlite:///tmp/app.db",
             );

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -150,11 +150,9 @@ mod tests {
 
     #[tokio::test]
     async fn append_and_load_succeed_for_cli_sqlite_connection_id() {
-        use sabiql_app::cmd::cli_sqlite::connection_id_for_path;
-
         let tmp = TempDir::new().unwrap();
         let store = FileQueryHistoryStore::with_base_dir(tmp.path().to_path_buf());
-        let conn_id = connection_id_for_path("/tmp/app.db");
+        let conn_id = ConnectionId::from_string("cli-sqlite-test");
 
         assert!(!conn_id.as_str().contains('/'));
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -54,9 +54,7 @@ mod cli_sqlite_startup {
     use std::fs;
     use std::path::Path;
 
-    use sabiql_app::cmd::cli_sqlite::{
-        activate_cli_sqlite_connection, connection_id_for_path, resolve_cli_sqlite_target,
-    };
+    use sabiql_app::cmd::cli_sqlite::{activate_cli_sqlite_connection, resolve_cli_sqlite_target};
     use sabiql_app::model::app_state::AppState;
     use sabiql_app::ports::outbound::{AccessMode, QueryExecutor};
     use sabiql_infra::adapters::{FsSqlitePathValidator, SqliteAdapter};
@@ -68,11 +66,7 @@ mod cli_sqlite_startup {
         let path = dir.path().join("app.db");
         fs::write(&path, b"SQLite format 3\0rest").unwrap();
 
-        let target =
-            resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).unwrap();
-
-        assert_eq!(target.path(), path.to_str().unwrap());
-        assert_eq!(target.dsn(), format!("sqlite://{}", path.display()));
+        assert!(resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).is_ok());
     }
 
     #[test]
@@ -81,10 +75,7 @@ mod cli_sqlite_startup {
         let path = dir.path().join("History");
         fs::write(&path, b"SQLite format 3\0rest").unwrap();
 
-        let target =
-            resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).unwrap();
-
-        assert_eq!(target.path(), path.to_str().unwrap());
+        assert!(resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).is_ok());
     }
 
     #[test]
@@ -173,7 +164,6 @@ mod cli_sqlite_startup {
         let canonical_a = database_a.to_str().unwrap();
         let expected_dsn = format!("sqlite://{canonical_a}");
 
-        assert_eq!(absolute.0, connection_id_for_path(canonical_a));
         assert_eq!(absolute.0, relative.0);
         assert_eq!(absolute.0, symlinked.0);
         assert_eq!(absolute.1, expected_dsn);


### PR DESCRIPTION
## Problem
CliSqliteTarget exposes helper endpoints that are only needed inside the SQLite startup implementation and its tests.

## Background
The startup boundary needs target resolution and activation, while parsing, path access, display formatting, and connection identity helpers are internal details.

## Approach
Keep the target and error contracts used by startup, make the helper methods and connection identity calculation private, and simplify the affected tests without changing startup behavior.

## Validation
Focused app and infra tests, targeted Clippy, fmt, and lint_all passed.