### PR TITLE
refactor(test): consolidate SQLite diagnostics fixtures

### DIFF
--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -7,12 +7,31 @@ use sabiql_app::model::shared::settings::KeymapPreset;
 use sabiql_app::model::sql_editor::modal::SqlModalStatus;
 use sabiql_app::policy::write::sql_risk::AcknowledgeReason;
 use sabiql_domain::query_history::{QueryHistoryEntry, QueryResultStatus};
-use sabiql_domain::{ConnectionId, DatabaseDiagnostic, DiagnosticLevel, QueryResult};
+use sabiql_domain::{
+    ConnectionId, DatabaseDiagnostic, DiagnosticField, DiagnosticLevel, QueryResult,
+    SqliteDiagnosticsSnapshot,
+};
 
 const POSTGRES_SEQ_SCAN_PLAN: &str =
     "Seq Scan on users  (cost=0.00..1000.00 rows=2550 width=36)\n  Filter: (id > 10)";
 const POSTGRES_INDEX_SCAN_PLAN: &str = "Index Scan using idx_users_id on users  (cost=0.28..8.30 rows=1 width=36)\n  Index Cond: (id > 10)";
 const POSTGRES_PLAN_QUERY: &str = "SELECT * FROM users WHERE id > 10";
+
+fn baseline_sqlite_diagnostics_snapshot() -> SqliteDiagnosticsSnapshot {
+    SqliteDiagnosticsSnapshot {
+        db_file: DiagnosticField::ok("/tmp/app.db"),
+        sqlite_version: DiagnosticField::ok("3.45.0"),
+        feature_summary: DiagnosticField::ok(
+            "FTS5: available\nFTS4: not available\nRTree: available\nJSON: available",
+        ),
+        foreign_keys: DiagnosticField::ok("on"),
+        journal_mode: DiagnosticField::ok("wal"),
+        query_only: DiagnosticField::ok("off"),
+        busy_timeout: DiagnosticField::ok("5000"),
+        database_list: DiagnosticField::ok("0: main @ /tmp/app.db"),
+        quick_check: DiagnosticField::ok("ok"),
+    }
+}
 
 #[test]
 fn sql_modal_with_completion() {
@@ -1026,28 +1045,13 @@ fn sqlite_diagnostics_overlay_loading() {
 
 #[test]
 fn sqlite_diagnostics_overlay_loaded() {
-    use sabiql_domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
-
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
     let run_id = state.sqlite_diagnostics.begin_core_fetch();
-    state.sqlite_diagnostics.set_core_loaded(
-        run_id,
-        SqliteDiagnosticsSnapshot {
-            db_file: DiagnosticField::ok("/tmp/app.db"),
-            sqlite_version: DiagnosticField::ok("3.45.0"),
-            feature_summary: DiagnosticField::ok(
-                "FTS5: available\nFTS4: not available\nRTree: available\nJSON: available",
-            ),
-            foreign_keys: DiagnosticField::ok("on"),
-            journal_mode: DiagnosticField::ok("wal"),
-            query_only: DiagnosticField::ok("off"),
-            busy_timeout: DiagnosticField::ok("5000"),
-            database_list: DiagnosticField::ok("0: main @ /tmp/app.db"),
-            quick_check: DiagnosticField::ok("ok"),
-        },
-    );
+    state
+        .sqlite_diagnostics
+        .set_core_loaded(run_id, baseline_sqlite_diagnostics_snapshot());
     state.modal.set_mode(InputMode::SqliteDiagnostics);
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -1057,26 +1061,17 @@ fn sqlite_diagnostics_overlay_loaded() {
 
 #[test]
 fn sqlite_diagnostics_overlay_partial_failure() {
-    use sabiql_domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
-
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
     let run_id = state.sqlite_diagnostics.begin_core_fetch();
-    state.sqlite_diagnostics.set_core_loaded(
-        run_id,
-        SqliteDiagnosticsSnapshot {
-            db_file: DiagnosticField::ok("/tmp/app.db"),
-            sqlite_version: DiagnosticField::ok("3.45.0"),
-            feature_summary: DiagnosticField::Unavailable,
-            foreign_keys: DiagnosticField::err("timeout"),
-            journal_mode: DiagnosticField::ok("delete"),
-            query_only: DiagnosticField::ok("on"),
-            busy_timeout: DiagnosticField::ok("5000"),
-            database_list: DiagnosticField::ok("0: main @ /tmp/app.db"),
-            quick_check: DiagnosticField::ok("row 1 missing from index idx_users"),
-        },
-    );
+    let mut snapshot = baseline_sqlite_diagnostics_snapshot();
+    snapshot.feature_summary = DiagnosticField::Unavailable;
+    snapshot.foreign_keys = DiagnosticField::err("timeout");
+    snapshot.journal_mode = DiagnosticField::ok("delete");
+    snapshot.query_only = DiagnosticField::ok("on");
+    snapshot.quick_check = DiagnosticField::ok("row 1 missing from index idx_users");
+    state.sqlite_diagnostics.set_core_loaded(run_id, snapshot);
     state.modal.set_mode(InputMode::SqliteDiagnostics);
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -1086,28 +1081,13 @@ fn sqlite_diagnostics_overlay_partial_failure() {
 
 #[test]
 fn sqlite_diagnostics_overlay_quick_check_pending() {
-    use sabiql_domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
-
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
     let run_id = state.sqlite_diagnostics.begin_core_fetch();
-    state.sqlite_diagnostics.set_core_loaded(
-        run_id,
-        SqliteDiagnosticsSnapshot {
-            db_file: DiagnosticField::ok("/tmp/app.db"),
-            sqlite_version: DiagnosticField::ok("3.45.0"),
-            feature_summary: DiagnosticField::ok(
-                "FTS5: available\nFTS4: not available\nRTree: available\nJSON: available",
-            ),
-            foreign_keys: DiagnosticField::ok("on"),
-            journal_mode: DiagnosticField::ok("wal"),
-            query_only: DiagnosticField::ok("off"),
-            busy_timeout: DiagnosticField::ok("5000"),
-            database_list: DiagnosticField::ok("0: main @ /tmp/app.db"),
-            quick_check: DiagnosticField::Pending,
-        },
-    );
+    state
+        .sqlite_diagnostics
+        .set_core_loaded(run_id, baseline_sqlite_diagnostics_snapshot());
     state.sqlite_diagnostics.begin_quick_check();
     state.modal.set_mode(InputMode::SqliteDiagnostics);
 
@@ -1118,28 +1098,13 @@ fn sqlite_diagnostics_overlay_quick_check_pending() {
 
 #[test]
 fn sqlite_diagnostics_overlay_quick_check_not_run() {
-    use sabiql_domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
-
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal();
 
     let run_id = state.sqlite_diagnostics.begin_core_fetch();
-    state.sqlite_diagnostics.set_core_loaded(
-        run_id,
-        SqliteDiagnosticsSnapshot {
-            db_file: DiagnosticField::ok("/tmp/app.db"),
-            sqlite_version: DiagnosticField::ok("3.45.0"),
-            feature_summary: DiagnosticField::ok(
-                "FTS5: available\nFTS4: not available\nRTree: available\nJSON: available",
-            ),
-            foreign_keys: DiagnosticField::ok("on"),
-            journal_mode: DiagnosticField::ok("wal"),
-            query_only: DiagnosticField::ok("off"),
-            busy_timeout: DiagnosticField::ok("5000"),
-            database_list: DiagnosticField::ok("0: main @ /tmp/app.db"),
-            quick_check: DiagnosticField::Pending,
-        },
-    );
+    let mut snapshot = baseline_sqlite_diagnostics_snapshot();
+    snapshot.quick_check = DiagnosticField::Pending;
+    state.sqlite_diagnostics.set_core_loaded(run_id, snapshot);
     state.modal.set_mode(InputMode::SqliteDiagnostics);
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -1149,30 +1114,15 @@ fn sqlite_diagnostics_overlay_quick_check_not_run() {
 
 #[test]
 fn sqlite_diagnostics_overlay_wrapped_scroll() {
-    use sabiql_domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
-
     let mut state = sqlite_connected_state();
     let mut terminal = create_test_terminal_sized(50, 24);
 
     let run_id = state.sqlite_diagnostics.begin_core_fetch();
-    state.sqlite_diagnostics.set_core_loaded(
-        run_id,
-        SqliteDiagnosticsSnapshot {
-            db_file: DiagnosticField::ok(
-                "/tmp/very/long/database/path/that/will/wrap/in/a/narrow/viewport/app.db",
-            ),
-            sqlite_version: DiagnosticField::ok("3.45.0"),
-            feature_summary: DiagnosticField::ok(
-                "FTS5: available\nFTS4: not available\nRTree: available\nJSON: available",
-            ),
-            foreign_keys: DiagnosticField::ok("on"),
-            journal_mode: DiagnosticField::ok("wal"),
-            query_only: DiagnosticField::ok("off"),
-            busy_timeout: DiagnosticField::ok("5000"),
-            database_list: DiagnosticField::ok("0: main @ /tmp/app.db"),
-            quick_check: DiagnosticField::ok("ok"),
-        },
+    let mut snapshot = baseline_sqlite_diagnostics_snapshot();
+    snapshot.db_file = DiagnosticField::ok(
+        "/tmp/very/long/database/path/that/will/wrap/in/a/narrow/viewport/app.db",
     );
+    state.sqlite_diagnostics.set_core_loaded(run_id, snapshot);
     state.sqlite_diagnostics.set_scroll_offset(8);
     state.modal.set_mode(InputMode::SqliteDiagnostics);
 


### PR DESCRIPTION
## Problem
SQLite diagnostics snapshot tests repeated the same full snapshot fixture in several scenarios.

## Background
The repeated setup obscured which fields differ between the rendered states.

## Approach
Share one baseline snapshot fixture and override only scenario-specific diagnostic fields. Preserve all existing snapshot expectations and production behavior.