### PR TITLE
refactor(app): remove duplicate adhoc probe guard

### DIFF
--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -4,17 +4,12 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::ports::outbound::AccessMode;
 use crate::update::dispatch_result::DispatchResult;
-use crate::update::helpers::reject_pending_mysql_connection_probe;
 
 pub(super) fn start_adhoc_if_connected(
     state: &mut AppState,
     query: String,
     now: Instant,
 ) -> DispatchResult {
-    if reject_pending_mysql_connection_probe(state) {
-        return DispatchResult::handled();
-    }
-
     let Some(dsn) = state.session.dsn().map(String::from) else {
         state
             .sql_modal


### PR DESCRIPTION
## Problem
The private adhoc-start helper repeats a MySQL connection-probe rejection already enforced by both of its callers.

## Background
The synchronous caller checks keep the SQL modal from starting work during a pending connection switch, while the helper has no independent production entry point.

## Approach
Keep the guard at the caller boundaries and remove the redundant helper-level check so the existing probe-blocking behavior remains explicit and unchanged.