### PR TITLE
refactor(sqlite): return diagnostic rows as tuples

### DIFF
--- a/src/app/model/sqlite/diagnostics.rs
+++ b/src/app/model/sqlite/diagnostics.rs
@@ -43,12 +43,6 @@ impl DiagnosticFieldKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DiagnosticDisplayRow<'a> {
-    pub kind: DiagnosticFieldKind,
-    pub field: &'a DiagnosticField,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct SqliteDiagnosticsState {
     next_run_id: u64,
@@ -196,7 +190,9 @@ impl SqliteDiagnosticsState {
     }
 }
 
-pub fn display_rows(snapshot: &SqliteDiagnosticsSnapshot) -> Vec<DiagnosticDisplayRow<'_>> {
+pub fn display_rows(
+    snapshot: &SqliteDiagnosticsSnapshot,
+) -> impl Iterator<Item = (DiagnosticFieldKind, &DiagnosticField)> {
     [
         (DiagnosticFieldKind::DbFile, &snapshot.db_file),
         (DiagnosticFieldKind::SqliteVersion, &snapshot.sqlite_version),
@@ -212,8 +208,6 @@ pub fn display_rows(snapshot: &SqliteDiagnosticsSnapshot) -> Vec<DiagnosticDispl
         (DiagnosticFieldKind::QuickCheck, &snapshot.quick_check),
     ]
     .into_iter()
-    .map(|(kind, field)| DiagnosticDisplayRow { kind, field })
-    .collect()
 }
 
 pub fn display_field(field: &DiagnosticField) -> String {

--- a/src/ui/features/overlays/sqlite_diagnostics.rs
+++ b/src/ui/features/overlays/sqlite_diagnostics.rs
@@ -112,26 +112,20 @@ pub fn build_render_lines(
         .add_modifier(Modifier::BOLD);
 
     let mut lines = vec![Line::raw("")];
-    for row in display_rows(snapshot) {
-        let field_value = display_field(row.field);
-        let value = if row.kind == DiagnosticFieldKind::QuickCheck {
+    for (kind, field) in display_rows(snapshot) {
+        let field_value = display_field(field);
+        let value = if kind == DiagnosticFieldKind::QuickCheck {
             quick_check_override.unwrap_or(&field_value)
         } else {
             &field_value
         };
         let value_style =
-            if row.kind == DiagnosticFieldKind::QuickCheck && quick_check_override.is_some() {
+            if kind == DiagnosticFieldKind::QuickCheck && quick_check_override.is_some() {
                 Style::default().fg(theme.semantic.status.warning)
             } else {
-                field_style(row.kind, row.field, snapshot, theme)
+                field_style(kind, field, snapshot, theme)
             };
-        append_field_lines(
-            &mut lines,
-            row.kind.label(),
-            value,
-            label_style,
-            value_style,
-        );
+        append_field_lines(&mut lines, kind.label(), value, label_style, value_style);
     }
     lines
 }


### PR DESCRIPTION
## Problem
SQLite diagnostics passed display data through an intermediate row type and collection step before rendering.

## Approach
Return the existing diagnostic values directly as tuples and destructure them at the rendering boundary, preserving ordering, field states, QuickCheck styling, and partial-failure behavior.