### PR TITLE
refactor(app): remove dead ER prefetch action

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -475,9 +475,6 @@ pub enum Action {
     StartCompletionPrefetch {
         tables: Vec<String>,
     },
-    ExpandPrefetchWithFkNeighbors {
-        run_id: u64,
-    },
     FkNeighborsDiscovered {
         run_id: u64,
         tables: Vec<String>,

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -19,12 +19,6 @@ pub(super) fn expand_prefetch_with_fk_neighbors(state: &AppState, run_id: u64) -
 
 pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
-        Action::ExpandPrefetchWithFkNeighbors { run_id } => {
-            if reject_pending_mysql_connection_probe(state) {
-                return DispatchResult::handled();
-            }
-            DispatchResult::handled_with(expand_prefetch_with_fk_neighbors(state, *run_id))
-        }
         Action::FkNeighborsDiscovered { run_id, tables } => {
             if reject_pending_mysql_connection_probe(state) {
                 return DispatchResult::handled();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -1478,48 +1478,6 @@ mod tests {
                     if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache))
             )));
         }
-
-        #[test]
-        fn stale_expand_does_not_start_neighbor_extraction() {
-            let mut state = state_with_dsn("postgres://localhost/test");
-            let stale_run_id = state.table_prefetch.begin_er_prefetch();
-            let current_run_id = state.table_prefetch.begin_er_prefetch();
-
-            let effects = dispatch_metadata(
-                &mut state,
-                &Action::ExpandPrefetchWithFkNeighbors {
-                    run_id: stale_run_id,
-                },
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert_eq!(
-                state.table_prefetch.active_prefetch_run_id(),
-                Some(current_run_id)
-            );
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn pending_mysql_probe_rejects_neighbor_expansion() {
-            let mut state = state_with_pending_mysql_probe();
-            let run_id = state.table_prefetch.begin_er_prefetch();
-            let _ = state.er_preparation.start_waiting_run();
-            state.er_preparation.mark_fk_unexpanded();
-
-            let effects = dispatch_metadata(
-                &mut state,
-                &Action::ExpandPrefetchWithFkNeighbors { run_id },
-                Instant::now(),
-            )
-            .into_effects()
-            .expect("neighbor expansion action should be handled");
-
-            assert!(effects.is_empty());
-            assert!(state.er_preparation.is_waiting());
-            assert!(!state.er_preparation.fk_expanded());
-        }
     }
 
     mod fk_neighbors_discovered {


### PR DESCRIPTION
## Problem
A legacy ER prefetch Action has no production producer, leaving an obsolete reducer entry point in the public Action surface.

## Background
The ER completion flow already invokes the private helper directly, while FK-neighbor completion remains delivered through the existing async Action.

## Approach
Remove the unused Action and reducer arm plus their Action-level tests. Preserve the direct ER completion helper, run freshness checks, FK-neighbor handling, and pending MySQL connection-probe rejection.

## Screenshots
Not applicable.