### PR TITLE
fix: stop retrying permanent metadata failures

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -1268,6 +1268,7 @@ mod tests {
                     failed_at: now,
                     error: "connection timeout".to_string(),
                     retry_count: 0,
+                    retryable: true,
                 },
             );
 
@@ -1299,6 +1300,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: 0,
+                    retryable: true,
                 },
             );
             state

--- a/src/app/model/table_prefetch.rs
+++ b/src/app/model/table_prefetch.rs
@@ -10,6 +10,7 @@ pub struct FailedPrefetchEntry {
     pub failed_at: Instant,
     pub error: String,
     pub retry_count: u32,
+    pub retryable: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -167,7 +168,7 @@ impl TablePrefetchState {
     }
 
     fn is_permanent_failure(&self, table: &str, entry: &FailedPrefetchEntry) -> bool {
-        entry.retry_count >= MAX_PREFETCH_RETRIES
+        (!entry.retryable || entry.retry_count >= MAX_PREFETCH_RETRIES)
             && !self.is_prefetch_queued(table)
             && !self.prefetching_tables.contains(table)
     }
@@ -189,6 +190,7 @@ mod tests {
                 failed_at: Instant::now(),
                 error: "error".to_string(),
                 retry_count: 0,
+                retryable: true,
             },
         );
 
@@ -226,6 +228,7 @@ mod tests {
                 failed_at,
                 error: "timeout".to_string(),
                 retry_count: 1,
+                retryable: true,
             },
         );
 
@@ -246,6 +249,7 @@ mod tests {
                 failed_at: Instant::now(),
                 error: "timeout".to_string(),
                 retry_count: 3,
+                retryable: true,
             },
         );
 
@@ -263,6 +267,7 @@ mod tests {
                 failed_at: Instant::now(),
                 error: "timeout".to_string(),
                 retry_count: 1,
+                retryable: true,
             },
         );
 
@@ -276,6 +281,7 @@ mod tests {
                 failed_at: Instant::now(),
                 error: "timeout".to_string(),
                 retry_count: MAX_PREFETCH_RETRIES,
+                retryable: true,
             },
         );
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -778,10 +778,7 @@ mod tests {
 
         #[rstest::rstest]
         #[case(DbOperationError::PermissionDenied("denied".to_string()))]
-        #[case(DbOperationError::ConnectionFailedWithKind {
-            kind: ConnectionFailureKind::Auth,
-            details: "invalid password".to_string(),
-        })]
+        #[case(DbOperationError::QueryFailed("unknown SQL failure".to_string()))]
         #[case(DbOperationError::ObjectMissing("table dropped".to_string()))]
         #[case(DbOperationError::UnsupportedOperation("unsupported".to_string()))]
         fn permanent_failure_finishes_er_without_requeue_and_new_run_can_retry(
@@ -857,6 +854,96 @@ mod tests {
                 effects.as_slice(),
                 [Effect::PrefetchTableColumnsAndFks { .. }]
             ));
