### PR TITLE
refactor(test): reuse MySQL single-statement loop

### DIFF
--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -63,28 +63,3 @@ pub(super) async fn run_mysql_single_statement_process_with_diagnostics(
         diagnostics,
     })
 }
-
-#[cfg(test)]
-pub(super) mod test_support {
-    use super::super::super::xml::MySqlResultSet;
-    use super::super::read_one_mysql_resultset;
-    use super::*;
-
-    pub async fn run_mysql_single_statement_process(
-        process: &mut MySqlProcess,
-        query: &str,
-        access_mode: AccessMode,
-    ) -> Result<MySqlResultSet, DbOperationError> {
-        configure_mysql_session(process, access_mode).await?;
-        write_mysql_statement(process, query).await?;
-
-        #[cfg(unix)]
-        let stdout = read_one_mysql_resultset(process).await?;
-        let result = finish_mysql_session(process).await?;
-        validate_mysql_session_exit(&result, process.client_packet_limit_bytes)?;
-        #[cfg(unix)]
-        return parse_mysql_xml(&stdout);
-        #[cfg(not(unix))]
-        parse_mysql_xml(&result.stdout)
-    }
-}

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -68,7 +68,9 @@ fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
             "timeout" => "while :; do :; done".to_string(),
             _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_session_marker\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
         };
-    let user_response = if mode == "failure" {
+    let user_response = if mode == "nonzero_exit" {
+        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'"
+    } else if mode == "failure" {
         "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    exit_status=1\n    [ \"$adhoc\" -eq 0 ] && printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2"
     } else if mode == "no_result_failure" {
         "printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2\n    exit 1"
@@ -90,6 +92,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
     } else {
         ""
     };
+    let finish_status = if mode == "nonzero_exit" { "exit 1" } else { "" };
     let settings_timeout = if mode == "timeout" {
         "while :; do :; done"
     } else {
@@ -123,6 +126,7 @@ while IFS= read -r line; do
       else
         printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
         {finish_error}
+        {finish_status}
       fi
       ;;
     *)

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -13,7 +13,6 @@ use super::metadata::{
     run_mysql_metadata_query_with_read_only_session_with_timeout,
 };
 use super::single::run_mysql_single_statement_process_with_diagnostics;
-use super::single::test_support::run_mysql_single_statement_process;
 use super::*;
 use crate::adapters::csv_export::export_to_path;
 use crate::domain::mysql_sql::{classify_mysql_statement, split_mysql_statements};
@@ -35,23 +34,6 @@ async fn export_mysql_csv_with_program(
     .await
 }
 async fn run_mysql_single_statement_with_program(
-    program: &OsStr,
-    option_file: &std::path::Path,
-    query: &str,
-    access_mode: AccessMode,
-    execution_timeout: Duration,
-) -> Result<MySqlResultSet, DbOperationError> {
-    let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
-    run_mysql_process_with_timeout(
-        execution_timeout,
-        &mut process,
-        RefreshScope::None,
-        async |process| run_mysql_single_statement_process(process, query, access_mode).await,
-    )
-    .await
-}
-
-async fn run_mysql_single_statement_with_diagnostics_with_program(
     program: &OsStr,
     option_file: &std::path::Path,
     query: &str,
@@ -87,7 +69,7 @@ fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
             _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_session_marker\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
         };
     let user_response = if mode == "failure" {
-        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit 1"
+        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit_status=1"
     } else if mode == "no_result_failure" {
         "printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2\n    exit 1"
     } else if mode == "connection_refused" {
@@ -113,9 +95,10 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 eof=$(printf '\004')
+exit_status=0
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
-  [ "$line" = "$eof" ] && exit 0
+  [ "$line" = "$eof" ] && exit "$exit_status"
   [ "$line" = ";" ] && continue
   case "$line" in
     "SET SESSION autocommit=1, completion_type=NO_CHAIN")
@@ -134,7 +117,6 @@ while IFS= read -r line; do
       ;;
     *)
       {user_response}
-      exit 0
       ;;
   esac
 done

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -69,7 +69,7 @@ fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
             _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_session_marker\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
         };
     let user_response = if mode == "failure" {
-        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit_status=1"
+        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    exit_status=1\n    [ \"$adhoc\" -eq 0 ] && printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2"
     } else if mode == "no_result_failure" {
         "printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2\n    exit 1"
     } else if mode == "connection_refused" {
@@ -85,6 +85,11 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
     } else {
         ""
     };
+    let finish_error = if mode == "failure" {
+        "printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2"
+    } else {
+        ""
+    };
     let settings_timeout = if mode == "timeout" {
         "while :; do :; done"
     } else {
@@ -96,9 +101,13 @@ option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 eof=$(printf '\004')
 exit_status=0
+adhoc=0
+case "$*" in
+  *--show-warnings*) adhoc=1 ;;
+esac
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
-  [ "$line" = "$eof" ] && exit "$exit_status"
+  [ "$line" = "$eof" ] && break
   [ "$line" = ";" ] && continue
   case "$line" in
     "SET SESSION autocommit=1, completion_type=NO_CHAIN")
