### PR TITLE
refactor(mysql): collapse metadata fallback execution kinds

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -20,10 +20,8 @@ pub(super) const MYSQL_SESSION_SQL_MODE_COLUMN: &str = "__sabiql_sql_mode";
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum MySqlMetadataFallbackKind {
-    Select,
-    Table,
-    Show,
-    Describe,
+    Session,
+    External,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -99,11 +97,11 @@ pub(in crate::adapters::mysql) fn validate_mysql_export_query(
 pub(super) fn mysql_metadata_fallback_kind(
     kind: &MySqlStatementKind,
 ) -> Option<MySqlMetadataFallbackKind> {
+    use MySqlMetadataFallbackKind::{External, Session};
+
     match kind {
-        MySqlStatementKind::Select => Some(MySqlMetadataFallbackKind::Select),
-        MySqlStatementKind::Table => Some(MySqlMetadataFallbackKind::Table),
-        MySqlStatementKind::Show => Some(MySqlMetadataFallbackKind::Show),
-        MySqlStatementKind::Describe => Some(MySqlMetadataFallbackKind::Describe),
+        MySqlStatementKind::Select | MySqlStatementKind::Table => Some(Session),
+        MySqlStatementKind::Show | MySqlStatementKind::Describe => Some(External),
         _ => None,
     }
 }

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -31,10 +31,10 @@ pub(in crate::adapters::mysql::cli) async fn mysql_metadata_columns_with_diagnos
     access_mode: AccessMode,
 ) -> Result<(Vec<String>, Vec<DatabaseDiagnostic>), DbOperationError> {
     let query = match kind {
-        MySqlMetadataFallbackKind::Select | MySqlMetadataFallbackKind::Table => {
+        MySqlMetadataFallbackKind::Session => {
             return mysql_metadata_select_columns_with_diagnostics(process, query).await;
         }
-        MySqlMetadataFallbackKind::Show | MySqlMetadataFallbackKind::Describe => {
+        MySqlMetadataFallbackKind::External => {
             query.trim().trim_end_matches(';').trim_end().to_string()
         }
     };


### PR DESCRIPTION
## Summary
- Collapse MySQL metadata fallback classification to in-session and external execution paths.
- Preserve the existing SELECT/TABLE and SHOW/DESCRIBE routing.

## Validation
- cargo fmt --all -- --check
- focused MySQL fallback tests
- cargo check and Clippy for sabiql-infra
- scripts/lint_all.sh