### PR TITLE
fix(app): preserve quoted table identity

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -9,6 +9,7 @@ use crate::cmd::metadata_task::MetadataTaskRegistry;
 use crate::cmd::single_task_owner::SingleTaskOwner;
 use crate::cmd::sqlite_path_validate::validate_sqlite_database_path;
 use crate::domain::sqlite_path_from_dsn;
+use crate::model::table_prefetch::PrefetchTableTarget;
 use crate::policy::sqlite_path::to_db_operation_error;
 use crate::ports::outbound::{DbOperationError, MetadataProvider, SqlitePathValidator};
 use crate::update::action::Action;
@@ -198,8 +199,8 @@ async fn prefetch_table_detail(
     schema: String,
     table: String,
 ) {
-    let qualified_name = format!("{schema}.{table}");
-    let already_cached = completion_engine.borrow().has_cached_table(&qualified_name);
+    let target = PrefetchTableTarget::qualified(&schema, &table);
+    let already_cached = completion_engine.borrow().has_cached_table_target(&target);
 
     if already_cached {
         action_tx

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
 
-use crate::domain::{DatabaseMetadata, DatabaseType, Table, TableSummary};
+use crate::domain::{DatabaseMetadata, DatabaseType, Table};
 use crate::model::shared::text_input::char_to_byte_index;
 use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
+use crate::model::table_prefetch::PrefetchTableTarget;
 use crate::policy::sql::lexer::{
     MYSQL_KEYWORDS, POSTGRESQL_KEYWORDS, SqlContext, SqlLexer, TableReference, Token, TokenKind,
 };
@@ -131,26 +132,27 @@ impl CompletionEngine {
         &self,
         prep: &PreparedCompletion,
         metadata: Option<&DatabaseMetadata>,
-    ) -> Vec<String> {
+    ) -> Vec<PrefetchTableTarget> {
         const MAX_MISSING_TABLES: usize = 10;
 
         let mut missing = Vec::new();
-        let mut seen = HashSet::new();
+        let mut seen: HashSet<PrefetchTableTarget> = HashSet::new();
 
         for table_ref in &prep.candidate_context.tables {
             if prep.cte_names.contains(&table_ref.table.to_lowercase()) {
                 continue;
             }
-            let Some(qualified_name) =
-                self.qualified_name_from_ref_for_database(table_ref, metadata, prep.database_type)
+            let Some(target) =
+                self.table_target_from_ref_for_database(table_ref, metadata, prep.database_type)
             else {
                 continue;
             };
-            if seen.contains(&qualified_name) || self.table_detail_cache.contains(&qualified_name) {
+            let qualified_name = target.qualified_name();
+            if seen.contains(&target) || self.table_detail_cache.contains(&qualified_name) {
                 continue;
             }
-            seen.insert(qualified_name.clone());
-            missing.push(qualified_name);
+            seen.insert(target.clone());
+            missing.push(target);
             if missing.len() >= MAX_MISSING_TABLES {
                 break;
             }
@@ -1094,19 +1096,19 @@ impl CompletionEngine {
             .collect()
     }
 
-    fn qualified_name_from_ref_for_database(
+    fn table_target_from_ref_for_database(
         &self,
         table_ref: &TableReference,
         metadata: Option<&DatabaseMetadata>,
         database_type: DatabaseType,
-    ) -> Option<String> {
+    ) -> Option<PrefetchTableTarget> {
         if let Some(ref schema) = table_ref.schema {
             if database_type != DatabaseType::MySQL {
-                return Some(format!("{}.{}", schema, table_ref.table));
+                return Some(PrefetchTableTarget::qualified(schema, &table_ref.table));
             }
 
             let Some(metadata) = metadata else {
-                return Some(format!("{}.{}", schema, table_ref.table));
+                return Some(PrefetchTableTarget::qualified(schema, &table_ref.table));
             };
 
             if let Some(table) = metadata
@@ -1114,7 +1116,7 @@ impl CompletionEngine {
                 .iter()
                 .find(|t| t.schema == *schema && t.name == table_ref.table)
             {
-                return Some(table.qualified_name());
+                return Some(PrefetchTableTarget::qualified(&table.schema, &table.name));
             }
 
             let schema_lower = schema.to_lowercase();
@@ -1126,11 +1128,14 @@ impl CompletionEngine {
             return case_insensitive
                 .next()
                 .is_none()
-                .then(|| table.qualified_name());
+                .then(|| PrefetchTableTarget::qualified(&table.schema, &table.name));
         }
 
         let Some(metadata) = metadata else {
-            return Some(table_ref.table.clone());
+            return Some(PrefetchTableTarget {
+                schema: None,
+                table: table_ref.table.clone(),
+            });
         };
 
         if database_type == DatabaseType::MySQL {
@@ -1139,7 +1144,7 @@ impl CompletionEngine {
                 .iter()
                 .find(|t| t.name == table_ref.table)
             {
-                return Some(table.qualified_name());
+                return Some(PrefetchTableTarget::qualified(&table.schema, &table.name));
             }
 
             let table_lower = table_ref.table.to_lowercase();
@@ -1151,7 +1156,7 @@ impl CompletionEngine {
             return case_insensitive
                 .next()
                 .is_none()
-                .then(|| table.qualified_name());
+                .then(|| PrefetchTableTarget::qualified(&table.schema, &table.name));
         }
 
         Some(
@@ -1159,8 +1164,24 @@ impl CompletionEngine {
                 .table_summaries
                 .iter()
                 .find(|t| t.name.to_lowercase() == table_ref.table.to_lowercase())
-                .map_or_else(|| table_ref.table.clone(), TableSummary::qualified_name),
+                .map_or_else(
+                    || PrefetchTableTarget {
+                        schema: None,
+                        table: table_ref.table.clone(),
+                    },
+                    |table| PrefetchTableTarget::qualified(&table.schema, &table.name),
+                ),
         )
+    }
+
+    fn qualified_name_from_ref_for_database(
+        &self,
+        table_ref: &TableReference,
+        metadata: Option<&DatabaseMetadata>,
+        database_type: DatabaseType,
+    ) -> Option<String> {
+        self.table_target_from_ref_for_database(table_ref, metadata, database_type)
+            .map(|target| target.qualified_name())
     }
 }
 
@@ -1247,6 +1268,7 @@ fn sort_candidates(candidates: &mut [CompletionCandidate]) {
 mod tests {
     use crate::domain::Column;
     use crate::domain::ColumnAttributes;
+    use crate::domain::TableSummary;
     use crate::test_support;
 
     use super::*;
@@ -1375,6 +1397,9 @@ mod tests {
         ) -> Vec<String> {
             let prep = self.prepare_for_database(content, content.len(), DatabaseType::PostgreSQL);
             self.missing_tables_prepared(&prep, metadata)
+                .into_iter()
+                .map(|target| target.qualified_name())
+                .collect()
         }
     }
 
@@ -3265,8 +3290,8 @@ mod tests {
                 assert_eq!(
                     missing,
                     vec![
-                        "public.nested_table".to_string(),
-                        "public.current_table".to_string(),
+                        PrefetchTableTarget::qualified("public", "nested_table"),
+                        PrefetchTableTarget::qualified("public", "current_table"),
                     ]
                 );
             }
@@ -3291,7 +3316,7 @@ mod tests {
             );
             assert_eq!(
                 engine().missing_tables_prepared(&before_prep, Some(&metadata)),
-                vec!["public.first_table".to_string()]
+                vec![PrefetchTableTarget::qualified("public", "first_table")]
             );
 
             let after_prep = engine().prepare_for_database(
@@ -3312,7 +3337,22 @@ mod tests {
 
             assert_eq!(
                 engine().missing_tables_prepared(&comment_prep, Some(&metadata)),
-                vec!["public.current_table".to_string()]
+                vec![PrefetchTableTarget::qualified("public", "current_table")]
+            );
+        }
+
+        #[test]
+        fn quoted_schema_and_table_keep_dots_inside_each_identifier() {
+            let e = engine();
+            let sql = r#"SELECT * FROM "sales.region"."Orders.Archive""#;
+            let prep = e.prepare_for_database(sql, sql.len(), DatabaseType::PostgreSQL);
+
+            assert_eq!(
+                e.missing_tables_prepared(&prep, None),
+                vec![PrefetchTableTarget::qualified(
+                    "sales.region",
+                    "Orders.Archive"
+                )]
             );
         }
 

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -41,7 +41,7 @@ pub(crate) struct PreparedCompletion {
 }
 
 pub struct CompletionEngine {
-    table_detail_cache: LruCache<String, Table>,
+    table_detail_cache: LruCache<PrefetchTableTarget, Table>,
 }
 
 impl CompletionEngine {
@@ -57,17 +57,33 @@ impl CompletionEngine {
         }
     }
 
-    pub(crate) fn cache_table_detail(&mut self, qualified_name: String, table: Table) {
-        let _ = self.table_detail_cache.put(qualified_name, table);
+    pub(crate) fn cache_table_detail(&mut self, _qualified_name: String, table: Table) {
+        let target = PrefetchTableTarget::qualified(&table.schema, &table.name);
+        let _ = self.table_detail_cache.put(target, table);
     }
 
+    #[cfg(test)]
     pub(crate) fn has_cached_table(&self, qualified_name: &str) -> bool {
-        self.table_detail_cache.contains(qualified_name)
+        self.table_detail_cache
+            .iter()
+            .any(|(target, _)| target.qualified_name() == qualified_name)
+    }
+
+    pub(crate) fn has_cached_table_target(&self, target: &PrefetchTableTarget) -> bool {
+        self.table_detail_cache.contains(target)
     }
 
     pub(crate) fn evict_tables(&mut self, tables: &[String]) {
         for table in tables {
-            let _ = self.table_detail_cache.pop(table);
+            let keys: Vec<_> = self
+                .table_detail_cache
+                .iter()
+                .filter(|(target, _)| target.qualified_name() == *table)
+                .map(|(target, _)| target.clone())
+                .collect();
+            for key in keys {
+                let _ = self.table_detail_cache.pop(&key);
+            }
         }
     }
 
@@ -80,7 +96,9 @@ impl CompletionEngine {
             .resize(NonZeroUsize::new(new_capacity).expect("capacity must be > 0"));
     }
 
-    pub(crate) fn table_details_iter(&self) -> impl Iterator<Item = (&String, &Table)> {
+    pub(crate) fn table_details_iter(
+        &self,
+    ) -> impl Iterator<Item = (&PrefetchTableTarget, &Table)> {
         self.table_detail_cache.iter()
     }
 
@@ -147,8 +165,7 @@ impl CompletionEngine {
             else {
                 continue;
             };
-            let qualified_name = target.qualified_name();
-            if seen.contains(&target) || self.table_detail_cache.contains(&qualified_name) {
+            if seen.contains(&target) || self.has_cached_table_target(&target) {
                 continue;
             }
             seen.insert(target.clone());
@@ -212,27 +229,27 @@ impl CompletionEngine {
                 let after_comma = before_token.ends_with(',');
 
                 let target_qualified = prep.candidate_context.target_table.as_ref().and_then(|t| {
-                    self.qualified_name_from_ref_for_database(t, metadata, scope.database_type)
+                    self.table_target_from_ref_for_database(t, metadata, scope.database_type)
                 });
 
                 let mut columns = self.column_candidates_with_fk(table_detail, &current_token);
 
                 // UPDATE/DELETE/INSERT target table columns get priority
                 if let (Some(detail), Some(target)) = (table_detail, &target_qualified)
-                    && detail.qualified_name() == *target
+                    && PrefetchTableTarget::qualified(&detail.schema, &detail.name) == *target
                 {
                     for col in &mut columns {
                         col.score += 200;
                     }
                 }
 
-                let referenced_tables: HashSet<String> = prep
+                let referenced_tables: HashSet<PrefetchTableTarget> = prep
                     .candidate_context
                     .tables
                     .iter()
                     .filter(|t| !prep.cte_names.contains(&t.table.to_lowercase()))
                     .filter_map(|t| {
-                        self.qualified_name_from_ref_for_database(t, metadata, scope.database_type)
+                        self.table_target_from_ref_for_database(t, metadata, scope.database_type)
                     })
                     .collect();
                 let has_unresolved_reference = prep
@@ -241,22 +258,23 @@ impl CompletionEngine {
                     .iter()
                     .filter(|t| !prep.cte_names.contains(&t.table.to_lowercase()))
                     .any(|t| {
-                        self.qualified_name_from_ref_for_database(t, metadata, scope.database_type)
+                        self.table_target_from_ref_for_database(t, metadata, scope.database_type)
                             .is_none()
                     });
 
-                let selected_qualified = table_detail.map(Table::qualified_name);
+                let selected_qualified = table_detail
+                    .map(|table| PrefetchTableTarget::qualified(&table.schema, &table.name));
                 let use_all_cache = referenced_tables.is_empty() && !has_unresolved_reference;
-                for (qualified_name, cached_table) in &self.table_detail_cache {
-                    if selected_qualified.as_ref() == Some(qualified_name) {
+                for (target, cached_table) in &self.table_detail_cache {
+                    if selected_qualified.as_ref() == Some(target) {
                         continue;
                     }
-                    if !use_all_cache && !referenced_tables.contains(qualified_name) {
+                    if !use_all_cache && !referenced_tables.contains(target) {
                         continue;
                     }
                     let mut cached_columns =
                         self.column_candidates_with_fk(Some(cached_table), &current_token);
-                    if target_qualified.as_ref() == Some(qualified_name) {
+                    if target_qualified.as_ref() == Some(target) {
                         for col in &mut cached_columns {
                             col.score += 200;
                         }
@@ -982,11 +1000,10 @@ impl CompletionEngine {
         };
 
         // Try to find the table in cache
-        let qualified_name =
-            self.qualified_name_from_ref_for_database(table_ref, metadata, database_type);
+        let target = self.table_target_from_ref_for_database(table_ref, metadata, database_type);
 
-        if let Some(qualified_name) = qualified_name
-            && let Some(table) = self.table_detail_cache.peek(&qualified_name)
+        if let Some(target) = target
+            && let Some(table) = self.table_detail_cache.peek(&target)
         {
             return self.column_candidates(Some(table), prefix);
         }
@@ -1172,16 +1189,6 @@ impl CompletionEngine {
                     |table| PrefetchTableTarget::qualified(&table.schema, &table.name),
                 ),
         )
-    }
-
-    fn qualified_name_from_ref_for_database(
-        &self,
-        table_ref: &TableReference,
-        metadata: Option<&DatabaseMetadata>,
-        database_type: DatabaseType,
-    ) -> Option<String> {
-        self.table_target_from_ref_for_database(table_ref, metadata, database_type)
-            .map(|target| target.qualified_name())
     }
 }
 
@@ -1516,6 +1523,16 @@ mod tests {
         fn insert_target_column_list_returns_column_context() {
             let e = engine();
             let (token, ctx) = e.analyze("INSERT INTO users (na", 21);
+
+            assert_eq!(token, "na");
+            assert_eq!(ctx, CompletionContext::Column);
+        }
+
+        #[test]
+        fn quoted_keyword_table_does_not_end_insert_column_context() {
+            let e = engine();
+            let sql = r#"INSERT INTO "VALUES" (na"#;
+            let (token, ctx) = e.analyze(sql, sql.chars().count());
 
             assert_eq!(token, "na");
             assert_eq!(ctx, CompletionContext::Column);
@@ -3006,6 +3023,41 @@ mod tests {
         }
 
         #[test]
+        fn dotted_cache_identity_does_not_use_another_table_for_alias_columns() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "sales.region.orders".to_string(),
+                create_table("sales.region", "orders", &["wrong_table"]),
+            );
+            let sql_context = SqlContext {
+                tables: vec![TableReference {
+                    schema: Some("sales".to_string()),
+                    table: "region.orders".to_string(),
+                    alias: Some("o".to_string()),
+                }],
+                ctes: vec![],
+                target_table: None,
+            };
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = vec![TableSummary::new(
+                "sales".to_string(),
+                "region.orders".to_string(),
+                None,
+                false,
+            )];
+
+            let candidates = e.alias_column_candidates(
+                "o",
+                &sql_context,
+                Some(&metadata),
+                "",
+                DatabaseType::PostgreSQL,
+            );
+
+            assert!(candidates.is_empty());
+        }
+
+        #[test]
         fn non_cached_table_returns_empty() {
             let e = engine();
 
@@ -3354,6 +3406,55 @@ mod tests {
                     "Orders.Archive"
                 )]
             );
+        }
+
+        #[test]
+        fn cache_identity_does_not_collide_on_qualified_name() {
+            let mut e = engine();
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = vec![
+                TableSummary::new(
+                    "sales.region".to_string(),
+                    "orders".to_string(),
+                    None,
+                    false,
+                ),
+                TableSummary::new(
+                    "sales".to_string(),
+                    "region.orders".to_string(),
+                    None,
+                    false,
+                ),
+            ];
+            e.cache_table_detail(
+                "sales.region.orders".to_string(),
+                create_table("sales.region", "orders", &["first"]),
+            );
+
+            let sql =
+                r#"SELECT * FROM "sales.region"."orders" JOIN "sales"."region.orders" ON 1 = 1"#;
+            let prep = e.prepare_for_database(sql, sql.len(), DatabaseType::PostgreSQL);
+
+            assert_eq!(
+                e.missing_tables_prepared(&prep, Some(&metadata)),
+                vec![PrefetchTableTarget::qualified("sales", "region.orders")]
+            );
+        }
+
+        #[test]
+        fn quoted_keyword_cte_is_not_prefetched_as_a_table() {
+            let e = engine();
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = vec![TableSummary::new(
+                "public".to_string(),
+                "SELECT".to_string(),
+                None,
+                false,
+            )];
+            let sql = r#"WITH "SELECT" AS (SELECT 1) SELECT * FROM "SELECT""#;
+            let prep = e.prepare_for_database(sql, sql.len(), DatabaseType::PostgreSQL);
+
+            assert!(e.missing_tables_prepared(&prep, Some(&metadata)).is_empty());
         }
 
         #[test]
@@ -3988,7 +4089,10 @@ mod tests {
             e.cache_table_detail("public.t1".to_string(), t1);
             e.cache_table_detail("public.t2".to_string(), t2);
 
-            let names: Vec<_> = e.table_details_iter().map(|(k, _)| k.clone()).collect();
+            let names: Vec<_> = e
+                .table_details_iter()
+                .map(|(k, _)| k.qualified_name())
+                .collect();
             assert_eq!(names.len(), 2);
             assert!(names.contains(&"public.t1".to_string()));
             assert!(names.contains(&"public.t2".to_string()));
@@ -4050,7 +4154,8 @@ mod tests {
                 create_table("public", "t2", &["id"]),
             );
 
-            assert!(e.table_detail_cache.peek("public.t1").is_some());
+            let target = PrefetchTableTarget::qualified("public", "t1");
+            assert!(e.table_detail_cache.peek(&target).is_some());
             assert!(e.has_cached_table("public.t1"));
 
             e.cache_table_detail(

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -326,7 +326,10 @@ fn collect_cached_er_tables(completion_engine: &RefCell<CompletionEngine>) -> Ve
     let engine = completion_engine.borrow();
     engine
         .table_details_iter()
-        .map(|(name, table)| ErTableInfo::from_table(name, table))
+        .map(|(name, table)| {
+            let qualified_name = name.qualified_name();
+            ErTableInfo::from_table(&qualified_name, table)
+        })
         .collect()
 }
 
@@ -337,12 +340,15 @@ fn collect_seed_and_cached_names(
     let engine = completion_engine.borrow();
     let seeds = engine
         .table_details_iter()
-        .filter(|(name, _)| seed_set.contains(name.as_str()))
-        .map(|(name, table)| ErTableInfo::from_table(name, table))
+        .filter(|(name, _)| seed_set.contains(name.qualified_name().as_str()))
+        .map(|(name, table)| {
+            let qualified_name = name.qualified_name();
+            ErTableInfo::from_table(&qualified_name, table)
+        })
         .collect();
     let all_cached = engine
         .table_details_iter()
-        .map(|(name, _)| name.clone())
+        .map(|(name, _)| name.qualified_name())
         .collect();
     (seeds, all_cached)
 }
@@ -351,7 +357,7 @@ fn collect_cached_table_names(completion_engine: &RefCell<CompletionEngine>) -> 
     let engine = completion_engine.borrow();
     engine
         .table_details_iter()
-        .map(|(name, _)| name.clone())
+        .map(|(name, _)| name.qualified_name())
         .collect()
 }
 

--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -52,16 +52,15 @@ pub(in crate::cmd) fn run(
             let mut actions = Vec::new();
             if !missing.is_empty() {
                 if let Some(run_id) = state.table_prefetch.active_prefetch_run_id() {
-                    for action in missing.into_iter().filter_map(|qualified_name| {
-                        qualified_name.split_once('.').map(|(schema, table)| {
-                            Action::PrefetchTableDetail {
-                                run_id,
-                                schema: schema.to_string(),
-                                table: table.to_string(),
-                            }
-                        })
-                    }) {
-                        actions.push(action);
+                    for target in missing {
+                        let Some(schema) = target.schema else {
+                            continue;
+                        };
+                        actions.push(Action::PrefetchTableDetail {
+                            run_id,
+                            schema,
+                            table: target.table,
+                        });
                     }
                 } else {
                     actions.push(Action::StartCompletionPrefetch { tables: missing });
@@ -107,6 +106,7 @@ mod tests {
     use super::*;
     use crate::domain::{DatabaseMetadata, TableSummary};
     use crate::model::shared::input_mode::InputMode;
+    use crate::model::table_prefetch::PrefetchTableTarget;
     use std::sync::Arc;
 
     #[test]
@@ -135,7 +135,38 @@ mod tests {
         assert!(matches!(
             actions.as_slice(),
             [Action::StartCompletionPrefetch { tables }, Action::CompletionUpdated { .. }]
-                if *tables == vec!["public.users".to_string()]
+                if *tables == vec![PrefetchTableTarget::qualified("public", "users")]
+        ));
+    }
+
+    #[test]
+    fn active_prefetch_preserves_quoted_schema_and_table_identity() {
+        let mut state = AppState::new("test".to_string());
+        state.modal.set_mode(InputMode::SqlModal);
+        state
+            .sql_modal
+            .editor_mut_for_input()
+            .set_content(r#"SELECT * FROM "sales.region"."Orders.Archive""#.to_string());
+        let run_id = state.table_prefetch.begin_completion_prefetch();
+
+        let actions = run(
+            Effect::TriggerCompletion,
+            &state,
+            &RefCell::new(CompletionEngine::new()),
+        );
+
+        assert!(matches!(
+            actions.as_slice(),
+            [
+                Action::PrefetchTableDetail {
+                    run_id: actual_run_id,
+                    schema,
+                    table,
+                },
+                Action::CompletionUpdated { .. }
+            ] if *actual_run_id == run_id
+                && schema == "sales.region"
+                && table == "Orders.Archive"
         ));
     }
 }

--- a/src/app/model/table_prefetch.rs
+++ b/src/app/model/table_prefetch.rs
@@ -19,17 +19,12 @@ impl PrefetchTableTarget {
         }
     }
 
-    pub(crate) fn from_qualified_name(name: impl Into<String>) -> Self {
-        let name = name.into();
-        let (schema, table) = name
-            .split_once('.')
-            .map_or((None, name.as_str()), |(schema, table)| {
-                (Some(schema), table)
-            });
-        Self {
-            schema: schema.map(str::to_string),
-            table: table.to_string(),
+    pub(crate) fn from_unambiguous_qualified_name(name: &str) -> Option<Self> {
+        let (schema, table) = name.split_once('.')?;
+        if schema.contains('.') || table.contains('.') {
+            return None;
         }
+        Some(Self::qualified(schema, table))
     }
 
     pub(crate) fn qualified_name(&self) -> String {
@@ -37,24 +32,6 @@ impl PrefetchTableTarget {
             || self.table.clone(),
             |schema| format!("{schema}.{}", self.table),
         )
-    }
-}
-
-impl From<String> for PrefetchTableTarget {
-    fn from(name: String) -> Self {
-        Self::from_qualified_name(name)
-    }
-}
-
-impl From<&str> for PrefetchTableTarget {
-    fn from(name: &str) -> Self {
-        Self::from_qualified_name(name)
-    }
-}
-
-impl From<&String> for PrefetchTableTarget {
-    fn from(name: &String) -> Self {
-        Self::from_qualified_name(name)
     }
 }
 
@@ -178,16 +155,25 @@ impl TablePrefetchState {
             .count()
     }
 
-    pub fn queue_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
-        let table = table.into();
+    pub fn queue_table_prefetch(&mut self, table: String) {
+        if let Some(table) = PrefetchTableTarget::from_unambiguous_qualified_name(&table) {
+            self.queue_table_prefetch_target(table);
+        }
+    }
+
+    pub(crate) fn queue_table_prefetch_target(&mut self, table: PrefetchTableTarget) {
         if self.prefetching_tables.contains(&table) || self.is_prefetch_target_queued(&table) {
             return;
         }
         self.prefetch_queue.push_back(table);
     }
 
-    pub fn queue_pending_table(&mut self, table: impl Into<PrefetchTableTarget>) -> bool {
-        let table = table.into();
+    pub fn queue_pending_table(&mut self, table: String) -> bool {
+        PrefetchTableTarget::from_unambiguous_qualified_name(&table)
+            .is_some_and(|table| self.queue_pending_table_target(table))
+    }
+
+    pub(crate) fn queue_pending_table_target(&mut self, table: PrefetchTableTarget) -> bool {
         if self.prefetching_tables.contains(&table) || self.is_prefetch_target_queued(&table) {
             return false;
         }
@@ -196,8 +182,13 @@ impl TablePrefetchState {
         true
     }
 
-    pub fn defer_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
-        let table = table.into();
+    pub fn defer_table_prefetch(&mut self, table: String) {
+        if let Some(table) = PrefetchTableTarget::from_unambiguous_qualified_name(&table) {
+            self.defer_table_prefetch_target(table);
+        }
+    }
+
+    pub(crate) fn defer_table_prefetch_target(&mut self, table: PrefetchTableTarget) {
         if self.prefetching_tables.contains(&table) || self.is_prefetch_target_queued(&table) {
             return;
         }
@@ -213,39 +204,58 @@ impl TablePrefetchState {
         self.prefetch_queue.pop_front()
     }
 
-    pub fn start_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
-        let table = table.into();
+    pub fn start_table_prefetch(&mut self, table: String) {
+        if let Some(table) = PrefetchTableTarget::from_unambiguous_qualified_name(&table) {
+            self.start_table_prefetch_target(table);
+        }
+    }
+
+    pub(crate) fn start_table_prefetch_target(&mut self, table: PrefetchTableTarget) {
         self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.insert(table);
     }
 
-    pub fn complete_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
-        let table = table.into();
+    pub fn complete_table_prefetch(&mut self, table: &str) {
+        if let Some(table) = PrefetchTableTarget::from_unambiguous_qualified_name(table) {
+            self.complete_table_prefetch_target(table);
+        }
+    }
+
+    pub(crate) fn complete_table_prefetch_target(&mut self, table: PrefetchTableTarget) {
         self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.remove(&table);
         self.failed_prefetch_tables.remove(&table);
     }
 
-    pub fn fail_table_prefetch(
+    pub fn fail_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) {
+        if let Some(table) = PrefetchTableTarget::from_unambiguous_qualified_name(&table) {
+            self.fail_table_prefetch_target(table, entry);
+        }
+    }
+
+    pub(crate) fn fail_table_prefetch_target(
         &mut self,
-        table: impl Into<PrefetchTableTarget>,
+        table: PrefetchTableTarget,
         entry: FailedPrefetchEntry,
     ) {
-        let table = table.into();
         self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.remove(&table);
         self.failed_prefetch_tables.insert(table, entry);
     }
 
-    pub fn retry_table_prefetch(
+    pub fn retry_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) -> bool {
+        PrefetchTableTarget::from_unambiguous_qualified_name(&table)
+            .is_some_and(|table| self.retry_table_prefetch_target(table, entry))
+    }
+
+    pub(crate) fn retry_table_prefetch_target(
         &mut self,
-        table: impl Into<PrefetchTableTarget>,
+        table: PrefetchTableTarget,
         entry: FailedPrefetchEntry,
     ) -> bool {
-        let table = table.into();
         let had_other_pending_before_requeue = self.has_pending_prefetch();
-        self.fail_table_prefetch(table.clone(), entry);
-        self.queue_table_prefetch(table);
+        self.fail_table_prefetch_target(table.clone(), entry);
+        self.queue_table_prefetch_target(table);
         had_other_pending_before_requeue
     }
 

--- a/src/app/model/table_prefetch.rs
+++ b/src/app/model/table_prefetch.rs
@@ -5,6 +5,59 @@ use crate::model::shared::async_run::AsyncRun;
 
 pub(crate) const MAX_PREFETCH_RETRIES: u32 = 3;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrefetchTableTarget {
+    pub(crate) schema: Option<String>,
+    pub(crate) table: String,
+}
+
+impl PrefetchTableTarget {
+    pub(crate) fn qualified(schema: impl Into<String>, table: impl Into<String>) -> Self {
+        Self {
+            schema: Some(schema.into()),
+            table: table.into(),
+        }
+    }
+
+    pub(crate) fn from_qualified_name(name: impl Into<String>) -> Self {
+        let name = name.into();
+        let (schema, table) = name
+            .split_once('.')
+            .map_or((None, name.as_str()), |(schema, table)| {
+                (Some(schema), table)
+            });
+        Self {
+            schema: schema.map(str::to_string),
+            table: table.to_string(),
+        }
+    }
+
+    pub(crate) fn qualified_name(&self) -> String {
+        self.schema.as_ref().map_or_else(
+            || self.table.clone(),
+            |schema| format!("{schema}.{}", self.table),
+        )
+    }
+}
+
+impl From<String> for PrefetchTableTarget {
+    fn from(name: String) -> Self {
+        Self::from_qualified_name(name)
+    }
+}
+
+impl From<&str> for PrefetchTableTarget {
+    fn from(name: &str) -> Self {
+        Self::from_qualified_name(name)
+    }
+}
+
+impl From<&String> for PrefetchTableTarget {
+    fn from(name: &String) -> Self {
+        Self::from_qualified_name(name)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FailedPrefetchEntry {
     pub failed_at: Instant,
@@ -14,9 +67,9 @@ pub struct FailedPrefetchEntry {
 
 #[derive(Debug, Clone, Default)]
 pub struct TablePrefetchState {
-    prefetch_queue: VecDeque<String>,
-    prefetching_tables: HashSet<String>,
-    failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
+    prefetch_queue: VecDeque<PrefetchTableTarget>,
+    prefetching_tables: HashSet<PrefetchTableTarget>,
+    failed_prefetch_tables: HashMap<PrefetchTableTarget, FailedPrefetchEntry>,
     prefetch_tracks_er: bool,
     prefetch_run: AsyncRun,
 }
@@ -69,11 +122,15 @@ impl TablePrefetchState {
     }
 
     pub fn is_prefetch_queued(&self, table: &str) -> bool {
-        self.prefetch_queue.iter().any(|queued| queued == table)
+        self.prefetch_queue
+            .iter()
+            .any(|queued| queued.qualified_name() == table)
     }
 
     pub fn is_table_prefetching(&self, table: &str) -> bool {
-        self.prefetching_tables.contains(table)
+        self.prefetching_tables
+            .iter()
+            .any(|prefetching| prefetching.qualified_name() == table)
     }
 
     pub fn prefetch_in_flight_count(&self) -> usize {
@@ -81,6 +138,24 @@ impl TablePrefetchState {
     }
 
     pub fn failed_prefetch(&self, table: &str) -> Option<&FailedPrefetchEntry> {
+        self.failed_prefetch_tables
+            .iter()
+            .find(|(failed, _)| failed.qualified_name() == table)
+            .map(|(_, entry)| entry)
+    }
+
+    pub(crate) fn is_prefetch_target_queued(&self, table: &PrefetchTableTarget) -> bool {
+        self.prefetch_queue.iter().any(|queued| queued == table)
+    }
+
+    pub(crate) fn is_prefetch_target_in_flight(&self, table: &PrefetchTableTarget) -> bool {
+        self.prefetching_tables.contains(table)
+    }
+
+    pub(crate) fn failed_prefetch_target(
+        &self,
+        table: &PrefetchTableTarget,
+    ) -> Option<&FailedPrefetchEntry> {
         self.failed_prefetch_tables.get(table)
     }
 
@@ -88,7 +163,7 @@ impl TablePrefetchState {
         self.failed_prefetch_tables
             .iter()
             .filter(|(table, entry)| self.is_permanent_failure(table, entry))
-            .map(|(table, entry)| (table.clone(), entry.error.clone()))
+            .map(|(table, entry)| (table.qualified_name(), entry.error.clone()))
             .collect()
     }
 
@@ -103,15 +178,17 @@ impl TablePrefetchState {
             .count()
     }
 
-    pub fn queue_table_prefetch(&mut self, table: String) {
-        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
+    pub fn queue_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
+        let table = table.into();
+        if self.prefetching_tables.contains(&table) || self.is_prefetch_target_queued(&table) {
             return;
         }
         self.prefetch_queue.push_back(table);
     }
 
-    pub fn queue_pending_table(&mut self, table: String) -> bool {
-        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
+    pub fn queue_pending_table(&mut self, table: impl Into<PrefetchTableTarget>) -> bool {
+        let table = table.into();
+        if self.prefetching_tables.contains(&table) || self.is_prefetch_target_queued(&table) {
             return false;
         }
         self.failed_prefetch_tables.remove(&table);
@@ -119,35 +196,53 @@ impl TablePrefetchState {
         true
     }
 
-    pub fn defer_table_prefetch(&mut self, table: String) {
-        if self.prefetching_tables.contains(&table) || self.is_prefetch_queued(&table) {
+    pub fn defer_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
+        let table = table.into();
+        if self.prefetching_tables.contains(&table) || self.is_prefetch_target_queued(&table) {
             return;
         }
         self.prefetch_queue.push_front(table);
     }
 
     pub fn take_next_prefetch(&mut self) -> Option<String> {
+        self.take_next_prefetch_target()
+            .map(|table| table.qualified_name())
+    }
+
+    pub(crate) fn take_next_prefetch_target(&mut self) -> Option<PrefetchTableTarget> {
         self.prefetch_queue.pop_front()
     }
 
-    pub fn start_table_prefetch(&mut self, table: String) {
+    pub fn start_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
+        let table = table.into();
         self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.insert(table);
     }
 
-    pub fn complete_table_prefetch(&mut self, table: &str) {
-        self.prefetch_queue.retain(|queued| queued != table);
-        self.prefetching_tables.remove(table);
-        self.failed_prefetch_tables.remove(table);
+    pub fn complete_table_prefetch(&mut self, table: impl Into<PrefetchTableTarget>) {
+        let table = table.into();
+        self.prefetch_queue.retain(|queued| queued != &table);
+        self.prefetching_tables.remove(&table);
+        self.failed_prefetch_tables.remove(&table);
     }
 
-    pub fn fail_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) {
+    pub fn fail_table_prefetch(
+        &mut self,
+        table: impl Into<PrefetchTableTarget>,
+        entry: FailedPrefetchEntry,
+    ) {
+        let table = table.into();
         self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.remove(&table);
         self.failed_prefetch_tables.insert(table, entry);
     }
 
-    pub fn retry_table_prefetch(&mut self, table: String, entry: FailedPrefetchEntry) -> bool {
+    pub fn retry_table_prefetch(
+        &mut self,
+        table: impl Into<PrefetchTableTarget>,
+        entry: FailedPrefetchEntry,
+    ) -> bool {
+        let table = table.into();
         let had_other_pending_before_requeue = self.has_pending_prefetch();
         self.fail_table_prefetch(table.clone(), entry);
         self.queue_table_prefetch(table);
@@ -166,9 +261,13 @@ impl TablePrefetchState {
         self.prefetch_queue.is_empty() && self.prefetching_tables.is_empty()
     }
 
-    fn is_permanent_failure(&self, table: &str, entry: &FailedPrefetchEntry) -> bool {
+    fn is_permanent_failure(
+        &self,
+        table: &PrefetchTableTarget,
+        entry: &FailedPrefetchEntry,
+    ) -> bool {
         entry.retry_count >= MAX_PREFETCH_RETRIES
-            && !self.is_prefetch_queued(table)
+            && !self.is_prefetch_target_queued(table)
             && !self.prefetching_tables.contains(table)
     }
 }

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -518,8 +518,12 @@ impl SqlLexer {
                         }
                         // End of identifier
                         let text: String = chars[token_start..=pos].iter().collect();
+                        let name = chars[token_start + 1..pos]
+                            .iter()
+                            .collect::<String>()
+                            .replace("\"\"", "\"");
                         tokens.push(Token {
-                            kind: TokenKind::Identifier(text.clone()),
+                            kind: TokenKind::Identifier(name),
                             text,
                             start: token_start,
                             end: pos + 1,
@@ -667,7 +671,11 @@ impl SqlLexer {
                 | LexerState::InDoubleQuoteString
                 | LexerState::InDollarQuote
                 | LexerState::InEscapeString => TokenKind::StringLiteral,
-                LexerState::InDoubleQuoteIdentifier => TokenKind::Identifier(text.clone()),
+                LexerState::InDoubleQuoteIdentifier => TokenKind::Identifier(
+                    text.strip_prefix('"')
+                        .unwrap_or(&text)
+                        .replace("\"\"", "\""),
+                ),
                 LexerState::InBacktickIdentifier => {
                     TokenKind::BacktickIdentifier(text[1..].to_string())
                 }
@@ -1858,6 +1866,22 @@ mod tests {
             assert_eq!(refs.len(), 1);
             assert_eq!(refs[0].schema, Some("public".to_string()));
             assert_eq!(refs[0].table, "users");
+        }
+
+        #[test]
+        fn double_quoted_schema_and_table_preserve_case_and_embedded_dots() {
+            let l = lexer();
+            let sql = r#"SELECT * FROM "Sales.Region"."Orders.Archive""#;
+            let tokens = l.tokenize(sql, sql.chars().count());
+
+            assert_eq!(
+                l.extract_table_references(&tokens),
+                vec![TableReference {
+                    schema: Some("Sales.Region".to_string()),
+                    table: "Orders.Archive".to_string(),
+                    alias: None,
+                }]
+            );
         }
 
         #[test]

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -518,12 +518,8 @@ impl SqlLexer {
                         }
                         // End of identifier
                         let text: String = chars[token_start..=pos].iter().collect();
-                        let name = chars[token_start + 1..pos]
-                            .iter()
-                            .collect::<String>()
-                            .replace("\"\"", "\"");
                         tokens.push(Token {
-                            kind: TokenKind::Identifier(name),
+                            kind: TokenKind::Identifier(text.clone()),
                             text,
                             start: token_start,
                             end: pos + 1,
@@ -671,11 +667,7 @@ impl SqlLexer {
                 | LexerState::InDoubleQuoteString
                 | LexerState::InDollarQuote
                 | LexerState::InEscapeString => TokenKind::StringLiteral,
-                LexerState::InDoubleQuoteIdentifier => TokenKind::Identifier(
-                    text.strip_prefix('"')
-                        .unwrap_or(&text)
-                        .replace("\"\"", "\""),
-                ),
+                LexerState::InDoubleQuoteIdentifier => TokenKind::Identifier(text.clone()),
                 LexerState::InBacktickIdentifier => {
                     TokenKind::BacktickIdentifier(text[1..].to_string())
                 }
@@ -965,26 +957,16 @@ impl SqlLexer {
         let mut alias = None;
 
         // Get first identifier (could be schema or table)
-        match &tokens[*i].kind {
-            TokenKind::Identifier(name)
-            | TokenKind::BacktickIdentifier(name)
-            | TokenKind::Keyword(name) => {
-                table = name.clone();
-            }
-            _ => return None,
-        }
+        table = Self::identifier_value(&tokens[*i])?;
         *i += 1;
 
         // Check for schema.table pattern
         if *i < tokens.len() && tokens[*i].kind == TokenKind::Punctuation('.') {
             *i += 1;
             let token = tokens.get(*i)?;
-            if let TokenKind::Identifier(name)
-            | TokenKind::BacktickIdentifier(name)
-            | TokenKind::Keyword(name) = &token.kind
-            {
+            if let Some(name) = Self::identifier_value(token) {
                 schema = Some(table);
-                table = name.clone();
+                table = name;
                 *i += 1;
             } else {
                 return None;
@@ -1027,16 +1009,13 @@ impl SqlLexer {
 
         // Get alias if present (identifier that's not a keyword like ON, WHERE, etc.)
         if *i < tokens.len() {
-            match &tokens[*i].kind {
-                TokenKind::Identifier(name) | TokenKind::BacktickIdentifier(name) => {
-                    alias = Some(name.clone());
-                    *i += 1;
-                }
-                TokenKind::Keyword(kw) if !Self::is_clause_keyword(kw) => {
-                    alias = Some(kw.clone());
-                    *i += 1;
-                }
-                _ => {}
+            let is_clause_keyword = matches!(
+                &tokens[*i].kind,
+                TokenKind::Keyword(kw) if Self::is_clause_keyword(kw)
+            );
+            if !is_clause_keyword && let Some(name) = Self::identifier_value(&tokens[*i]) {
+                alias = Some(name);
+                *i += 1;
             }
         }
 
@@ -1045,6 +1024,20 @@ impl SqlLexer {
             table,
             alias,
         })
+    }
+
+    fn identifier_value(token: &Token) -> Option<String> {
+        match &token.kind {
+            TokenKind::Identifier(_)
+                if token.text.starts_with('"') && token.text.ends_with('"') =>
+            {
+                Some(token.text[1..token.text.len() - 1].replace("\"\"", "\""))
+            }
+            TokenKind::Identifier(name)
+            | TokenKind::BacktickIdentifier(name)
+            | TokenKind::Keyword(name) => Some(name.clone()),
+            _ => None,
+        }
     }
 
     fn is_clause_keyword(kw: &str) -> bool {
@@ -1104,13 +1097,15 @@ impl SqlLexer {
                     }
 
                     // Get CTE name
-                    if let TokenKind::Identifier(name)
-                    | TokenKind::BacktickIdentifier(name)
-                    | TokenKind::Keyword(name) = &tokens[i].kind
-                    {
-                        // Don't treat SELECT as a CTE name
-                        if name != "SELECT" {
-                            ctes.push(name.clone());
+                    if let Some(name) = Self::identifier_value(&tokens[i]) {
+                        // Don't treat the SELECT keyword as a CTE name. A quoted
+                        // identifier named SELECT is a valid CTE name.
+                        let is_select_keyword = matches!(
+                            &tokens[i].kind,
+                            TokenKind::Keyword(keyword) if keyword == "SELECT"
+                        );
+                        if !is_select_keyword {
+                            ctes.push(name);
                         }
                         i += 1;
 
@@ -1885,6 +1880,22 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_double_quoted_schema_and_table_preserve_identity() {
+            let l = SqlLexer::new(DatabaseType::SQLite);
+            let sql = r#"SELECT * FROM "Sales.Region"."Orders.Archive""#;
+            let tokens = l.tokenize(sql, sql.chars().count());
+
+            assert_eq!(
+                l.extract_table_references(&tokens),
+                vec![TableReference {
+                    schema: Some("Sales.Region".to_string()),
+                    table: "Orders.Archive".to_string(),
+                    alias: None,
+                }]
+            );
+        }
+
+        #[test]
         fn join_returns_multiple_references() {
             let l = lexer();
             let tokens = l.tokenize("SELECT * FROM users u JOIN posts p ON u.id = p.user_id", 54);
@@ -2057,6 +2068,26 @@ mod tests {
 
             assert_eq!(ctes.len(), 1);
             assert_eq!(ctes[0], "tree");
+        }
+
+        #[test]
+        fn quoted_keyword_is_a_cte_name() {
+            let l = lexer();
+            let sql = r#"WITH "SELECT" AS (SELECT 1) SELECT * FROM "SELECT""#;
+            let tokens = l.tokenize(sql, sql.len());
+
+            assert_eq!(
+                l.extract_cte_definitions(&tokens),
+                vec!["SELECT".to_string()]
+            );
+            assert_eq!(
+                l.extract_table_references(&tokens),
+                vec![TableReference {
+                    schema: None,
+                    table: "SELECT".to_string(),
+                    alias: None,
+                }]
+            );
         }
 
         #[test]

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -11,6 +11,7 @@ use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
+use crate::model::table_prefetch::PrefetchTableTarget;
 use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
@@ -473,7 +474,7 @@ pub enum Action {
         tables: Vec<String>,
     },
     StartCompletionPrefetch {
-        tables: Vec<String>,
+        tables: Vec<PrefetchTableTarget>,
     },
     ExpandPrefetchWithFkNeighbors {
         run_id: u64,

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -42,7 +42,10 @@ pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> Disp
             for qualified_name in tables {
                 state
                     .table_prefetch
-                    .queue_pending_table(qualified_name.clone());
+                    .queue_pending_table(super::table_target_for_qualified_name(
+                        state,
+                        qualified_name,
+                    ));
             }
             DispatchResult::handled_with(vec![Effect::SchedulePrefetchQueueProcessing {
                 run_id: *run_id,

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -39,13 +39,8 @@ pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> Disp
                 return DispatchResult::handled_with(check_er_completion(state));
             }
 
-            for qualified_name in tables {
-                state
-                    .table_prefetch
-                    .queue_pending_table(super::table_target_for_qualified_name(
-                        state,
-                        qualified_name,
-                    ));
+            for target in super::table_targets_for_qualified_names(state, tables) {
+                state.table_prefetch.queue_pending_table_target(target);
             }
             DispatchResult::handled_with(vec![Effect::SchedulePrefetchQueueProcessing {
                 run_id: *run_id,

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -3,6 +3,7 @@
     reason = "metadata dispatch is re-exported through the crate-local update facade and used by AppState tests"
 )]
 
+use std::collections::HashMap;
 use std::time::Instant;
 
 mod er_neighbors;
@@ -45,23 +46,32 @@ pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
     }]
 }
 
-pub(super) fn table_target_for_qualified_name(
+pub(super) fn table_targets_for_qualified_names(
     state: &AppState,
-    qualified_name: &str,
-) -> PrefetchTableTarget {
-    state
-        .session
-        .metadata()
-        .and_then(|metadata| {
-            metadata
-                .table_summaries
-                .iter()
-                .find(|table| table.qualified_name() == qualified_name)
+    qualified_names: &[String],
+) -> Vec<PrefetchTableTarget> {
+    let metadata_targets = state.session.metadata().map(|metadata| {
+        metadata
+            .table_summaries
+            .iter()
+            .map(|table| {
+                (
+                    table.qualified_name(),
+                    PrefetchTableTarget::qualified(&table.schema, &table.name),
+                )
+            })
+            .collect::<HashMap<_, _>>()
+    });
+
+    qualified_names
+        .iter()
+        .filter_map(|qualified_name| {
+            metadata_targets
+                .as_ref()
+                .and_then(|targets| targets.get(qualified_name).cloned())
+                .or_else(|| PrefetchTableTarget::from_unambiguous_qualified_name(qualified_name))
         })
-        .map_or_else(
-            || PrefetchTableTarget::from_qualified_name(qualified_name),
-            |table| PrefetchTableTarget::qualified(&table.schema, &table.name),
-        )
+        .collect()
 }
 
 pub(crate) fn dispatch_metadata(
@@ -1347,6 +1357,24 @@ mod tests {
         }
 
         #[test]
+        fn ambiguous_dotted_name_without_metadata_is_not_prefetched() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let tables = vec!["Sales.Region.Orders.Archive".to_string()];
+
+            dispatch_metadata(
+                &mut state,
+                &Action::StartErPrefetchScoped {
+                    tables: tables.clone(),
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.er_preparation.seed_tables(), tables);
+            assert!(!state.table_prefetch.has_pending_prefetch());
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
+        }
+
+        #[test]
         fn resizes_to_total_table_count_before_processing_scoped_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(560)));
@@ -1441,6 +1469,68 @@ mod tests {
                 state
                     .table_prefetch
                     .is_table_prefetching("sales.region.Orders.Archive")
+            );
+        }
+
+        #[test]
+        fn cached_dotted_target_clears_in_flight_and_keeps_cache_key() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.table_prefetch.begin_completion_prefetch();
+            let target = PrefetchTableTarget::qualified("sales.region", "Orders.Archive");
+            state.table_prefetch.start_table_prefetch_target(target);
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "sales.region".to_string(),
+                    table: "Orders.Archive".to_string(),
+                    detail: Some(empty_table("sales.region", "Orders.Archive")),
+                },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("cached detail should be handled");
+
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::CacheTableInCompletionEngine { qualified_name, .. }
+                    if qualified_name == "sales.region.Orders.Archive"
+            )));
+        }
+
+        #[test]
+        fn failed_dotted_target_requeues_without_leaving_in_flight() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.table_prefetch.begin_completion_prefetch();
+            let target = PrefetchTableTarget::qualified("sales.region", "Orders.Archive");
+            state.table_prefetch.start_table_prefetch_target(target);
+
+            dispatch_metadata(
+                &mut state,
+                &Action::TableDetailCacheFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "sales.region".to_string(),
+                    table: "Orders.Archive".to_string(),
+                    error: DbOperationError::ConnectionFailed("timeout".to_string()),
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 0);
+            assert!(
+                state
+                    .table_prefetch
+                    .is_prefetch_queued("sales.region.Orders.Archive")
+            );
+            assert!(
+                state
+                    .table_prefetch
+                    .failed_prefetch("sales.region.Orders.Archive")
+                    .is_some()
             );
         }
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -13,6 +13,7 @@ mod table_detail;
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::er_state::ErStatus;
+use crate::model::table_prefetch::PrefetchTableTarget;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
@@ -44,6 +45,25 @@ pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
     }]
 }
 
+pub(super) fn table_target_for_qualified_name(
+    state: &AppState,
+    qualified_name: &str,
+) -> PrefetchTableTarget {
+    state
+        .session
+        .metadata()
+        .and_then(|metadata| {
+            metadata
+                .table_summaries
+                .iter()
+                .find(|table| table.qualified_name() == qualified_name)
+        })
+        .map_or_else(
+            || PrefetchTableTarget::from_qualified_name(qualified_name),
+            |table| PrefetchTableTarget::qualified(&table.schema, &table.name),
+        )
+}
+
 pub(crate) fn dispatch_metadata(
     state: &mut AppState,
     action: &Action,
@@ -65,7 +85,7 @@ mod tests {
     use crate::model::app_state::AppState;
     use crate::model::browse::session::TableDetailState;
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::table_prefetch::FailedPrefetchEntry;
+    use crate::model::table_prefetch::{FailedPrefetchEntry, PrefetchTableTarget};
     use crate::ports::outbound::DbOperationError;
     use crate::update::action::Action;
     use std::sync::Arc;
@@ -1356,7 +1376,10 @@ mod tests {
         #[test]
         fn queues_only_referenced_tables_without_er_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let tables = vec!["public.users".to_string(), "public.orders".to_string()];
+            let tables = vec![
+                PrefetchTableTarget::qualified("public", "users"),
+                PrefetchTableTarget::qualified("public", "orders"),
+            ];
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -1376,6 +1399,48 @@ mod tests {
                 effects
                     .iter()
                     .all(|effect| !matches!(effect, Effect::ResizeCompletionCache { .. }))
+            );
+        }
+
+        #[test]
+        fn process_queue_preserves_quoted_schema_and_table_identity() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.table_prefetch.begin_completion_prefetch();
+
+            dispatch_metadata(
+                &mut state,
+                &Action::StartCompletionPrefetch {
+                    tables: vec![PrefetchTableTarget::qualified(
+                        "sales.region",
+                        "Orders.Archive",
+                    )],
+                },
+                Instant::now(),
+            );
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("prefetch queue should be handled");
+
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::PrefetchTableColumnsAndFks {
+                    run_id: actual_run_id,
+                    schema,
+                    table,
+                    ..
+                }] if *actual_run_id == run_id
+                    && schema == "sales.region"
+                    && table == "Orders.Archive"
+            ));
+            assert!(
+                state
+                    .table_prefetch
+                    .is_table_prefetching("sales.region.Orders.Archive")
             );
         }
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -5,7 +5,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::model::table_prefetch::FailedPrefetchEntry;
+use crate::model::table_prefetch::{FailedPrefetchEntry, PrefetchTableTarget};
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
@@ -29,20 +29,20 @@ fn completion_cache_capacity(table_count: usize) -> usize {
 fn prefetch_table_detail(
     state: &mut AppState,
     run_id: u64,
-    schema: &str,
-    table: &str,
+    target: &PrefetchTableTarget,
     now: Instant,
 ) -> Vec<Effect> {
     if !state.table_prefetch.is_current_prefetch_run(run_id) {
         return vec![];
     }
-    let qualified_name = format!("{schema}.{table}");
-
-    if state.table_prefetch.is_table_prefetching(&qualified_name) {
+    let Some(schema) = target.schema.as_deref() else {
+        return vec![];
+    };
+    if state.table_prefetch.is_prefetch_target_in_flight(target) {
         return vec![];
     }
 
-    if let Some(entry) = state.table_prefetch.failed_prefetch(&qualified_name) {
+    if let Some(entry) = state.table_prefetch.failed_prefetch_target(target) {
         if entry.retry_count >= MAX_PREFETCH_RETRIES {
             let mut effects = if state.table_prefetch.prefetch_tracks_er() {
                 check_er_completion(state)
@@ -62,7 +62,7 @@ fn prefetch_table_detail(
         let elapsed = now.saturating_duration_since(entry.failed_at).as_secs();
         if elapsed < backoff_secs {
             let remaining = backoff_secs - elapsed;
-            state.table_prefetch.queue_table_prefetch(qualified_name);
+            state.table_prefetch.queue_table_prefetch(target.clone());
             return vec![Effect::DelayedProcessPrefetchQueue {
                 run_id,
                 delay_secs: remaining,
@@ -71,17 +71,17 @@ fn prefetch_table_detail(
     }
 
     let Some(dsn) = state.session.dsn().map(String::from) else {
-        state.table_prefetch.defer_table_prefetch(qualified_name);
+        state.table_prefetch.defer_table_prefetch(target.clone());
         return vec![];
     };
 
-    state.table_prefetch.start_table_prefetch(qualified_name);
+    state.table_prefetch.start_table_prefetch(target.clone());
 
     vec![Effect::PrefetchTableColumnsAndFks {
         dsn,
         run_id,
         schema: schema.to_string(),
-        table: table.to_string(),
+        table: target.table.clone(),
     }]
 }
 
@@ -122,8 +122,13 @@ pub(super) fn reduce_prefetch(
 
                 let resize_capacity = completion_cache_capacity(metadata.table_summaries.len());
 
-                for qualified_name in qualified_names {
-                    state.table_prefetch.queue_table_prefetch(qualified_name);
+                for table in &metadata.table_summaries {
+                    state
+                        .table_prefetch
+                        .queue_table_prefetch(PrefetchTableTarget::qualified(
+                            &table.schema,
+                            &table.name,
+                        ));
                 }
                 DispatchResult::handled_with(vec![
                     Effect::ResizeCompletionCache {
@@ -146,9 +151,9 @@ pub(super) fn reduce_prefetch(
                 state.er_preparation.begin_scoped_prefetch(tables);
 
                 for qualified_name in tables {
-                    state
-                        .table_prefetch
-                        .queue_table_prefetch(qualified_name.clone());
+                    state.table_prefetch.queue_table_prefetch(
+                        super::table_target_for_qualified_name(state, qualified_name),
+                    );
                 }
                 let mut effects = Vec::with_capacity(2);
                 if let Some(metadata) = state.session.metadata() {
@@ -171,10 +176,8 @@ pub(super) fn reduce_prefetch(
             } else {
                 state.table_prefetch.begin_completion_prefetch()
             };
-            for qualified_name in tables {
-                state
-                    .table_prefetch
-                    .queue_table_prefetch(qualified_name.clone());
+            for target in tables {
+                state.table_prefetch.queue_table_prefetch(target.clone());
             }
             DispatchResult::handled_with(vec![Effect::SchedulePrefetchQueueProcessing { run_id }])
         }
@@ -191,17 +194,14 @@ pub(super) fn reduce_prefetch(
 
             let mut effects = Vec::new();
             for _ in 0..batch_size {
-                let Some(qualified_name) = state.table_prefetch.take_next_prefetch() else {
+                let Some(target) = state.table_prefetch.take_next_prefetch_target() else {
                     break;
                 };
-                if !processed_tables.insert(qualified_name.clone()) {
-                    state.table_prefetch.defer_table_prefetch(qualified_name);
+                if !processed_tables.insert(target.clone()) {
+                    state.table_prefetch.defer_table_prefetch(target);
                     break;
                 }
-                let Some((schema, table)) = qualified_name.split_once('.') else {
-                    continue;
-                };
-                effects.extend(prefetch_table_detail(state, *run_id, schema, table, now));
+                effects.extend(prefetch_table_detail(state, *run_id, &target, now));
             }
 
             DispatchResult::handled_with(effects)
@@ -211,9 +211,12 @@ pub(super) fn reduce_prefetch(
             run_id,
             schema,
             table,
-        } => {
-            DispatchResult::handled_with(prefetch_table_detail(state, *run_id, schema, table, now))
-        }
+        } => DispatchResult::handled_with(prefetch_table_detail(
+            state,
+            *run_id,
+            &PrefetchTableTarget::qualified(schema, table),
+            now,
+        )),
 
         Action::TableDetailCached {
             dsn,
@@ -227,10 +230,9 @@ pub(super) fn reduce_prefetch(
             {
                 return DispatchResult::handled();
             }
-            let qualified_name = format!("{schema}.{table}");
-            state
-                .table_prefetch
-                .complete_table_prefetch(&qualified_name);
+            let target = PrefetchTableTarget::qualified(schema, table);
+            let qualified_name = target.qualified_name();
+            state.table_prefetch.complete_table_prefetch(target);
 
             let mut effects = Vec::new();
             if let Some(detail) = detail {
@@ -265,14 +267,14 @@ pub(super) fn reduce_prefetch(
             {
                 return DispatchResult::handled();
             }
-            let qualified_name = format!("{schema}.{table}");
+            let target = PrefetchTableTarget::qualified(schema, table);
 
             let prev_count = state
                 .table_prefetch
-                .failed_prefetch(&qualified_name)
+                .failed_prefetch_target(&target)
                 .map_or(0, |e| e.retry_count);
             let had_other_pending_before_requeue = state.table_prefetch.retry_table_prefetch(
-                qualified_name,
+                target,
                 FailedPrefetchEntry {
                     failed_at: now,
                     error: error.user_message(),

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -62,7 +62,9 @@ fn prefetch_table_detail(
         let elapsed = now.saturating_duration_since(entry.failed_at).as_secs();
         if elapsed < backoff_secs {
             let remaining = backoff_secs - elapsed;
-            state.table_prefetch.queue_table_prefetch(target.clone());
+            state
+                .table_prefetch
+                .queue_table_prefetch_target(target.clone());
             return vec![Effect::DelayedProcessPrefetchQueue {
                 run_id,
                 delay_secs: remaining,
@@ -71,11 +73,15 @@ fn prefetch_table_detail(
     }
 
     let Some(dsn) = state.session.dsn().map(String::from) else {
-        state.table_prefetch.defer_table_prefetch(target.clone());
+        state
+            .table_prefetch
+            .defer_table_prefetch_target(target.clone());
         return vec![];
     };
 
-    state.table_prefetch.start_table_prefetch(target.clone());
+    state
+        .table_prefetch
+        .start_table_prefetch_target(target.clone());
 
     vec![Effect::PrefetchTableColumnsAndFks {
         dsn,
@@ -123,12 +129,9 @@ pub(super) fn reduce_prefetch(
                 let resize_capacity = completion_cache_capacity(metadata.table_summaries.len());
 
                 for table in &metadata.table_summaries {
-                    state
-                        .table_prefetch
-                        .queue_table_prefetch(PrefetchTableTarget::qualified(
-                            &table.schema,
-                            &table.name,
-                        ));
+                    state.table_prefetch.queue_table_prefetch_target(
+                        PrefetchTableTarget::qualified(&table.schema, &table.name),
+                    );
                 }
                 DispatchResult::handled_with(vec![
                     Effect::ResizeCompletionCache {
@@ -150,10 +153,8 @@ pub(super) fn reduce_prefetch(
                 let run_id = state.table_prefetch.begin_er_prefetch();
                 state.er_preparation.begin_scoped_prefetch(tables);
 
-                for qualified_name in tables {
-                    state.table_prefetch.queue_table_prefetch(
-                        super::table_target_for_qualified_name(state, qualified_name),
-                    );
+                for target in super::table_targets_for_qualified_names(state, tables) {
+                    state.table_prefetch.queue_table_prefetch_target(target);
                 }
                 let mut effects = Vec::with_capacity(2);
                 if let Some(metadata) = state.session.metadata() {
@@ -177,7 +178,9 @@ pub(super) fn reduce_prefetch(
                 state.table_prefetch.begin_completion_prefetch()
             };
             for target in tables {
-                state.table_prefetch.queue_table_prefetch(target.clone());
+                state
+                    .table_prefetch
+                    .queue_table_prefetch_target(target.clone());
             }
             DispatchResult::handled_with(vec![Effect::SchedulePrefetchQueueProcessing { run_id }])
         }
@@ -198,7 +201,7 @@ pub(super) fn reduce_prefetch(
                     break;
                 };
                 if !processed_tables.insert(target.clone()) {
-                    state.table_prefetch.defer_table_prefetch(target);
+                    state.table_prefetch.defer_table_prefetch_target(target);
                     break;
                 }
                 effects.extend(prefetch_table_detail(state, *run_id, &target, now));
@@ -232,7 +235,7 @@ pub(super) fn reduce_prefetch(
             }
             let target = PrefetchTableTarget::qualified(schema, table);
             let qualified_name = target.qualified_name();
-            state.table_prefetch.complete_table_prefetch(target);
+            state.table_prefetch.complete_table_prefetch_target(target);
 
             let mut effects = Vec::new();
             if let Some(detail) = detail {
@@ -273,14 +276,15 @@ pub(super) fn reduce_prefetch(
                 .table_prefetch
                 .failed_prefetch_target(&target)
                 .map_or(0, |e| e.retry_count);
-            let had_other_pending_before_requeue = state.table_prefetch.retry_table_prefetch(
-                target,
-                FailedPrefetchEntry {
-                    failed_at: now,
-                    error: error.user_message(),
-                    retry_count: prev_count + 1,
-                },
-            );
+            let had_other_pending_before_requeue =
+                state.table_prefetch.retry_table_prefetch_target(
+                    target,
+                    FailedPrefetchEntry {
+                        failed_at: now,
+                        error: error.user_message(),
+                        retry_count: prev_count + 1,
+                    },
+                );
             let mut effects = Vec::new();
 
             if had_other_pending_before_requeue {


### PR DESCRIPTION
## Problem

Completion prefetch split qualified table names at the first dot, which corrupted quoted schemas or tables containing dots and could request metadata for the wrong object.

## Background

The SQL lexer already identifies schema and table components separately, but the prefetch path flattened those components into a string before dispatching work.

## Approach

Carry schema and table as a structured prefetch target through completion actions, queue state, retry handling, and metadata responses. Normalize PostgreSQL double-quoted identifier contents while preserving case and embedded dots, and keep the existing DSN and run freshness checks unchanged.
