### PR TITLE
refactor(app): pass typed payloads to singleton commands

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -304,13 +304,21 @@ impl EffectRunner {
                 Ok(vec![])
             }
 
-            e @ Effect::LoadQueryHistory { .. } => {
-                spawn_query_history_load(e, &self.action_tx, &self.query.query_history_store);
+            Effect::LoadQueryHistory {
+                project_name,
+                scope,
+            } => {
+                spawn_query_history_load(
+                    project_name,
+                    scope,
+                    &self.action_tx,
+                    &self.query.query_history_store,
+                );
                 Ok(vec![])
             }
 
-            e @ Effect::SaveSettings { .. } => {
-                cmd_settings::run(e, &self.action_tx, &self.settings_store).await;
+            Effect::SaveSettings { settings } => {
+                cmd_settings::run(settings, &self.action_tx, &self.settings_store).await;
                 Ok(vec![])
             }
 

--- a/src/app/cmd/settings.rs
+++ b/src/app/cmd/settings.rs
@@ -1,18 +1,13 @@
 use tokio::sync::mpsc;
 
-use crate::cmd::effect::Effect;
-use crate::ports::outbound::SettingsStore;
+use crate::ports::outbound::{AppSettings, SettingsStore};
 use crate::update::action::Action;
 
 pub(crate) async fn run(
-    effect: Effect,
+    settings: AppSettings,
     action_tx: &mpsc::Sender<Action>,
     settings_store: &std::sync::Arc<dyn SettingsStore>,
 ) {
-    let Effect::SaveSettings { settings } = effect else {
-        return;
-    };
-
     let result = settings_store.save(settings.clone());
     let action = match result {
         Ok(()) => Action::SettingsSaved(settings),
@@ -28,7 +23,7 @@ mod tests {
     use super::*;
     use crate::model::shared::settings::KeymapPreset;
     use crate::model::shared::theme_id::ThemeId;
-    use crate::ports::outbound::{AppSettings, SettingsStoreError};
+    use crate::ports::outbound::SettingsStoreError;
 
     struct RecordingSettingsStore {
         saved: Mutex<Vec<AppSettings>>,
@@ -67,12 +62,10 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
 
         run(
-            Effect::SaveSettings {
-                settings: AppSettings {
-                    theme_id: ThemeId::Light,
-                    keymap_preset: KeymapPreset::Ide,
-                    er_browser: Some("Firefox".to_string()),
-                },
+            AppSettings {
+                theme_id: ThemeId::Light,
+                keymap_preset: KeymapPreset::Ide,
+                er_browser: Some("Firefox".to_string()),
             },
             &tx,
             &(store.clone() as Arc<dyn SettingsStore>),
@@ -103,12 +96,10 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
 
         run(
-            Effect::SaveSettings {
-                settings: AppSettings {
-                    theme_id: ThemeId::Light,
-                    keymap_preset: KeymapPreset::default(),
-                    er_browser: None,
-                },
+            AppSettings {
+                theme_id: ThemeId::Light,
+                keymap_preset: KeymapPreset::default(),
+                er_browser: None,
             },
             &tx,
             &(store as Arc<dyn SettingsStore>),

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -2,40 +2,33 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
-use crate::cmd::effect::Effect;
+use crate::domain::query_history::QueryHistoryScope;
 use crate::ports::outbound::QueryHistoryStore;
 use crate::update::action::Action;
 
 pub fn spawn_query_history_load(
-    effect: Effect,
+    project_name: String,
+    scope: QueryHistoryScope,
     action_tx: &mpsc::Sender<Action>,
     query_history_store: &Arc<dyn QueryHistoryStore>,
 ) {
-    match effect {
-        Effect::LoadQueryHistory {
-            project_name,
-            scope,
-        } => {
-            let store = Arc::clone(query_history_store);
-            let tx = action_tx.clone();
+    let store = Arc::clone(query_history_store);
+    let tx = action_tx.clone();
 
-            tokio::spawn(async move {
-                let action = match store.load(&project_name, &scope).await {
-                    Ok(entries) => Action::QueryHistoryLoaded(scope, entries),
-                    Err(e) => Action::QueryHistoryLoadFailed(scope, e.to_string()),
-                };
-                tx.send(action).await.ok();
-            });
-        }
-        _ => unreachable!("spawn_query_history_load called with non-query-history effect"),
-    }
+    tokio::spawn(async move {
+        let action = match store.load(&project_name, &scope).await {
+            Ok(entries) => Action::QueryHistoryLoaded(scope, entries),
+            Err(e) => Action::QueryHistoryLoadFailed(scope, e.to_string()),
+        };
+        tx.send(action).await.ok();
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::domain::connection::ConnectionId;
-    use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
+    use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
     use crate::ports::outbound::QueryHistoryError;
 
     struct TestQueryHistoryStore {
@@ -100,14 +93,7 @@ mod tests {
         });
         let (tx, rx) = mpsc::channel(2);
 
-        spawn_query_history_load(
-            Effect::LoadQueryHistory {
-                project_name: "test".to_string(),
-                scope: scope.clone(),
-            },
-            &tx,
-            &store,
-        );
+        spawn_query_history_load("test".to_string(), scope.clone(), &tx, &store);
         drop(tx);
 
         let action = receive_one(rx).await;
@@ -130,14 +116,7 @@ mod tests {
         });
         let (tx, rx) = mpsc::channel(2);
 
-        spawn_query_history_load(
-            Effect::LoadQueryHistory {
-                project_name: "test".to_string(),
-                scope: scope.clone(),
-            },
-            &tx,
-            &store,
-        );
+        spawn_query_history_load("test".to_string(), scope.clone(), &tx, &store);
         drop(tx);
 
         let action = receive_one(rx).await;


### PR DESCRIPTION
## Problem
Singleton command handlers re-match their `Effect` variants after the runner has already selected the command.

## Background
The duplicated dispatch boundary makes these handlers depend on the full effect enum and leaves unreachable branches in singleton commands.

## Approach
The runner destructures each selected effect and passes only its typed payload to the command. Existing store calls, spawned task behavior, and completion actions remain unchanged.