### PR TITLE
fix: keep PostgreSQL passwords out of process arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,10 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
         run: cargo nextest run -p sabiql-infra --run-ignored ignored-only -E 'test(provider_classifies_full_and_light_missing_relations_without_losing_empty_tables)' --show-progress=none
+      - name: Verify PostgreSQL password transport with a local protocol fixture
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
+        run: cargo nextest run -p sabiql-infra --run-ignored ignored-only -E 'test(real_libpq_preserves_special_passwords_and_explicit_precedence)' --show-progress=none
       - name: Run Oracle MySQL 8.4 integration tests (Tier 2)
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod settings_store;
 pub(crate) mod sqlite;
 #[cfg(test)]
 pub(crate) mod test_support;
+#[cfg(windows)]
+mod windows_file_security;
 pub use cached_result_exporter::CsvCachedResultExporter;
 pub use clipboard::ArboardClipboard;
 pub use config_writer::FileConfigWriter;

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -361,113 +361,7 @@ fn set_file_permissions(file: &File) -> io::Result<()> {
             "injected ACL failure",
         ));
     }
-    use std::os::windows::io::AsRawHandle;
-    use std::ptr::{null, null_mut};
-
-    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE, LocalFree};
-    use windows_sys::Win32::Security::Authorization::{
-        EXPLICIT_ACCESS_W, GRANT_ACCESS, SetEntriesInAclW, SetSecurityInfo, TRUSTEE_IS_SID,
-        TRUSTEE_IS_USER, TRUSTEE_W,
-    };
-    use windows_sys::Win32::Security::{
-        DACL_SECURITY_INFORMATION, NO_INHERITANCE, PROTECTED_DACL_SECURITY_INFORMATION, TOKEN_QUERY,
-    };
-    use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
-    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
-
-    let mut token: HANDLE = null_mut();
-    let opened = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) };
-    if opened == 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    let sid_result = current_user_sid(token);
-    unsafe {
-        CloseHandle(token);
-    }
-    let mut sid = sid_result?;
-
-    let trustee = TRUSTEE_W {
-        pMultipleTrustee: null_mut(),
-        MultipleTrusteeOperation: 0,
-        TrusteeForm: TRUSTEE_IS_SID,
-        TrusteeType: TRUSTEE_IS_USER,
-        ptstrName: sid.as_mut_ptr().cast(),
-    };
-    let access = EXPLICIT_ACCESS_W {
-        grfAccessPermissions: FILE_GENERIC_READ | FILE_GENERIC_WRITE,
-        grfAccessMode: GRANT_ACCESS,
-        grfInheritance: NO_INHERITANCE,
-        Trustee: trustee,
-    };
-    let mut acl = null_mut();
-    let status = unsafe { SetEntriesInAclW(1, &raw const access, null(), &raw mut acl) };
-    if status != ERROR_SUCCESS {
-        return Err(io::Error::from_raw_os_error(status as i32));
-    }
-
-    let status = unsafe {
-        SetSecurityInfo(
-            file.as_raw_handle(),
-            windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-            null_mut(),
-            null_mut(),
-            acl,
-            null(),
-        )
-    };
-    unsafe {
-        LocalFree(acl.cast());
-    }
-    if status != ERROR_SUCCESS {
-        return Err(io::Error::from_raw_os_error(status as i32));
-    }
-
-    Ok(())
-}
-
-#[cfg(windows)]
-fn current_user_sid(token: windows_sys::Win32::Foundation::HANDLE) -> io::Result<Vec<u8>> {
-    use std::ptr::null_mut;
-
-    use windows_sys::Win32::Security::{
-        CopySid, GetLengthSid, GetTokenInformation, TOKEN_USER, TokenUser,
-    };
-
-    let mut required_size = 0;
-    unsafe {
-        GetTokenInformation(token, TokenUser, null_mut(), 0, &raw mut required_size);
-    }
-    if required_size == 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    let word_count = (required_size as usize).div_ceil(size_of::<u64>());
-    let mut buffer = vec![0_u64; word_count];
-    let success = unsafe {
-        GetTokenInformation(
-            token,
-            TokenUser,
-            buffer.as_mut_ptr().cast(),
-            required_size,
-            &raw mut required_size,
-        )
-    };
-    if success == 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    let token_user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
-    let sid_length = unsafe { GetLengthSid(token_user.User.Sid) };
-    if sid_length == 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let mut sid = vec![0_u8; sid_length as usize];
-    if unsafe { CopySid(sid_length, sid.as_mut_ptr().cast(), token_user.User.Sid) } == 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(sid)
+    crate::adapters::windows_file_security::restrict_to_current_user(file)
 }
 
 impl Drop for MySqlOptionFile {
@@ -904,7 +798,9 @@ ssl-mode = \"REQUIRED\"\n"
             );
         }
         #[cfg(windows)]
-        assert_owner_only_acl(&option_file.path);
+        crate::adapters::windows_file_security::test_support::assert_owner_only_acl(
+            &option_file.path,
+        );
         let path = option_file.path.clone();
         drop(option_file);
         assert!(!path.exists());
@@ -943,115 +839,6 @@ ssl-mode = \"REQUIRED\"\n"
                 if details == "Unable to secure MySQL option file: injected ACL failure"
         ));
         assert!(!path.exists());
