### PR TITLE
fix: protect config temporary files at creation

### DIFF
--- a/src/infra/adapters/app_config_file.rs
+++ b/src/infra/adapters/app_config_file.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
@@ -41,22 +42,7 @@ pub(super) fn write_config_file(config_dir: &Path, content: &str) -> Result<(), 
         counter,
     ));
 
-    if let Err(e) = fs::write(&tmp_path, content) {
-        let _ = fs::remove_file(&tmp_path);
-        return Err(e);
-    }
-
-    if let Err(e) = set_file_permissions(&tmp_path) {
-        let _ = fs::remove_file(&tmp_path);
-        return Err(e);
-    }
-
-    if let Err(e) = fs::rename(&tmp_path, &path) {
-        let _ = fs::remove_file(&tmp_path);
-        return Err(e);
-    }
-
-    Ok(())
+    write_config_at(&path, &tmp_path, content)
 }
 
 pub(super) fn render_config_file(content: &str) -> String {
@@ -65,15 +51,153 @@ pub(super) fn render_config_file(content: &str) -> String {
     )
 }
 
-#[cfg(unix)]
-fn set_file_permissions(path: &Path) -> Result<(), std::io::Error> {
-    use std::os::unix::fs::PermissionsExt;
-    let perms = fs::Permissions::from_mode(0o600);
-    fs::set_permissions(path, perms)?;
+fn write_config_at(path: &Path, tmp_path: &Path, content: &str) -> Result<(), std::io::Error> {
+    let mut file = create_config_temp_file(tmp_path)?;
+    let result = file.write_all(content.as_bytes());
+    drop(file);
+
+    if let Err(error) = result.and_then(|()| fs::rename(tmp_path, path)) {
+        let _ = fs::remove_file(tmp_path);
+        return Err(error);
+    }
     Ok(())
 }
 
-#[cfg(not(unix))]
-fn set_file_permissions(_path: &Path) -> Result<(), std::io::Error> {
-    Ok(())
+fn create_config_temp_file(path: &Path) -> Result<File, std::io::Error> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_old_config_without_leaving_temporary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_file_path(dir.path());
+        fs::write(&path, "old config").unwrap();
+
+        write_config_file(dir.path(), "new config").unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "new config");
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn existing_temporary_file_is_preserved_on_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_file_path(dir.path());
+        let tmp_path = dir.path().join("collision.tmp");
+        fs::write(&path, "old config").unwrap();
+        fs::write(&tmp_path, "other writer").unwrap();
+
+        let error = write_config_at(&path, &tmp_path, "secret").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read_to_string(tmp_path).unwrap(), "other writer");
+        assert_eq!(fs::read_to_string(path).unwrap(), "old config");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temporary_symlink_is_rejected_without_changing_target() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let tmp_path = dir.path().join("collision.tmp");
+        fs::write(&target, "unrelated").unwrap();
+        symlink(&target, &tmp_path).unwrap();
+
+        let error =
+            write_config_at(&config_file_path(dir.path()), &tmp_path, "secret").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(tmp_path.is_symlink());
+        assert_eq!(fs::read_to_string(target).unwrap(), "unrelated");
+    }
+
+    #[test]
+    fn rename_failure_removes_temporary_file_and_preserves_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_file_path(dir.path());
+        let tmp_path = dir.path().join("config.tmp");
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("keep"), "original").unwrap();
+
+        assert!(write_config_at(&path, &tmp_path, "secret").is_err());
+
+        assert!(!tmp_path.exists());
+        assert_eq!(fs::read_to_string(path.join("keep")).unwrap(), "original");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn permissive_umask_keeps_new_and_replaced_config_private() {
+        use std::os::unix::fs::PermissionsExt;
+        run_isolated(
+            "permissive_umask_keeps_new_and_replaced_config_private",
+            "umask 000",
+        );
+        if std::env::var_os("SABIQL_CONFIG_FILE_CHILD").is_none() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let tmp_path = dir.path().join("new.tmp");
+
+        let file = create_config_temp_file(&tmp_path).unwrap();
+
+        assert_eq!(file.metadata().unwrap().permissions().mode() & 0o777, 0o600);
+        let path = config_file_path(dir.path());
+        fs::write(&path, "old config").unwrap();
+        write_config_file(dir.path(), "secret").unwrap();
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_failure_removes_temporary_file_and_preserves_old_config() {
+        run_isolated(
+            "write_failure_removes_temporary_file_and_preserves_old_config",
+            "ulimit -f 0; trap '' XFSZ",
+        );
+        if std::env::var_os("SABIQL_CONFIG_FILE_CHILD").is_none() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_file_path(dir.path());
+        File::create(&path).unwrap();
+
+        assert!(write_config_file(dir.path(), "secret").is_err());
+
+        assert_eq!(fs::read(path).unwrap(), b"");
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    fn run_isolated(test: &str, setup: &str) {
+        use std::process::Command;
+        if std::env::var_os("SABIQL_CONFIG_FILE_CHILD").is_some() {
+            return;
+        }
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(format!("{setup}; exec \"$1\" --exact \"$2\""))
+            .arg("config-file-test")
+            .arg(std::env::current_exe().unwrap())
+            .arg(format!("adapters::app_config_file::tests::{test}"))
+            .env("SABIQL_CONFIG_FILE_CHILD", "1")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
 }


### PR DESCRIPTION
## Problem

Saving connection settings could briefly expose a plaintext temporary file under a permissive umask. A pre-existing temporary path could also be overwritten or followed as a symlink.

## Approach

Create temporary files exclusively with owner-only permissions on Unix before writing any credentials. Preserve collisions untouched, remove owned temporary files after write or rename failure, and retain atomic replacement of the saved configuration.

## Validation

- Six focused filesystem tests, including creation under umask 000, collision and symlink rejection, write failure under a subprocess file-size limit, rename failure, and replacement.
- All 19 connection-store tests passed.
- Targeted infra Clippy, workspace format check, and custom lint suite passed.
- Full workspace validation is delegated to PR CI. No cloud connections or resources were used; Windows ACL guarantees are outside this change.
