### PR TITLE
fix: preserve CSV save results when folder opening fails

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -156,6 +156,8 @@ pub enum Effect {
     },
     OpenFolder {
         path: std::path::PathBuf,
+        message_revision: u64,
+        export_message: String,
     },
 
     LoadQueryHistory {

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -33,10 +33,18 @@ pub(in crate::cmd) async fn run(
                 }
             });
         }
-        Effect::OpenFolder { path } => {
+        Effect::OpenFolder {
+            path,
+            message_revision,
+            export_message,
+        } => {
             if let Err(e) = folder_opener.open(&path) {
                 action_tx
-                    .send(Action::OpenFolderFailed(Arc::new(e)))
+                    .send(Action::OpenFolderFailed {
+                        message_revision,
+                        export_message,
+                        error: Arc::new(e),
+                    })
                     .await
                     .ok();
             }
@@ -193,6 +201,8 @@ mod tests {
             run(
                 Effect::OpenFolder {
                     path: PathBuf::from("/tmp/export"),
+                    message_revision: 7,
+                    export_message: "Exported → /tmp/export/data.csv".to_string(),
                 },
                 &tx,
                 &clipboard,
@@ -215,6 +225,8 @@ mod tests {
             run(
                 Effect::OpenFolder {
                     path: PathBuf::from("/nonexistent"),
+                    message_revision: 7,
+                    export_message: "Exported → /nonexistent/data.csv".to_string(),
                 },
                 &tx,
                 &clipboard,
@@ -227,8 +239,14 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             match action {
-                Action::OpenFolderFailed(e) => {
-                    assert_eq!(e.to_string(), "No such file or directory");
+                Action::OpenFolderFailed {
+                    message_revision,
+                    export_message,
+                    error,
+                } => {
+                    assert_eq!(message_revision, 7);
+                    assert_eq!(export_message, "Exported → /nonexistent/data.csv");
+                    assert_eq!(error.to_string(), "No such file or directory");
                 }
                 other => panic!("expected OpenFolderFailed, got {other:?}"),
             }

--- a/src/app/model/shared/message.rs
+++ b/src/app/model/shared/message.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Default)]
 pub struct MessageState {
+    revision: u64,
     pub(crate) last_error: Option<String>,
     pub(crate) last_success: Option<String>,
     pub(crate) expires_at: Option<Instant>,
@@ -22,13 +23,26 @@ impl MessageState {
         self.expires_at
     }
 
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn keep_success_with_detail(&mut self, revision: u64, message: String) {
+        if self.revision == revision {
+            self.last_success = Some(message);
+            self.expires_at = None;
+        }
+    }
+
     pub fn set_error(&mut self, msg: String) {
+        self.revision += 1;
         self.last_error = Some(msg);
         self.last_success = None;
         self.expires_at = None;
     }
 
     pub fn set_success_at(&mut self, msg: String, now: Instant) {
+        self.revision += 1;
         self.last_success = Some(msg);
         self.last_error = None;
         self.expires_at = Some(now + Duration::from_secs(Self::SUCCESS_TIMEOUT_SECS));
@@ -48,6 +62,7 @@ impl MessageState {
     }
 
     pub fn clear(&mut self) {
+        self.revision += 1;
         self.last_error = None;
         self.last_success = None;
         self.expires_at = None;
@@ -133,6 +148,19 @@ mod tests {
 
         state.clear_error();
 
+        assert!(state.last_error().is_none());
+    }
+
+    #[test]
+    fn cleared_notification_rejects_delayed_success_detail() {
+        let mut state = MessageState::default();
+        state.set_success_at("Saved".to_string(), fixed_instant());
+        let revision = state.revision();
+        state.clear();
+
+        state.keep_success_with_detail(revision, "Saved; opener failed".to_string());
+
+        assert!(state.last_success().is_none());
         assert!(state.last_error().is_none());
     }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -587,7 +587,11 @@ pub enum Action {
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
     CopyFailed(ClipboardError),
-    OpenFolderFailed(Arc<std::io::Error>),
+    OpenFolderFailed {
+        message_revision: u64,
+        export_message: String,
+        error: Arc<std::io::Error>,
+    },
     ToggleFocus,
     ToggleReadOnly,
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -174,11 +174,15 @@ pub(in crate::update) fn reduce_pagination(
                 Some(n) => format!("Exported {n} rows → {path}"),
                 None => format!("Exported → {path}"),
             };
-            state.messages.set_success_at(msg, now);
+            state.messages.set_success_at(msg.clone(), now);
             let folder = Path::new(path)
                 .parent()
                 .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-            DispatchResult::handled_with(vec![Effect::OpenFolder { path: folder }])
+            DispatchResult::handled_with(vec![Effect::OpenFolder {
+                path: folder,
+                message_revision: state.messages.revision(),
+                export_message: msg,
+            }])
         }
 
         Action::CsvExportFailed { run_id, error } => {
@@ -191,10 +195,15 @@ pub(in crate::update) fn reduce_pagination(
             DispatchResult::handled()
         }
 
-        Action::OpenFolderFailed(error) => {
-            state
-                .messages
-                .set_error(format!("Failed to open folder: {error}"));
+        Action::OpenFolderFailed {
+            message_revision,
+            export_message,
+            error,
+        } => {
+            state.messages.keep_success_with_detail(
+                *message_revision,
+                format!("{export_message}; folder could not be opened: {error}"),
+            );
 
             DispatchResult::handled()
         }
@@ -640,6 +649,98 @@ mod tests {
                     .unwrap()
                     .contains("/tmp/export.csv")
             );
+        }
+
+        fn folder_failure(effects: Vec<Effect>) -> Action {
+            let Effect::OpenFolder {
+                path,
+                message_revision,
+                export_message,
+            } = effects.into_iter().next().unwrap()
+            else {
+                panic!("expected folder opener");
+            };
+            assert_eq!(path, PathBuf::from("/tmp"));
+            Action::OpenFolderFailed {
+                message_revision,
+                export_message,
+                error: Arc::new(std::io::Error::other("opener unavailable")),
+            }
+        }
+
+        #[test]
+        fn folder_failure_keeps_saved_path_and_idle_after_success_expires() {
+            let mut state = create_test_state();
+            let now = Instant::now();
+            let action = csv_succeeded_action(&mut state, "/tmp/export.csv", Some(42));
+            let failure = folder_failure(dispatch_query(&mut state, &action, now).unwrap());
+            let later = now + std::time::Duration::from_secs(10);
+            state.messages.clear_expired_at(later);
+
+            let effects = dispatch_query(&mut state, &failure, later).unwrap();
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
+            assert!(state.messages.last_error().is_none());
+            assert_eq!(
+                state.messages.last_success(),
+                Some(
+                    "Exported 42 rows → /tmp/export.csv; folder could not be opened: opener unavailable"
+                )
+            );
+            assert!(state.messages.expires_at().is_none());
+        }
+
+        #[test]
+        fn old_folder_failure_preserves_new_export_to_same_path() {
+            let mut state = create_test_state();
+            let now = Instant::now();
+            let action = csv_succeeded_action(&mut state, "/tmp/export.csv", Some(42));
+            let failure = folder_failure(dispatch_query(&mut state, &action, now).unwrap());
+            let action = csv_succeeded_action(&mut state, "/tmp/export.csv", Some(42));
+            dispatch_query(&mut state, &action, now).unwrap();
+
+            dispatch_query(&mut state, &failure, now).unwrap();
+
+            assert_eq!(
+                state.messages.last_success(),
+                Some("Exported 42 rows → /tmp/export.csv")
+            );
+            assert!(state.messages.last_error().is_none());
+            assert!(!state.query.is_running());
+        }
+
+        #[test]
+        fn old_folder_failure_preserves_unrelated_success() {
+            let mut state = create_test_state();
+            let now = Instant::now();
+            let action = csv_succeeded_action(&mut state, "/tmp/export.csv", None);
+            let failure = folder_failure(dispatch_query(&mut state, &action, now).unwrap());
+            state.messages.set_success_at("Copied".to_string(), now);
+
+            dispatch_query(&mut state, &failure, now).unwrap();
+
+            assert_eq!(state.messages.last_success(), Some("Copied"));
+        }
+
+        #[test]
+        fn old_folder_failure_preserves_new_export_error() {
+            let mut state = create_test_state();
+            let now = Instant::now();
+            let action = csv_succeeded_action(&mut state, "/tmp/export.csv", None);
+            let failure = folder_failure(dispatch_query(&mut state, &action, now).unwrap());
+            let action = csv_failed_action(
+                &mut state,
+                DbOperationError::QueryFailed("export failed".to_string()),
+            );
+            assert!(dispatch_query(&mut state, &action, now).unwrap().is_empty());
+            let error = state.messages.last_error().unwrap().to_string();
+
+            dispatch_query(&mut state, &failure, now).unwrap();
+
+            assert_eq!(state.messages.last_error(), Some(error.as_str()));
+            assert!(state.messages.last_success().is_none());
+            assert!(!state.query.is_running());
         }
 
         #[test]


### PR DESCRIPTION
## Problem

CSV files were saved successfully, but a failed folder opener replaced the saved-path notification with an error. A delayed opener failure could also overwrite a newer operation's result.

## Approach

Keep the saved path and row count visible with a persistent folder-opening failure detail. Associate that detail with the original notification so later exports and other operation results remain intact. Automatic folder opening remains enabled.

Validated pagination reducer tests (36), utility tests (5), message-state tests (8), targeted app Clippy, formatting, and custom lints. Full workspace validation runs in CI; no cloud resources or shared database fixtures were used.