-    }
-
-    #[cfg(windows)]
-    fn assert_owner_only_acl(path: &std::path::Path) {
-        use std::os::windows::ffi::OsStrExt;
-        use std::ptr::null_mut;
-
-        use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, LocalFree};
-        use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
-        use windows_sys::Win32::Security::{
-            ACCESS_ALLOWED_ACE, AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid, GetAce,
-            GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
-            PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED, TOKEN_QUERY,
-        };
-        use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
-        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
-
-        let path = path
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect::<Vec<_>>();
-        let mut dacl = null_mut();
-        let mut security_descriptor: PSECURITY_DESCRIPTOR = null_mut();
-        let status = unsafe {
-            GetNamedSecurityInfoW(
-                path.as_ptr(),
-                windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
-                DACL_SECURITY_INFORMATION,
-                null_mut(),
-                null_mut(),
-                &raw mut dacl,
-                null_mut(),
-                &raw mut security_descriptor,
-            )
-        };
-        assert_eq!(status, ERROR_SUCCESS);
-
-        let mut control = 0;
-        let mut revision = 0;
-        assert_ne!(
-            unsafe {
-                GetSecurityDescriptorControl(
-                    security_descriptor,
-                    &raw mut control,
-                    &raw mut revision,
-                )
-            },
-            0
-        );
-        assert_ne!(control & SE_DACL_PROTECTED, 0);
-
-        let mut dacl_present = 0;
-        let mut dacl_defaulted = 0;
-        assert_ne!(
-            unsafe {
-                GetSecurityDescriptorDacl(
-                    security_descriptor,
-                    &raw mut dacl_present,
-                    &raw mut dacl,
-                    &raw mut dacl_defaulted,
-                )
-            },
-            0
-        );
-        assert_ne!(dacl_present, 0);
-        assert!(!dacl.is_null());
-
-        let mut acl_info = windows_sys::Win32::Security::ACL_SIZE_INFORMATION::default();
-        assert_ne!(
-            unsafe {
-                GetAclInformation(
-                    dacl,
-                    (&raw mut acl_info).cast::<std::ffi::c_void>(),
-                    std::mem::size_of_val(&acl_info) as u32,
-                    AclSizeInformation,
-                )
-            },
-            0
-        );
-        assert_eq!(acl_info.AceCount, 1);
-
-        let mut ace = null_mut();
-        assert_ne!(unsafe { GetAce(dacl, 0, &raw mut ace) }, 0);
-        let allowed_ace = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
-        assert_eq!(allowed_ace.Header.AceType, 0);
-        assert_eq!(allowed_ace.Header.AceFlags, 0);
-        assert_eq!(
-            allowed_ace.Mask & (FILE_GENERIC_READ | FILE_GENERIC_WRITE),
-            FILE_GENERIC_READ | FILE_GENERIC_WRITE
-        );
-        let ace_sid = std::ptr::addr_of!(allowed_ace.SidStart).cast_mut().cast();
-        let mut token = null_mut();
-        assert_ne!(
-            unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) },
-            0
-        );
-        let current_sid = current_user_sid(token).unwrap();
-        unsafe {
-            CloseHandle(token);
-        }
-        assert_ne!(
-            unsafe { EqualSid(current_sid.as_ptr().cast_mut().cast(), ace_sid) },
-            0
-        );
-
-        unsafe {
-            LocalFree(security_descriptor.cast());
-        }
     }
 
     #[test]

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -49,12 +49,28 @@ fn push_conninfo_part(parts: &mut Vec<String>, key: &str, value: &str) {
     }
 }
 
