### PR TITLE
refactor: own config writer io errors directly

### DIFF
--- a/src/app/ports/outbound/config_writer.rs
+++ b/src/app/ports/outbound/config_writer.rs
@@ -1,17 +1,16 @@
 use std::path::PathBuf;
-use std::sync::Arc;
 
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ConfigWriterError {
     #[error("cache directory is unavailable")]
     MissingCacheDir,
     #[error("I/O error: {0}")]
-    Io(#[source] Arc<std::io::Error>),
+    Io(#[source] std::io::Error),
 }
 
 impl From<std::io::Error> for ConfigWriterError {
     fn from(error: std::io::Error) -> Self {
-        Self::Io(Arc::new(error))
+        Self::Io(error)
     }
 }
 


### PR DESCRIPTION
## Problem

Config writer errors wrapped each I/O error in an atomic reference despite remaining local to the configuration boundary.

## Approach

Store the standard I/O error directly in the port error type and preserve the existing error conversion and display behavior without shared ownership.