+        }
+
+        #[rstest::rstest]
+        #[case(DbOperationError::ConnectionLost("disconnected".to_string()))]
+        #[case(DbOperationError::ConnectionFailed("invalid connection".to_string()))]
+        #[case(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::Auth, details: "invalid password".to_string(),
+        })]
+        #[case(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::HostUnreachable, details: "unreachable".to_string(),
+        })]
+        #[case(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::ConnectionRefused, details: "refused".to_string(),
+        })]
+        fn connection_failure_stops_queue_rejects_late_results_and_allows_new_run(
+            #[case] error: DbOperationError,
+            #[values(false, true)] tracks_er: bool,
+        ) {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = if tracks_er {
+                let _ = state.er_preparation.start_waiting_run();
+                state.table_prefetch.begin_er_prefetch()
+            } else {
+                state.table_prefetch.begin_completion_prefetch()
+            };
+            let tables: Vec<String> = (0..10).map(|i| format!("public.table{i}")).collect();
+            for table in &tables {
+                state.table_prefetch.queue_table_prefetch(table.clone());
+            }
+            let now = Instant::now();
+            let effects =
+                dispatch_metadata(&mut state, &Action::ProcessPrefetchQueue { run_id }, now)
+                    .unwrap();
+            assert_eq!(effects.len(), 4);
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailCacheFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "table0".to_string(),
+                    error,
+                },
+                now,
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(state.table_prefetch.is_complete());
+            assert!(!state.table_prefetch.is_current_prefetch_run(run_id));
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            for action in [
+                Action::ProcessPrefetchQueue { run_id },
+                Action::TableDetailCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "table1".to_string(),
+                    detail: Some(empty_table("public", "table1")),
+                },
+                Action::TableDetailCacheFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "table2".to_string(),
+                    error: DbOperationError::Timeout("late timeout".to_string()),
+                },
+            ] {
+                assert!(
+                    dispatch_metadata(&mut state, &action, now)
+                        .unwrap()
+                        .is_empty()
+                );
+            }
+            dispatch_metadata(&mut state, &Action::StartErPrefetchScoped { tables }, now);
+            let next_run = state.table_prefetch.active_prefetch_run_id().unwrap();
+            assert!(next_run > run_id);
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id: next_run },
+                now,
+            )
+            .unwrap();
+            assert_eq!(effects.len(), 4);
+            assert!(
+                effects
+                    .iter()
+                    .all(|effect| matches!(effect, Effect::PrefetchTableColumnsAndFks { .. }))
+            );
         }
 
         #[test]

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::model::browse::session::TableDetailState;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::table_prefetch::FailedPrefetchEntry;
-    use crate::ports::outbound::DbOperationError;
+    use crate::ports::outbound::{ConnectionFailureKind, DbOperationError};
     use crate::update::action::Action;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -420,6 +420,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: 1,
+                    retryable: true,
                 },
             );
 
@@ -459,6 +460,7 @@ mod tests {
                     failed_at,
                     error: "timeout".to_string(),
                     retry_count: 1,
+                    retryable: true,
                 },
             );
 
@@ -492,6 +494,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: 1,
+                    retryable: true,
                 },
             );
             state.table_prefetch.queue_table_prefetch(qualified.clone());
@@ -596,6 +599,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: MAX_PREFETCH_RETRIES,
+                    retryable: true,
                 },
             );
 
@@ -628,6 +632,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: MAX_PREFETCH_RETRIES,
+                    retryable: true,
                 },
             );
 
@@ -667,6 +672,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: MAX_PREFETCH_RETRIES,
+                    retryable: true,
                 },
             );
 
@@ -703,6 +709,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: MAX_PREFETCH_RETRIES,
+                    retryable: true,
                 },
             );
             state.table_prefetch.queue_table_prefetch(failed);
@@ -741,6 +748,7 @@ mod tests {
                     failed_at: Instant::now().checked_sub(Duration::from_secs(10)).unwrap(),
                     error: "timeout".to_string(),
                     retry_count: 1,
+                    retryable: true,
                 },
             );
 
