### PR TITLE
refactor(test): use BrowseSession connection transitions

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -873,49 +873,26 @@ impl BrowseSession {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
-pub mod test_support {
-    use super::{ActiveConnection, BrowseSession, ConnectionId, ConnectionOrigin, DatabaseType};
+#[cfg(test)]
+mod test_support {
+    use super::BrowseSession;
+    use crate::domain::MetadataState;
+    use crate::model::connection::state::ConnectionState;
 
     impl BrowseSession {
         #[doc(hidden)]
-        pub fn set_active_connection_identity_for_test(
-            &mut self,
-            id: &ConnectionId,
-            name: &str,
-            database_type: DatabaseType,
-        ) {
-            self.active_connection = Some(ActiveConnection {
-                id: id.clone(),
-                name: name.to_string(),
-                database_type,
-                origin: ConnectionOrigin::Profile,
-                database: None,
-            });
+        pub(crate) fn set_metadata_state(&mut self, state: MetadataState) {
+            self.metadata_state = state;
         }
-    }
 
-    #[cfg(test)]
-    mod unit_tests {
-        use super::BrowseSession;
-        use crate::domain::MetadataState;
-        use crate::model::connection::state::ConnectionState;
+        #[doc(hidden)]
+        pub(crate) fn set_connection_state(&mut self, state: ConnectionState) {
+            self.connection_state = state;
+        }
 
-        impl BrowseSession {
-            #[doc(hidden)]
-            pub(crate) fn set_metadata_state(&mut self, state: MetadataState) {
-                self.metadata_state = state;
-            }
-
-            #[doc(hidden)]
-            pub(crate) fn set_connection_state(&mut self, state: ConnectionState) {
-                self.connection_state = state;
-            }
-
-            #[doc(hidden)]
-            pub(crate) fn set_selection_generation(&mut self, value: u64) {
-                self.selection_generation = value;
-            }
+        #[doc(hidden)]
+        pub(crate) fn set_selection_generation(&mut self, value: u64) {
+            self.selection_generation = value;
         }
     }
 }

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -331,11 +331,6 @@ mod tests {
         #[test]
         fn no_dsn_returns_error() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_active_connection_identity_for_test(
-                &ConnectionId::new(),
-                "postgres",
-                DatabaseType::PostgreSQL,
-            );
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -28,10 +28,11 @@ pub fn test_instant() -> Instant {
 
 pub fn create_test_state() -> AppState {
     let mut state = AppState::new("test_project".to_string());
-    state.session.set_active_connection_identity_for_test(
+    state.session.activate_connection_with_dsn(
         &ConnectionId::from_string("test-connection"),
         "localhost:5432/test",
         DatabaseType::PostgreSQL,
+        "localhost:5432/test",
     );
     state
 }

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -48,10 +48,11 @@ fn connection_selector_with_multiple_connections() {
 
     let (active_id, connections) = three_connections();
     state.set_connections(connections);
-    state.session.set_active_connection_identity_for_test(
+    state.session.activate_connection_with_dsn(
         &active_id,
         "localhost:5432/test",
         sabiql_domain::DatabaseType::PostgreSQL,
+        "localhost:5432/test",
     );
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
@@ -78,10 +79,11 @@ fn connection_selector_with_service_entries() {
             },
         ],
     );
-    state.session.set_active_connection_identity_for_test(
+    state.session.activate_connection_with_dsn(
         &active_id,
         "localhost:5432/test",
         sabiql_domain::DatabaseType::PostgreSQL,
+        "localhost:5432/test",
     );
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
@@ -126,10 +128,11 @@ fn connection_selector_with_active_service() {
         },
     ]);
     // Set active connection to the first service entry
-    state.session.set_active_connection_identity_for_test(
+    state.session.activate_connection_with_dsn(
         &ConnectionId::from_string("service:dev-local".to_string()),
         "localhost:5432/test",
         sabiql_domain::DatabaseType::PostgreSQL,
+        "localhost:5432/test",
     );
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_delete_preview_low_risk.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_delete_preview_low_risk.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_json_and_string_mixed.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_json_and_string_mixed.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_json_key_order_normalized.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_json_key_order_normalized.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_json_structured_diff_with_ellipsis.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_json_structured_diff_with_ellipsis.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_long_json.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_long_json.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_multi_column.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_multi_column.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_narrow_terminal.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_narrow_terminal.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-te… ▸ … ▸ - no dsn | localhost:5432/test
+tes… ▸ … connected | localhost:5432/test
 ┌╭ Confirm UPDATE: users ─────────────╮]
 ││                                    │┐
 ││ ✓ LOW RISK                         ││

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_rich.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_rich.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_scrollable.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_scrollable.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_collapsed.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_collapsed.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_long_details_capped.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_long_details_capped.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_with_tabs.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_with_tabs.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 237
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 255
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 273
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 67
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_password_focused.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_password_focused.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 90
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 28
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 104
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 85
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 131
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_omits_empty_optional_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_omits_empty_optional_fields.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 114
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_uses_postgres_conninfo_escaping.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_uses_postgres_conninfo_escaping.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 141
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_with_max_length_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_with_max_length_fields.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 219
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 177
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_sqlite_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_sqlite_form.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 287
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/connection_flow.rs
 assertion_line: 309
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_active_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_active_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_inactive_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_inactive_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_active_service.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_active_service.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_long_service_name.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_long_service_name.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multibyte_service_name.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multibyte_service_name.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multiple_connections.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multiple_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_service_entries.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_service_entries.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_all_selected.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_all_selected.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_filtered.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_filtered.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_modal.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_modal.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_multi_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_multi_select.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_single_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_single_select.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_waiting_progress.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_waiting_progress.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/initial_state.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_marks_read_only_generated_columns.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_marks_read_only_generated_columns.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name    Type           Null   PK   Read-only   Default   Comment                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_caps_wide_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_caps_wide_comment.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                     connected | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Type           Null   PK   Default   Comment                                    │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_keeps_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_keeps_horizontal_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                     connected | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Name    Type           Null   PK   Default   Comment                            │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_right_edge_truncates_cjk_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_right_edge_truncates_cjk_comment.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                     connected | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Type      Null   PK   Default   Comment                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_ddl_tab_uses_source_ddl.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_ddl_tab_uses_source_ddl.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││CREATE VIRTUAL TABLE users USING fts5(name, email);                                                                       │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_marks_unresolved_reference.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_marks_unresolved_reference.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                   Columns         References                             On update   On delete                       │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                  Columns         References               On update   On delete                                      │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name              Columns   Type    Unique                                                                                │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   (none)                                                                                                           │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││No triggers                                                                                                               │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                            Timing             Event                    Function                    Security          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_line_input.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_line_input.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/overlays.rs
 assertion_line: 414
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_filtered_current_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_filtered_current_result.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ t… ▸ - no dsn | localhost:5432/test
+test_proj… ▸ … ▸ - connected | localhost:5432/test
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │> publi╭ Help ───────────────────────────╮──────┐
 │  publi│                             Ret▲│      │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_empty.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_filter_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_filter_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_with_entries.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_with_entries.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram_custom_browser.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram_custom_browser.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_keymap.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_keymap.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_analyze_read_only_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_analyze_read_only_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_analyze_unknown_risk_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_analyze_unknown_risk_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_empty.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_narrow_stacked.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_narrow_stacked.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -  no dsn | localhost:5432/test
+test_pro… ▸ - ▸ - not loaded | localhost:5432/test
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │ Press 'r' │┌ [2] Inspector ────────────────────┐
 │           ││(select a table)                   │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_right_only.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_right_only.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_unavailable.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_unavailable.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_with_verdict.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_with_verdict.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_completion_popup_with_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_completion_popup_with_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_matched.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_matched.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_unmatched.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_unmatched.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_head.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_middle.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_tail.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_error_with_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_error_with_message.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_high_risk_without_target_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_high_risk_without_target_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_ide_editing.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_ide_editing.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_non_atomic_transaction_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_non_atomic_transaction_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_cursor_at_tail.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_initial.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_initial.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_placeholder.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_placeholder.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_error.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_error.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_plan_text.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_plan_text.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_ddl_create_table.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_ddl_create_table.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_dml_with_command_tag.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_dml_with_command_tag.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_select.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_with_mysql_diagnostics.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_with_mysql_diagnostics.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
+test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_unknown_risk_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_unknown_risk_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_with_completion.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_with_completion.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__table_picker_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__table_picker_overlay.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_pending_draft.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_pending_draft.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_detail_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_detail_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.notes                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││Owner:   (none)                                                                                                           │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_head.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_middle.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_tail.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_json_detail_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_json_detail_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_json_detail_shows_vertical_scrollbar.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_json_detail_shows_vertical_scrollbar.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                              no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                           connected | localhost:5432/test
 ┌ [1] Explorer ─────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                
 │> public.users         │┌ [2] Inspector ──────────────────────────────────────────────────────────┐
 │  public.posts         ││Owner:   postgres                                                        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_json_edit_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_json_edit_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_narrow_pane_keeps_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_narrow_pane_keeps_horizontal_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                     connected | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Owner:   postgres                                                               │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_shows_scrollbars.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_shows_scrollbars.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                              no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                           connected | localhost:5432/test
 ┌ [1] Explorer ─────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                
 │> public.users         │┌ [2] Inspector ──────────────────────────────────────────────────────────┐
 │  public.posts         ││(select a table)                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_staged_delete_row.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_staged_delete_row.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_view_cell_active_hides_write_hints.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_view_cell_active_hides_write_hints.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__error_message_in_footer.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__error_message_in_footer.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_mode_fullscreen_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_mode_fullscreen_result.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [3] Result (2 rows, 15ms) ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │id   name    email                                                                                                                                                 │
 │1    Alice   alice@example.com                                                                                                                                     │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__long_error_message_wraps_into_footer_and_command_line.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__long_error_message_wraps_into_footer_and_command_line.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+test_project ▸ test_db ▸ -                                                                                                            connected | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/style_assertions/style_colors.rs
+++ b/src/tests/render_snapshots/style_assertions/style_colors.rs
@@ -186,6 +186,7 @@ fn header_status_uses_success_warning_and_error_colors() {
     );
 
     let mut no_dsn = create_test_state();
+    no_dsn.session.clear_connection();
     let no_dsn_buffer = render_and_get_buffer_at(&mut terminal, &mut no_dsn, now);
     assert_header_status_color(
         &no_dsn_buffer,


### PR DESCRIPTION
## Problem
Test fixtures bypassed BrowseSession connection lifecycle through a raw identity setter.

## Approach
Replace the test-only setter with `activate_connection_with_dsn`, remove the unused seam, preserve the explicit no-DSN case, and update affected snapshots to reflect semantic connection state.

## Testing
Focused render snapshots, workspace package tests, targeted Clippy, `cargo fmt --all -- --check`, and `scripts/lint_all.sh` passed. One unrelated SQLite infra classification test remains failing in the current environment.