### PR TITLE
fix(mysql): support Oracle server version differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -fsSL https://raw.githubusercontent.com/riii111/sabiql/main/install.sh | sh
 sabiql uses the CLI for the database you want to open:
 
 - **To use PostgreSQL:** install `psql`
-- **To use MySQL:** install `mysql`
+- **To use MySQL:** install the Oracle MySQL `mysql` CLI 8.4.x. Oracle MySQL servers 5.7, 8.0, and 8.4 can be connected to; 8.4 is the continuously validated server version and older or newer Oracle server versions are not fully guaranteed.
 - **To use SQLite:** install `sqlite3` version 3.41.1 or later
 
 Graphviz is optional and enables ER diagrams for PostgreSQL and MySQL.

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -2,13 +2,23 @@
 
 Use this page to check whether your MySQL server, connection method, and expected workflow are supported.
 
-sabiql supports Oracle MySQL server 8.4 LTS through the Oracle `mysql` CLI from the 8.4 series. MariaDB, Percona Server, TiDB, and other MySQL-compatible products are not formally supported.
+sabiql requires the Oracle MySQL `mysql` CLI from the 8.4 series. The server may be Oracle MySQL 5.7, 8.0, or 8.4; 8.4 is the continuously validated server version, while other Oracle server versions are not fully guaranteed. MariaDB, Percona Server, TiDB, Vitess, Aurora, and other MySQL-compatible products are not supported; the named products are rejected separately when `VERSION()` identifies them.
 
 ## Connection requirements
 
 MySQL connections can use TCP, a Unix socket file on Unix-like systems, or a Windows named pipe. Select the transport explicitly and provide its socket or pipe path when required. Shared-memory transport and automatic transport fallback are not supported. When connecting to a remote server, install the local `mysql` CLI; a local MySQL server is not required.
 
 Passphrase-protected TLS client keys are not supported. An unencrypted PEM private key can be used, but it weakens at-rest protection; store it with restrictive file permissions.
+
+## Version differences
+
+The Explorer, Inspector, and query-result panes select metadata and empty-result queries from the server version reported by `VERSION()`:
+
+- MySQL 5.7 uses `GENERATION_EXPRESSION` where available, but the legacy `STATISTICS` shape without functional-index expressions or index visibility. Empty `SELECT` column names use a derived-table fallback because common table expressions are unavailable.
+- MySQL 8.0 uses `GENERATION_EXPRESSION` and `IS_VISIBLE` where available. Functional-index expressions are selected from MySQL 8.0.13 onward, and common table expressions from 8.0.1 onward.
+- MySQL 8.4 uses the complete metadata shape, including functional-index expressions and invisible-index state.
+
+The Oracle MySQL 8.4 CLI remains required for local execution and XML result parsing. These version differences do not expand support for version-specific `EXPLAIN`, `EXPLAIN ANALYZE`, or `TABLE` behavior.
 
 ## SQL and session behavior
 

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -310,12 +310,12 @@ mod tests {
         #[case(
             UnsupportedOperationKind::ClientVersion,
             "Unsupported MySQL CLI version",
-            "Install the Oracle MySQL 8.4 client"
+            "Install the Oracle MySQL 8.4 client; the MySQL CLI is required"
         )]
         #[case(
