### PR TITLE
chore: update Rust toolchain to 1.98.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"
 [workspace.package]
 version = "3.0.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.98"
 license = "MIT"
 repository = "https://github.com/riii111/sabiql"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.96"
+msrv = "1.98"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8
 # Allow std and third-party crate roots; update this list when adding dependencies.

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780802404,
-        "narHash": "sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM=",
+        "lastModified": 1788505699,
+        "narHash": "sha256-PSPDCdbEBEbSDCWcqv5GkbyD2ACQ9Diz6vmEbWdy4dM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8e596a8430f2ce54d55c742198187d6945a5501e",
+        "rev": "9eccf73c5b810052f08aa77ae0548c383259f17f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
       forAllSystems = nixpkgs.lib.genAttrs systems;
 
-      rustVersion = "1.96.0";
+      rustVersion = "1.98.1";
       mkRustToolchain =
         pkgs:
         pkgs.rust-bin.stable.${rustVersion}.default.override {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.98.1"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]

--- a/src/infra/adapters/mysql/cli/diagnostics.rs
+++ b/src/infra/adapters/mysql/cli/diagnostics.rs
@@ -12,10 +12,9 @@ fn parse_mysql_cli_diagnostic_line(line: &[u8]) -> Option<DatabaseDiagnostic> {
     let line = line.trim();
     let (level, rest) = if let Some(rest) = line.strip_prefix("Warning (Code ") {
         (DiagnosticLevel::Warning, rest)
-    } else if let Some(rest) = line.strip_prefix("Note (Code ") {
-        (DiagnosticLevel::Note, rest)
     } else {
-        return None;
+        let rest = line.strip_prefix("Note (Code ")?;
+        (DiagnosticLevel::Note, rest)
     };
     let (code, message) = rest.split_once("): ")?;
     Some(DatabaseDiagnostic {

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -213,7 +213,7 @@ fn decode_base64(encoded: &[u8]) -> Option<Vec<u8>> {
         return None;
     }
     let mut decoded = Vec::with_capacity(encoded.len() / 4 * 3);
-    for (chunk_index, chunk) in encoded.chunks_exact(4).enumerate() {
+    for (chunk_index, chunk) in encoded.as_chunks::<4>().0.iter().enumerate() {
         let last_chunk = chunk_index + 1 == encoded.len() / 4;
         let first = base64_value(chunk[0])?;
         let second = base64_value(chunk[1])?;

--- a/src/infra/adapters/sqlite/sqlite3/parser/output.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/output.rs
@@ -198,8 +198,7 @@ fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
         ));
     }
     let mut bytes = Vec::with_capacity(hex.len() / 2);
-    let mut chars = hex.as_bytes().chunks_exact(2);
-    for pair in &mut chars {
+    for pair in hex.as_bytes().as_chunks::<2>().0 {
         let raw = std::str::from_utf8(pair)
             .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
         let byte = u8::from_str_radix(raw, 16)


### PR DESCRIPTION
## Summary
- Update the Rust toolchain and MSRV settings to 1.98.1 / 1.98.
- Refresh only the rust-overlay lock input.
- Apply the Rust 1.98.1 Clippy fixes required by the updated toolchain.