@@ -768,6 +776,187 @@ mod tests {
     mod table_detail_cache_failed {
         use super::*;
 
+        #[rstest::rstest]
+        #[case(DbOperationError::PermissionDenied("denied".to_string()))]
+        #[case(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::Auth,
+            details: "invalid password".to_string(),
+        })]
+        #[case(DbOperationError::ObjectMissing("table dropped".to_string()))]
+        #[case(DbOperationError::UnsupportedOperation("unsupported".to_string()))]
+        fn permanent_failure_finishes_er_without_requeue_and_new_run_can_retry(
+            #[case] error: DbOperationError,
+        ) {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.table_prefetch.begin_er_prefetch();
+            let _ = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_fk_expanded();
+            state
+                .table_prefetch
+                .start_table_prefetch("public.users".to_string());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailCacheFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    error,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.table_prefetch.is_complete());
+            assert_eq!(state.table_prefetch.failed_prefetch_count(), 1);
+            assert_eq!(
+                state
+                    .table_prefetch
+                    .failed_prefetch("public.users")
+                    .unwrap()
+                    .retry_count,
+                1
+            );
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::WriteErFailureLog { .. }]
+            ));
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::PrefetchTableDetail {
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                },
+                Instant::now(),
+            )
+            .unwrap();
+            assert!(effects.is_empty());
+
+            state.table_prefetch.invalidate_prefetch();
+            let _ = state.er_preparation.start_waiting_run();
+            dispatch_metadata(
+                &mut state,
+                &Action::StartErPrefetchScoped {
+                    tables: vec!["public.users".to_string()],
+                },
+                Instant::now(),
+            );
+            let next_run = state.table_prefetch.active_prefetch_run_id().unwrap();
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue { run_id: next_run },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(next_run > run_id);
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::PrefetchTableColumnsAndFks { .. }]
+            ));
+        }
+
+        #[test]
+        fn permission_failure_keeps_four_slots_and_ignores_stale_failure() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let old_run = state.table_prefetch.begin_er_prefetch();
+            state.table_prefetch.invalidate_prefetch();
+            let run_id = state.table_prefetch.begin_er_prefetch();
+            for index in 0..10 {
+                state
+                    .table_prefetch
+                    .queue_table_prefetch(format!("public.table{index}"));
+            }
+            let now = Instant::now();
+            let effects =
+                dispatch_metadata(&mut state, &Action::ProcessPrefetchQueue { run_id }, now)
+                    .unwrap();
+            assert_eq!(effects.len(), 4);
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 4);
+
+            for failed_run in [old_run, run_id] {
+                let effects = dispatch_metadata(
+                    &mut state,
+                    &Action::TableDetailCacheFailed {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id: failed_run,
+                        schema: "public".to_string(),
+                        table: "table0".to_string(),
+                        error: DbOperationError::PermissionDenied("denied".to_string()),
+                    },
+                    now,
+                )
+                .unwrap();
+                if failed_run == old_run {
+                    assert!(effects.is_empty());
+                    assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 4);
+                    assert!(
+                        state
+                            .table_prefetch
+                            .failed_prefetch("public.table0")
+                            .is_none()
+                    );
+                } else {
+                    assert!(matches!(
+                        effects.as_slice(),
+                        [Effect::SchedulePrefetchQueueProcessing { .. }]
+                    ));
+                    assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 3);
+                }
+            }
+            let effects =
+                dispatch_metadata(&mut state, &Action::ProcessPrefetchQueue { run_id }, now)
+                    .unwrap();
+            assert_eq!(effects.len(), 1);
+            assert_eq!(state.table_prefetch.prefetch_in_flight_count(), 4);
+            assert_eq!(state.table_prefetch.failed_prefetch_count(), 1);
+        }
+
+        #[test]
+        fn third_transient_failure_finishes_without_another_delayed_retry() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.table_prefetch.begin_er_prefetch();
+            let _ = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_fk_expanded();
+            let now = Instant::now();
+
+            for attempt in 1..=3 {
+                state
+                    .table_prefetch
+                    .start_table_prefetch("public.users".to_string());
+                let effects = dispatch_metadata(
+                    &mut state,
+                    &Action::TableDetailCacheFailed {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id,
+                        schema: "public".to_string(),
+                        table: "users".to_string(),
+                        error: DbOperationError::Timeout("timed out".to_string()),
+                    },
+                    now,
+                )
+                .unwrap();
+                if attempt < 3 {
+                    assert!(matches!(
+                        effects.as_slice(),
+                        [Effect::DelayedProcessPrefetchQueue { .. }]
+                    ));
+                    assert!(state.table_prefetch.is_prefetch_queued("public.users"));
+                } else {
+                    assert!(matches!(
+                        effects.as_slice(),
+                        [Effect::WriteErFailureLog { .. }]
+                    ));
+                    assert!(state.table_prefetch.is_complete());
+                    assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+                    assert_eq!(state.table_prefetch.failed_prefetch_count(), 1);
+                }
+            }
+        }
+
         #[test]
         fn increments_retry_count() {
             let mut state = state_with_dsn("postgres://localhost/test");
@@ -779,6 +968,7 @@ mod tests {
                     failed_at: Instant::now().checked_sub(Duration::from_mins(1)).unwrap(),
                     error: "old error".to_string(),
                     retry_count: 1,
+                    retryable: true,
                 },
             );
             state.table_prefetch.start_table_prefetch(qualified.clone());
