### PR TITLE
refactor: merge ER added tables into cache misses

### DIFF
--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -408,6 +408,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn uncached_new_tables_are_reported_as_missing_in_cache() {
+        let dsn = "mysql://user:password@localhost:3306/app";
+        let state = state_with_mysql_dsn(dsn);
+        let completion_engine = RefCell::new(CompletionEngine::new());
+        let (action_tx, mut action_rx) = mpsc::channel(1);
+
+        handle_smart_refresh_cache_and_diff(
+            &action_tx,
+            &state,
+            &completion_engine,
+            dsn.to_string(),
+            1,
+            Arc::new(DatabaseMetadata::new("app".to_string())),
+            Arc::new(TableSignatureSnapshot {
+                signatures: vec![TableSignature {
+                    schema: "app".to_string(),
+                    name: "new_table".to_string(),
+                    signature: "signature".to_string(),
+                }],
+                prefetched_table_details: vec![],
+            }),
+        )
+        .await
+        .unwrap();
+
+        let Action::SmartErRefreshCompleted(result) = action_rx.recv().await.unwrap() else {
+            panic!("expected smart refresh completion");
+        };
+        assert_eq!(result.missing_in_cache, vec!["app.new_table"]);
+    }
+
+    #[tokio::test]
     async fn pending_mysql_probe_drops_smart_refresh_cache_diff() {
         let dsn = "mysql://user:password@localhost:3306/app";
         let mut state = state_with_mysql_dsn(dsn);

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -286,11 +286,6 @@ async fn handle_smart_refresh_cache_and_diff(
     let old_names: HashSet<&str> = old_signatures.keys().map(String::as_str).collect();
     let new_names: HashSet<&str> = new_signatures.keys().map(String::as_str).collect();
 
-    let added_tables: Vec<String> = new_names
-        .difference(&old_names)
-        .filter(|name| !cached_tables.contains(**name))
-        .map(ToString::to_string)
-        .collect();
     let removed_tables: Vec<String> = old_names
         .difference(&new_names)
         .map(ToString::to_string)
@@ -318,7 +313,6 @@ async fn handle_smart_refresh_cache_and_diff(
             run_id,
             new_metadata,
             stale_tables,
-            added_tables,
             removed_tables,
             missing_in_cache,
             new_signatures,
@@ -410,7 +404,6 @@ mod tests {
         let Action::SmartErRefreshCompleted(result) = action_rx.recv().await.unwrap() else {
             panic!("expected smart refresh completion");
         };
-        assert!(result.added_tables.is_empty());
         assert!(result.missing_in_cache.is_empty());
     }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -211,7 +211,6 @@ pub struct SmartErRefreshResult {
     pub run_id: u64,
     pub new_metadata: Arc<DatabaseMetadata>,
     pub stale_tables: Vec<String>,
-    pub added_tables: Vec<String>,
     pub removed_tables: Vec<String>,
     pub missing_in_cache: Vec<String>,
     pub new_signatures: HashMap<String, String>,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1669,7 +1669,6 @@ mod tests {
                     run_id: old_er_run_id,
                     new_metadata: Arc::new(DatabaseMetadata::new("new".to_string())),
                     stale_tables: vec![],
-                    added_tables: vec![],
                     removed_tables: vec![],
                     missing_in_cache: vec![],
                     new_signatures: std::collections::HashMap::new(),

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -212,7 +212,6 @@ mod tests {
                     run_id,
                     new_metadata: make_metadata(1),
                     stale_tables: vec![],
-                    added_tables: vec![],
                     removed_tables: vec![],
                     missing_in_cache: vec![],
                     new_signatures: HashMap::new(),
@@ -469,7 +468,6 @@ mod tests {
                 run_id: 1,
                 new_metadata: make_metadata(2),
                 stale_tables: vec![],
-                added_tables: vec![],
                 removed_tables: vec![],
                 missing_in_cache: vec![],
                 new_signatures: HashMap::new(),
@@ -498,7 +496,6 @@ mod tests {
                 run_id: 1,
                 new_metadata: make_metadata(2),
                 stale_tables: vec!["public.users".to_string()],
-                added_tables: vec![],
                 removed_tables: vec![],
                 missing_in_cache: vec![],
                 new_signatures: HashMap::new(),
@@ -521,35 +518,6 @@ mod tests {
         }
 
         #[test]
-        fn added_tables_trigger_scoped_prefetch() {
-            let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
-            state.session.set_metadata(Some(make_metadata(0)));
-
-            let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
-                dsn: "postgres://localhost/test".to_string(),
-                run_id: 1,
-                new_metadata: make_metadata(3),
-                stale_tables: vec![],
-                added_tables: vec!["public.new_table".to_string()],
-                removed_tables: vec![],
-                missing_in_cache: vec![],
-                new_signatures: HashMap::new(),
-            });
-
-            let effects = reduce_er(&mut state, &action, Instant::now())
-                .into_effects()
-                .expect("reducer should handle action");
-
-            assert!(effects.iter().any(|e| matches!(
-                e,
-                Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchScoped { .. }))
-            )));
-        }
-
-        #[test]
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
@@ -561,7 +529,6 @@ mod tests {
                 run_id: 1,
                 new_metadata: make_metadata(1),
                 stale_tables: vec![],
-                added_tables: vec![],
                 removed_tables: vec!["public.dropped".to_string()],
                 missing_in_cache: vec![],
                 new_signatures: HashMap::new(),
@@ -590,7 +557,6 @@ mod tests {
                 run_id: 1,
                 new_metadata: make_metadata(2),
                 stale_tables: vec![],
-                added_tables: vec![],
                 removed_tables: vec![],
                 missing_in_cache: vec!["public.uncached".to_string()],
                 new_signatures: HashMap::new(),
@@ -618,7 +584,6 @@ mod tests {
                 run_id: 3,
                 new_metadata: make_metadata(0),
                 stale_tables: vec![],
-                added_tables: vec![],
                 removed_tables: vec![],
                 missing_in_cache: vec![],
                 new_signatures: HashMap::new(),
@@ -646,7 +611,6 @@ mod tests {
                 run_id: 1,
                 new_metadata: make_metadata(5),
                 stale_tables: vec![],
-                added_tables: vec![],
                 removed_tables: vec![],
                 missing_in_cache: vec![],
                 new_signatures: new_sigs.clone(),

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -556,6 +556,40 @@ mod tests {
                 dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(2),
+                stale_tables: vec![],
+                removed_tables: vec![],
+                missing_in_cache: vec!["public.uncached".to_string()],
+                new_signatures: HashMap::new(),
+            });
+
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            let Some(Effect::DispatchActions(actions)) = effects.iter().find(|effect| {
+                matches!(effect, Effect::DispatchActions(actions) if actions.iter().any(
+                    |action| matches!(action, Action::StartErPrefetchScoped { .. })
+                ))
+            }) else {
+                panic!("expected scoped prefetch");
+            };
+            assert!(matches!(
+                actions.as_slice(),
+                [Action::StartErPrefetchScoped { tables }] if tables == &["public.uncached"]
+            ));
+        }
+
+        #[test]
+        fn stale_and_missing_tables_are_prefetched_once() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            set_active_run_id(&mut state, 1);
+            state.er_preparation.mark_waiting_for_test();
+            state.session.set_metadata(Some(make_metadata(0)));
+
+            let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
+                run_id: 1,
+                new_metadata: make_metadata(2),
                 stale_tables: vec!["public.uncached".to_string()],
                 removed_tables: vec![],
                 missing_in_cache: vec!["public.uncached".to_string()],

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -556,7 +556,7 @@ mod tests {
                 dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(2),
-                stale_tables: vec![],
+                stale_tables: vec!["public.uncached".to_string()],
                 removed_tables: vec![],
                 missing_in_cache: vec!["public.uncached".to_string()],
                 new_signatures: HashMap::new(),
@@ -566,11 +566,17 @@ mod tests {
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert!(effects.iter().any(|e| matches!(
-                e,
-                Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartErPrefetchScoped { .. }))
-            )));
+            let Some(Effect::DispatchActions(actions)) = effects.iter().find(|effect| {
+                matches!(effect, Effect::DispatchActions(actions) if actions.iter().any(
+                    |action| matches!(action, Action::StartErPrefetchScoped { .. })
+                ))
+            }) else {
+                panic!("expected scoped prefetch");
+            };
+            assert!(matches!(
+                actions.as_slice(),
+                [Action::StartErPrefetchScoped { tables }] if tables == &["public.uncached"]
+            ));
         }
 
         #[test]

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -19,7 +19,6 @@ pub(super) fn reduce_smart_refresh_completed(
             run_id,
             new_metadata,
             stale_tables,
-            added_tables,
             removed_tables,
             missing_in_cache,
             new_signatures,
@@ -43,7 +42,6 @@ pub(super) fn reduce_smart_refresh_completed(
 
             let mut refetch: Vec<String> = stale_tables
                 .iter()
-                .chain(added_tables)
                 .chain(missing_in_cache)
                 .cloned()
                 .collect();


### PR DESCRIPTION
## Summary

- Remove the redundant `SmartErRefreshResult::added_tables` payload and calculation.
- Use `missing_in_cache` as the single refetch source while preserving stale/removed handling and deduplication.

## Validation

- `cargo test -p sabiql-app update::er`
- `cargo test -p sabiql-app cmd::er`
- `cargo test -p sabiql-app ddl_metadata_refresh_rejects_old_er_completion`
- `cargo fmt --all -- --check`
- `cargo clippy -p sabiql-app --all-targets -- -D warnings`
- `bash scripts/lint_all.sh`
- `cargo test --workspace` (1049 passed, 2 unrelated existing infra failures; both reproduced in isolation)