### PR TITLE
test(mysql): synchronize fake client EOF handshake

### DIFF
--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -88,7 +88,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>'"
         ""
     };
     let finish_status = if mode == "nonzero_exit" {
-        "exit_status=1\n        dd bs=1 count=1 >/dev/null 2>&1\n        break"
+        "exit_status=1\n        IFS= read -r marker_terminator\n        dd bs=1 count=1 >/dev/null 2>&1\n        break"
     } else {
         ""
     };


### PR DESCRIPTION
## Problem

The status-only MySQL fixture can consume the marker statement delimiter as its shutdown byte and exit before the production process writes EOF.

## Background

The merged single-statement test now exercises the production session lifecycle, including the final PTY shutdown and non-zero exit classification.

## Approach

Consume the marker statement terminator before waiting for the production EOF byte, then exit with the configured non-zero status. This keeps the fake client alive through the shutdown write and makes the status-only assertion deterministic.