@@ -1659,6 +1849,7 @@ mod tests {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: MAX_PREFETCH_RETRIES,
+                    retryable: true,
                 },
             );
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -6,7 +6,7 @@ use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::table_prefetch::FailedPrefetchEntry;
-use crate::ports::outbound::{ConnectionFailureKind, DbOperationError};
+use crate::ports::outbound::DbOperationError;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
@@ -266,6 +266,28 @@ pub(super) fn reduce_prefetch(
             {
                 return DispatchResult::handled();
             }
+            if matches!(
+                error,
+                DbOperationError::ConnectionLost(_)
+                    | DbOperationError::ConnectionFailed(_)
+                    | DbOperationError::ConnectionFailedWithKind { .. }
+            ) {
+                let tracks_er = state.table_prefetch.prefetch_tracks_er();
+                state.table_prefetch.reset_prefetch();
+                if tracks_er {
+                    state.er_preparation.invalidate_run();
+                }
+                state.messages.set_error(format!(
+                    "Metadata prefetch stopped: {}{}",
+                    error.user_message(),
+                    if tracks_er {
+                        " 'e' to retry after recovery."
+                    } else {
+                        ""
+                    }
+                ));
+                return DispatchResult::handled();
+            }
             let qualified_name = format!("{schema}.{table}");
 
             let prev_count = state
@@ -274,16 +296,7 @@ pub(super) fn reduce_prefetch(
                 .map_or(0, |e| e.retry_count);
             let retryable = matches!(
                 error,
-                DbOperationError::Timeout(_)
-                    | DbOperationError::LockTimeout(_)
-                    | DbOperationError::ConnectionLost(_)
-                    | DbOperationError::ConnectionFailed(_)
-                    | DbOperationError::QueryFailed(_)
-                    | DbOperationError::ConnectionFailedWithKind {
-                        kind: ConnectionFailureKind::HostUnreachable
-                            | ConnectionFailureKind::ConnectionRefused,
-                        ..
-                    }
+                DbOperationError::Timeout(_) | DbOperationError::LockTimeout(_)
             );
             let entry = FailedPrefetchEntry {
                 failed_at: now,

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -6,6 +6,7 @@ use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::table_prefetch::FailedPrefetchEntry;
+use crate::ports::outbound::{ConnectionFailureKind, DbOperationError};
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::reject_pending_mysql_connection_probe;
@@ -43,7 +44,7 @@ fn prefetch_table_detail(
     }
 
     if let Some(entry) = state.table_prefetch.failed_prefetch(&qualified_name) {
-        if entry.retry_count >= MAX_PREFETCH_RETRIES {
+        if !entry.retryable || entry.retry_count >= MAX_PREFETCH_RETRIES {
             let mut effects = if state.table_prefetch.prefetch_tracks_er() {
                 check_er_completion(state)
             } else {
@@ -271,23 +272,46 @@ pub(super) fn reduce_prefetch(
                 .table_prefetch
                 .failed_prefetch(&qualified_name)
                 .map_or(0, |e| e.retry_count);
-            let had_other_pending_before_requeue = state.table_prefetch.retry_table_prefetch(
-                qualified_name,
-                FailedPrefetchEntry {
-                    failed_at: now,
-                    error: error.user_message(),
-                    retry_count: prev_count + 1,
-                },
+            let retryable = matches!(
+                error,
+                DbOperationError::Timeout(_)
+                    | DbOperationError::LockTimeout(_)
+                    | DbOperationError::ConnectionLost(_)
+                    | DbOperationError::ConnectionFailed(_)
+                    | DbOperationError::QueryFailed(_)
+                    | DbOperationError::ConnectionFailedWithKind {
+                        kind: ConnectionFailureKind::HostUnreachable
+                            | ConnectionFailureKind::ConnectionRefused,
+                        ..
+                    }
             );
+            let entry = FailedPrefetchEntry {
+                failed_at: now,
+                error: error.user_message(),
+                retry_count: prev_count + 1,
+                retryable,
+            };
             let mut effects = Vec::new();
-
-            if had_other_pending_before_requeue {
-                effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
+            if retryable && entry.retry_count < MAX_PREFETCH_RETRIES {
+                let delay_secs = backoff_secs_for(entry.retry_count);
+                let had_other_pending = state
+                    .table_prefetch
+                    .retry_table_prefetch(qualified_name, entry);
+                if had_other_pending {
+                    effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
+                }
+                effects.push(Effect::DelayedProcessPrefetchQueue {
+                    run_id: *run_id,
+                    delay_secs,
+                });
+            } else {
+                state
+                    .table_prefetch
+                    .fail_table_prefetch(qualified_name, entry);
+                if state.table_prefetch.has_pending_prefetch() {
+                    effects.push(Effect::SchedulePrefetchQueueProcessing { run_id: *run_id });
+                }
             }
-            effects.push(Effect::DelayedProcessPrefetchQueue {
-                run_id: *run_id,
-                delay_secs: backoff_secs_for(prev_count + 1),
-            });
 
             if state.table_prefetch.prefetch_tracks_er() {
                 effects.extend(check_er_completion(state));

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -732,11 +732,69 @@ mod tests {
     }
 
     mod smart_er_refresh_failed {
+        use std::ptr;
+
         use super::*;
-        use crate::ports::outbound::DbOperationError;
+        use crate::ports::outbound::{ConnectionFailureKind, DbOperationError};
+
+        #[rstest::rstest]
+        #[case(DbOperationError::Timeout("timed out".to_string()))]
+        #[case(DbOperationError::ConnectionLost("disconnected".to_string()))]
+        #[case(DbOperationError::PermissionDenied("denied".to_string()))]
+        #[case(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::Auth,
+            details: "password=secret".to_string(),
+        })]
+        #[case(DbOperationError::QueryFailed("unknown failure".to_string()))]
+        #[case(DbOperationError::MetadataParseFailed("invalid metadata".to_string()))]
+        fn operation_failure_preserves_cache_and_allows_explicit_retry(
+            #[case] error: DbOperationError,
+            #[values(false, true)] metadata_fetched: bool,
+        ) {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let metadata = make_metadata(5);
+            state.session.set_metadata(Some(Arc::clone(&metadata)));
+            let signatures = HashMap::from([("public.old".to_string(), "sig".to_string())]);
+            state
+                .er_preparation
+                .apply_refresh_metadata(signatures.clone(), 5);
+            let run_id = state.er_preparation.start_waiting_run();
+
+            let effects = reduce_er(
+                &mut state,
+                &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    error,
+                    new_metadata: metadata_fetched.then(|| make_metadata(20)),
+                }),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert!(!state.er_preparation.is_current_run(run_id));
+            assert!(ptr::eq(
+                state.session.metadata().unwrap(),
+                metadata.as_ref()
+            ));
+            assert_eq!(state.er_preparation.last_signatures(), &signatures);
+            assert!(state.table_prefetch.is_complete());
+            let message = state.messages.last_error.as_deref().unwrap();
+            assert!(message.contains("'e' to retry"));
+            assert!(!message.contains("secret"));
+
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+
+            assert!(
+                matches!(effects.as_slice(), [Effect::SmartErRefresh { run_id: next_run, .. }] if *next_run > run_id)
+            );
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
+        }
 
         #[test]
-        fn falls_back_to_full_prefetch() {
+        fn missing_object_after_metadata_fetch_falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_waiting_run_id(&mut state, 1);
             state.session.set_metadata(Some(make_metadata(5)));
@@ -750,8 +808,8 @@ mod tests {
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
-                    error: DbOperationError::Timeout("timed out".to_string()),
-                    new_metadata: None,
+                    error: DbOperationError::ObjectMissing("table removed".to_string()),
+                    new_metadata: Some(make_metadata(5)),
                 }),
                 Instant::now(),
             )
@@ -878,7 +936,7 @@ mod tests {
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
-                    error: DbOperationError::QueryFailed("sig fetch failed".to_string()),
+                    error: DbOperationError::ObjectMissing("table removed".to_string()),
                     new_metadata: Some(make_metadata(20)),
                 }),
                 Instant::now(),

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
+use crate::ports::outbound::DbOperationError;
 use crate::update::action::{Action, SmartErRefreshError};
 use crate::update::dispatch_result::DispatchResult;
 
@@ -17,19 +18,16 @@ pub(super) fn reduce_smart_refresh_failed(state: &mut AppState, action: &Action)
                 return DispatchResult::handled();
             }
 
-            let mut effects = Vec::new();
-
-            if let Some(md) = new_metadata {
-                state.session.set_metadata(Some(Arc::clone(md)));
-            }
-
-            let Some(metadata) = &state.session.metadata() else {
-                state.er_preparation.mark_idle();
-                state
-                    .messages
-                    .set_error("Metadata not loaded yet".to_string());
-                return DispatchResult::handled_with(effects);
+            let (DbOperationError::ObjectMissing(_), Some(metadata)) = (error, new_metadata) else {
+                state.er_preparation.invalidate_run();
+                state.messages.set_error(format!(
+                    "ER refresh failed: {} 'e' to retry after recovery.",
+                    error.user_message()
+                ));
+                return DispatchResult::handled();
             };
+
+            state.session.set_metadata(Some(Arc::clone(metadata)));
             state
                 .er_preparation
                 .invalidate_refresh_signatures(metadata.table_summaries.len());
@@ -37,11 +35,10 @@ pub(super) fn reduce_smart_refresh_failed(state: &mut AppState, action: &Action)
             state.messages.set_error(format!(
                 "Smart refresh failed ({error}), falling back to full refresh"
             ));
-            effects.extend([
+            DispatchResult::handled_with(vec![
                 Effect::ClearCompletionEngineCache,
                 Effect::DispatchActions(vec![Action::StartErPrefetchAll]),
-            ]);
-            DispatchResult::handled_with(effects)
+            ])
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -3076,7 +3076,7 @@ mod tests {
         }
 
         #[test]
-        fn failed_refresh_prefetches_source_and_selected_tables() {
+        fn schema_race_prefetches_source_and_selected_tables() {
             let mut state = state_with_metadata();
             state
                 .er_preparation
@@ -3088,8 +3088,12 @@ mod tests {
                 Action::SmartErRefreshFailed(SmartErRefreshError {
                     dsn: "postgres://localhost/test".to_string(),
                     run_id,
-                    error: DbOperationError::Timeout("timed out".to_string()),
-                    new_metadata: None,
+                    error: DbOperationError::ObjectMissing("table removed".to_string()),
+                    new_metadata: state_with_metadata()
+                        .session
+                        .metadata()
+                        .cloned()
+                        .map(Arc::new),
                 }),
                 Instant::now(),
                 &AppServices::stub(),
@@ -3167,6 +3171,7 @@ mod tests {
                     failed_at: now,
                     error: "timeout".to_string(),
                     retry_count: 3,
+                    retryable: true,
                 },
             );
             let effects = reduce(


### PR DESCRIPTION
## Problem
Permanent metadata failures consumed the same retry budget as transient errors, while a failed Smart ER check could trigger reads for every table during an outage.

## Approach
Stop the prefetch run on connection-wide failures so queued tables do not amplify an outage and late completions cannot mutate the cache. Retry only timeouts and lock contention, keeping the existing backoff, three-attempt limit, four concurrent reads, and explicit recovery through a new ER run.

Keep the previous metadata, signatures, and completion cache when Smart ER fails. Only a missing-object error after metadata was fetched can trigger the schema-race fallback; successful schema diffs keep their existing refresh behavior.

## Validation
- Focused app tests: metadata (82), ER (40), prefetch state (5), schema-race reducer (1).
- Targeted app Clippy, formatting, and repository lints.
- Workspace and database checks run in CI; no cloud connections or resources used.
