### PR TITLE
refactor(app): remove unused JSON detail scroll target

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -51,7 +51,6 @@ pub enum ScrollTarget {
     ExplainCompare,
     ExplainConfirm,
     Explorer,
-    JsonDetail,
     CellDetail,
     SqliteDiagnostics,
     RowDetail,


### PR DESCRIPTION
## Problem
`ScrollTarget` exposes a JSON detail target that no production or test input path can construct, leaving an unreachable parameter value in the app action surface.

## Background
JSON detail navigation uses its dedicated detail actions and input modes, so this target is a stale enum value.

## Approach
Remove the unreachable target while preserving dedicated JSON detail scrolling, search navigation, editing, and modal lifecycle.