-            UnsupportedOperationKind::ServerVersion,
-            "Unsupported MySQL server version",
-            "Connect to an Oracle MySQL 8.4 server"
+            UnsupportedOperationKind::ServerProduct,
+            "Unsupported MySQL server product",
+            "Connect to an Oracle MySQL server; 8.4 is continuously validated, other versions are not fully guaranteed"
         )]
         #[case(
             UnsupportedOperationKind::SessionMode,

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -33,7 +33,7 @@ impl DatabaseCli {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedOperationKind {
     ClientVersion,
-    ServerVersion,
+    ServerProduct,
     SessionMode,
 }
 
@@ -42,11 +42,11 @@ impl UnsupportedOperationKind {
         match self {
             Self::ClientVersion => (
                 "Unsupported MySQL CLI version",
-                "Install the Oracle MySQL 8.4 client",
+                "Install the Oracle MySQL 8.4 client; the MySQL CLI is required",
             ),
-            Self::ServerVersion => (
-                "Unsupported MySQL server version",
-                "Connect to an Oracle MySQL 8.4 server",
+            Self::ServerProduct => (
+                "Unsupported MySQL server product",
+                "Connect to an Oracle MySQL server; 8.4 is continuously validated, other versions are not fully guaranteed",
             ),
             Self::SessionMode => (
                 "Unsupported MySQL sql_mode",

--- a/src/app/update/input/keybindings/connections.rs
+++ b/src/app/update/input/keybindings/connections.rs
@@ -134,7 +134,7 @@ pub mod connection_error {
         key_short: "d",
         key: "d",
         desc_short: "Details",
-        description: "Toggle error details",
+        description: "Toggle error details and requirements",
         bindings: &[ExecBinding {
             action: Action::ToggleConnectionErrorDetails,
             combos: &[KeyCombo::plain(Key::Char('d'))],

--- a/src/infra/adapters/mysql/capability.rs
+++ b/src/infra/adapters/mysql/capability.rs
@@ -1,0 +1,86 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct MySqlServerCapabilities {
+    pub(super) lower_case_table_names: u8,
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl MySqlServerCapabilities {
+    pub(super) fn from_version(version: &str, lower_case_table_names: u8) -> Self {
+        let mut numbers = version
+            .split(|character: char| !character.is_ascii_digit())
+            .filter(|part| !part.is_empty())
+            .filter_map(|part| part.parse::<u32>().ok());
+        Self {
+            major: numbers.next().unwrap_or_default(),
+            minor: numbers.next().unwrap_or_default(),
+            patch: numbers.next().unwrap_or_default(),
+            lower_case_table_names,
+        }
+    }
+
+    pub(super) fn supports_generation_expression(self) -> bool {
+        self.at_least(5, 7, 6)
+    }
+
+    pub(super) fn supports_statistics_expression(self) -> bool {
+        self.at_least(8, 0, 13)
+    }
+
+    pub(super) fn supports_statistics_visibility(self) -> bool {
+        self.at_least(8, 0, 0)
+    }
+
+    pub(super) fn supports_common_table_expressions(self) -> bool {
+        self.at_least(8, 0, 1)
+    }
+
+    fn at_least(self, major: u32, minor: u32, patch: u32) -> bool {
+        (self.major, self.minor, self.patch) >= (major, minor, patch)
+    }
+}
+
+impl Default for MySqlServerCapabilities {
+    fn default() -> Self {
+        Self::from_version("8.4.10", 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_capabilities_at_mysql_version_boundaries() {
+        let mysql_57 = MySqlServerCapabilities::from_version("5.7.44", 0);
+        assert!(mysql_57.supports_generation_expression());
+        assert!(!mysql_57.supports_statistics_expression());
+        assert!(!mysql_57.supports_statistics_visibility());
+        assert!(!mysql_57.supports_common_table_expressions());
+
+        let mysql_80 = MySqlServerCapabilities::from_version("8.0.12", 1);
+        assert!(mysql_80.supports_generation_expression());
+        assert!(!mysql_80.supports_statistics_expression());
+        assert!(mysql_80.supports_statistics_visibility());
+        assert!(mysql_80.supports_common_table_expressions());
+
+        let mysql_801 = MySqlServerCapabilities::from_version("8.0.1", 1);
+        assert!(mysql_801.supports_common_table_expressions());
+
+        let mysql_84 = MySqlServerCapabilities::from_version("8.4.10", 0);
+        assert!(mysql_84.supports_statistics_expression());
+        assert!(mysql_84.supports_statistics_visibility());
+        assert!(mysql_84.supports_common_table_expressions());
+    }
+
+    #[test]
+    fn omits_features_for_versions_without_verifiable_components() {
+        let unknown = MySqlServerCapabilities::from_version("unknown", 2);
+        assert_eq!(unknown.lower_case_table_names, 2);
+        assert!(!unknown.supports_generation_expression());
+        assert!(!unknown.supports_statistics_expression());
+        assert!(!unknown.supports_statistics_visibility());
+        assert!(!unknown.supports_common_table_expressions());
+    }
+}

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -14,6 +14,7 @@ use quick_xml::events::Event;
 use tokio::io::{AsyncRead, BufReader, ReadBuf};
 
 use super::super::{
+    capability::MySqlServerCapabilities,
     dsn::{MySqlDsn, map_mysql_tls_failure},
     option_file::MySqlOptionFile,
 };
@@ -21,6 +22,7 @@ use super::error::{classify_mysql_query_failure_with_packet_limit, has_mysql_cli
 #[cfg(not(unix))]
 use super::pipe::MySqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
+use super::probe::{mysql_server_capabilities, probe_mysql_server};
 use super::process::metadata::mysql_metadata_columns_with_diagnostics;
 use super::process::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
@@ -351,22 +353,37 @@ pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
     path: PathBuf,
 ) -> Result<(), DbOperationError> {
     let option_file = MySqlOptionFile::create(&target)?;
+    let probe = probe_mysql_server(&option_file.path)
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
+    let capabilities =
+        mysql_server_capabilities(&probe.server_version, probe.lower_case_table_names);
     let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
     let result = run_mysql_process_with_timeout(
         MYSQL_EXPORT_TIMEOUT,
         &mut process,
         RefreshScope::None,
-        async |process| run_mysql_export_process(process, &option_file.path, query, path).await,
+        async |process| {
+            run_mysql_export_process_with_capabilities(
+                process,
+                &option_file.path,
+                query,
+                path,
+                capabilities,
+            )
+            .await
+        },
     )
     .await;
     result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
 }
 
-pub(super) async fn run_mysql_export_process(
+pub(super) async fn run_mysql_export_process_with_capabilities(
     process: &mut MySqlProcess,
     option_file: &std::path::Path,
     query: &str,
     path: PathBuf,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<(), DbOperationError> {
     configure_mysql_session(process, AccessMode::ReadOnly).await?;
     write_mysql_statement(process, query).await?;
@@ -386,7 +403,7 @@ pub(super) async fn run_mysql_export_process(
             query,
             fallback_kind,
             AccessMode::ReadOnly,
-            super::super::capability::MySqlServerCapabilities::default(),
+            capabilities,
         )
         .await?
         .0;

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -386,6 +386,7 @@ pub(super) async fn run_mysql_export_process(
             query,
             fallback_kind,
             AccessMode::ReadOnly,
+            super::super::capability::MySqlServerCapabilities::default(),
         )
         .await?
         .0;

--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -25,9 +25,10 @@ pub(super) use policy::{
     validate_mysql_export_query, validate_mysql_multi_query,
     validate_mysql_multi_query_with_lower_case_table_names,
 };
-pub(super) use probe::{check_mysql_cli_version, probe_mysql_server};
+pub(super) use probe::{check_mysql_cli_version, mysql_server_capabilities, probe_mysql_server};
 pub(super) use process::{
-    MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, run_mysql_adhoc, run_mysql_single_statement,
+    MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, run_mysql_adhoc,
+    run_mysql_adhoc_with_server_capabilities, run_mysql_single_statement,
 };
 
 pub(super) use xml::MySqlResultSet;

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -11,6 +11,7 @@ use crate::domain::{
     },
 };
 
+use super::super::capability::MySqlServerCapabilities;
 use super::super::sql;
 use super::probe::validate_sql_mode;
 use super::xml::MySqlResultSet;
@@ -129,10 +130,11 @@ pub(super) fn mysql_metadata_fallback_has_unsupported_session_state(
     false
 }
 
-pub(super) fn mysql_metadata_select_query(
+pub(super) fn mysql_metadata_select_query_for_capabilities(
     query: &str,
     source_alias: &str,
     marker_alias: &str,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<String, DbOperationError> {
     let query = query.trim().trim_end_matches(';').trim_end();
     if query.is_empty() {
@@ -149,11 +151,12 @@ pub(super) fn mysql_metadata_select_query(
                 .to_string(),
         ));
     }
-    Ok(sql::build_metadata_select_query(
-        &query,
-        source_alias,
-        marker_alias,
-    ))
+    let build_query = if capabilities.supports_common_table_expressions() {
+        sql::build_metadata_select_query
+    } else {
+        sql::build_legacy_metadata_select_query
+    };
+    Ok(build_query(&query, source_alias, marker_alias))
 }
 
 fn strip_mysql_sql_calc_found_rows(query: &str) -> String {
@@ -503,6 +506,19 @@ mod tests {
 
     use super::*;
 
+    fn mysql_metadata_select_query(
+        query: &str,
+        source_alias: &str,
+        marker_alias: &str,
+    ) -> Result<String, DbOperationError> {
+        super::mysql_metadata_select_query_for_capabilities(
+            query,
+            source_alias,
+            marker_alias,
+            MySqlServerCapabilities::default(),
+        )
+    }
+
     #[test]
     fn csv_export_accepts_one_read_only_result_query() {
         assert!(validate_mysql_export_query("SELECT 1", Some("app")).is_ok());
@@ -734,6 +750,22 @@ mod tests {
             )
         );
         assert_eq!(fallback_query.matches("SELECT SLEEP(10)").count(), 1);
+    }
+
+    #[test]
+    fn metadata_fallback_uses_the_server_supported_wrapper() {
+        let mysql_57 =
+            super::super::super::capability::MySqlServerCapabilities::from_version("5.7.44", 0);
+        let fallback_query = mysql_metadata_select_query_for_capabilities(
+            "SELECT id FROM items",
+            "__source",
+            "__marker",
+            mysql_57,
+        )
+        .unwrap();
+
+        assert!(fallback_query.starts_with("SELECT __source.* FROM (SELECT * FROM (SELECT"));
+        assert!(!fallback_query.starts_with("WITH "));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -3,31 +3,36 @@ use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 
-use serde::Deserialize;
 use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::app::ports::outbound::{
-    ConnectionFailureKind, DbOperationError, MySqlConnectionProbeResult, UnsupportedOperationKind,
+    ConnectionFailureKind, DbOperationError, UnsupportedOperationKind,
 };
 
+use super::super::capability::MySqlServerCapabilities;
 use super::args::mysql_connection_args;
 use super::error::{
     clean_mysql_stderr, is_mysql_connect_timeout_message, map_mysql_cli_spawn_error,
 };
 use super::sanitize_mysql_command_environment;
+use super::xml::{MySqlResultSet, parse_mysql_xml};
 
 const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
-const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('version', VERSION(), 'sql_mode', @@SESSION.sql_mode, 'lower_case_table_names', @@lower_case_table_names)";
+const MYSQL_PROBE_QUERY: &str = "SELECT VERSION() AS __sabiql_server_version, @@SESSION.sql_mode AS __sabiql_sql_mode, @@lower_case_table_names AS __sabiql_lower_case_table_names";
+const MYSQL_PROBE_RESULT_COLUMNS: [&str; 3] = [
+    "__sabiql_server_version",
+    "__sabiql_sql_mode",
+    "__sabiql_lower_case_table_names",
+];
 const MYSQL_VERSION_ARGS: [&str; 3] = ["--no-defaults", "--no-login-paths", "--version"];
 const MYSQL_SUPPORTED_MAJOR: u32 = 8;
 const MYSQL_SUPPORTED_MINOR: u32 = 4;
 
-#[derive(Debug, Deserialize)]
-struct MySqlProbeResponse {
-    version: String,
-    sql_mode: String,
-    lower_case_table_names: u8,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::adapters::mysql) struct MySqlServerProbeResult {
+    pub(in crate::adapters::mysql) lower_case_table_names: u8,
+    pub(in crate::adapters::mysql) server_version: String,
 }
 
 pub(in crate::adapters::mysql) async fn check_mysql_cli_version() -> Result<(), DbOperationError> {
@@ -71,7 +76,7 @@ async fn run_mysql_version_command(
 
 pub(in crate::adapters::mysql) async fn probe_mysql_server(
     option_file: &Path,
-) -> Result<MySqlConnectionProbeResult, DbOperationError> {
+) -> Result<MySqlServerProbeResult, DbOperationError> {
     let output = run_mysql_command_with_timeout(
         mysql_probe_args(option_file),
         MYSQL_PROBE_TIMEOUT,
@@ -85,13 +90,49 @@ pub(in crate::adapters::mysql) async fn probe_mysql_server(
         )));
     }
 
-    let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
-    validate_server_version(&response.version)?;
-    validate_sql_mode(&response.sql_mode)?;
-    validate_lower_case_table_names(response.lower_case_table_names)?;
-    Ok(MySqlConnectionProbeResult {
-        lower_case_table_names: response.lower_case_table_names,
+    let result = parse_mysql_xml(&output.stdout)?;
+    let (version, sql_mode, lower_case_table_names) = parse_mysql_probe_result(&result)?;
+    validate_server_product(version)?;
+    validate_sql_mode(sql_mode)?;
+    validate_lower_case_table_names(lower_case_table_names)?;
+    Ok(MySqlServerProbeResult {
+        lower_case_table_names,
+        server_version: version.to_string(),
     })
+}
+
+fn parse_mysql_probe_result(result: &MySqlResultSet) -> Result<(&str, &str, u8), DbOperationError> {
+    if result.columns != MYSQL_PROBE_RESULT_COLUMNS
+        || result.values.len() != 1
+        || result.values[0].len() != MYSQL_PROBE_RESULT_COLUMNS.len()
+    {
+        return Err(DbOperationError::QueryFailed(
+            "mysql connection probe returned an unexpected result".to_string(),
+        ));
+    }
+    let values = &result.values[0];
+    let version = values[0].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed(
+            "mysql connection probe returned no server version".to_string(),
+        )
+    })?;
+    let sql_mode = values[1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql connection probe returned no sql_mode".to_string())
+    })?;
+    let lower_case_table_names = values[2]
+        .as_str()
+        .ok_or_else(|| {
+            DbOperationError::QueryFailed(
+                "mysql connection probe returned no lower_case_table_names".to_string(),
+            )
+        })?
+        .parse::<u8>()
+        .map_err(|_| {
+            DbOperationError::MetadataParseFailed(
+                "invalid MySQL lower_case_table_names value".to_string(),
+            )
+        })?;
+    Ok((version, sql_mode, lower_case_table_names))
 }
 
 pub(super) fn validate_lower_case_table_names(value: u8) -> Result<(), DbOperationError> {
@@ -121,15 +162,22 @@ fn is_oracle_mysql_84_version(value: &str) -> bool {
         && version_major_minor(value) == Some((MYSQL_SUPPORTED_MAJOR, MYSQL_SUPPORTED_MINOR))
 }
 
-fn validate_server_version(version: &str) -> Result<(), DbOperationError> {
-    if is_oracle_mysql_84_version(version) {
-        Ok(())
-    } else {
+pub(super) fn validate_server_product(version: &str) -> Result<(), DbOperationError> {
+    if contains_unsupported_mysql_product(version) {
         Err(DbOperationError::UnsupportedOperationWithKind {
-            kind: UnsupportedOperationKind::ServerVersion,
+            kind: UnsupportedOperationKind::ServerProduct,
             details: version.to_string(),
         })
+    } else {
+        Ok(())
     }
+}
+
+pub(in crate::adapters::mysql) fn mysql_server_capabilities(
+    version: &str,
+    lower_case_table_names: u8,
+) -> MySqlServerCapabilities {
+    MySqlServerCapabilities::from_version(version, lower_case_table_names)
 }
 
 pub(super) fn validate_sql_mode(sql_mode: &str) -> Result<(), DbOperationError> {
@@ -158,10 +206,11 @@ fn version_major_minor(value: &str) -> Option<(u32, u32)> {
 fn mysql_probe_args(option_file: &std::path::Path) -> Vec<String> {
     let mut args = mysql_connection_args(option_file);
     args.extend([
-        "--batch".to_string(),
-        "--raw".to_string(),
-        "--skip-column-names".to_string(),
+        "--xml".to_string(),
         "--binary-mode".to_string(),
+        "--batch".to_string(),
+        "--silent".to_string(),
+        "--prompt=".to_string(),
     ]);
     args.push(format!("--execute={MYSQL_PROBE_QUERY}"));
     args
@@ -281,13 +330,24 @@ mod probe_tests {
         assert!(is_oracle_mysql_84_version("8.4.3"));
         assert!(!is_oracle_mysql_84_version("8.4.3-TiDB"));
         assert!(!is_oracle_mysql_84_version("8.4.3-Percona"));
-        assert!(matches!(
-            validate_server_version("8.0.36"),
-            Err(DbOperationError::UnsupportedOperationWithKind {
-                kind: UnsupportedOperationKind::ServerVersion,
-                ..
-            })
-        ));
+        assert!(validate_server_product("5.7.44").is_ok());
+        assert!(validate_server_product("8.0.36").is_ok());
+        assert!(validate_server_product("8.4.10").is_ok());
+        for product_version in [
+            "8.4.10-MariaDB",
+            "8.4.10-Percona",
+            "8.4.10-TiDB",
+            "8.4.10-Vitess",
+            "8.4.10-Aurora",
+        ] {
+            assert!(matches!(
+                validate_server_product(product_version),
+                Err(DbOperationError::UnsupportedOperationWithKind {
+                    kind: UnsupportedOperationKind::ServerProduct,
+                    ..
+                })
+            ));
+        }
         assert!(validate_sql_mode("STRICT_TRANS_TABLES").is_ok());
         assert!(validate_sql_mode("").is_ok());
         assert!(matches!(
@@ -297,6 +357,22 @@ mod probe_tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn parses_representative_versions_from_the_shared_mysql_xml_result() {
+        for version in ["5.7.44", "8.0.36", "8.4.10"] {
+            let xml = format!(
+                "<resultset><row><field name=\"__sabiql_server_version\">{version}</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field><field name=\"__sabiql_lower_case_table_names\">0</field></row></resultset>"
+            );
+            let result = parse_mysql_xml(xml.as_bytes()).unwrap();
+
+            assert_eq!(
+                parse_mysql_probe_result(&result).unwrap(),
+                (version, "STRICT_TRANS_TABLES", 0)
+            );
+            validate_server_product(version).unwrap();
+        }
     }
 
     #[test]
@@ -333,13 +409,15 @@ mod probe_tests {
                 "--no-login-paths".to_string(),
                 "--connect-timeout=10".to_string(),
                 "--skip-reconnect".to_string(),
-                "--batch".to_string(),
-                "--raw".to_string(),
-                "--skip-column-names".to_string(),
+                "--xml".to_string(),
                 "--binary-mode".to_string(),
+                "--batch".to_string(),
+                "--silent".to_string(),
+                "--prompt=".to_string(),
                 format!("--execute={MYSQL_PROBE_QUERY}"),
             ]
         );
+        assert!(!args.iter().any(|argument| argument.contains("JSON_OBJECT")));
         assert!(!args.iter().any(|argument| argument == "--quick"));
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -40,7 +40,9 @@ use super::xml::{MySqlResultSetFrameScanner, parse_mysql_xml, trace_mysql_statem
 mod session;
 pub(in crate::adapters::mysql) use session::MySqlMetadataSession;
 mod adhoc;
-pub(in crate::adapters::mysql) use adhoc::run_mysql_adhoc;
+pub(in crate::adapters::mysql) use adhoc::{
+    run_mysql_adhoc, run_mysql_adhoc_with_server_capabilities,
+};
 mod single;
 #[cfg(feature = "test-support")]
 pub(in crate::adapters::mysql) mod test_support;

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -14,6 +14,7 @@ use crate::domain::{
     },
 };
 
+use super::super::super::capability::MySqlServerCapabilities;
 use super::super::policy::{
     MySqlExecutionResult, is_mysql_single_marker, mysql_command_tag,
     mysql_metadata_fallback_has_unsupported_session_state, mysql_possible_refresh_scope,
@@ -32,22 +33,61 @@ pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
     statements: &[MySqlStatement],
     access_mode: AccessMode,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
-    run_mysql_adhoc_with_program_and_statements(
+    run_mysql_adhoc_with_server_capabilities(
+        option_file,
+        statements,
+        access_mode,
+        MySqlServerCapabilities::default(),
+    )
+    .await
+}
+
+pub(in crate::adapters::mysql) async fn run_mysql_adhoc_with_server_capabilities(
+    option_file: &Path,
+    statements: &[MySqlStatement],
+    access_mode: AccessMode,
+    capabilities: MySqlServerCapabilities,
+) -> Result<MySqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_capabilities(
         OsStr::new("mysql"),
         option_file,
         statements,
         access_mode,
         MYSQL_QUERY_TIMEOUT,
+        capabilities,
     )
     .await
 }
 
+#[allow(
+    dead_code,
+    reason = "shared by MySQL process tests and the test-support feature"
+)]
 pub(super) async fn run_mysql_adhoc_with_program_and_statements(
     program: &OsStr,
     option_file: &Path,
     statements: &[MySqlStatement],
     access_mode: AccessMode,
     execution_timeout: Duration,
+) -> Result<MySqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_capabilities(
+        program,
+        option_file,
+        statements,
+        access_mode,
+        execution_timeout,
+        MySqlServerCapabilities::default(),
+    )
+    .await
+}
+
+async fn run_mysql_adhoc_with_program_and_capabilities(
+    program: &OsStr,
+    option_file: &Path,
+    statements: &[MySqlStatement],
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     if mysql_metadata_fallback_has_unsupported_session_state(statements) {
         return Err(DbOperationError::UnsupportedOperation(
@@ -62,7 +102,8 @@ pub(super) async fn run_mysql_adhoc_with_program_and_statements(
         &mut process,
         possible_refresh_scope,
         async |process| {
-            run_mysql_adhoc_process(process, option_file, statements, access_mode).await
+            run_mysql_adhoc_process(process, option_file, statements, access_mode, capabilities)
+                .await
         },
     )
     .await
@@ -81,6 +122,7 @@ async fn fill_mysql_empty_result_columns(
     query: &str,
     kind: &MySqlStatementKind,
     access_mode: AccessMode,
+    capabilities: MySqlServerCapabilities,
     diagnostics: &mut Vec<DatabaseDiagnostic>,
 ) -> Result<MySqlResultSet, DbOperationError> {
     if !result.columns.is_empty() || !result.values.is_empty() {
@@ -98,6 +140,7 @@ async fn fill_mysql_empty_result_columns(
         query,
         fallback_kind,
         access_mode,
+        capabilities,
     )
     .await?;
     diagnostics.extend(metadata_diagnostics);
@@ -181,6 +224,7 @@ async fn fill_mysql_last_result_columns(
     last_result_set: &mut Option<MySqlResultSet>,
     last_result_statement: Option<&MySqlStatement>,
     access_mode: AccessMode,
+    capabilities: MySqlServerCapabilities,
     refresh_scope: RefreshScope,
     diagnostics: &mut Vec<DatabaseDiagnostic>,
 ) -> Result<(), DbOperationError> {
@@ -198,6 +242,7 @@ async fn fill_mysql_last_result_columns(
         statement.sql(),
         statement.kind(),
         access_mode,
+        capabilities,
         diagnostics,
     )
     .await
@@ -211,6 +256,7 @@ async fn run_mysql_adhoc_process(
     option_file: &Path,
     statements: &[MySqlStatement],
     access_mode: AccessMode,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<MySqlExecutionResult, DbOperationError> {
     configure_mysql_session(process, access_mode).await?;
     let mut last_result_set = None;
@@ -232,6 +278,7 @@ async fn run_mysql_adhoc_process(
                 &mut last_result_set,
                 last_result_statement,
                 access_mode,
+                capabilities,
                 refresh_scope,
                 &mut diagnostics,
             )
@@ -252,6 +299,7 @@ async fn run_mysql_adhoc_process(
         &mut last_result_set,
         last_result_statement,
         access_mode,
+        capabilities,
         refresh_scope,
         &mut diagnostics,
     )

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -10,12 +10,15 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{DatabaseDiagnostic, QueryValue};
 
+use super::super::super::capability::MySqlServerCapabilities;
 use super::super::args::mysql_metadata_args;
 use super::super::error::{
     classify_mysql_query_failure, has_mysql_cli_error, is_mysql_batch_diagnostic,
     map_mysql_cli_spawn_error,
 };
-use super::super::policy::{MySqlMetadataFallbackKind, mysql_metadata_select_query};
+use super::super::policy::{
+    MySqlMetadataFallbackKind, mysql_metadata_select_query_for_capabilities,
+};
 use super::super::probe::{run_mysql_command_with_timeout, validate_sql_mode};
 use super::super::sanitize_mysql_command_environment;
 use super::{
@@ -29,10 +32,12 @@ pub(in crate::adapters::mysql::cli) async fn mysql_metadata_columns_with_diagnos
     query: &str,
     kind: MySqlMetadataFallbackKind,
     access_mode: AccessMode,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<(Vec<String>, Vec<DatabaseDiagnostic>), DbOperationError> {
     let query = match kind {
         MySqlMetadataFallbackKind::Session => {
-            return mysql_metadata_select_columns_with_diagnostics(process, query).await;
+            return mysql_metadata_select_columns_with_diagnostics(process, query, capabilities)
+                .await;
         }
         MySqlMetadataFallbackKind::External => {
             query.trim().trim_end_matches(';').trim_end().to_string()
@@ -53,11 +58,17 @@ pub(in crate::adapters::mysql::cli) async fn mysql_metadata_columns_with_diagnos
 async fn mysql_metadata_select_columns_with_diagnostics(
     process: &mut MySqlProcess,
     query: &str,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<(Vec<String>, Vec<DatabaseDiagnostic>), DbOperationError> {
     let suffix = Uuid::new_v4().simple().to_string();
     let source_alias = format!("__sabiql_metadata_source_{suffix}");
     let marker_alias = format!("__sabiql_metadata_marker_{suffix}");
-    let query = mysql_metadata_select_query(query, &source_alias, &marker_alias)?;
+    let query = mysql_metadata_select_query_for_capabilities(
+        query,
+        &source_alias,
+        &marker_alias,
+        capabilities,
+    )?;
     write_mysql_statement(process, &query).await?;
     let (xml, diagnostics) = match read_one_mysql_resultset_with_diagnostics(process).await {
         Err(DbOperationError::QueryFailed(details))

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -4,10 +4,13 @@ use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
+use super::super::super::capability::MySqlServerCapabilities;
 use super::super::super::option_file::MySqlOptionFile;
 use super::super::args::{mysql_metadata_session_args, mysql_query_args};
 use super::super::policy::is_mysql_single_marker;
-use super::super::probe::validate_lower_case_table_names;
+use super::super::probe::{
+    mysql_server_capabilities, validate_lower_case_table_names, validate_server_product,
+};
 use super::super::xml::{MySqlResultSet, parse_mysql_preview_xml, parse_mysql_xml};
 use super::{
     MySqlProcess, cleanup_mysql_process, configure_mysql_session, finish_mysql_session,
@@ -55,11 +58,11 @@ impl MySqlMetadataSession {
 
     pub(in crate::adapters::mysql) async fn prepare_read_only_and_probe(
         &mut self,
-    ) -> Result<u8, DbOperationError> {
+    ) -> Result<MySqlServerCapabilities, DbOperationError> {
         configure_mysql_session(&mut self.process, AccessMode::ReadOnly).await?;
         let marker = Uuid::new_v4().simple().to_string();
         let query = format!(
-            "SELECT '{marker}' AS __sabiql_probe, @@lower_case_table_names AS __sabiql_lower_case_table_names"
+            "SELECT '{marker}' AS __sabiql_probe, VERSION() AS __sabiql_server_version, @@lower_case_table_names AS __sabiql_lower_case_table_names"
         );
         let result = self.execute(&query).await?;
         validate_metadata_probe(&result, &marker)
@@ -173,21 +176,33 @@ fn normalize_empty_result_columns(result: &mut MySqlResultSet, expected_columns:
     }
 }
 
-fn validate_metadata_probe(result: &MySqlResultSet, marker: &str) -> Result<u8, DbOperationError> {
+fn validate_metadata_probe(
+    result: &MySqlResultSet,
+    marker: &str,
+) -> Result<MySqlServerCapabilities, DbOperationError> {
     if result.values.len() != 1
-        || result.columns != ["__sabiql_probe", "__sabiql_lower_case_table_names"]
+        || result.columns
+            != [
+                "__sabiql_probe",
+                "__sabiql_server_version",
+                "__sabiql_lower_case_table_names",
+            ]
     {
         return Err(DbOperationError::QueryFailed(
             "mysql metadata probe returned an unexpected result".to_string(),
         ));
     }
     let values = &result.values[0];
-    if values.len() != 2 || values[0].as_str() != Some(marker) {
+    if values.len() != 3 || values[0].as_str() != Some(marker) {
         return Err(DbOperationError::QueryFailed(
             "mysql metadata probe returned an unexpected result".to_string(),
         ));
     }
-    let lower_case_table_names = values[1]
+    let server_version = values[1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql metadata probe returned no server version".to_string())
+    })?;
+    validate_server_product(server_version)?;
+    let lower_case_table_names = values[2]
         .as_str()
         .ok_or_else(|| {
             DbOperationError::QueryFailed(
@@ -201,5 +216,8 @@ fn validate_metadata_probe(result: &MySqlResultSet, marker: &str) -> Result<u8, 
             )
         })?;
     validate_lower_case_table_names(lower_case_table_names)?;
-    Ok(lower_case_table_names)
+    Ok(mysql_server_capabilities(
+        server_version,
+        lower_case_table_names,
+    ))
 }

--- a/src/infra/adapters/mysql/cli/process/tests/export.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/export.rs
@@ -11,6 +11,7 @@ async fn exports_mysql_xml_rows_through_the_shared_csv_writer() {
         "SELECT 1",
         path.clone(),
         Duration::from_secs(5),
+        MySqlServerCapabilities::default(),
     )
     .await
     .unwrap();
@@ -30,6 +31,7 @@ async fn configures_read_only_session_before_user_sql() {
         "SELECT 1",
         path,
         Duration::from_secs(5),
+        MySqlServerCapabilities::default(),
     )
     .await
     .unwrap();
@@ -54,6 +56,7 @@ async fn ignores_cli_error_text_inside_resultset_fields() {
         "SELECT 1",
         path.clone(),
         Duration::from_secs(5),
+        MySqlServerCapabilities::default(),
     )
     .await
     .unwrap();
@@ -78,6 +81,7 @@ async fn read_only_session_failure_never_writes_user_sql_or_partial_file() {
             "SELECT 123",
             path,
             Duration::from_secs(5),
+            MySqlServerCapabilities::default(),
         )
     })
     .await;
@@ -103,6 +107,7 @@ async fn failure_removes_the_partial_file() {
             "SELECT 1",
             path,
             Duration::from_secs(5),
+            MySqlServerCapabilities::default(),
         )
     })
     .await;
@@ -125,6 +130,7 @@ async fn timeout_kills_the_process_and_removes_the_partial_file() {
             "SELECT 1",
             path,
             Duration::from_millis(50),
+            MySqlServerCapabilities::default(),
         )
     })
     .await;
@@ -132,4 +138,27 @@ async fn timeout_kills_the_process_and_removes_the_partial_file() {
     assert!(matches!(result, Err(DbOperationError::Timeout(_))));
     assert!(!final_path.exists());
     assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+}
+
+#[tokio::test]
+async fn exports_empty_mysql_57_select_with_derived_metadata_fallback() {
+    let (_directory, program, option_file) = fake_mysql_multi();
+    let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+    let path = option_file.with_file_name("export.csv");
+
+    export_mysql_csv_with_program(
+        OsStr::new(&program),
+        &option_file,
+        "SELECT 1 WHERE FALSE",
+        path.clone(),
+        Duration::from_secs(5),
+        MySqlServerCapabilities::from_version("5.7.44", 0),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(fs::read_to_string(path).unwrap(), "value\n");
+    let log = fs::read_to_string(log_file).unwrap();
+    assert!(log.contains("SELECT __sabiql_metadata_source_"), "{log}");
+    assert!(!log.contains("WITH __sabiql_metadata_source_"), "{log}");
 }

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 
+use super::super::super::capability::MySqlServerCapabilities;
 use super::super::export::run_mysql_export_process_with_capabilities;
 use super::super::policy::MySqlExecutionResult;
 use super::super::xml::MySqlResultSet;
@@ -23,6 +24,7 @@ async fn export_mysql_csv_with_program(
     query: &str,
     path: PathBuf,
     execution_timeout: Duration,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<(), DbOperationError> {
     let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
     run_mysql_process_with_timeout(
@@ -35,7 +37,7 @@ async fn export_mysql_csv_with_program(
                 option_file,
                 query,
                 path,
-                super::super::super::capability::MySqlServerCapabilities::default(),
+                capabilities,
             )
             .await
         },
@@ -328,6 +330,9 @@ while IFS= read -r line; do
       ;;
     *__sabiql_marker*)
       {marker_response}
+      ;;
+    "SELECT __sabiql_metadata_source_"*)
+      printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="value" xsi:nil="true"/></row></resultset>'
       ;;
     *"WITH "*__sabiql_metadata_source*)
       case "$line" in

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -303,7 +303,7 @@ while IFS= read -r line; do
       ;;
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_server_version">8.4.10</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
       ;;
     "SET SESSION autocommit=1, completion_type=NO_CHAIN"|"SET SESSION TRANSACTION READ ONLY")
       ;;

--- a/src/infra/adapters/mysql/cli/process/tests/mod.rs
+++ b/src/infra/adapters/mysql/cli/process/tests/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 
-use super::super::export::run_mysql_export_process;
+use super::super::export::run_mysql_export_process_with_capabilities;
 use super::super::policy::MySqlExecutionResult;
 use super::super::xml::MySqlResultSet;
 use super::adhoc::run_mysql_adhoc_with_program_and_statements;
@@ -29,7 +29,16 @@ async fn export_mysql_csv_with_program(
         execution_timeout,
         &mut process,
         RefreshScope::None,
-        async |process| run_mysql_export_process(process, option_file, query, path).await,
+        async |process| {
+            run_mysql_export_process_with_capabilities(
+                process,
+                option_file,
+                query,
+                path,
+                super::super::super::capability::MySqlServerCapabilities::default(),
+            )
+            .await
+        },
     )
     .await
 }

--- a/src/infra/adapters/mysql/connection.rs
+++ b/src/infra/adapters/mysql/connection.rs
@@ -17,6 +17,10 @@ impl MySqlConnectionProbe for MySqlAdapter {
         let option_file = MySqlOptionFile::create(&target)?;
         let result = super::cli::probe_mysql_server(&option_file.path).await;
         drop(option_file);
-        result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
+        result
+            .map(|probe| MySqlConnectionProbeResult {
+                lower_case_table_names: probe.lower_case_table_names,
+            })
+            .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))
     }
 }

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 
 use super::adapter::MySqlAdapter;
 use super::cli::{
-    export_mysql_csv_to_file, probe_mysql_server, run_mysql_adhoc, run_mysql_single_statement,
+    export_mysql_csv_to_file, mysql_server_capabilities, probe_mysql_server, run_mysql_adhoc,
+    run_mysql_adhoc_with_server_capabilities, run_mysql_single_statement,
     validate_mysql_export_query, validate_mysql_multi_query,
     validate_mysql_multi_query_with_lower_case_table_names,
 };
@@ -47,15 +48,16 @@ async fn execute_adhoc_with_target(
     }
 
     let option_file = MySqlOptionFile::create(target)?;
-    let lower_case_table_names = probe_mysql_server(&option_file.path)
+    let probe = probe_mysql_server(&option_file.path)
         .await
-        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?
-        .lower_case_table_names;
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
+    let capabilities =
+        mysql_server_capabilities(&probe.server_version, probe.lower_case_table_names);
     let statements = validate_mysql_multi_query_with_lower_case_table_names(
         query,
         target.database.as_deref(),
         access_mode,
-        lower_case_table_names,
+        capabilities.lower_case_table_names,
     )?;
 
     #[expect(
@@ -63,7 +65,13 @@ async fn execute_adhoc_with_target(
         reason = "infra measures mysql execution time at the I/O boundary"
     )]
     let start = Instant::now();
-    let result = run_mysql_adhoc(&option_file.path, &statements, access_mode).await;
+    let result = run_mysql_adhoc_with_server_capabilities(
+        &option_file.path,
+        &statements,
+        access_mode,
+        capabilities,
+    )
+    .await;
     drop(option_file);
     let execution = result.map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
     let elapsed = start.elapsed().as_millis() as u64;

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -9,13 +9,14 @@ use crate::domain::{
 };
 
 use super::super::{
+    capability::MySqlServerCapabilities,
     cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
     dsn::{MySqlDsn, map_mysql_tls_failure},
     option_file::MySqlOptionFile,
     sql::{
-        COLUMN_METADATA_BASE_RESULT_COLUMNS, COLUMN_METADATA_RESULT_COLUMNS,
-        FOREIGN_KEY_RESULT_COLUMNS, PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, TABLES_QUERY,
-        TABLES_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS,
+        COLUMN_METADATA_BASE_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS,
+        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
+        UNIQUE_COLUMN_RESULT_COLUMNS, column_metadata_result_columns,
     },
 };
 
@@ -108,12 +109,13 @@ pub(super) fn find_table(
         .ok_or_else(|| mysql_table_not_found(schema, table))
 }
 
-pub(super) fn parse_columns_for_table(
+pub(super) fn parse_columns_for_table_with_capabilities(
     result: &MySqlResultSet,
     schema: &str,
     table: &str,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
-    let columns = parse_column_metadata(result)?;
+    let columns = parse_column_metadata_with_capabilities(result, capabilities)?;
     if columns.is_empty() {
         return Err(mysql_table_not_found(schema, table));
     }
@@ -155,20 +157,20 @@ pub(super) async fn execute_metadata_query(
     query: &str,
     expected_columns: &[&str],
 ) -> Result<(u8, MySqlResultSet), DbOperationError> {
-    let (lower_case_table_names, results) =
+    let (capabilities, results) =
         execute_metadata_queries_in_session(target, &[(query, expected_columns)]).await?;
     let result = results.into_iter().next().ok_or_else(|| {
         DbOperationError::MetadataParseFailed(
             "MySQL metadata query returned no result set".to_string(),
         )
     })?;
-    Ok((lower_case_table_names, result))
+    Ok((capabilities.lower_case_table_names, result))
 }
 
 pub(super) async fn execute_metadata_queries_in_session(
     target: &MySqlDsn,
     queries: &[(&str, &[&str])],
-) -> Result<(u8, Vec<MySqlResultSet>), DbOperationError> {
+) -> Result<(MySqlServerCapabilities, Vec<MySqlResultSet>), DbOperationError> {
     execute_metadata_queries_in_session_with_program(
         target,
         queries,
@@ -183,11 +185,11 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
     queries: &[(&str, &[&str])],
     program: &OsStr,
     timeout: Duration,
-) -> Result<(u8, Vec<MySqlResultSet>), DbOperationError> {
+) -> Result<(MySqlServerCapabilities, Vec<MySqlResultSet>), DbOperationError> {
     let option_file = MySqlOptionFile::create(target)?;
     let mut session = MySqlMetadataSession::spawn_with_metadata_program(program, option_file)?;
     let result = tokio::time::timeout(timeout, async {
-        let lower_case_table_names = session.prepare_read_only_and_probe().await?;
+        let capabilities = session.prepare_read_only_and_probe().await?;
         let mut results = Vec::with_capacity(queries.len());
         for (query, expected_columns) in queries {
             results.push(
@@ -197,7 +199,7 @@ pub(super) async fn execute_metadata_queries_in_session_with_program(
             );
         }
         session.finish().await?;
-        Ok((lower_case_table_names, results))
+        Ok((capabilities, results))
     })
     .await;
     session
@@ -307,18 +309,20 @@ fn parse_table_metadata(
         .collect()
 }
 
-fn parse_column_metadata(
+fn parse_column_metadata_with_capabilities(
     result: &MySqlResultSet,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
-    expect_columns(result, COLUMN_METADATA_RESULT_COLUMNS)?;
+    let expected_columns = column_metadata_result_columns(capabilities);
+    expect_columns(result, expected_columns)?;
     result
         .values
         .iter()
         .map(|row| {
-            if row.len() != COLUMN_METADATA_RESULT_COLUMNS.len() {
+            if row.len() != expected_columns.len() {
                 return Err(metadata_shape_error("COLUMNS row"));
             }
-            parse_column_metadata_row_with_details(row, "COLUMNS row")
+            parse_column_metadata_row_with_details(row, "COLUMNS row", capabilities)
         })
         .collect()
 }
@@ -358,15 +362,21 @@ pub(super) fn parse_column_metadata_row(
 fn parse_column_metadata_row_with_details(
     row: &[QueryValue],
     field: &str,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<MySqlColumnMetadata, DbOperationError> {
-    if row.len() != COLUMN_METADATA_RESULT_COLUMNS.len() {
+    let expected_columns = column_metadata_result_columns(capabilities);
+    if row.len() != expected_columns.len() {
         return Err(metadata_shape_error(field));
     }
     let mut column =
         parse_column_metadata_row(&row[..COLUMN_METADATA_BASE_RESULT_COLUMNS.len()], field)?;
     column.character_set_name = optional_nonempty_string(&row[8], "CHARACTER_SET_NAME")?;
     column.collation_name = optional_nonempty_string(&row[9], "COLLATION_NAME")?;
-    column.generation_expression = optional_nonempty_string(&row[10], "GENERATION_EXPRESSION")?;
+    column.generation_expression = if capabilities.supports_generation_expression() {
+        optional_nonempty_string(&row[10], "GENERATION_EXPRESSION")?
+    } else {
+        None
+    };
     column.generation_kind = generation_kind(required_text(&row[4], "EXTRA")?);
     Ok(column)
 }
@@ -647,8 +657,29 @@ pub(super) fn metadata_shape_error(field: &str) -> DbOperationError {
 
 #[cfg(test)]
 mod tests {
+    use crate::adapters::mysql::sql::COLUMN_METADATA_RESULT_COLUMNS;
+
     use super::super::test_support::result;
     use super::*;
+
+    fn parse_column_metadata(
+        result: &MySqlResultSet,
+    ) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
+        super::parse_column_metadata_with_capabilities(result, MySqlServerCapabilities::default())
+    }
+
+    fn parse_columns_for_table(
+        result: &MySqlResultSet,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
+        super::parse_columns_for_table_with_capabilities(
+            result,
+            schema,
+            table,
+            MySqlServerCapabilities::default(),
+        )
+    }
 
     #[test]
     fn optional_nonempty_string_preserves_catalog_value_boundaries() {
@@ -1199,5 +1230,53 @@ mod tests {
         }
         let unicode_case_insensitive = foreign_keys_from_metadata(unicode_raw, "äpp", 1).unwrap();
         assert!(unicode_case_insensitive[0].is_reference_resolved());
+    }
+
+    #[test]
+    fn parses_generation_expression_for_mysql_57_capabilities() {
+        let capabilities = MySqlServerCapabilities::from_version("5.7.44", 0);
+        let columns = parse_columns_for_table_with_capabilities(
+            &result(
+                &[
+                    "COLUMN_NAME",
+                    "COLUMN_TYPE",
+                    "IS_NULLABLE",
+                    "COLUMN_DEFAULT",
+                    "EXTRA",
+                    "COLUMN_COMMENT",
+                    "ORDINAL_POSITION",
+                    "PRIMARY_KEY_POSITION",
+                    "CHARACTER_SET_NAME",
+                    "COLLATION_NAME",
+                    "GENERATION_EXPRESSION",
+                ],
+                vec![vec![
+                    QueryValue::Text("generated_value".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("STORED GENERATED".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("value + 1".to_string()),
+                ]],
+            ),
+            "app",
+            "items",
+            capabilities,
+        )
+        .unwrap();
+
+        assert_eq!(
+            columns[0].generation_expression.as_deref(),
+            Some("value + 1")
+        );
+        assert_eq!(
+            columns[0].generation_kind,
+            Some(ColumnGenerationKind::Stored)
+        );
     }
 }

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -91,7 +91,8 @@ async fn execute_preview_with_session(
     limit: usize,
     offset: usize,
 ) -> Result<PreviewExecution, DbOperationError> {
-    let lower_case_table_names = session.prepare_read_only_and_probe().await?;
+    let capabilities = session.prepare_read_only_and_probe().await?;
+    let lower_case_table_names = capabilities.lower_case_table_names;
     validate_selected_schema_name(database, schema, lower_case_table_names)?;
 
     let column_result = session
@@ -430,7 +431,7 @@ while IFS= read -r line; do
     ";") ;;
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)'.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_server_version">8.4.10</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
       ;;
     *"SET SESSION TRANSACTION READ ONLY"*) ;;
     *__sabiql_session_marker*)

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -42,7 +42,7 @@ async fn fetch_table_signatures_with_program(
 ) -> Result<TableSignatureSnapshot, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let database = selected_database(&target)?;
-    let (lower_case_table_names, results) = execute_metadata_queries_in_session_with_program(
+    let (capabilities, results) = execute_metadata_queries_in_session_with_program(
         &target,
         &[
             (TABLES_QUERY, TABLES_RESULT_COLUMNS),
@@ -57,6 +57,7 @@ async fn fetch_table_signatures_with_program(
         timeout,
     )
     .await?;
+    let lower_case_table_names = capabilities.lower_case_table_names;
     let tables =
         metadata_snapshot_from_result(database, None, &results[0], lower_case_table_names)?;
     table_signatures_from_metadata(
@@ -708,7 +709,7 @@ while IFS= read -r line; do
     case "$line" in
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_probe.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_server_version">8.4.10</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
       ;;
     *"SET SESSION TRANSACTION READ ONLY")
       ;;

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -9,12 +9,13 @@ use crate::domain::{
 };
 
 use super::super::sql::{
-    COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS,
-    TABLES_RESULT_COLUMNS, TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, columns_query,
-    foreign_keys_query, indexes_query, show_create_query, show_create_result_columns, table_query,
-    triggers_query, unique_columns_query,
+    FOREIGN_KEY_RESULT_COLUMNS, TABLES_RESULT_COLUMNS, TRIGGER_RESULT_COLUMNS,
+    UNIQUE_COLUMN_RESULT_COLUMNS, column_metadata_result_columns, columns_query_for_capabilities,
+    foreign_keys_query, index_result_columns, indexes_query_for_capabilities, show_create_query,
+    show_create_result_columns, table_query, triggers_query, unique_columns_query,
 };
 use super::super::{
+    capability::MySqlServerCapabilities,
     cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
     dsn::{map_mysql_tls_failure, parse_and_validate_mysql_dsn},
     option_file::MySqlOptionFile,
@@ -22,9 +23,9 @@ use super::super::{
 use super::catalog::{
     MySqlColumnMetadata, MySqlTableMetadata, column_from_metadata, expect_columns, find_table,
     foreign_keys_from_metadata, mark_single_column_unique, metadata_shape_error,
-    metadata_snapshot_from_result, optional_text, parse_boolean_flag, parse_columns_for_table,
-    parse_foreign_key_metadata, parse_optional_positive_i32, parse_positive_i32,
-    parse_unique_column_metadata, primary_key_names, required_text, selected_database,
+    metadata_snapshot_from_result, optional_text, parse_boolean_flag, parse_foreign_key_metadata,
+    parse_optional_positive_i32, parse_positive_i32, parse_unique_column_metadata,
+    primary_key_names, required_text, selected_database,
 };
 
 #[derive(Debug, Clone)]
@@ -73,31 +74,57 @@ async fn fetch_table_columns_and_fks_with_program(
 ) -> Result<Table, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let database = selected_database(&target)?;
-    let table_query = table_query(schema, table);
-    let columns_query = columns_query(schema, table);
-    let unique_columns_query = unique_columns_query(schema, table);
-    let foreign_keys_query = foreign_keys_query(schema, table);
-    let (lower_case_table_names, results) =
-        super::catalog::execute_metadata_queries_in_session_with_program(
-            &target,
-            &[
-                (table_query.as_str(), TABLES_RESULT_COLUMNS),
-                (columns_query.as_str(), COLUMN_METADATA_RESULT_COLUMNS),
-                (unique_columns_query.as_str(), UNIQUE_COLUMN_RESULT_COLUMNS),
-                (foreign_keys_query.as_str(), FOREIGN_KEY_RESULT_COLUMNS),
-            ],
-            program,
-            timeout,
-        )
-        .await?;
-    let table_metadata =
-        table_metadata_from_result(database, schema, table, &results[0], lower_case_table_names)?;
-    let mut columns = parse_columns_for_table(&results[1], schema, table)?;
+    let option_file = MySqlOptionFile::create(&target)?;
+    let mut session = MySqlMetadataSession::spawn_with_metadata_program(program, option_file)?;
+    let result = tokio::time::timeout(timeout, async {
+        let capabilities = session.prepare_read_only_and_probe().await?;
+        let table_query = table_query(schema, table);
+        let columns_query = columns_query_for_capabilities(schema, table, capabilities);
+        let unique_columns_query = unique_columns_query(schema, table);
+        let foreign_keys_query = foreign_keys_query(schema, table);
+        let results = vec![
+            session
+                .execute_with_expected_columns(&table_query, TABLES_RESULT_COLUMNS)
+                .await?,
+            session
+                .execute_with_expected_columns(
+                    &columns_query,
+                    column_metadata_result_columns(capabilities),
+                )
+                .await?,
+            session
+                .execute_with_expected_columns(&unique_columns_query, UNIQUE_COLUMN_RESULT_COLUMNS)
+                .await?,
+            session
+                .execute_with_expected_columns(&foreign_keys_query, FOREIGN_KEY_RESULT_COLUMNS)
+                .await?,
+        ];
+        session.finish().await?;
+        Ok((capabilities, results))
+    })
+    .await;
+    let (capabilities, results) = session
+        .resolve_timed_result(result)
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
+    let table_metadata = table_metadata_from_result(
+        database,
+        schema,
+        table,
+        &results[0],
+        capabilities.lower_case_table_names,
+    )?;
+    let mut columns = super::catalog::parse_columns_for_table_with_capabilities(
+        &results[1],
+        schema,
+        table,
+        capabilities,
+    )?;
     mark_single_column_unique(&mut columns, &parse_unique_column_metadata(&results[2])?);
     let foreign_keys = foreign_keys_from_metadata(
         parse_foreign_key_metadata(&results[3])?,
         database,
-        lower_case_table_names,
+        capabilities.lower_case_table_names,
     )?;
     Ok(table_from_columns_and_foreign_keys(
         table_metadata,
@@ -134,7 +161,7 @@ async fn fetch_table_detail_with_session(
     schema: &str,
     table: &str,
 ) -> Result<Table, DbOperationError> {
-    let lower_case_table_names = session.prepare_read_only_and_probe().await?;
+    let capabilities = session.prepare_read_only_and_probe().await?;
     let tables_result = session
         .execute_with_expected_columns(&table_query(schema, table), TABLES_RESULT_COLUMNS)
         .await?;
@@ -143,23 +170,28 @@ async fn fetch_table_detail_with_session(
         schema,
         table,
         &tables_result,
-        lower_case_table_names,
+        capabilities.lower_case_table_names,
     )?;
 
-    let mut columns = parse_columns_for_table(
+    let mut columns = super::catalog::parse_columns_for_table_with_capabilities(
         &session
             .execute_with_expected_columns(
-                &columns_query(schema, table),
-                COLUMN_METADATA_RESULT_COLUMNS,
+                &columns_query_for_capabilities(schema, table, capabilities),
+                column_metadata_result_columns(capabilities),
             )
             .await?,
         schema,
         table,
+        capabilities,
     )?;
-    let raw_indexes = parse_index_metadata(
+    let raw_indexes = parse_index_metadata_with_capabilities(
         &session
-            .execute_with_expected_columns(&indexes_query(schema, table), INDEX_RESULT_COLUMNS)
+            .execute_with_expected_columns(
+                &indexes_query_for_capabilities(schema, table, capabilities),
+                index_result_columns(capabilities),
+            )
             .await?,
+        capabilities,
     )?;
     let unique_single_columns = unique_single_columns_from_metadata(&raw_indexes);
     mark_single_column_unique(&mut columns, &unique_single_columns);
@@ -174,7 +206,7 @@ async fn fetch_table_detail_with_session(
                 .await?,
         )?,
         database,
-        lower_case_table_names,
+        capabilities.lower_case_table_names,
     )?;
     let triggers = parse_trigger_metadata(
         &session
@@ -298,21 +330,32 @@ fn parse_source_ddl(result: &MySqlResultSet, kind: TableKind) -> Result<String, 
     Ok(ddl.to_string())
 }
 
-fn parse_index_metadata(
+fn parse_index_metadata_with_capabilities(
     result: &MySqlResultSet,
+    capabilities: MySqlServerCapabilities,
 ) -> Result<Vec<MySqlIndexMetadata>, DbOperationError> {
-    expect_columns(result, INDEX_RESULT_COLUMNS)?;
+    let expected_columns = index_result_columns(capabilities);
+    expect_columns(result, expected_columns)?;
     result
         .values
         .iter()
         .map(|row| {
-            if row.len() != INDEX_RESULT_COLUMNS.len() {
+            if row.len() != expected_columns.len() {
                 return Err(metadata_shape_error("STATISTICS row"));
             }
             let column_name = optional_text(&row[4], "COLUMN_NAME")?;
             let sub_part = parse_optional_positive_i32(&row[5], "SUB_PART")?;
-            let expression = optional_text(&row[6], "EXPRESSION")?;
-            let descending = match optional_text(&row[7], "COLLATION")? {
+            let expression = if capabilities.supports_statistics_expression() {
+                optional_text(&row[6], "EXPRESSION")?
+            } else {
+                None
+            };
+            let collation_index = if capabilities.supports_statistics_expression() {
+                7
+            } else {
+                6
+            };
+            let descending = match optional_text(&row[collation_index], "COLLATION")? {
                 None => false,
                 Some(value) if value.eq_ignore_ascii_case("A") => false,
                 Some(value) if value.eq_ignore_ascii_case("D") => true,
@@ -322,7 +365,11 @@ fn parse_index_metadata(
                     ));
                 }
             };
-            let invisible = !parse_boolean_flag(&row[8], "IS_VISIBLE")?;
+            let invisible = if capabilities.supports_statistics_visibility() {
+                !parse_boolean_flag(&row[collation_index + 1], "IS_VISIBLE")?
+            } else {
+                false
+            };
             let (column_name, expression) = match (column_name, expression) {
                 (Some(column_name), None) => (column_name.to_string(), None),
                 (None, Some(expression)) => {
@@ -480,7 +527,7 @@ while IFS= read -r line; do
       printf '%s\n' '<resultset><row><field name="wrong">x</field></row></resultset>'
     else
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)'.*/\1/")
-      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_server_version">8.4.10</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
     fi
     continue
   fi
@@ -855,9 +902,17 @@ done
 
 #[cfg(test)]
 mod tests {
+    use crate::adapters::mysql::sql::INDEX_RESULT_COLUMNS;
+
     use super::super::test_support::result;
     use super::*;
     use crate::domain::QueryValue;
+
+    fn parse_index_metadata(
+        result: &MySqlResultSet,
+    ) -> Result<Vec<MySqlIndexMetadata>, DbOperationError> {
+        super::parse_index_metadata_with_capabilities(result, MySqlServerCapabilities::default())
+    }
 
     #[test]
     fn trigger_metadata_preserves_action_order_context_and_definition() {
@@ -1294,5 +1349,40 @@ mod tests {
             DbOperationError::MetadataParseFailed(message)
                 if message.contains("neither COLUMN_NAME nor EXPRESSION")
         ));
+    }
+
+    #[test]
+    fn parses_mysql_57_indexes_without_expression_or_visibility_columns() {
+        let capabilities = MySqlServerCapabilities::from_version("5.7.44", 0);
+        let raw = parse_index_metadata_with_capabilities(
+            &result(
+                &[
+                    "INDEX_NAME",
+                    "NON_UNIQUE",
+                    "INDEX_TYPE",
+                    "SEQ_IN_INDEX",
+                    "COLUMN_NAME",
+                    "SUB_PART",
+                    "COLLATION",
+                ],
+                vec![vec![
+                    QueryValue::Text("idx_payload".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("payload".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("D".to_string()),
+                ]],
+            ),
+            capabilities,
+        )
+        .unwrap();
+
+        let indexes = indexes_from_metadata(raw);
+        assert_eq!(indexes[0].name, "idx_payload");
+        assert_eq!(indexes[0].columns, ["payload DESC"]);
+        assert!(indexes[0].has_descending_key());
+        assert!(!indexes[0].is_invisible());
     }
 }

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -1,4 +1,5 @@
 mod adapter;
+mod capability;
 mod cli;
 mod connection;
 mod dsn;

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -1,3 +1,4 @@
+use super::super::capability::MySqlServerCapabilities;
 use super::literal::{quote_identifier, quote_string};
 use crate::domain::{Column, TableKind};
 
@@ -38,6 +39,18 @@ pub(in crate::adapters::mysql) const COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &
     "COLLATION_NAME",
     "GENERATION_EXPRESSION",
 ];
+pub(in crate::adapters::mysql) const COLUMN_METADATA_RESULT_COLUMNS_WITHOUT_GENERATION: &[&str] = &[
+    "COLUMN_NAME",
+    "COLUMN_TYPE",
+    "IS_NULLABLE",
+    "COLUMN_DEFAULT",
+    "EXTRA",
+    "COLUMN_COMMENT",
+    "ORDINAL_POSITION",
+    "PRIMARY_KEY_POSITION",
+    "CHARACTER_SET_NAME",
+    "COLLATION_NAME",
+];
 pub(in crate::adapters::mysql) const PREVIEW_COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &[
     "COLUMN_NAME",
     "COLUMN_TYPE",
@@ -71,9 +84,28 @@ pub(in crate::adapters::mysql) fn table_query(schema: &str, table: &str) -> Stri
     )
 }
 
-pub(in crate::adapters::mysql) fn columns_query(schema: &str, table: &str) -> String {
+pub(in crate::adapters::mysql) fn column_metadata_result_columns(
+    capabilities: MySqlServerCapabilities,
+) -> &'static [&'static str] {
+    if capabilities.supports_generation_expression() {
+        COLUMN_METADATA_RESULT_COLUMNS
+    } else {
+        COLUMN_METADATA_RESULT_COLUMNS_WITHOUT_GENERATION
+    }
+}
+
+pub(in crate::adapters::mysql) fn columns_query_for_capabilities(
+    schema: &str,
+    table: &str,
+    capabilities: MySqlServerCapabilities,
+) -> String {
+    let generation_expression = if capabilities.supports_generation_expression() {
+        ", c.GENERATION_EXPRESSION"
+    } else {
+        ""
+    };
     format!(
-        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION, c.CHARACTER_SET_NAME, c.COLLATION_NAME, c.GENERATION_EXPRESSION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION, c.CHARACTER_SET_NAME, c.COLLATION_NAME{generation_expression} FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
         quote_string(schema),
         quote_string(table),
     )
@@ -133,6 +165,25 @@ pub(in crate::adapters::mysql) const INDEX_RESULT_COLUMNS: &[&str] = &[
     "COLLATION",
     "IS_VISIBLE",
 ];
+pub(in crate::adapters::mysql) const INDEX_RESULT_COLUMNS_WITHOUT_EXPRESSION: &[&str] = &[
+    "INDEX_NAME",
+    "NON_UNIQUE",
+    "INDEX_TYPE",
+    "SEQ_IN_INDEX",
+    "COLUMN_NAME",
+    "SUB_PART",
+    "COLLATION",
+    "IS_VISIBLE",
+];
+pub(in crate::adapters::mysql) const INDEX_RESULT_COLUMNS_LEGACY: &[&str] = &[
+    "INDEX_NAME",
+    "NON_UNIQUE",
+    "INDEX_TYPE",
+    "SEQ_IN_INDEX",
+    "COLUMN_NAME",
+    "SUB_PART",
+    "COLLATION",
+];
 pub(in crate::adapters::mysql) const TRIGGER_RESULT_COLUMNS: &[&str] = &[
     "TRIGGER_NAME",
     "ACTION_ORDER",
@@ -149,9 +200,36 @@ pub(in crate::adapters::mysql) const TRIGGER_RESULT_COLUMNS: &[&str] = &[
 const TABLE_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["Table", "Create Table"];
 const VIEW_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["View", "Create View"];
 
-pub(in crate::adapters::mysql) fn indexes_query(schema: &str, table: &str) -> String {
+pub(in crate::adapters::mysql) fn index_result_columns(
+    capabilities: MySqlServerCapabilities,
+) -> &'static [&'static str] {
+    match (
+        capabilities.supports_statistics_expression(),
+        capabilities.supports_statistics_visibility(),
+    ) {
+        (true, _) => INDEX_RESULT_COLUMNS,
+        (false, true) => INDEX_RESULT_COLUMNS_WITHOUT_EXPRESSION,
+        (false, false) => INDEX_RESULT_COLUMNS_LEGACY,
+    }
+}
+
+pub(in crate::adapters::mysql) fn indexes_query_for_capabilities(
+    schema: &str,
+    table: &str,
+    capabilities: MySqlServerCapabilities,
+) -> String {
+    let expression = if capabilities.supports_statistics_expression() {
+        ", s.EXPRESSION"
+    } else {
+        ""
+    };
+    let visibility = if capabilities.supports_statistics_visibility() {
+        ", s.IS_VISIBLE"
+    } else {
+        ""
+    };
     format!(
-        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.SUB_PART, s.EXPRESSION, s.COLLATION, s.IS_VISIBLE FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.SUB_PART{expression}, s.COLLATION{visibility} FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
         quote_string(schema),
         quote_string(table),
     )
@@ -248,6 +326,16 @@ pub(in crate::adapters::mysql) fn build_metadata_select_query(
     )
 }
 
+pub(in crate::adapters::mysql) fn build_legacy_metadata_select_query(
+    query: &str,
+    source_alias: &str,
+    marker_alias: &str,
+) -> String {
+    format!(
+        "SELECT {source_alias}.* FROM (SELECT * FROM ({query}) AS __sabiql_metadata_inner LIMIT 0) AS {source_alias} RIGHT JOIN (SELECT 1 AS {marker_alias}) AS __sabiql_metadata_marker ON TRUE"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::super::metadata_test_support::column;
@@ -287,7 +375,8 @@ mod tests {
             )
         );
 
-        let columns_sql = columns_query(schema, table);
+        let columns_sql =
+            columns_query_for_capabilities(schema, table, MySqlServerCapabilities::default());
         assert_eq!(
             columns_sql,
             format!(
@@ -319,7 +408,8 @@ mod tests {
             )
         );
 
-        let indexes_sql = indexes_query(schema, table);
+        let indexes_sql =
+            indexes_query_for_capabilities(schema, table, MySqlServerCapabilities::default());
         assert_eq!(
             indexes_sql,
             format!(
@@ -517,6 +607,52 @@ mod tests {
         assert_eq!(
             build_preview_query("app", "items", &[], &visible_columns, &[], 10, 0,),
             "SELECT `payload` FROM `app`.`items` LIMIT 10 OFFSET 0"
+        );
+    }
+
+    #[test]
+    fn metadata_queries_follow_server_catalog_capabilities() {
+        let mysql_57 = MySqlServerCapabilities::from_version("5.7.44", 0);
+        assert_eq!(
+            column_metadata_result_columns(mysql_57),
+            COLUMN_METADATA_RESULT_COLUMNS
+        );
+        let columns = columns_query_for_capabilities("app", "items", mysql_57);
+        assert!(columns.contains("GENERATION_EXPRESSION"));
+        assert_eq!(index_result_columns(mysql_57), INDEX_RESULT_COLUMNS_LEGACY);
+        let indexes = indexes_query_for_capabilities("app", "items", mysql_57);
+        assert!(!indexes.contains("EXPRESSION"));
+        assert!(!indexes.contains("IS_VISIBLE"));
+
+        let mysql_80 = MySqlServerCapabilities::from_version("8.0.12", 1);
+        assert_eq!(
+            index_result_columns(mysql_80),
+            INDEX_RESULT_COLUMNS_WITHOUT_EXPRESSION
+        );
+        let indexes = indexes_query_for_capabilities("app", "items", mysql_80);
+        assert!(!indexes.contains("s.EXPRESSION"));
+        assert!(indexes.contains("s.IS_VISIBLE"));
+
+        let mysql_84 = MySqlServerCapabilities::from_version("8.4.10", 0);
+        assert_eq!(
+            column_metadata_result_columns(mysql_84),
+            COLUMN_METADATA_RESULT_COLUMNS
+        );
+        assert_eq!(index_result_columns(mysql_84), INDEX_RESULT_COLUMNS);
+        assert!(
+            columns_query_for_capabilities("app", "items", mysql_84)
+                .contains("GENERATION_EXPRESSION")
+        );
+        assert!(indexes_query_for_capabilities("app", "items", mysql_84).contains("s.EXPRESSION"));
+    }
+
+    #[test]
+    fn legacy_metadata_fallback_uses_derived_tables_instead_of_ctes() {
+        let query = build_legacy_metadata_select_query("SELECT id FROM items", "source", "marker");
+        assert!(query.starts_with("SELECT source.* FROM (SELECT * FROM (SELECT id FROM items)"));
+        assert!(!query.starts_with("WITH "));
+        assert!(
+            query.ends_with("RIGHT JOIN (SELECT 1 AS marker) AS __sabiql_metadata_marker ON TRUE")
         );
     }
 }

--- a/src/infra/adapters/mysql/sql/mod.rs
+++ b/src/infra/adapters/mysql/sql/mod.rs
@@ -3,13 +3,17 @@ mod literal;
 mod metadata;
 
 pub(super) use metadata::{
-    COLUMN_METADATA_BASE_RESULT_COLUMNS, COLUMN_METADATA_RESULT_COLUMNS, EFFECTIVE_USER_QUERY,
-    EFFECTIVE_USER_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS,
-    PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY,
+    COLUMN_METADATA_BASE_RESULT_COLUMNS, EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS,
+    FOREIGN_KEY_RESULT_COLUMNS, PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY,
     SIGNATURE_COLUMNS_RESULT_COLUMNS, SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
     SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
-    TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_metadata_select_query,
-    build_preview_query, columns_query, foreign_keys_query, indexes_query, preview_columns_query,
-    preview_identity_alias, show_create_query, show_create_result_columns, table_query,
-    triggers_query, unique_columns_query,
+    TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_legacy_metadata_select_query,
+    build_metadata_select_query, build_preview_query, column_metadata_result_columns,
+    columns_query_for_capabilities, foreign_keys_query, index_result_columns,
+    indexes_query_for_capabilities, preview_columns_query, preview_identity_alias,
+    show_create_query, show_create_result_columns, table_query, triggers_query,
+    unique_columns_query,
 };
+
+#[allow(unused_imports, reason = "re-exported for MySQL metadata unit tests")]
+pub(super) use metadata::{COLUMN_METADATA_RESULT_COLUMNS, INDEX_RESULT_COLUMNS};


### PR DESCRIPTION
## Summary
- Keep the Oracle MySQL 8.4 CLI requirement while accepting Oracle MySQL 5.7, 8.0, and 8.4 servers.
- Replace the JSON probe with the existing XML parser and select metadata/empty-result SQL by server capabilities.
- Reject identified compatible products separately and document the support boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Oracle MySQL 5.7, 8.0, and 8.4 servers.
  * Metadata, indexes, previews, and query results now adapt to server capabilities.
  * Added compatibility for older servers that do not support common table expressions or newer metadata fields.

* **Bug Fixes**
  * Improved detection and messaging for unsupported MySQL-compatible products.
  * Clarified MySQL CLI and server version requirements.

* **Documentation**
  * Expanded MySQL setup guidance, supported versions, limitations, and version-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->