-fn quote_conninfo_value(value: &str) -> String {
+pub(super) fn quote_conninfo_value(value: &str) -> String {
     let escaped = value.replace('\\', "\\\\").replace('\'', "\\'");
     format!("'{escaped}'")
 }
 
 fn find_conninfo_value(dsn: &str, key: &str) -> Option<String> {
+    find_conninfo_part(dsn, key).map(|(value, _)| value)
+}
+
+// This scanner serves the quoted conninfo emitted by build_dsn, not arbitrary libpq input.
+pub(super) fn take_explicit_password(dsn: &str) -> Option<(String, String)> {
+    let (password, range) = find_conninfo_part(dsn, "password")?;
+    if password.is_empty() {
+        return None;
+    }
+    let mut connection = dsn.to_string();
+    // An explicit empty password suppresses service/environment defaults while allowing passfile.
+    connection.replace_range(range, "password=''");
+    Some((connection, password))
+}
+
+fn find_conninfo_part(dsn: &str, key: &str) -> Option<(String, std::ops::Range<usize>)> {
     let bytes = dsn.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -78,7 +94,7 @@ fn find_conninfo_value(dsn: &str, key: &str) -> Option<String> {
         i += 1;
         let (value, next) = parse_conninfo_value(dsn, i);
         if candidate.eq_ignore_ascii_case(key) {
-            return Some(value);
+            return Some((value, key_start..next));
         }
         i = next;
     }

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -12,20 +12,27 @@ use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{CommandTag, QueryResult, QuerySource, RefreshScope, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
+use super::super::dsn::{quote_conninfo_value, take_explicit_password};
 use super::error::{classify_cli_spawn_error, classify_query_error};
 use super::parser::{ParseCommandTagError, split_sql_statements};
+use super::passfile::Passfile;
 
 async fn collect_csv_output(
-    mut child: tokio::process::Child,
+    mut process: PsqlProcess,
     path: &Path,
     timeout_duration: Duration,
 ) -> Result<(), DbOperationError> {
+    let file = match tokio::fs::File::create(path).await {
+        Ok(file) => file,
+        Err(error) => {
+            process.stop().await;
+            return Err(DbOperationError::ExportIo(Arc::new(error)));
+        }
+    };
+    let child = process.child.as_mut().expect("owned psql child");
     let mut stdout = child.stdout.take().expect("piped psql stdout");
     let mut stderr_handle = child.stderr.take().expect("piped psql stderr");
 
-    let file = tokio::fs::File::create(path)
-        .await
-        .map_err(|e| DbOperationError::ExportIo(Arc::new(e)))?;
     let mut writer = tokio::io::BufWriter::new(file);
 
     let result = timeout(timeout_duration, async {
@@ -58,6 +65,9 @@ async fn collect_csv_output(
     .await;
 
     drop(writer);
+    if !matches!(&result, Ok(Ok(_))) {
+        process.stop().await;
+    }
     match result {
         Ok(Ok((status, _))) if status.success() => Ok(()),
         Ok(Ok((status, stderr))) => {
@@ -154,9 +164,9 @@ impl PostgresAdapter {
         query_args: &[&str],
         read_only: bool,
     ) -> Result<String, DbOperationError> {
-        let mut cmd = Self::build_psql_command(dsn, extra_args, query_args, read_only);
+        let (mut cmd, passfile) = Self::build_psql_command(dsn, extra_args, query_args, read_only)?;
 
-        Self::collect_output(&mut cmd, self.timeout_secs).await
+        Self::collect_output(&mut cmd, passfile, self.timeout_secs).await
     }
 
     fn build_psql_command(
@@ -164,14 +174,14 @@ impl PostgresAdapter {
         extra_args: &[&str],
         query_args: &[&str],
         read_only: bool,
-    ) -> Command {
+    ) -> Result<(Command, Option<Passfile>), DbOperationError> {
         let mut cmd = Command::new("psql");
         if read_only {
             Self::apply_read_only_pgoptions(&mut cmd);
         }
-        Self::apply_psql_base_args(&mut cmd, dsn);
+        let passfile = Self::apply_psql_base_args(&mut cmd, dsn)?;
         cmd.args(extra_args).args(query_args);
-        cmd
+        Ok((cmd, passfile))
     }
 
     fn apply_read_only_pgoptions(cmd: &mut Command) {
@@ -182,27 +192,42 @@ impl PostgresAdapter {
         cmd.env("PGOPTIONS", merged);
     }
 
-    fn apply_psql_base_args(cmd: &mut Command, dsn: &str) {
-        cmd.arg(dsn)
-            .arg("-X")
+    fn apply_psql_base_args(
+        cmd: &mut Command,
+        dsn: &str,
+    ) -> Result<Option<Passfile>, DbOperationError> {
+        let passfile = if let Some((mut connection, password)) = take_explicit_password(dsn) {
+            let passfile = Passfile::create(&password)?;
+            let path = passfile.path.to_str().ok_or_else(|| {
+                DbOperationError::ConnectionFailed(
+                    "PostgreSQL password file path is not UTF-8".into(),
+                )
+            })?;
+            connection.push_str(" passfile=");
+            connection.push_str(&quote_conninfo_value(path));
+            cmd.arg(connection).env_remove("PGPASSWORD");
+            Some(passfile)
+        } else {
+            cmd.arg(dsn);
+            None
+        };
+        cmd.arg("-X")
             .arg("-v")
             .arg("ON_ERROR_STOP=1")
             .arg("-v")
             .arg("VERBOSITY=verbose")
             .arg("-v")
             .arg("SHOW_CONTEXT=never");
+        Ok(passfile)
     }
 
     async fn collect_output(
         cmd: &mut Command,
+        passfile: Option<Passfile>,
         timeout_secs: u64,
     ) -> Result<String, DbOperationError> {
-        let mut child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(classify_cli_spawn_error)?;
+        let mut process = PsqlProcess::spawn(cmd, passfile)?;
+        let child = process.child.as_mut().expect("owned psql child");
 
         let mut stdout_handle = child.stdout.take().expect("piped psql stdout");
         let mut stderr_handle = child.stderr.take().expect("piped psql stderr");
@@ -227,11 +252,13 @@ impl PostgresAdapter {
 
             Ok::<_, std::io::Error>((status, stdout, stderr))
         })
-        .await
-        .map_err(|e| DbOperationError::Timeout(e.to_string()))?
-        .map_err(|e| DbOperationError::QueryFailed(e.to_string()))?;
-
-        let (status, stdout, stderr) = result;
+        .await;
+        if !matches!(&result, Ok(Ok(_))) {
+            process.stop().await;
+        }
+        let (status, stdout, stderr) = result
+            .map_err(|e| DbOperationError::Timeout(e.to_string()))?
+            .map_err(|e| DbOperationError::QueryFailed(e.to_string()))?;
         if !status.success() {
             return Err(classify_query_error(&stderr, status));
         }
@@ -420,16 +447,11 @@ impl PostgresAdapter {
         path: &std::path::Path,
         read_only: bool,
     ) -> Result<(), DbOperationError> {
-        let mut cmd = Self::build_psql_command(dsn, &["--csv"], &["-c", query], read_only);
+        let (mut cmd, passfile) =
+            Self::build_psql_command(dsn, &["--csv"], &["-c", query], read_only)?;
+        let process = PsqlProcess::spawn(&mut cmd, passfile)?;
 
-        let child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(classify_cli_spawn_error)?;
-
-        collect_csv_output(child, path, Duration::from_secs(self.timeout_secs * 10)).await?;
+        collect_csv_output(process, path, Duration::from_secs(self.timeout_secs * 10)).await?;
 
         Ok(())
     }
@@ -459,6 +481,54 @@ impl PostgresAdapter {
             })
     }
 }
+
+struct PsqlProcess {
+    child: Option<tokio::process::Child>,
+    passfile: Option<Passfile>,
+}
+
+impl PsqlProcess {
+    async fn stop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill().await;
+        }
+    }
+
+    fn spawn(cmd: &mut Command, passfile: Option<Passfile>) -> Result<Self, DbOperationError> {
+        let child = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(classify_cli_spawn_error)?;
+        Ok(Self {
+            child: Some(child),
+            passfile,
+        })
+    }
+}
+
+impl Drop for PsqlProcess {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return;
+        }
+        let _ = child.start_kill();
+        let passfile = self.passfile.take();
+        // Cancellation must keep the secret file owned until the child has been reaped.
+        tokio::spawn(async move {
+            let _ = child.wait().await;
+            drop(passfile);
+        });
+    }
+}
+
+#[cfg(test)]
+#[path = "password_tests.rs"]
+mod password_tests;
 
 #[cfg(test)]
 mod tests {
@@ -700,9 +770,16 @@ mod tests {
                 .spawn()
                 .unwrap();
 
-            collect_csv_output(child, &path, std::time::Duration::from_secs(2))
-                .await
-                .unwrap();
+            collect_csv_output(
+                super::super::PsqlProcess {
+                    child: Some(child),
+                    passfile: None,
+                },
+                &path,
+                std::time::Duration::from_secs(2),
+            )
+            .await
+            .unwrap();
 
             assert_eq!(
                 tokio::fs::read_to_string(path).await.unwrap(),
@@ -725,7 +802,15 @@ mod tests {
                 .spawn()
                 .unwrap();
 
-            let result = collect_csv_output(child, &path, std::time::Duration::from_secs(2)).await;
+            let result = collect_csv_output(
+                super::super::PsqlProcess {
+                    child: Some(child),
+                    passfile: None,
+                },
+                &path,
+                std::time::Duration::from_secs(2),
+            )
+            .await;
 
             assert!(matches!(result, Err(DbOperationError::PermissionDenied(_))));
             assert!(!path.exists());
@@ -744,7 +829,15 @@ mod tests {
                 .spawn()
                 .unwrap();
 
-            let result = collect_csv_output(child, &path, std::time::Duration::from_secs(2)).await;
+            let result = collect_csv_output(
+                super::super::PsqlProcess {
+                    child: Some(child),
+                    passfile: None,
+                },
+                &path,
+                std::time::Duration::from_secs(2),
+            )
+            .await;
 
             assert!(matches!(
                 result,
@@ -767,7 +860,7 @@ mod tests {
             let mut command = Command::new("sh");
             command.args(["-c", "exit 7"]);
 
-            let result = PostgresAdapter::collect_output(&mut command, 2).await;
+            let result = PostgresAdapter::collect_output(&mut command, None, 2).await;
 
             assert!(matches!(
                 result,
@@ -784,7 +877,7 @@ mod tests {
                 "printf 'ERROR:  42501: permission denied\\n' >&2; exit 7",
             ]);
 
-            let result = PostgresAdapter::collect_output(&mut command, 2).await;
+            let result = PostgresAdapter::collect_output(&mut command, None, 2).await;
 
             assert!(matches!(
                 result,
@@ -799,7 +892,7 @@ mod tests {
             command.args(["-c", "exit 0"]);
 
             assert_eq!(
-                PostgresAdapter::collect_output(&mut command, 2)
+                PostgresAdapter::collect_output(&mut command, None, 2)
                     .await
                     .unwrap(),
                 ""
@@ -811,7 +904,7 @@ mod tests {
             let mut command = Command::new("sh");
             command.args(["-c", "kill -TERM $$"]);
 
-            let result = PostgresAdapter::collect_output(&mut command, 2).await;
+            let result = PostgresAdapter::collect_output(&mut command, None, 2).await;
 
             assert!(matches!(
                 result,

--- a/src/infra/adapters/postgres/psql/mod.rs
+++ b/src/infra/adapters/postgres/psql/mod.rs
@@ -1,3 +1,4 @@
 pub(in crate::adapters::postgres) mod error;
 pub(in crate::adapters::postgres) mod executor;
 pub(in crate::adapters::postgres) mod parser;
+mod passfile;

--- a/src/infra/adapters/postgres/psql/passfile.rs
+++ b/src/infra/adapters/postgres/psql/passfile.rs
@@ -12,10 +12,10 @@ pub(super) struct Passfile {
 
 impl Passfile {
     pub(super) fn create(password: &str) -> Result<Self, DbOperationError> {
-        // libpq reads one physical line; escaping LF cannot preserve the password.
-        if password.contains(['\n', '\0']) {
+        // libpq reads physical lines and strips trailing CR; neither can be escaped losslessly.
+        if password.contains(['\n', '\0']) || password.ends_with('\r') {
             return Err(DbOperationError::ConnectionFailed(
-                "PostgreSQL passwords containing LF or NUL cannot be passed through a password file"
+                "PostgreSQL passwords containing LF, NUL, or a trailing CR cannot be passed through a password file"
                     .to_string(),
             ));
         }
@@ -51,8 +51,7 @@ fn write_password(mut file: File, password: &str) -> std::io::Result<()> {
     crate::adapters::windows_file_security::restrict_to_current_user(&file)?;
     let escaped = password.replace('\\', "\\\\").replace(':', "\\:");
     // A per-process wildcard retains libpq's socket, host list and default-user semantics.
-    // The final delimiter prevents libpq from stripping a password's trailing CR.
-    writeln!(file, "*:*:*:*:{escaped}:")
+    writeln!(file, "*:*:*:*:{escaped}")
 }
 
 fn passfile_error(error: std::io::Error) -> DbOperationError {
@@ -66,13 +65,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn escapes_password_and_preserves_trailing_carriage_return() {
-        let file = Passfile::create("p:a\\ss '日本語'\t\r").unwrap();
+    fn escapes_password_and_preserves_embedded_carriage_return() {
+        let file = Passfile::create("p:a\\ss '日本語'\t\rend").unwrap();
         let path = file.path.clone();
 
         assert_eq!(
             fs::read_to_string(&path).unwrap(),
-            "*:*:*:*:p\\:a\\\\ss '日本語'\t\r:\n"
+            "*:*:*:*:p\\:a\\\\ss '日本語'\t\rend\n"
         );
         #[cfg(unix)]
         {
@@ -88,9 +87,12 @@ mod tests {
         assert!(!path.exists());
     }
 
-    #[test]
-    fn nul_is_rejected_without_echoing_password() {
-        let error = Passfile::create("private\0value").err().unwrap();
+    #[rstest::rstest]
+    #[case("private\0value")]
+    #[case("private\nvalue")]
+    #[case("private\r")]
+    fn unrepresentable_password_is_rejected_without_echoing_secret(#[case] password: &str) {
+        let error = Passfile::create(password).err().unwrap();
 
         assert!(!error.to_string().contains("private"));
         assert!(matches!(error, DbOperationError::ConnectionFailed(_)));

--- a/src/infra/adapters/postgres/psql/passfile.rs
+++ b/src/infra/adapters/postgres/psql/passfile.rs
@@ -1,0 +1,98 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+use uuid::Uuid;
+
+use crate::app::ports::outbound::DbOperationError;
+
+pub(super) struct Passfile {
+    pub(super) path: PathBuf,
+}
+
+impl Passfile {
+    pub(super) fn create(password: &str) -> Result<Self, DbOperationError> {
+        // libpq reads one physical line; escaping LF cannot preserve the password.
+        if password.contains(['\n', '\0']) {
+            return Err(DbOperationError::ConnectionFailed(
+                "PostgreSQL passwords containing LF or NUL cannot be passed through a password file"
+                    .to_string(),
+            ));
+        }
+        let path = std::path::absolute(
+            std::env::temp_dir().join(format!("sabiql-pg-{}.pgpass", Uuid::new_v4())),
+        )
+        .map_err(passfile_error)?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+        #[cfg(windows)]
+        std::os::windows::fs::OpenOptionsExt::access_mode(
+            &mut options,
+            windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE
+                | windows_sys::Win32::Storage::FileSystem::WRITE_DAC,
+        );
+        let file = options.open(&path).map_err(passfile_error)?;
+        let passfile = Self { path };
+        write_password(file, password).map_err(passfile_error)?;
+        Ok(passfile)
+    }
+}
+
+impl Drop for Passfile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn write_password(mut file: File, password: &str) -> std::io::Result<()> {
+    #[cfg(windows)]
+    crate::adapters::windows_file_security::restrict_to_current_user(&file)?;
+    let escaped = password.replace('\\', "\\\\").replace(':', "\\:");
+    // A per-process wildcard retains libpq's socket, host list and default-user semantics.
+    // The final delimiter prevents libpq from stripping a password's trailing CR.
+    writeln!(file, "*:*:*:*:{escaped}:")
+}
+
+fn passfile_error(error: std::io::Error) -> DbOperationError {
+    DbOperationError::ConnectionFailed(format!(
+        "Unable to prepare PostgreSQL password file: {error}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_password_and_preserves_trailing_carriage_return() {
+        let file = Passfile::create("p:a\\ss '日本語'\t\r").unwrap();
+        let path = file.path.clone();
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "*:*:*:*:p\\:a\\\\ss '日本語'\t\r:\n"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        #[cfg(windows)]
+        crate::adapters::windows_file_security::test_support::assert_owner_only_acl(&path);
+        drop(file);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn nul_is_rejected_without_echoing_password() {
+        let error = Passfile::create("private\0value").err().unwrap();
+
+        assert!(!error.to_string().contains("private"));
+        assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
+    }
+}

--- a/src/infra/adapters/postgres/psql/password_tests.rs
+++ b/src/infra/adapters/postgres/psql/password_tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+use crate::app::ports::outbound::DsnBuilder;
+use crate::domain::connection::{ConnectionProfile, SslMode};
+
+fn profile_dsn(host: &str, password: &str) -> String {
+    let profile = ConnectionProfile::new_postgres(
+        "test",
+        host,
+        5432,
+        "db name",
+        "user'名",
+        password,
+        SslMode::Disable,
+    )
+    .unwrap();
+    PostgresAdapter::new().build_dsn(&profile)
+}
+
+#[test]
+fn generated_password_is_absent_from_argv_for_tcp_socket_and_ipv6() {
+    for host in ["localhost", "/tmp/pg socket", "::1"] {
+        let dsn = profile_dsn(host, "private :\\' 日本語\r");
+        let (cmd, passfile) =
+            PostgresAdapter::build_psql_command(&dsn, &["--csv"], &["-c", "SELECT 1"], true)
+                .unwrap();
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|s| s.to_string_lossy())
+            .collect();
+
+        assert!(!args.iter().any(|arg| arg.contains("private")));
+        assert!(args[0].contains("password=''"));
+        assert!(args[0].contains(host));
+        assert!(args[0].contains(passfile.as_ref().unwrap().path.to_str().unwrap()));
+        assert!(
+            cmd.as_std()
+                .get_envs()
+                .any(|(key, value)| key == "PGPASSWORD" && value.is_none())
+        );
+    }
+}
+
+#[test]
+fn password_text_inside_another_field_is_not_extracted() {
+    let dsn = "host='host password=not-a-secret' dbname='db'";
+    let (cmd, file) = PostgresAdapter::build_psql_command(dsn, &[], &[], false).unwrap();
+
+    assert!(file.is_none());
+    assert_eq!(cmd.as_std().get_args().next().unwrap(), dsn);
+}
+
+#[test]
+fn no_explicit_password_preserves_service_passfile_and_environment() {
+    for dsn in [
+        "service=mydb",
+        "host='localhost' passfile='/existing/file'",
+        "host='localhost' password=''",
+        "port='5432' dbname='db'",
+    ] {
+        let (cmd, file) = PostgresAdapter::build_psql_command(dsn, &[], &[], false).unwrap();
+
+        assert!(file.is_none());
+        assert_eq!(cmd.as_std().get_args().next().unwrap(), dsn);
+        assert!(
+            !cmd.as_std()
+                .get_envs()
+                .any(|(key, _)| key == "PGPASSWORD" || key == "PGPASSFILE")
+        );
+    }
+}
+
+#[cfg(unix)]
+fn fake_command(script: &str) -> (Command, Option<Passfile>, std::path::PathBuf) {
+    let dsn = profile_dsn("localhost", "private :\\' 日本語");
+    let (real, passfile) =
+        PostgresAdapter::build_psql_command(&dsn, &[], &["-c", "SELECT 1"], false).unwrap();
+    let path = passfile.as_ref().unwrap().path.clone();
+    let mut fake = Command::new("sh");
+    fake.args(["-c", script, "fake-psql"]);
+    fake.args(real.as_std().get_args());
+    fake.env("TEST_PASSFILE", &path);
+    (fake, passfile, path)
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn fake_cli_observes_safe_argv_and_file_is_removed_after_success_or_failure() {
+    for status in [0, 7] {
+        let script = format!(
+            "case \"$*\" in *private*) exit 99;; esac; test -r \"$TEST_PASSFILE\" || exit 98; printf ok; exit {status}"
+        );
+        let (mut cmd, file, path) = fake_command(&script);
+
+        let result = PostgresAdapter::collect_output(&mut cmd, file, 2).await;
+
+        if status == 0 {
+            assert_eq!(result.unwrap(), "ok");
+        } else {
+            assert!(
+                matches!(result, Err(DbOperationError::QueryFailed(message)) if message == "psql exited with status code 7")
+            );
+        }
+        assert!(!path.exists());
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn spawn_failure_removes_passfile() {
+    let (_, file, path) = fake_command("exit 0");
+    let mut cmd = Command::new("/nonexistent/sabiql-cf02-psql");
+
+    assert!(
+        PostgresAdapter::collect_output(&mut cmd, file, 1)
+            .await
+            .is_err()
+    );
+    assert!(!path.exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn timeout_reaps_child_and_removes_passfile() {
+    let (mut cmd, file, path) = fake_command("exec sleep 30");
+
+    let result = PostgresAdapter::collect_output(&mut cmd, file, 0).await;
+
+    assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+    assert!(!path.exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn cancellation_reaps_child_before_removing_passfile() {
+    let (mut cmd, file, path) = fake_command("printf ready; exec sleep 30");
+    let mut process = PsqlProcess::spawn(&mut cmd, file).unwrap();
+    let child = process.child.as_mut().unwrap();
+    let pid = child.id().unwrap();
+    let mut ready = [0; 5];
+    child
+        .stdout
+        .as_mut()
+        .unwrap()
+        .read_exact(&mut ready)
+        .await
+        .unwrap();
+    assert_eq!(&ready, b"ready");
+    let task = tokio::spawn(async move {
+        process.child.as_mut().unwrap().wait().await.unwrap();
+    });
+
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while path.exists() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(unsafe { libc::kill(pid as i32, 0) }, -1);
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ESRCH)
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn csv_cancellation_removes_passfile_and_reaps_child() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("export.csv");
+    let (mut cmd, file, path) = fake_command("printf ready; exec sleep 30");
+    let mut process = PsqlProcess::spawn(&mut cmd, file).unwrap();
+    let child = process.child.as_mut().unwrap();
+    let pid = child.id().unwrap();
+    let mut ready = [0; 5];
+    child
+        .stdout
+        .as_mut()
+        .unwrap()
+        .read_exact(&mut ready)
+        .await
+        .unwrap();
+    let task =
+        tokio::spawn(
+            async move { collect_csv_output(process, &output, Duration::from_secs(30)).await },
+        );
+    tokio::task::yield_now().await;
+
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while path.exists() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(unsafe { libc::kill(pid as i32, 0) }, -1);
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ESRCH)
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn csv_success_failure_and_timeout_remove_passfile() {
+    let dir = tempfile::tempdir().unwrap();
+    for (script, duration, succeeds) in [
+        ("printf 'id\\n1\\n'", Duration::from_secs(2), true),
+        ("exit 7", Duration::from_secs(2), false),
+        ("exec sleep 30", Duration::ZERO, false),
+    ] {
+        let (mut cmd, file, path) = fake_command(script);
+        let process = PsqlProcess::spawn(&mut cmd, file).unwrap();
+        let output = dir.path().join("export.csv");
+
+        let result = collect_csv_output(process, &output, duration).await;
+
+        assert_eq!(result.is_ok(), succeeds);
+        assert!(!path.exists());
+        if succeeds {
+            assert_eq!(std::fs::read_to_string(output).unwrap(), "id\n1\n");
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires psql and a loopback listener; no database required"]
+async fn real_libpq_preserves_special_passwords_and_explicit_precedence() {
+    for password in [
+        "p:a\\ss '日本語'\t",
+        "middle\rcarriage",
+        "trailing\r",
+        "last\\",
+        &"long:秘密\\".repeat(1000),
+    ] {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            let start = std::time::Instant::now();
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(
+                            start.elapsed() < Duration::from_secs(5),
+                            "psql did not connect"
+                        );
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("{error}"),
+                }
+            };
+            stream.set_nonblocking(false).unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut size = [0; 4];
+            stream.read_exact(&mut size).unwrap();
+            let mut startup = vec![0; u32::from_be_bytes(size) as usize - 4];
+            stream.read_exact(&mut startup).unwrap();
+            stream.write_all(&[b'R', 0, 0, 0, 8, 0, 0, 0, 3]).unwrap();
+            let mut tag = [0; 1];
+            stream.read_exact(&mut tag).unwrap();
+            assert_eq!(tag, [b'p']);
+            stream.read_exact(&mut size).unwrap();
+            let mut supplied = vec![0; u32::from_be_bytes(size) as usize - 4];
+            stream.read_exact(&mut supplied).unwrap();
+            assert_eq!(supplied.pop(), Some(0));
+            String::from_utf8(supplied).unwrap()
+        });
+        let profile = ConnectionProfile::new_postgres(
+            "test",
+            "127.0.0.1",
+            port,
+            "db",
+            "user",
+            password,
+            SslMode::Disable,
+        )
+        .unwrap();
+        let dsn = PostgresAdapter::new().build_dsn(&profile);
+        let (mut cmd, file) =
+            PostgresAdapter::build_psql_command(&dsn, &["-w"], &["-c", "SELECT 1"], false).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let service = dir.path().join("pg_service.conf");
+        std::fs::write(
+            &service,
+            "[test]\npassword=wrong-service-password\npassfile=/nonexistent/service-passfile\n",
+        )
+        .unwrap();
+        cmd.env_clear()
+            .env("PATH", std::env::var_os("PATH").unwrap())
+            .env("PGGSSENCMODE", "disable")
+            .env("PGSERVICEFILE", service)
+            .env("PGSERVICE", "test")
+            .env("PGPASSWORD", "wrong-environment-password")
+            .env("PGPASSFILE", "/nonexistent/environment-passfile");
+        let path = file.as_ref().unwrap().path.clone();
+
+        // The fixture closes after authentication; it never executes SQL.
+        assert!(
+            PostgresAdapter::collect_output(&mut cmd, file, 5)
+                .await
+                .is_err()
+        );
+
+        assert_eq!(server.join().unwrap(), password);
+        assert!(!path.exists());
+    }
+}

--- a/src/infra/adapters/postgres/psql/password_tests.rs
+++ b/src/infra/adapters/postgres/psql/password_tests.rs
@@ -19,7 +19,7 @@ fn profile_dsn(host: &str, password: &str) -> String {
 #[test]
 fn generated_password_is_absent_from_argv_for_tcp_socket_and_ipv6() {
     for host in ["localhost", "/tmp/pg socket", "::1"] {
-        let dsn = profile_dsn(host, "private :\\' 日本語\r");
+        let dsn = profile_dsn(host, "private :\\' 日本語\rend");
         let (cmd, passfile) =
             PostgresAdapter::build_psql_command(&dsn, &["--csv"], &["-c", "SELECT 1"], true)
                 .unwrap();
@@ -32,7 +32,8 @@ fn generated_password_is_absent_from_argv_for_tcp_socket_and_ipv6() {
         assert!(!args.iter().any(|arg| arg.contains("private")));
         assert!(args[0].contains("password=''"));
         assert!(args[0].contains(host));
-        assert!(args[0].contains(passfile.as_ref().unwrap().path.to_str().unwrap()));
+        let path = passfile.as_ref().unwrap().path.to_str().unwrap();
+        assert!(args[0].ends_with(&format!("passfile={}", quote_conninfo_value(path))));
         assert!(
             cmd.as_std()
                 .get_envs()
@@ -236,7 +237,6 @@ async fn real_libpq_preserves_special_passwords_and_explicit_precedence() {
     for password in [
         "p:a\\ss '日本語'\t",
         "middle\rcarriage",
-        "trailing\r",
         "last\\",
         &"long:秘密\\".repeat(1000),
     ] {

--- a/src/infra/adapters/windows_file_security.rs
+++ b/src/infra/adapters/windows_file_security.rs
@@ -1,0 +1,225 @@
+use std::fs::File;
+use std::io;
+
+pub(super) fn restrict_to_current_user(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr::{null, null_mut};
+
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        EXPLICIT_ACCESS_W, GRANT_ACCESS, SetEntriesInAclW, SetSecurityInfo, TRUSTEE_IS_SID,
+        TRUSTEE_IS_USER, TRUSTEE_W,
+    };
+    use windows_sys::Win32::Security::{
+        DACL_SECURITY_INFORMATION, NO_INHERITANCE, PROTECTED_DACL_SECURITY_INFORMATION, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut token: HANDLE = null_mut();
+    let opened = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) };
+    if opened == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let sid_result = current_user_sid(token);
+    unsafe {
+        CloseHandle(token);
+    }
+    let mut sid = sid_result?;
+
+    let trustee = TRUSTEE_W {
+        pMultipleTrustee: null_mut(),
+        MultipleTrusteeOperation: 0,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_USER,
+        ptstrName: sid.as_mut_ptr().cast(),
+    };
+    let access = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: trustee,
+    };
+    let mut acl = null_mut();
+    let status = unsafe { SetEntriesInAclW(1, &raw const access, null(), &raw mut acl) };
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    let status = unsafe {
+        SetSecurityInfo(
+            file.as_raw_handle(),
+            windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            acl,
+            null(),
+        )
+    };
+    unsafe {
+        LocalFree(acl.cast());
+    }
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn current_user_sid(token: windows_sys::Win32::Foundation::HANDLE) -> io::Result<Vec<u8>> {
+    use std::ptr::null_mut;
+
+    use windows_sys::Win32::Security::{
+        CopySid, GetLengthSid, GetTokenInformation, TOKEN_USER, TokenUser,
+    };
+
+    let mut required_size = 0;
+    unsafe {
+        GetTokenInformation(token, TokenUser, null_mut(), 0, &raw mut required_size);
+    }
+    if required_size == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let word_count = (required_size as usize).div_ceil(size_of::<u64>());
+    let mut buffer = vec![0_u64; word_count];
+    let success = unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            required_size,
+            &raw mut required_size,
+        )
+    };
+    if success == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let token_user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
+    let sid_length = unsafe { GetLengthSid(token_user.User.Sid) };
+    if sid_length == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut sid = vec![0_u8; sid_length as usize];
+    if unsafe { CopySid(sid_length, sid.as_mut_ptr().cast(), token_user.User.Sid) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(sid)
+}
+
+#[cfg(test)]
+pub(super) mod test_support {
+    use super::current_user_sid;
+
+    pub(in crate::adapters) fn assert_owner_only_acl(path: &std::path::Path) {
+        use std::os::windows::ffi::OsStrExt;
+        use std::ptr::null_mut;
+
+        use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, LocalFree};
+        use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+        use windows_sys::Win32::Security::{
+            ACCESS_ALLOWED_ACE, AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid, GetAce,
+            GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
+            PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED, TOKEN_QUERY,
+        };
+        use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        let path = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let mut dacl = null_mut();
+        let mut security_descriptor: PSECURITY_DESCRIPTOR = null_mut();
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                path.as_ptr(),
+                windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                null_mut(),
+                null_mut(),
+                &raw mut dacl,
+                null_mut(),
+                &raw mut security_descriptor,
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS);
+
+        let mut control = 0;
+        let mut revision = 0;
+        assert_ne!(
+            unsafe {
+                GetSecurityDescriptorControl(
+                    security_descriptor,
+                    &raw mut control,
+                    &raw mut revision,
+                )
+            },
+            0
+        );
+        assert_ne!(control & SE_DACL_PROTECTED, 0);
+
+        let mut dacl_present = 0;
+        let mut dacl_defaulted = 0;
+        assert_ne!(
+            unsafe {
+                GetSecurityDescriptorDacl(
+                    security_descriptor,
+                    &raw mut dacl_present,
+                    &raw mut dacl,
+                    &raw mut dacl_defaulted,
+                )
+            },
+            0
+        );
+        assert_ne!(dacl_present, 0);
+        assert!(!dacl.is_null());
+
+        let mut acl_info = windows_sys::Win32::Security::ACL_SIZE_INFORMATION::default();
+        assert_ne!(
+            unsafe {
+                GetAclInformation(
+                    dacl,
+                    (&raw mut acl_info).cast::<std::ffi::c_void>(),
+                    std::mem::size_of_val(&acl_info) as u32,
+                    AclSizeInformation,
+                )
+            },
+            0
+        );
+        assert_eq!(acl_info.AceCount, 1);
+
+        let mut ace = null_mut();
+        assert_ne!(unsafe { GetAce(dacl, 0, &raw mut ace) }, 0);
+        let allowed_ace = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+        assert_eq!(allowed_ace.Header.AceType, 0);
+        assert_eq!(allowed_ace.Header.AceFlags, 0);
+        assert_eq!(
+            allowed_ace.Mask & (FILE_GENERIC_READ | FILE_GENERIC_WRITE),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE
+        );
+        let ace_sid = std::ptr::addr_of!(allowed_ace.SidStart).cast_mut().cast();
+        let mut token = null_mut();
+        assert_ne!(
+            unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) },
+            0
+        );
+        let current_sid = current_user_sid(token).unwrap();
+        unsafe {
+            CloseHandle(token);
+        }
+        assert_ne!(
+            unsafe { EqualSid(current_sid.as_ptr().cast_mut().cast(), ace_sid) },
+            0
+        );
+
+        unsafe {
+            LocalFree(security_descriptor.cast());
+        }
+    }
+}


### PR DESCRIPTION
## Problem

PostgreSQL connections with a saved explicit password expose that password in the `psql` process arguments, including query, metadata, preview, and CSV export operations.

## Approach

Move the explicit password into a unique, owner-only passfile before launching `psql`, and retain ownership until the child is reaped. Preserve service and environment authentication when no explicit password exists; otherwise the explicit password retains precedence. Reuse the existing conninfo scanner for application-generated connections and share the existing Windows ACL implementation with MySQL.

Colon and backslash are escaped. Embedded CR is preserved within the documented five-field format. Timeout and cancellation kill/reap the child before removing the passfile.

## Validation

- PostgreSQL focused tests: 364 passed; MySQL option-file tests: 18 passed.
- Targeted infra Clippy, format check, and `scripts/lint_all.sh` passed.
- Real `psql` 18.4 with a dedicated loopback authentication fixture: special characters, intermediate CR, long passwords, and precedence over service password/passfile and `PGPASSWORD`/`PGPASSFILE` passed. No database or cloud connection was used.
- The real-client regression is saved in `password_tests.rs` and wired into CI. Exact-head CI passed, including Windows ACL and workspace verification.

## Compatibility

The implementation rejects LF, trailing CR, and NUL before spawning, without echoing credentials. NUL was already unsupported by argv. LF and trailing CR are new restrictions: the old conninfo path preserves them, while the documented passfile format cannot round-trip them. These restrictions avoid adding a separate secret transport and cleanup path. Embedded CR and the literal two-character sequence `\n` remain supported.
