### PR TITLE
refactor(test): simplify ER test fixtures

### DIFF
--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -152,23 +152,6 @@ impl ErPreparationState {
 }
 
 #[cfg(test)]
-pub mod test_support {
-    use super::{ErPreparationState, ErStatus};
-
-    impl ErPreparationState {
-        #[doc(hidden)]
-        pub fn total_tables(&self) -> usize {
-            self.total_tables
-        }
-
-        #[doc(hidden)]
-        pub fn mark_waiting_for_test(&mut self) {
-            self.status = ErStatus::Waiting;
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -608,7 +608,7 @@ mod tests {
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
@@ -645,7 +645,7 @@ mod tests {
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
@@ -684,7 +684,7 @@ mod tests {
         fn process_queue_keeps_later_table_owned_after_terminal_failure() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
@@ -895,7 +895,7 @@ mod tests {
         fn transient_failure_then_success_clears_er_failure_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             state.table_prefetch.start_table_prefetch(qualified.clone());
@@ -1444,7 +1444,7 @@ mod tests {
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_unexpanded();
             let effects = check_er_completion(&mut state);
 
@@ -1458,7 +1458,7 @@ mod tests {
         #[test]
         fn complete_fk_expanded_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_expanded();
 
             let effects = check_er_completion(&mut state);
@@ -1496,7 +1496,7 @@ mod tests {
         fn pending_mysql_probe_rejects_neighbor_expansion() {
             let mut state = state_with_pending_mysql_probe();
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_unexpanded();
 
             let effects = dispatch_metadata(
@@ -1521,7 +1521,7 @@ mod tests {
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1545,7 +1545,7 @@ mod tests {
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1570,7 +1570,7 @@ mod tests {
         #[test]
         fn stale_neighbors_without_active_run_do_not_mutate_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1591,7 +1591,7 @@ mod tests {
         fn pending_mysql_probe_rejects_discovered_neighbors_without_queueing() {
             let mut state = state_with_pending_mysql_probe();
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_unexpanded();
 
             let effects = dispatch_metadata(
@@ -1615,7 +1615,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             let stale_run_id = state.table_prefetch.begin_er_prefetch();
             let current_run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1639,7 +1639,7 @@ mod tests {
         fn duplicate_neighbors_are_not_requeued() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state
                 .table_prefetch
                 .queue_table_prefetch("public.posts".to_string());
@@ -1682,7 +1682,7 @@ mod tests {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();
             state.table_prefetch.queue_table_prefetch(neighbor.clone());

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -92,6 +92,12 @@ mod tests {
         state.er_preparation.mark_idle();
     }
 
+    fn set_waiting_run_id(state: &mut AppState, run_id: u64) {
+        for _ in 0..run_id {
+            let _ = state.er_preparation.start_waiting_run();
+        }
+    }
+
     fn make_metadata(table_count: usize) -> Arc<DatabaseMetadata> {
         let tables: Vec<TableSummary> = (0..table_count)
             .map(|i| TableSummary::new("public".to_string(), format!("t{i}"), None, false))
@@ -188,7 +194,6 @@ mod tests {
             let mut state = state_with_mysql_connection();
             state.session.set_metadata(Some(make_metadata(1)));
             let run_id = state.er_preparation.start_waiting_run();
-            state.er_preparation.mark_waiting_for_test();
             let prefetch_run_id = state.table_prefetch.begin_er_prefetch();
             let _ = state.session.begin_mysql_connection_probe(
                 &ConnectionId::from_string("mysql-target"),
@@ -254,7 +259,6 @@ mod tests {
             let mut state = state_with_mysql_connection();
             state.session.set_metadata(Some(make_metadata(1)));
             let run_id = state.er_preparation.start_waiting_run();
-            state.er_preparation.mark_waiting_for_test();
             let _ = state.table_prefetch.begin_er_prefetch();
             let _ = state.session.begin_mysql_connection_probe(
                 &ConnectionId::from_string("mysql-target"),
@@ -361,7 +365,7 @@ mod tests {
         #[test]
         fn waiting_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -459,8 +463,7 @@ mod tests {
         #[test]
         fn no_changes_dispatches_generate_from_cache() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -487,8 +490,7 @@ mod tests {
         #[test]
         fn stale_tables_trigger_evict_and_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -520,8 +522,7 @@ mod tests {
         #[test]
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -548,8 +549,7 @@ mod tests {
         #[test]
         fn missing_in_cache_triggers_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -582,8 +582,7 @@ mod tests {
         #[test]
         fn stale_and_missing_tables_are_prefetched_once() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -616,8 +615,7 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_completed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 5);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 5);
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
                 dsn: "postgres://localhost/test".to_string(),
@@ -639,8 +637,7 @@ mod tests {
         #[test]
         fn updates_metadata_and_signatures() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let new_sigs: HashMap<String, String> =
@@ -690,8 +687,7 @@ mod tests {
         #[test]
         fn matching_connection_and_run_emits_cache_diff_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
 
             let effects = reduce_er(
                 &mut state,
@@ -710,8 +706,7 @@ mod tests {
         #[test]
         fn mismatched_connection_or_run_does_not_emit_cache_diff_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 2);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 2);
 
             assert!(
                 reduce_er(
@@ -744,8 +739,7 @@ mod tests {
         #[test]
         fn falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(5)));
             state.er_preparation.apply_refresh_metadata(
                 HashMap::from([("public.old".to_string(), "sig".to_string())]),
@@ -788,8 +782,7 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 5);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 5);
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -832,8 +825,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -857,8 +849,7 @@ mod tests {
         #[test]
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
 
             let effects = reduce_er(
                 &mut state,
@@ -880,8 +871,7 @@ mod tests {
         #[test]
         fn new_metadata_applied_before_fallback() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
+            set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(3)));
 
             let effects = reduce_er(

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1824,7 +1824,7 @@ mod tests {
         #[test]
         fn metadata_failed_resets_er_waiting_to_idle() {
             let mut state = create_test_state();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             let now = Instant::now();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
@@ -3107,7 +3107,7 @@ mod tests {
             let mut state = state_with_metadata();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state
                 .er_preparation
                 .begin_all_prefetch(["public.users".to_string()]);
@@ -3145,7 +3145,7 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
             let run_id = state.table_prefetch.begin_er_prefetch();
-            state.er_preparation.mark_waiting_for_test();
+            let _ = state.er_preparation.start_waiting_run();
             state
                 .er_preparation
                 .begin_all_prefetch(["public.posts".to_string(), "public.users".to_string()]);


### PR DESCRIPTION
## Problem
ER tests depend on an unused test-only accessor and can construct Waiting without an active ER run.

## Background
Those fixtures do not represent the lifecycle used by the application.

## Approach
Build Waiting fixtures through the existing ER start transition, preserving explicit run-id scenarios with a test-local helper that starts real waiting runs. Remove the unused ER test-support module.