### PR TITLE
refactor(app): simplify connection store action errors

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -153,7 +153,7 @@ pub(crate) async fn run(
                                 }
                                 Some(Err(e)) => {
                                     tx.blocking_send(Action::ConnectionSaveFailed {
-                                        error: e.into(),
+                                        error: ConnectionSaveError::Store(e.to_string()),
                                         run_id,
                                     })
                                     .ok();
@@ -197,7 +197,7 @@ pub(crate) async fn run(
                                     }
                                     Some(Err(e)) => {
                                         tx.send(Action::ConnectionSaveFailed {
-                                            error: e.into(),
+                                            error: ConnectionSaveError::Store(e.to_string()),
                                             run_id,
                                         })
                                         .await
@@ -245,7 +245,7 @@ pub(crate) async fn run(
                                 }
                                 Some(Err(e)) => {
                                     tx.send(Action::ConnectionSaveFailed {
-                                        error: e.into(),
+                                        error: ConnectionSaveError::Store(e.to_string()),
                                         run_id,
                                     })
                                     .await
@@ -305,12 +305,13 @@ pub(crate) async fn run(
                 }
                 Ok(None) => {
                     tx.blocking_send(Action::ConnectionEditLoadFailed(
-                        ConnectionStoreError::NotFound(id.to_string()),
+                        ConnectionStoreError::NotFound(id.to_string()).to_string(),
                     ))
                     .ok();
                 }
                 Err(e) => {
-                    tx.blocking_send(Action::ConnectionEditLoadFailed(e)).ok();
+                    tx.blocking_send(Action::ConnectionEditLoadFailed(e.to_string()))
+                        .ok();
                 }
             });
         }
@@ -352,7 +353,8 @@ pub(crate) async fn run(
                     tx.blocking_send(Action::ConnectionDeleted(id)).ok();
                 }
                 Err(e) => {
-                    tx.blocking_send(Action::ConnectionDeleteFailed(e)).ok();
+                    tx.blocking_send(Action::ConnectionDeleteFailed(e.to_string()))
+                        .ok();
                 }
             });
         }
@@ -820,7 +822,10 @@ mod tests {
 
             assert!(matches!(
                 run.actions.into_iter().next(),
-                Some(Action::ConnectionSaveFailed { run_id: 1, .. })
+                Some(Action::ConnectionSaveFailed {
+                    error: ConnectionSaveError::Store(error),
+                    run_id: 1,
+                }) if error == "IO error: save failed"
             ));
         }
 
@@ -1081,9 +1086,53 @@ mod tests {
 
             let action = run.actions.into_iter().next().expect("action dispatched");
             assert!(
-                matches!(action, Action::ConnectionDeleteFailed(_)),
+                matches!(
+                    action,
+                    Action::ConnectionDeleteFailed(ref error)
+                        if error == "Connection not found: id"
+                ),
                 "expected ConnectionDeleteFailed, got {action:?}"
             );
+        }
+    }
+
+    mod load_connection_for_edit {
+        use super::*;
+
+        #[tokio::test]
+        async fn missing_connection_returns_display_error() {
+            let mut mock_store = MockConnectionStore::new();
+            mock_store
+                .expect_find_by_id()
+                .once()
+                .returning(|_| Ok(None));
+
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(mock_store),
+                tx,
+            );
+
+            let run = test_fixtures::run_one_effect(
+                &runner,
+                Effect::LoadConnectionForEdit {
+                    id: ConnectionId::from_string("id"),
+                },
+                AppState::new("test".to_string()),
+                RefCell::new(CompletionEngine::new()),
+                &mut rx,
+                Some(std::time::Duration::from_millis(500)),
+            )
+            .await
+            .unwrap();
+
+            assert!(matches!(
+                run.actions.into_iter().next(),
+                Some(Action::ConnectionEditLoadFailed(error))
+                    if error == "Connection not found: id"
+            ));
         }
     }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -13,7 +13,6 @@ use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
 use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
-use crate::ports::outbound::connection_store::ConnectionStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
 
@@ -28,7 +27,7 @@ pub enum ConnectionSaveError {
     #[error("{0}")]
     Validation(#[from] ConnectionProfileError),
     #[error("{0}")]
-    Store(#[from] ConnectionStoreError),
+    Store(String),
     #[error("{0}")]
     Metadata(#[from] DbOperationError),
     #[error("{error}")]
@@ -395,7 +394,7 @@ pub enum Action {
         error: DbOperationError,
     },
     ConnectionEditLoaded(Box<ConnectionProfile>),
-    ConnectionEditLoadFailed(ConnectionStoreError),
+    ConnectionEditLoadFailed(String),
     CloseConnectionError,
     ToggleConnectionErrorDetails,
     CopyConnectionError,
@@ -405,7 +404,7 @@ pub enum Action {
     RequestDeleteSelectedConnection,
     DeleteConnection(ConnectionId),
     ConnectionDeleted(ConnectionId),
-    ConnectionDeleteFailed(ConnectionStoreError),
+    ConnectionDeleteFailed(String),
     RequestEditSelectedConnection,
 
     // SQLite diagnostics

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -97,8 +97,8 @@ pub(super) fn reduce_connection_selector(
                 vec![]
             })
         }
-        Action::ConnectionDeleteFailed(e) => {
-            state.messages.set_error(e.to_string());
+        Action::ConnectionDeleteFailed(error) => {
+            state.messages.set_error(error.clone());
             DispatchResult::handled()
         }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -46,8 +46,8 @@ pub fn reduce_connection_setup(
             state.modal.set_mode(InputMode::ConnectionSetup);
             DispatchResult::handled_with(cancel_effects)
         }
-        Action::ConnectionEditLoadFailed(e) => {
-            state.messages.set_error(e.to_string());
+        Action::ConnectionEditLoadFailed(error) => {
+            state.messages.set_error(error.clone());
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -206,7 +206,6 @@ mod tests {
     use crate::model::browse::session::TableDetailState;
     use crate::model::shared::ui_state::UiState;
     use crate::ports::outbound::DbOperationError;
-    use crate::ports::outbound::connection_store::ConnectionStoreError;
     use crate::update::action::ModalKind;
     use crate::update::action::QueryCompletionContext;
     use crate::update::action::{ConnectionSaveError, ConnectionTarget, SmartErRefreshError};
@@ -2095,9 +2094,7 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::ConnectionSaveFailed {
-                    error: ConnectionSaveError::Store(ConnectionStoreError::Io(Arc::new(
-                        std::io::Error::other("Write error"),
-                    ))),
+                    error: ConnectionSaveError::Store("IO error: Write error".to_string()),
                     run_id,
                 },
                 now,


### PR DESCRIPTION
## Problem\n\nConnectionStoreError currently crosses into Actions and is converted to a display string only in reducers, coupling the Action surface to persistence error types.\n\n## Approach\n\nConvert ConnectionStore failures to their existing display strings at the command boundary and carry those strings through save, edit-load, and delete failure Actions. Keep the persistence port and connection lifecycle behavior unchanged.