### PR TITLE
refactor: make settings loading concrete

### DIFF
--- a/src/app/cmd/settings.rs
+++ b/src/app/cmd/settings.rs
@@ -32,10 +32,6 @@ mod tests {
     struct FailingSettingsStore;
 
     impl SettingsStore for RecordingSettingsStore {
-        fn load(&self) -> Result<AppSettings, SettingsStoreError> {
-            Ok(AppSettings::default())
-        }
-
         fn save(&self, settings: AppSettings) -> Result<(), SettingsStoreError> {
             self.saved.lock().unwrap().push(settings);
             Ok(())
@@ -43,10 +39,6 @@ mod tests {
     }
 
     impl SettingsStore for FailingSettingsStore {
-        fn load(&self) -> Result<AppSettings, SettingsStoreError> {
-            Ok(AppSettings::default())
-        }
-
         fn save(&self, _settings: AppSettings) -> Result<(), SettingsStoreError> {
             Err(SettingsStoreError::Io(Arc::new(std::io::Error::other(
                 "disk full",

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -244,10 +244,6 @@ impl QueryHistoryStore for NoopQueryHistoryStore {
 
 pub struct NoopSettingsStore;
 impl SettingsStore for NoopSettingsStore {
-    fn load(&self) -> Result<AppSettings, SettingsStoreError> {
-        Ok(AppSettings::default())
-    }
-
     fn save(&self, _settings: AppSettings) -> Result<(), SettingsStoreError> {
         Ok(())
     }

--- a/src/app/ports/outbound/settings_store.rs
+++ b/src/app/ports/outbound/settings_store.rs
@@ -51,6 +51,5 @@ impl From<toml::de::Error> for SettingsStoreError {
 }
 
 pub trait SettingsStore: Send + Sync {
-    fn load(&self) -> Result<AppSettings, SettingsStoreError>;
     fn save(&self, settings: AppSettings) -> Result<(), SettingsStoreError>;
 }

--- a/src/infra/adapters/settings_store.rs
+++ b/src/infra/adapters/settings_store.rs
@@ -25,6 +25,12 @@ impl TomlSettingsStore {
         Self { config_dir }
     }
 
+    pub fn load(&self) -> Result<AppSettings, SettingsStoreError> {
+        Ok(self
+            .load_config_file_lenient()?
+            .map_or_else(AppSettings::default, app_settings))
+    }
+
     fn load_config_file_lenient(&self) -> Result<Option<ConnectionConfigFile>, SettingsStoreError> {
         let path = config_file_path(&self.config_dir);
         if !path.exists() {
@@ -67,12 +73,6 @@ impl TomlSettingsStore {
 }
 
 impl SettingsStore for TomlSettingsStore {
-    fn load(&self) -> Result<AppSettings, SettingsStoreError> {
-        Ok(self
-            .load_config_file_lenient()?
-            .map_or_else(AppSettings::default, app_settings))
-    }
-
     fn save(&self, settings: AppSettings) -> Result<(), SettingsStoreError> {
         let _guard = app_config_file::lock();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use sabiql_app::model::app_state::AppState;
 use sabiql_app::model::shared::input_mode::InputMode;
 use sabiql_app::ports::outbound::{
     ConnectionStore, ConnectionStoreError, MySqlConnectionProbe, PgServiceEntryReader,
-    ServiceFileError, SettingsStore, SqliteDiagnosticsProvider,
+    ServiceFileError, SqliteDiagnosticsProvider,
 };
 use sabiql_app::services::AppServices;
 use sabiql_app::update::action::Action;


### PR DESCRIPTION
## Problem
The settings loading operation was exposed through a generic port even though it is only needed by the concrete startup store.

## Approach
Keep the outbound port focused on persistence and use the concrete TOML settings store for loading at startup, preserving parsing behavior and existing settings coverage.