### PR TITLE
fix: merge PostgreSQL service files by name

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -329,17 +329,15 @@ pub(in crate::cmd) async fn run(
                     Ok(p) => (p, None),
                     Err(e) => (vec![], Some(e.to_string())),
                 };
-                let (services, service_file_path, service_load_warning) =
-                    match reader.read_services() {
-                        Ok((s, p)) => (s, Some(p), None),
-                        Err(ServiceFileError::NotFound(_)) => (vec![], None, None),
-                        Err(e) => (vec![], None, Some(e.to_string())),
-                    };
+                let (services, service_load_warning) = match reader.read_services() {
+                    Ok(contents) => (contents.entries, contents.warning.map(|e| e.to_string())),
+                    Err(ServiceFileError::NotFound(_)) => (vec![], None),
+                    Err(e) => (vec![], Some(e.to_string())),
+                };
 
                 tx.blocking_send(Action::ConnectionsLoaded(ConnectionsLoadedPayload {
                     profiles,
                     services,
-                    service_file_path,
                     profile_load_warning,
                     service_load_warning,
                 }))
@@ -1280,6 +1278,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.set_service_entries(vec![ServiceEntry {
                 service_name: "analytics".to_string(),
+                source_path: "/etc/pg_service.conf".into(),
             }]);
             let expected_id = state.service_entries()[0].connection_id();
             let mut renderer = NoopRenderer;

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -11,7 +11,7 @@ use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::effect::Effect;
 use crate::cmd::runner::{ConnectionDeps, EffectRunner, ErDeps, QueryDeps, UtilityDeps};
 use crate::domain::SqliteDiagnosticsSnapshot;