@@ -113,6 +122,7 @@ while IFS= read -r line; do
         {session_response}
       else
         printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+        {finish_error}
       fi
       ;;
     *)
@@ -120,6 +130,7 @@ while IFS= read -r line; do
       ;;
   esac
 done
+exit "$exit_status"
 "#,
     );
     fs::write(&program, script).unwrap();

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -71,7 +71,7 @@ fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
     let user_response = if mode == "nonzero_exit" {
         "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'"
     } else if mode == "failure" {
-        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    exit_status=1\n    [ \"$adhoc\" -eq 0 ] && printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2"
+        "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit_status=1"
     } else if mode == "no_result_failure" {
         "printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2\n    exit 1"
     } else if mode == "connection_refused" {
@@ -87,12 +87,11 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
     } else {
         ""
     };
-    let finish_error = if mode == "failure" {
-        "printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2"
+    let finish_status = if mode == "nonzero_exit" {
+        "exit_status=1\n        dd bs=1 count=1 >/dev/null 2>&1\n        break"
     } else {
         ""
     };
-    let finish_status = if mode == "nonzero_exit" { "exit 1" } else { "" };
     let settings_timeout = if mode == "timeout" {
         "while :; do :; done"
     } else {
@@ -104,10 +103,6 @@ option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 eof=$(printf '\004')
 exit_status=0
-adhoc=0
-case "$*" in
-  *--show-warnings*) adhoc=1 ;;
-esac
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
   [ "$line" = "$eof" ] && break
@@ -125,7 +120,6 @@ while IFS= read -r line; do
         {session_response}
       else
         printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
-        {finish_error}
         {finish_status}
       fi
       ;;

--- a/src/infra/adapters/mysql/cli/process/tests/single.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/single.rs
@@ -100,7 +100,12 @@ async fn nonzero_cli_exit_discards_any_collected_stdout() {
     )
     .await;
 
-    assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+    let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+    assert!(
+        matches!(result, Err(DbOperationError::QueryFailed(_))),
+        "result={result:?}; log={log}"
+    );
+    assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN), "{log}");
 }
 
 #[tokio::test]

--- a/src/infra/adapters/mysql/cli/process/tests/single.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/single.rs
@@ -6,7 +6,7 @@ async fn diagnostics_use_adhoc_args_and_follow_resultset_to_marker() {
     let (_directory, program, log_file) = fake_mysql_single_with_warning();
     let option_file = log_file.with_extension("cnf");
     fs::write(&option_file, "[client]\n").unwrap();
-    let result = run_mysql_single_statement_with_diagnostics_with_program(
+    let result = run_mysql_single_statement_with_program(
         OsStr::new(&program),
         &option_file,
         "EXPLAIN FORMAT=TREE SELECT 1",
@@ -49,8 +49,9 @@ async fn sends_user_sql_only_after_a_valid_session_configuration() {
     .await
     .unwrap();
 
-    assert_eq!(result.columns, vec!["value"]);
-    assert_eq!(result.values[0][0].as_str(), Some("ok"));
+    let result_set = result.result_set.unwrap();
+    assert_eq!(result_set.columns, vec!["value"]);
+    assert_eq!(result_set.values[0][0].as_str(), Some("ok"));
     let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
     let positions = [
         MYSQL_SESSION_SETTINGS,

--- a/src/infra/adapters/mysql/cli/process/tests/single.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/single.rs
@@ -88,7 +88,7 @@ async fn read_only_session_failure_never_writes_user_sql() {
 
 #[tokio::test]
 async fn nonzero_cli_exit_discards_any_collected_stdout() {
-    let (_directory, program, log_file) = fake_mysql("failure");
+    let (_directory, program, log_file) = fake_mysql("nonzero_exit");
     let option_file = log_file.with_extension("cnf");
     fs::write(&option_file, "[client]\n").unwrap();
     let result = run_mysql_single_statement_with_program(


### PR DESCRIPTION
## Problem

Single-statement MySQL process tests exercised a simplified path that could diverge from the production session lifecycle.

## Background

The production path now validates diagnostics and a completion marker before finishing the session, while the test-only path stopped after the first result set.

## Approach

Route the fake-client tests through the production lifecycle and keep the fake client alive until the explicit session shutdown. This preserves the existing error assertions while covering the same diagnostics, marker, and exit handling used in production.