-use crate::domain::connection::{ConnectionProfile, ServiceEntry};
+use crate::domain::connection::ConnectionProfile;
 use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::domain::{
     DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource, QueryValue,
@@ -25,8 +25,8 @@ use crate::ports::outbound::{
     ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter,
     FolderOpener, MetadataProvider, MySqlConnectionProbe, MySqlConnectionProbeResult,
     PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore, RenderOutput,
-    RenderResult, Renderer, ServiceFileError, SettingsStore, SettingsStoreError,
-    SqliteDiagnosticsProvider, SqlitePathValidator,
+    RenderResult, Renderer, ServiceFileContents, ServiceFileError, SettingsStore,
+    SettingsStoreError, SqliteDiagnosticsProvider, SqlitePathValidator,
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -142,8 +142,11 @@ impl MySqlConnectionProbe for NoopMySqlConnectionProbe {
 
 pub struct NoopPgServiceEntryReader;
 impl PgServiceEntryReader for NoopPgServiceEntryReader {
-    fn read_services(&self) -> Result<(Vec<ServiceEntry>, PathBuf), ServiceFileError> {
-        Ok((vec![], PathBuf::new()))
+    fn read_services(&self) -> Result<ServiceFileContents, ServiceFileError> {
+        Ok(ServiceFileContents {
+            entries: vec![],
+            warning: None,
+        })
     }
 }
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Instant;
 
 use super::explain_context::ExplainContext;
@@ -50,7 +50,6 @@ pub struct AppState {
 
     pub session: BrowseSession,
     project_name: String,
-    service_file_path: Option<PathBuf>,
     pub ui: UiState,
     pub query: QueryExecution,
     pub sql_modal: SqlModalContext,
@@ -86,7 +85,6 @@ impl AppState {
             render_dirty: true,
             session: BrowseSession::default(),
             project_name,
-            service_file_path: None,
             ui: UiState::new(),
             query: QueryExecution::default(),
             sql_modal: SqlModalContext::default(),
@@ -118,11 +116,11 @@ impl AppState {
     }
 
     pub fn service_file_path(&self) -> Option<&Path> {
-        self.service_file_path.as_deref()
-    }
-
-    pub fn set_service_file_path(&mut self, path: Option<PathBuf>) {
-        self.service_file_path = path;
+        let id = self.session.active_connection_id()?;
+        self.service_entries
+            .iter()
+            .find(|entry| &entry.connection_id() == id)
+            .map(|entry| entry.source_path.as_path())
     }
 
     pub fn input_mode(&self) -> InputMode {
@@ -1594,6 +1592,7 @@ mod tests {
         fn make_service(name: &str) -> ServiceEntry {
             ServiceEntry {
                 service_name: name.to_string(),
+                source_path: "/etc/pg_service.conf".into(),
             }
         }
 

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -43,7 +43,7 @@ pub use mysql_connection_probe::{MySqlConnectionProbe, MySqlConnectionProbeResul
 pub use query_executor::QueryExecutor;
 pub use query_history::{QueryHistoryError, QueryHistoryStore};
 pub use renderer::{CellDetailViewport, RenderError, RenderOutput, RenderResult, Renderer};
-pub use service_file::{PgServiceEntryReader, ServiceFileError};
+pub use service_file::{PgServiceEntryReader, ServiceFileContents, ServiceFileError};
 pub use settings_store::{AppSettings, SettingsStore, SettingsStoreError};
 pub use sqlite_diagnostics::SqliteDiagnosticsProvider;
 pub use sqlite_path_validator::SqlitePathValidator;

--- a/src/app/ports/outbound/service_file.rs
+++ b/src/app/ports/outbound/service_file.rs
@@ -15,7 +15,12 @@ pub enum ServiceFileError {
     },
 }
 
+pub struct ServiceFileContents {
+    pub entries: Vec<ServiceEntry>,
+    pub warning: Option<ServiceFileError>,
+}
+
 #[cfg_attr(test, mockall::automock)]
 pub trait PgServiceEntryReader: Send + Sync {
-    fn read_services(&self) -> Result<(Vec<ServiceEntry>, PathBuf), ServiceFileError>;
+    fn read_services(&self) -> Result<ServiceFileContents, ServiceFileError>;
 }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -224,7 +224,6 @@ pub struct ErDiagramInfo {
 pub struct ConnectionsLoadedPayload {
     pub profiles: Vec<ConnectionProfile>,
     pub services: Vec<ServiceEntry>,
-    pub service_file_path: Option<std::path::PathBuf>,
     pub profile_load_warning: Option<String>,
     pub service_load_warning: Option<String>,
 }

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -37,7 +37,6 @@ pub(in crate::update) fn reduce_connection_list(
         Action::ConnectionsLoaded(ConnectionsLoadedPayload {
             profiles,
             services,
-            service_file_path,
             profile_load_warning,
             service_load_warning,
         }) => {
@@ -48,7 +47,6 @@ pub(in crate::update) fn reduce_connection_list(
                     .cmp(&b.display_name().to_lowercase())
             });
             state.set_connections_and_services(sorted, services.clone());
-            state.set_service_file_path(service_file_path.clone());
 
             if let Some(warning) = profile_load_warning {
                 state.messages.set_error(warning.clone());
@@ -224,7 +222,6 @@ mod tests {
                 &Action::ConnectionsLoaded(ConnectionsLoadedPayload {
                     profiles,
                     services: vec![],
-                    service_file_path: None,
                     profile_load_warning: None,
                     service_load_warning: None,
                 }),
@@ -247,7 +244,6 @@ mod tests {
                 &Action::ConnectionsLoaded(ConnectionsLoadedPayload {
                     profiles,
                     services: vec![],
-                    service_file_path: None,
                     profile_load_warning: None,
                     service_load_warning: None,
                 }),
@@ -267,8 +263,10 @@ mod tests {
                 &mut state,
                 &Action::ConnectionsLoaded(ConnectionsLoadedPayload {
                     profiles: vec![],
-                    services: vec![],
-                    service_file_path: Some(path.clone()),
+                    services: vec![crate::domain::connection::ServiceEntry {
+                        service_name: "system".into(),
+                        source_path: path.clone(),
+                    }],
                     profile_load_warning: None,
                     service_load_warning: None,
                 }),
@@ -276,7 +274,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.service_file_path(), Some(path.as_path()));
+            assert_eq!(state.service_entries()[0].source_path, path);
         }
 
         #[test]
@@ -288,7 +286,6 @@ mod tests {
                 &Action::ConnectionsLoaded(ConnectionsLoadedPayload {
                     profiles: vec![],
                     services: vec![],
-                    service_file_path: None,
                     profile_load_warning: None,
                     service_load_warning: Some("parse error at line 5".to_string()),
                 }),

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -207,6 +207,7 @@ mod tests {
 
     mod connections_loaded {
         use super::*;
+        use crate::domain::connection::ServiceEntry;
 
         #[test]
         fn sorts_connections_by_name_case_insensitive() {
@@ -263,7 +264,7 @@ mod tests {
                 &mut state,
                 &Action::ConnectionsLoaded(ConnectionsLoadedPayload {
                     profiles: vec![],
-                    services: vec![crate::domain::connection::ServiceEntry {
+                    services: vec![ServiceEntry {
                         service_name: "system".into(),
                         source_path: path.clone(),
                     }],

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -644,6 +644,7 @@ mod tests {
                 vec![profile],
                 vec![ServiceEntry {
                     service_name: "mydb".to_string(),
+                    source_path: "/etc/pg_service.conf".into(),
                 }],
             );
             state.modal.set_mode(InputMode::Normal);

--- a/src/domain/connection/service_entry.rs
+++ b/src/domain/connection/service_entry.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::path::PathBuf;
 
 use super::ConnectionId;
 
@@ -7,6 +8,7 @@ const SERVICE_ID_PREFIX: &str = "service:";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceEntry {
     pub service_name: String,
+    pub source_path: PathBuf,
 }
 
 impl ServiceEntry {
@@ -32,6 +34,7 @@ mod tests {
     fn sample() -> ServiceEntry {
         ServiceEntry {
             service_name: "mydb".to_string(),
+            source_path: "/etc/pg_service.conf".into(),
         }
     }
 

--- a/src/infra/adapters/postgres/pg_service.rs
+++ b/src/infra/adapters/postgres/pg_service.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::app::ports::outbound::service_file::{PgServiceEntryReader, ServiceFileError};
+use crate::app::ports::outbound::service_file::{
+    PgServiceEntryReader, ServiceFileContents, ServiceFileError,
+};
 use crate::domain::connection::ServiceEntry;
 
 #[derive(Default)]
@@ -14,62 +16,91 @@ impl PgServiceFileReader {
 }
 
 impl PgServiceEntryReader for PgServiceFileReader {
-    fn read_services(&self) -> Result<(Vec<ServiceEntry>, PathBuf), ServiceFileError> {
-        let path = find_service_file()?;
-        let content =
-            std::fs::read_to_string(&path).map_err(|source| ServiceFileError::ReadAt {
-                path: path.clone(),
-                source: Arc::new(source),
-            })?;
-        let entries = parse(&content);
-        Ok((entries, path))
+    fn read_services(&self) -> Result<ServiceFileContents, ServiceFileError> {
+        let service_file = std::env::var_os("PGSERVICEFILE").map(PathBuf::from);
+        let sysconfdir = std::env::var_os("PGSYSCONFDIR").map(PathBuf::from);
+        let (user, system) = service_file_paths(
+            service_file.clone(),
+            user_service_file_path(),
+            sysconfdir,
+            || {
+                std::process::Command::new("pg_config")
+                    .arg("--sysconfdir")
+                    .output()
+                    .ok()
+                    .filter(|output| output.status.success())
+                    .map(|output| PathBuf::from(String::from_utf8_lossy(&output.stdout).trim()))
+            },
+        );
+        read_service_files(user.as_deref(), service_file.is_some(), system.as_deref())
     }
 }
 
-fn find_service_file() -> Result<PathBuf, ServiceFileError> {
-    if let Ok(val) = std::env::var("PGSERVICEFILE") {
-        let path = PathBuf::from(&val);
-        if path.is_file() {
-            return Ok(path);
+fn service_file_paths(
+    service_file: Option<PathBuf>,
+    default_user: Option<PathBuf>,
+    sysconfdir: Option<PathBuf>,
+    default_sysconfdir: impl FnOnce() -> Option<PathBuf>,
+) -> (Option<PathBuf>, Option<PathBuf>) {
+    (
+        service_file.or(default_user),
+        sysconfdir
+            .or_else(default_sysconfdir)
+            .map(|dir| dir.join("pg_service.conf")),
+    )
+}
+
+fn read_service_files(
+    user: Option<&Path>,
+    explicit_user: bool,
+    system: Option<&Path>,
+) -> Result<ServiceFileContents, ServiceFileError> {
+    let mut entries = Vec::new();
+    let mut found = false;
+    if let Some(path) = user
+        && let Some(content) = read_service_file(path, explicit_user)?
+    {
+        found = true;
+        entries = parse(&content, path);
+    }
+    let mut warning = None;
+    if let Some(path) = system {
+        match read_service_file(path, false) {
+            Ok(Some(content)) => {
+                found = true;
+                for entry in parse(&content, path) {
+                    if !entries
+                        .iter()
+                        .any(|user| user.service_name == entry.service_name)
+                    {
+                        entries.push(entry);
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(error) if !entries.is_empty() => warning = Some(error),
+            Err(error) => return Err(error),
         }
+    }
+    if !found {
         return Err(ServiceFileError::NotFound(format!(
-            "PGSERVICEFILE={val} does not exist"
+            "No pg_service.conf found (user: {}, system: {}; PGSERVICEFILE / PGSYSCONFDIR or pg_config --sysconfdir)",
+            user.map_or_else(|| "unavailable".into(), |path| path.display().to_string()),
+            system.map_or_else(|| "unavailable".into(), |path| path.display().to_string()),
         )));
     }
-
-    let user_service_path = user_service_file_path();
-    if let Some(path) = &user_service_path
-        && path.is_file()
-    {
-        return Ok(path.clone());
-    }
-
-    if let Some(output) = std::process::Command::new("pg_config")
-        .arg("--sysconfdir")
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-    {
-        let sysconfdir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let path = PathBuf::from(&sysconfdir).join("pg_service.conf");
-        if path.is_file() {
-            return Ok(path);
-        }
-    }
-
-    Err(ServiceFileError::NotFound(service_file_not_found_message(
-        user_service_path.as_deref(),
-    )))
+    Ok(ServiceFileContents { entries, warning })
 }
 
-fn service_file_not_found_message(user_service_path: Option<&Path>) -> String {
-    let user_path_hint = user_service_path.map_or_else(
-        || "the platform user config path".to_string(),
-        |path| path.display().to_string(),
-    );
-    format!(
-        "No pg_service.conf found (checked PGSERVICEFILE, {user_path_hint}, and pg_config --sysconfdir)"
-    )
+fn read_service_file(path: &Path, required: bool) -> Result<Option<String>, ServiceFileError> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(error) if !required && error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(ServiceFileError::ReadAt {
+            path: path.to_path_buf(),
+            source: Arc::new(source),
+        }),
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -92,7 +123,7 @@ fn unix_user_service_file_path(home_dir: &Path) -> PathBuf {
     home_dir.join(".pg_service.conf")
 }
 
-fn parse(content: &str) -> Vec<ServiceEntry> {
+fn parse(content: &str, path: &Path) -> Vec<ServiceEntry> {
     let mut entries: Vec<ServiceEntry> = Vec::new();
     let mut current: Option<ServiceEntry> = None;
 
@@ -108,7 +139,10 @@ fn parse(content: &str) -> Vec<ServiceEntry> {
                 entries.push(entry);
             }
             let name = line[1..line.len() - 1].trim().to_string();
-            current = Some(ServiceEntry { service_name: name });
+            current = Some(ServiceEntry {
+                service_name: name,
+                source_path: path.to_path_buf(),
+            });
         }
     }
 
@@ -116,10 +150,10 @@ fn parse(content: &str) -> Vec<ServiceEntry> {
         entries.push(entry);
     }
 
-    // Duplicate sections: last one wins (PostgreSQL convention)
+    // libpq uses the first matching section.
     let mut seen = std::collections::HashMap::new();
     for (i, entry) in entries.iter().enumerate() {
-        seen.insert(entry.service_name.clone(), i);
+        seen.entry(entry.service_name.clone()).or_insert(i);
     }
     let mut unique_indices: Vec<usize> = seen.into_values().collect();
     unique_indices.sort_unstable();
@@ -132,14 +166,10 @@ fn parse(content: &str) -> Vec<ServiceEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Guards env-var–mutating tests so they don't race each other.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn empty_content_returns_no_entries() {
-        assert_eq!(parse(""), Vec::new());
+        assert_eq!(parse("", Path::new("/test")), Vec::new());
     }
 
     #[test]
@@ -151,7 +181,7 @@ port=5432
 dbname=mydb
 user=admin
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
     }
@@ -168,7 +198,7 @@ host=prod.example.com
 dbname=proddb
 port=5433
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 2);
         assert_eq!(
             entries
@@ -191,7 +221,7 @@ host=localhost
 # inline section comment
 port=5432
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
     }
@@ -204,25 +234,29 @@ host=localhost
 this is not a valid line
 port=5432
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
     }
 
     #[test]
-    fn duplicate_sections_are_collapsed() {
+    fn duplicate_sections_preserve_first_occurrence_order() {
         let content = "\
 [mydb]
 host=first.example.com
 port=5432
 
+[other]
+host=other.example.com
+
 [mydb]
 host=second.example.com
 port=5433
 ";
-        let entries = parse(content);
-        assert_eq!(entries.len(), 1);
+        let entries = parse(content, Path::new("/test"));
+        assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].service_name, "mydb");
+        assert_eq!(entries[1].service_name, "other");
     }
 
     #[test]
@@ -230,7 +264,7 @@ port=5433
         let content = "\
 [empty]
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "empty");
     }
@@ -244,7 +278,7 @@ port=1234
 [mydb]
 host=localhost
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
     }
@@ -258,7 +292,7 @@ sslmode=require
 connect_timeout=10
 application_name=myapp
 ";
-        let entries = parse(content);
+        let entries = parse(content, Path::new("/test"));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].service_name, "mydb");
     }
@@ -282,59 +316,159 @@ application_name=myapp
     }
 
     #[test]
-    fn not_found_message_includes_resolved_user_service_file_path() {
-        let path = Path::new(r"C:\Users\test\AppData\Roaming\postgresql\.pg_service.conf");
+    fn user_services_override_duplicates_and_keep_system_only_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("user");
+        let system = dir.path().join("system");
+        std::fs::write(&user, "[shared]\nhost=user\n[user_only]\n").unwrap();
+        std::fs::write(&system, "[shared]\nhost=system\n[system_only]\n").unwrap();
 
-        let message = service_file_not_found_message(Some(path));
+        let result = read_service_files(Some(&user), false, Some(&system)).unwrap();
 
-        assert!(message.contains(&path.display().to_string()));
+        assert_eq!(
+            result
+                .entries
+                .iter()
+                .map(|e| e.service_name.as_str())
+                .collect::<Vec<_>>(),
+            ["shared", "user_only", "system_only"]
+        );
+        assert_eq!(result.entries[0].source_path, user);
+        assert_eq!(result.entries[2].source_path, system);
+        assert_eq!(result.entries[2].to_string(), "service=system_only");
+        assert!(result.warning.is_none());
     }
 
     #[test]
-    fn find_service_file_uses_pgservicefile_env() {
-        let _guard = ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    fn missing_default_user_still_lists_system_services() {
+        let dir = tempfile::tempdir().unwrap();
+        let system = dir.path().join("system");
+        std::fs::write(&system, "[system_only]\n").unwrap();
 
-        let tmpdir = std::env::temp_dir();
-        let path = tmpdir.join("test_pg_service.conf");
-        std::fs::write(&path, "[test]\nhost=localhost\n").unwrap();
+        let result =
+            read_service_files(Some(&dir.path().join("missing")), false, Some(&system)).unwrap();
 
-        let original = std::env::var("PGSERVICEFILE").ok();
-        // SAFETY: test-only, serialized by ENV_LOCK
-        unsafe { std::env::set_var("PGSERVICEFILE", &path) };
-
-        let result = find_service_file();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), path);
-
-        unsafe {
-            match original {
-                Some(val) => std::env::set_var("PGSERVICEFILE", val),
-                None => std::env::remove_var("PGSERVICEFILE"),
-            }
-        }
-        std::fs::remove_file(&path).ok();
+        assert_eq!(result.entries[0].service_name, "system_only");
+        assert_eq!(result.entries[0].source_path, system);
     }
 
     #[test]
-    fn find_service_file_errors_when_pgservicefile_missing() {
-        let _guard = ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    fn missing_explicit_user_does_not_fall_back_to_system() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing");
+        let system = dir.path().join("system");
+        std::fs::write(&system, "[system_only]\n").unwrap();
 
-        let original = std::env::var("PGSERVICEFILE").ok();
-        // SAFETY: test-only, serialized by ENV_LOCK
-        unsafe { std::env::set_var("PGSERVICEFILE", "/nonexistent/path/pg_service.conf") };
+        let result = read_service_files(Some(&missing), true, Some(&system));
 
-        let result = find_service_file();
-        assert!(result.is_err());
+        assert!(matches!(result, Err(ServiceFileError::ReadAt {path, ..}) if path == missing));
+    }
 
-        unsafe {
-            match original {
-                Some(val) => std::env::set_var("PGSERVICEFILE", val),
-                None => std::env::remove_var("PGSERVICEFILE"),
-            }
+    #[test]
+    fn absent_files_report_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let result = read_service_files(
+            Some(&dir.path().join("user")),
+            false,
+            Some(&dir.path().join("system")),
+        );
+
+        assert!(matches!(result, Err(ServiceFileError::NotFound(_))));
+    }
+
+    #[test]
+    fn unreadable_user_reports_source_path_without_system_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("user");
+        std::fs::write(&user, [0xff]).unwrap();
+
+        let result = read_service_files(Some(&user), false, None);
+
+        assert!(matches!(result, Err(ServiceFileError::ReadAt {path, ..}) if path == user));
+    }
+
+    #[test]
+    fn unreadable_system_preserves_user_services_with_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("user");
+        let system = dir.path().join("system");
+        std::fs::write(&user, "[user_only]\n").unwrap();
+        std::fs::write(&system, [0xff]).unwrap();
+
+        let result = read_service_files(Some(&user), false, Some(&system)).unwrap();
+
+        assert_eq!(result.entries[0].service_name, "user_only");
+        assert!(
+            matches!(result.warning, Some(ServiceFileError::ReadAt {path, ..}) if path == system)
+        );
+    }
+
+    #[test]
+    fn environment_paths_replace_defaults_without_pg_config_lookup() {
+        let (user, system) = service_file_paths(
+            Some("/custom/user".into()),
+            Some("/home/default".into()),
+            Some("/custom/system".into()),
+            || panic!("pg_config must not run"),
+        );
+
+        assert_eq!(user, Some("/custom/user".into()));
+        assert_eq!(
+            system,
+            Some(PathBuf::from("/custom/system/pg_service.conf"))
+        );
+    }
+
+    #[test]
+    fn absent_environment_uses_platform_user_and_pg_config_directory() {
+        let (user, system) = service_file_paths(None, Some("/home/default".into()), None, || {
+            Some("/postgres/etc".into())
+        });
+
+        assert_eq!(user, Some("/home/default".into()));
+        assert_eq!(system, Some(PathBuf::from("/postgres/etc/pg_service.conf")));
+    }
+    #[test]
+    fn environment_overrides_load_both_files_through_reader() {
+        const CHILD: &str = "SABIQL_CF06_SERVICE_READER_CHILD";
+        if std::env::var_os(CHILD).is_some() {
+            let result = PgServiceFileReader::new().read_services().unwrap();
+            assert_eq!(
+                result
+                    .entries
+                    .iter()
+                    .map(|e| e.service_name.as_str())
+                    .collect::<Vec<_>>(),
+                ["custom_user", "custom_system"]
+            );
+            assert_eq!(
+                result.entries[0].source_path,
+                PathBuf::from(std::env::var_os("PGSERVICEFILE").unwrap())
+            );
+            assert_eq!(
+                result.entries[1].source_path,
+                PathBuf::from(std::env::var_os("PGSYSCONFDIR").unwrap()).join("pg_service.conf")
+            );
+            return;
         }
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("custom.conf");
+        std::fs::write(&user, "[custom_user]\n").unwrap();
+        std::fs::write(dir.path().join("pg_service.conf"), "[custom_system]\n").unwrap();
+
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "adapters::postgres::pg_service::tests::environment_overrides_load_both_files_through_reader", "--nocapture"])
+            .env(CHILD, "1")
+            .env("PGSERVICEFILE", &user)
+            .env("PGSYSCONFDIR", dir.path())
+            .output().unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,11 +457,13 @@ fn dispatch_overflow_fallback(
 
 fn load_service_entries(state: &mut AppState, reader: &dyn PgServiceEntryReader) {
     match reader.read_services() {
-        Ok((services, path)) if !services.is_empty() => {
-            state.set_service_entries(services);
-            state.set_service_file_path(Some(path));
+        Ok(contents) => {
+            state.set_service_entries(contents.entries);
+            if let Some(warning) = contents.warning {
+                state.messages.set_error(warning.to_string());
+            }
         }
-        Ok(_) | Err(ServiceFileError::NotFound(_)) => {}
+        Err(ServiceFileError::NotFound(_)) => {}
         Err(e) => {
             state.messages.set_error(e.to_string());
         }

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -391,12 +391,15 @@ fn render_service_error_without_service_file_hint(save_and_connect: bool) -> Str
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();
     state.session.activate_connection_with_dsn(
-        &sabiql_domain::ConnectionId::from_string("service"),
+        &sabiql_domain::ConnectionId::from_string("service:mydb"),
         "service",
         DatabaseType::PostgreSQL,
         "service=mydb",
     );
-    state.set_service_file_path(Some(std::path::PathBuf::from("/etc/pg_service.conf")));
+    state.set_service_entries(vec![sabiql_domain::connection::ServiceEntry {
+        service_name: "mydb".into(),
+        source_path: "/etc/pg_service.conf".into(),
+    }]);
     if save_and_connect {
         state.connection_error.set_save_and_connect_error(
             ConnectionErrorInfo::from_db_operation_error(&DbOperationError::ConnectionFailed(
@@ -539,4 +542,49 @@ fn footer_shows_success_message() {
     let output = render_to_string(&mut terminal, &mut state);
 
     insta::assert_snapshot!(output);
+}
+
+#[test]
+fn service_connection_error_shows_selected_source_path() {
+    use sabiql_domain::connection::ServiceEntry;
+
+    let entries = vec![
+        ServiceEntry {
+            service_name: "user".into(),
+            source_path: "/home/me/.pg_service.conf".into(),
+        },
+        ServiceEntry {
+            service_name: "system".into(),
+            source_path: "/etc/pg_service.conf".into(),
+        },
+    ];
+    for selected in &entries {
+        let mut state = create_test_state();
+        let mut terminal = create_test_terminal();
+        state.set_service_entries(entries.clone());
+        state.session.activate_connection_with_dsn(
+            &selected.connection_id(),
+            &selected.service_name,
+            DatabaseType::PostgreSQL,
+            &selected.to_string(),
+        );
+        state
+            .connection_error
+            .set_error(ConnectionErrorInfo::from_db_operation_error(
+                &DbOperationError::ConnectionFailed("connection refused".into()),
+            ));
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        let output = render_to_string(&mut terminal, &mut state);
+
+        assert!(
+            output.contains(&format!("(edit {})", selected.source_path.display())),
+            "{output}"
+        );
+        let other = entries
+            .iter()
+            .find(|entry| entry.service_name != selected.service_name)
+            .unwrap();
+        assert!(!output.contains(&other.source_path.display().to_string()));
+    }
 }

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -5,6 +5,7 @@ use crate::tests::harness::{
 use sabiql_app::model::shared::settings::KeymapPreset;
 use sabiql_app::ports::outbound::DsnBuilder;
 use sabiql_domain::ConnectionProfile;
+use sabiql_domain::connection::ServiceEntry;
 
 struct EmptyPasswordDsnBuilder;
 
@@ -396,7 +397,7 @@ fn render_service_error_without_service_file_hint(save_and_connect: bool) -> Str
         DatabaseType::PostgreSQL,
         "service=mydb",
     );
-    state.set_service_entries(vec![sabiql_domain::connection::ServiceEntry {
+    state.set_service_entries(vec![ServiceEntry {
         service_name: "mydb".into(),
         source_path: "/etc/pg_service.conf".into(),
     }]);
@@ -546,8 +547,6 @@ fn footer_shows_success_message() {
 
 #[test]
 fn service_connection_error_shows_selected_source_path() {
-    use sabiql_domain::connection::ServiceEntry;
-
     let entries = vec![
         ServiceEntry {
             service_name: "user".into(),

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -73,9 +73,11 @@ fn connection_selector_with_service_entries() {
         vec![
             ServiceEntry {
                 service_name: "dev-db".to_string(),
+                source_path: "/etc/pg_service.conf".into(),
             },
             ServiceEntry {
                 service_name: "prod-replica".to_string(),
+                source_path: "/etc/pg_service.conf".into(),
             },
         ],
     );
@@ -101,9 +103,11 @@ fn connection_selector_with_long_service_name() {
     state.set_service_entries(vec![
         ServiceEntry {
             service_name: "my-very-long-service-name-that-exceeds-normal-length".to_string(),
+            source_path: "/etc/pg_service.conf".into(),
         },
         ServiceEntry {
             service_name: "short".to_string(),
+            source_path: "/etc/pg_service.conf".into(),
         },
     ]);
     state.modal.set_mode(InputMode::ConnectionSelector);
@@ -122,9 +126,11 @@ fn connection_selector_with_active_service() {
     state.set_service_entries(vec![
         ServiceEntry {
             service_name: "dev-local".to_string(),
+            source_path: "/etc/pg_service.conf".into(),
         },
         ServiceEntry {
             service_name: "prod-replica".to_string(),
+            source_path: "/etc/pg_service.conf".into(),
         },
     ]);
     // Set active connection to the first service entry
@@ -151,6 +157,7 @@ fn connection_selector_with_multibyte_service_name() {
 
     state.set_service_entries(vec![ServiceEntry {
         service_name: "本番データベース接続".to_string(),
+        source_path: "/etc/pg_service.conf".into(),
     }]);
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));


### PR DESCRIPTION
## Problem

PostgreSQL services defined only in the system file disappeared from the selector whenever a user file existed. The connection error hint also assumed every service came from the same file.

## Approach

Merge user and system services by name, with user definitions taking precedence. Honor `PGSERVICEFILE` and `PGSYSCONFDIR`, and carry each service's source into the edit hint while continuing to delegate connection resolution to libpq through `service=NAME`.

A system-file read failure preserves usable user services with a warning; an explicitly selected missing user file remains an error, matching libpq's lookup order.

## Validation

- 20 focused service-reader tests, including environment overrides in an isolated process
- 13 app service tests and 7 selector/error rendering tests
- Targeted Clippy, format check, and custom lints passed
- Full workspace validation runs in CI; no cloud connections or resources used
