### PR TITLE
feat: add explicit OSC 52 clipboard backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,6 +2799,7 @@ dependencies = [
  "crossterm",
  "dotenvy",
  "insta",
+ "libc",
  "ratatui",
  "sabiql-app",
  "sabiql-domain",
@@ -2849,6 +2850,7 @@ version = "3.0.1"
 dependencies = [
  "arboard",
  "async-trait",
+ "base64 0.22.1",
  "csv",
  "dirs",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ sabiql-app = { path = "src/app", version = "3.0.1" }
 sabiql-infra = { path = "src/infra", version = "3.0.1" }
 sabiql-ui = { path = "src/ui", version = "3.0.1" }
 arboard = "3"
+base64 = "0.22"
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
@@ -89,6 +90,7 @@ default = []
 self-update = ["dep:self_update"]
 
 [dev-dependencies]
+libc.workspace = true
 sabiql-domain.workspace = true
 sabiql-app = { workspace = true, features = ["test-support"] }
 sabiql-infra = { workspace = true, features = ["test-support"] }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ sabiql /path/to/app.db
 
 Use `Ctrl+R` before browsing data when you want to block writes. Press `?` for help, or open Settings with `,` to change the theme and keymap.
 
+For copying from SSH or a headless host, see [OSC 52 clipboard configuration](docs/clipboard.md).
+
 ## Roadmap
 
 - [x] Connection management UI

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,6 +5,7 @@ too-many-arguments-threshold = 8
 absolute-paths-allowed-crates = [
     "alloc",
     "arboard",
+    "base64",
     "async_trait",
     "clap",
     "color_eyre",

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -1,0 +1,19 @@
+# Clipboard over SSH
+
+The default `native` backend uses the clipboard on the machine running sabiql. To send copy requests to your terminal instead, add this top-level setting to your existing `connections.toml`, before any `[[connections]]` section, then restart sabiql:
+
+```toml
+clipboard_backend = "osc52"
+```
+
+The configuration file is in `~/Library/Application Support/sabiql/` on macOS and `~/.config/sabiql/` on Linux (or the configured XDG configuration directory). Omit the setting or use `"native"` to retain the default. Other backend names are rejected. Saving connections or changing UI settings preserves this setting. There is no terminal detection, automatic fallback, or new native Wayland support.
+
+OSC 52 sends the existing copy action's complete UTF-8 content, Base64-encoded, to terminal stdout. Cell, row, DDL, SQL/plan, connection-error, and JSON/detail actions retain their existing value selection and formatting, including error masking and row escaping; screen truncation is not applied by the backend. stdout must be a terminal. The output and the complete rendering frame share the standard stdout lock.
+
+The notification **“Sent via OSC 52; clipboard acceptance unverified”** means the output was written and flushed. It does not mean the terminal accepted it or that pasting will work. Native copy-success feedback is not shown for this backend. Disabled or unsupported terminal clipboard operations can silently ignore the request. Local output failures and size rejections produce an error, with no native fallback. A partial output failure may already have sent some bytes.
+
+sabiql limits each request to **74,994 UTF-8 bytes** before encoding. Base64 expands this to at most 99,992 bytes; `ESC ] 52 ; c ;` plus `BEL` adds eight bytes, for at most 100,000 output bytes. This is an application limit, not a universal terminal capacity. Larger values are rejected before any output, never truncated or split. Terminals may impose smaller limits.
+
+The receiving terminal must support and permit clipboard writes via [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html). Over SSH, this means the local terminal and every intervening multiplexer. In tmux, check its [clipboard configuration](https://github.com/tmux/tmux/wiki/Clipboard), including `set-clipboard on` (the `external` setting blocks requests from applications inside tmux) and the outer terminal's clipboard capability. sabiql sends ordinary OSC 52; it does not add tmux passthrough wrappers or configure tmux for you.
+
+Validation uses local simulated writers and a local PTY with the actual renderer. Real SSH, tmux, foot, Cloud Shell, and terminal clipboard acceptance have not been tested for this implementation; these are not certified configurations.

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -21,12 +21,12 @@ use crate::model::app_state::AppState;
 use crate::model::browse::session::ConnectionSaveGuard;
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
-    AppSettings, CachedResultExporter, ClipboardError, ClipboardWriter, ConfigWriter,
-    ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter,
-    FolderOpener, MetadataProvider, MySqlConnectionProbe, MySqlConnectionProbeResult,
-    PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore, RenderOutput,
-    RenderResult, Renderer, ServiceFileContents, ServiceFileError, SettingsStore,
-    SettingsStoreError, SqliteDiagnosticsProvider, SqlitePathValidator,
+    AppSettings, CachedResultExporter, ClipboardError, ClipboardOutcome, ClipboardWriter,
+    ConfigWriter, ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter,
+    ErExportResult, ErLogWriter, FolderOpener, MetadataProvider, MySqlConnectionProbe,
+    MySqlConnectionProbeResult, PgServiceEntryReader, QueryExecutor, QueryHistoryError,
+    QueryHistoryStore, RenderOutput, RenderResult, Renderer, ServiceFileContents, ServiceFileError,
+    SettingsStore, SettingsStoreError, SqliteDiagnosticsProvider, SqlitePathValidator,
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -152,8 +152,8 @@ impl PgServiceEntryReader for NoopPgServiceEntryReader {
 
 pub struct NoopClipboardWriter;
 impl ClipboardWriter for NoopClipboardWriter {
-    fn copy_text(&self, _content: &str) -> Result<(), ClipboardError> {
-        Ok(())
+    fn copy_text(&self, _content: &str) -> Result<ClipboardOutcome, ClipboardError> {
+        Ok(ClipboardOutcome::Copied)
     }
 }
 

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
-use crate::ports::outbound::{ClipboardWriter, FolderOpener};
+use crate::ports::outbound::{ClipboardError, ClipboardOutcome, ClipboardWriter, FolderOpener};
 use crate::update::action::Action;
 
 pub(in crate::cmd) async fn run(
@@ -21,11 +21,16 @@ pub(in crate::cmd) async fn run(
             let clipboard = Arc::clone(clipboard);
             let tx = action_tx.clone();
             tokio::task::spawn_blocking(move || match clipboard.copy_text(&content) {
-                Ok(()) => {
+                Ok(ClipboardOutcome::SentToTerminal) => {
+                    tx.blocking_send(Action::ClipboardSentToTerminal).ok();
+                }
+                Ok(ClipboardOutcome::Copied) => {
                     tx.blocking_send(*on_success).ok();
                 }
                 Err(e) => {
-                    if let Some(action) = on_failure {
+                    if matches!(e, ClipboardError::Terminal(_)) {
+                        tx.blocking_send(Action::CopyFailed(e)).ok();
+                    } else if let Some(action) = on_failure {
                         tx.blocking_send(*action).ok();
                     } else {
                         tx.blocking_send(Action::CopyFailed(e)).ok();
@@ -59,14 +64,12 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
-    use crate::ports::outbound::clipboard::ClipboardError;
-
     struct MockClipboard {
-        result: Result<(), ClipboardError>,
+        result: Result<ClipboardOutcome, ClipboardError>,
     }
 
     impl ClipboardWriter for MockClipboard {
-        fn copy_text(&self, _content: &str) -> Result<(), ClipboardError> {
+        fn copy_text(&self, _content: &str) -> Result<ClipboardOutcome, ClipboardError> {
             self.result.clone()
         }
     }
@@ -106,9 +109,68 @@ mod tests {
         use super::*;
 
         #[tokio::test]
+        async fn terminal_send_does_not_dispatch_native_success() {
+            let (tx, mut rx) = mpsc::channel(8);
+            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
+                result: Ok(ClipboardOutcome::SentToTerminal),
+            });
+            let folder_opener: Arc<dyn FolderOpener> = Arc::new(MockFolderOpener::new());
+
+            run(
+                Effect::CopyToClipboard {
+                    content: "日本語".into(),
+                    on_success: Box::new(Action::ConnectionErrorCopied),
+                    on_failure: None,
+                },
+                &tx,
+                &clipboard,
+                &folder_opener,
+            )
+            .await;
+
+            let action = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(matches!(action, Action::ClipboardSentToTerminal));
+            assert!(rx.try_recv().is_err());
+        }
+
+        #[tokio::test]
+        async fn terminal_failure_preserves_reason_despite_generic_fallback() {
+            let (tx, mut rx) = mpsc::channel(8);
+            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
+                result: Err(ClipboardError::Terminal("OSC 52 output failed".into())),
+            });
+            let folder_opener: Arc<dyn FolderOpener> = Arc::new(MockFolderOpener::new());
+
+            run(
+                Effect::CopyToClipboard {
+                    content: "hello".into(),
+                    on_success: Box::new(Action::Render),
+                    on_failure: Some(Box::new(Action::None)),
+                },
+                &tx,
+                &clipboard,
+                &folder_opener,
+            )
+            .await;
+
+            let action = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(
+                matches!(action, Action::CopyFailed(ClipboardError::Terminal(message)) if message == "OSC 52 output failed")
+            );
+        }
+
+        #[tokio::test]
         async fn on_success_dispatched_when_copy_succeeds() {
             let (tx, mut rx) = mpsc::channel(8);
-            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard { result: Ok(()) });
+            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
+                result: Ok(ClipboardOutcome::Copied),
+            });
             let folder_opener: Arc<dyn FolderOpener> = Arc::new(MockFolderOpener::new());
 
             run(
@@ -194,7 +256,9 @@ mod tests {
         #[tokio::test]
         async fn calls_folder_opener_port() {
             let (tx, _rx) = mpsc::channel(8);
-            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard { result: Ok(()) });
+            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
+                result: Ok(ClipboardOutcome::Copied),
+            });
             let opener = Arc::new(MockFolderOpener::new());
             let folder_opener: Arc<dyn FolderOpener> = Arc::clone(&opener) as _;
 
@@ -218,7 +282,9 @@ mod tests {
         #[tokio::test]
         async fn failure_dispatches_open_folder_failed() {
             let (tx, mut rx) = mpsc::channel(8);
-            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard { result: Ok(()) });
+            let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
+                result: Ok(ClipboardOutcome::Copied),
+            });
             let opener = Arc::new(MockFolderOpener::failing("No such file or directory"));
             let folder_opener: Arc<dyn FolderOpener> = Arc::clone(&opener) as _;
 

--- a/src/app/ports/outbound/clipboard.rs
+++ b/src/app/ports/outbound/clipboard.rs
@@ -6,6 +6,8 @@ pub enum ClipboardError {
     Backend(#[source] Arc<dyn std::error::Error + Send + Sync>),
     #[error("{0}")]
     Unavailable(String),
+    #[error("{0}")]
+    Terminal(String),
 }
 
 impl ClipboardError {
@@ -14,6 +16,12 @@ impl ClipboardError {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClipboardOutcome {
+    Copied,
+    SentToTerminal,
+}
+
 pub trait ClipboardWriter: Send + Sync {
-    fn copy_text(&self, content: &str) -> Result<(), ClipboardError>;
+    fn copy_text(&self, content: &str) -> Result<ClipboardOutcome, ClipboardError>;
 }

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -26,7 +26,7 @@ pub mod sqlite_path_validator;
 
 pub use access_mode::AccessMode;
 pub use cached_result_exporter::CachedResultExporter;
-pub use clipboard::{ClipboardError, ClipboardWriter};
+pub use clipboard::{ClipboardError, ClipboardOutcome, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -585,6 +585,7 @@ pub enum Action {
     ResultCancelCellEdit,
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
+    ClipboardSentToTerminal,
     CopyFailed(ClipboardError),
     OpenFolderFailed {
         message_revision: u64,

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -126,6 +126,13 @@ pub(in crate::update) fn reduce_yank(
             state.flash_timers.set(FlashId::Ddl, now);
             DispatchResult::handled()
         }
+        Action::ClipboardSentToTerminal => {
+            state.messages.set_success_at(
+                "Sent via OSC 52; clipboard acceptance unverified".into(),
+                now,
+            );
+            DispatchResult::handled()
+        }
         Action::CopyFailed(e) => {
             state.messages.set_error(e.to_string());
             DispatchResult::handled()
@@ -142,6 +149,25 @@ mod tests {
     };
     use crate::ports::outbound::ddl_generator::DdlGenerator;
     use std::sync::Arc;
+
+    #[test]
+    fn terminal_send_reports_unverified_acceptance_without_copy_feedback() {
+        let mut state = AppState::new("test".into());
+        let now = Instant::now();
+
+        reduce_yank(
+            &mut state,
+            &Action::ClipboardSentToTerminal,
+            &AppServices::stub(),
+            now,
+        );
+
+        assert_eq!(
+            state.messages.last_success(),
+            Some("Sent via OSC 52; clipboard acceptance unverified")
+        );
+        assert!(!state.connection_error.is_copied_visible_at(now));
+    }
 
     mod cell_yank {
         use super::*;

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -14,6 +14,7 @@ test-support = []
 path = "lib.rs"
 
 [dependencies]
+base64.workspace = true
 async-trait.workspace = true
 csv.workspace = true
 dirs.workspace = true

--- a/src/infra/adapters/clipboard.rs
+++ b/src/infra/adapters/clipboard.rs
@@ -1,21 +1,152 @@
-use crate::app::ports::outbound::clipboard::{ClipboardError, ClipboardWriter};
+use std::io::{IsTerminal, Write, stdout};
 
-pub struct ArboardClipboard;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
+use crate::app::ports::outbound::clipboard::{ClipboardError, ClipboardOutcome, ClipboardWriter};
+
+pub(super) struct ArboardClipboard;
+
+pub(super) struct Osc52Clipboard;
+
+// Bound the encoded sequence below 100 KB without truncating the source value.
+const MAX_OSC52_BYTES: usize = 74_994;
 
 impl ClipboardWriter for ArboardClipboard {
-    fn copy_text(&self, content: &str) -> Result<(), ClipboardError> {
-        copy_text(content)
+    fn copy_text(&self, content: &str) -> Result<ClipboardOutcome, ClipboardError> {
+        copy_native(content).map(|()| ClipboardOutcome::Copied)
     }
 }
 
+impl ClipboardWriter for Osc52Clipboard {
+    fn copy_text(&self, content: &str) -> Result<ClipboardOutcome, ClipboardError> {
+        let stdout = stdout();
+        if !stdout.is_terminal() {
+            return Err(ClipboardError::Terminal(
+                "OSC 52 requires terminal stdout".into(),
+            ));
+        }
+        // The renderer holds this same stdout lock for its entire frame.
+        write_osc52(content, &mut stdout.lock())
+    }
+}
+
+fn write_osc52(content: &str, output: &mut impl Write) -> Result<ClipboardOutcome, ClipboardError> {
+    if content.len() > MAX_OSC52_BYTES {
+        return Err(ClipboardError::Terminal(format!(
+            "OSC 52 copy exceeds {MAX_OSC52_BYTES} UTF-8 bytes; nothing sent"
+        )));
+    }
+    let sequence = format!("\x1b]52;c;{}\x07", STANDARD.encode(content));
+    output
+        .write_all(sequence.as_bytes())
+        .and_then(|()| output.flush())
+        .map_err(|error| ClipboardError::Terminal(format!("OSC 52 output failed: {error}")))?;
+    Ok(ClipboardOutcome::SentToTerminal)
+}
+
 #[cfg(not(target_os = "android"))]
-fn copy_text(content: &str) -> Result<(), ClipboardError> {
+fn copy_native(content: &str) -> Result<(), ClipboardError> {
     arboard::Clipboard::new()
         .and_then(|mut cb| cb.set_text(content))
         .map_err(ClipboardError::backend)
 }
 
 #[cfg(target_os = "android")]
-fn copy_text(_content: &str) -> Result<(), ClipboardError> {
+fn copy_native(_content: &str) -> Result<(), ClipboardError> {
     Err(ClipboardError::Unavailable("Clipboard unavailable".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[rstest::rstest]
+    #[case("", "")]
+    #[case("f", "Zg==")]
+    #[case("fo", "Zm8=")]
+    #[case("foo", "Zm9v")]
+    #[case("hello", "aGVsbG8=")]
+    #[case("日本語🙂", "5pel5pys6Kqe8J+Zgg==")]
+    #[case("\x1b]52;c;?\x07\n\t\0", "G101MjtjOz8HCgkA")]
+    fn encodes_original_utf8_without_raw_control_characters(
+        #[case] content: &str,
+        #[case] encoded: &str,
+    ) {
+        let mut output = Vec::new();
+
+        let outcome = write_osc52(content, &mut output).unwrap();
+
+        assert_eq!(outcome, ClipboardOutcome::SentToTerminal);
+        assert_eq!(output, format!("\x1b]52;c;{encoded}\x07").as_bytes());
+    }
+
+    #[test]
+    fn accepts_limit_and_rejects_next_utf8_byte_without_output() {
+        let content = "日".repeat(MAX_OSC52_BYTES / 3);
+        let mut output = Vec::new();
+
+        write_osc52(&content, &mut output).unwrap();
+
+        assert_eq!(output.len(), 100_000);
+        assert_eq!(
+            STANDARD.decode(&output[7..output.len() - 1]).unwrap(),
+            content.as_bytes()
+        );
+        output.clear();
+        assert!(write_osc52(&(content + "a"), &mut output).is_err());
+        assert!(output.is_empty());
+    }
+
+    #[rstest::rstest]
+    #[case(false)]
+    #[case(true)]
+    fn output_failure_never_reports_sent(#[case] fail_flush: bool) {
+        let mut output = FailingOutput { fail_flush };
+
+        let error = write_osc52("secret", &mut output).unwrap_err();
+
+        assert!(error.to_string().contains("OSC 52 output failed"));
+        assert!(!error.to_string().contains("secret"));
+    }
+
+    #[test]
+    fn retries_short_writes_until_sequence_is_complete() {
+        let mut output = ShortOutput(Vec::new());
+
+        write_osc52("hello", &mut output).unwrap();
+
+        assert_eq!(output.0, b"\x1b]52;c;aGVsbG8=\x07");
+    }
+
+    struct FailingOutput {
+        fail_flush: bool,
+    }
+
+    impl Write for FailingOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.fail_flush {
+                Ok(bytes.len())
+            } else {
+                Err(io::ErrorKind::BrokenPipe.into())
+            }
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::ErrorKind::BrokenPipe.into())
+        }
+    }
+
+    struct ShortOutput(Vec<u8>);
+
+    impl Write for ShortOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            let length = bytes.len().min(2);
+            self.0.extend_from_slice(&bytes[..length]);
+            Ok(length)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 }

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -53,6 +53,7 @@ impl TomlConnectionStore {
             config.theme = existing_config.theme;
             config.keymap_preset = existing_config.keymap_preset;
             config.er_browser = existing_config.er_browser;
+            config.clipboard_backend = existing_config.clipboard_backend;
         }
         let content = toml::to_string_pretty(&config)?;
         let content_with_header = render_config_file(&content);
@@ -320,7 +321,7 @@ ssl_mode = "prefer"
             let config_path = temp_dir.path().join(CONFIG_FILE_NAME);
             fs::write(
                 &config_path,
-                "version = 2\ntheme = \"light\"\nkeymap_preset = \"ide\"\ner_browser = \"Firefox\"\nconnections = []\n",
+                "version = 2\ntheme = \"light\"\nkeymap_preset = \"ide\"\ner_browser = \"Firefox\"\nclipboard_backend = \"osc52\"\nconnections = []\n",
             )
             .unwrap();
             let store = TomlConnectionStore::with_config_dir(temp_dir.path().to_path_buf());
@@ -332,6 +333,7 @@ ssl_mode = "prefer"
             assert!(content.contains("theme = \"light\""));
             assert!(content.contains("keymap_preset = \"ide\""));
             assert!(content.contains("er_browser = \"Firefox\""));
+            assert!(content.contains("clipboard_backend = \"osc52\""));
             assert!(content.contains("[[connections]]"));
         }
 

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -16,7 +16,6 @@ pub(crate) mod sqlite;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub use cached_result_exporter::CsvCachedResultExporter;
-pub use clipboard::ArboardClipboard;
 pub use config_writer::FileConfigWriter;
 pub use connection_store::TomlConnectionStore;
 pub use er_log_writer::FsErLogWriter;

--- a/src/infra/adapters/settings_store.rs
+++ b/src/infra/adapters/settings_store.rs
@@ -1,12 +1,17 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::clipboard::{ArboardClipboard, Osc52Clipboard};
 
 use super::app_config_file::{
     self, config_file_path, get_config_dir as app_config_dir, render_config_file, write_config_file,
 };
 use crate::app::model::shared::settings::KeymapPreset;
 use crate::app::model::shared::theme_id::ThemeId;
-use crate::app::ports::outbound::{AppSettings, SettingsStore, SettingsStoreError};
+use crate::app::ports::outbound::{
+    AppSettings, ClipboardWriter, SettingsStore, SettingsStoreError,
+};
 use crate::config::{
     CURRENT_VERSION, ConfigVersionCheck, ConnectionConfigFile, is_supported_config_version,
 };
@@ -29,6 +34,22 @@ impl TomlSettingsStore {
         Ok(self
             .load_config_file_lenient()?
             .map_or_else(AppSettings::default, app_settings))
+    }
+
+    pub fn load_clipboard(&self) -> Result<Arc<dyn ClipboardWriter>, SettingsStoreError> {
+        let config = self.load_config_file_lenient()?;
+        match config
+            .as_ref()
+            .and_then(|config| config.clipboard_backend.as_deref())
+        {
+            None | Some("native") => Ok(Arc::new(ArboardClipboard)),
+            Some("osc52") => Ok(Arc::new(Osc52Clipboard)),
+            Some(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "clipboard_backend must be native or osc52",
+            )
+            .into()),
+        }
     }
 
     fn load_config_file_lenient(&self) -> Result<Option<ConnectionConfigFile>, SettingsStoreError> {
@@ -83,6 +104,7 @@ impl SettingsStore for TomlSettingsStore {
                 theme: None,
                 keymap_preset: None,
                 er_browser: None,
+                clipboard_backend: None,
                 connections: vec![],
             });
         set_app_settings(&mut config, settings);
@@ -122,6 +144,56 @@ mod tests {
 
     use super::*;
     use tempfile::TempDir;
+
+    #[rstest::rstest]
+    #[case(2, "")]
+    #[case(3, "")]
+    #[case(3, "clipboard_backend = \"native\"\n")]
+    #[case(3, "clipboard_backend = \"osc52\"\n")]
+    fn loads_clipboard_with_legacy_or_explicit_configuration(
+        #[case] version: u32,
+        #[case] backend: &str,
+    ) {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            format!("version = {version}\n{backend}connections = []\n"),
+        )
+        .unwrap();
+        let store = TomlSettingsStore::with_config_dir(dir.path().to_path_buf());
+
+        assert!(store.load_clipboard().is_ok());
+    }
+
+    #[test]
+    fn unknown_clipboard_backend_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            "version = 3\nclipboard_backend = \"auto\"\nconnections = []\n",
+        )
+        .unwrap();
+        let store = TomlSettingsStore::with_config_dir(dir.path().to_path_buf());
+
+        assert!(store.load_clipboard().is_err());
+    }
+
+    #[test]
+    fn saving_ui_settings_preserves_explicit_clipboard_backend() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            "version = 3\nclipboard_backend = \"osc52\"\nconnections = []\n",
+        )
+        .unwrap();
+        let store = TomlSettingsStore::with_config_dir(dir.path().to_path_buf());
+
+        store.save(AppSettings::default()).unwrap();
+
+        let content = fs::read_to_string(dir.path().join(CONFIG_FILE_NAME)).unwrap();
+        let config: ConnectionConfigFile = toml::from_str(&content).unwrap();
+        assert_eq!(config.clipboard_backend.as_deref(), Some("osc52"));
+    }
 
     #[test]
     fn missing_file_returns_default_settings() {

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -33,6 +33,8 @@ pub(crate) struct ConnectionConfigFile {
     pub keymap_preset: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub er_browser: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clipboard_backend: Option<String>,
     pub connections: Vec<ConnectionConfigEntry>,
 }
 
@@ -81,6 +83,7 @@ impl From<&[ConnectionProfile]> for ConnectionConfigFile {
             theme: None,
             keymap_preset: None,
             er_browser: None,
+            clipboard_backend: None,
             connections: profiles.iter().map(ConnectionConfigEntry::from).collect(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,9 @@ use sabiql_app::update::input::handle_event;
 use sabiql_app::update::reducer::reduce;
 use sabiql_infra::adapters::mysql::MySqlAdapter;
 use sabiql_infra::adapters::{
-    ArboardClipboard, CsvCachedResultExporter, DbAdapterRegistry, FileConfigWriter,
-    FileQueryHistoryStore, FsErLogWriter, FsSqlitePathValidator, NativeFolderOpener,
-    PgServiceFileReader, SqliteAdapter, TomlConnectionStore, TomlSettingsStore,
+    CsvCachedResultExporter, DbAdapterRegistry, FileConfigWriter, FileQueryHistoryStore,
+    FsErLogWriter, FsSqlitePathValidator, NativeFolderOpener, PgServiceFileReader, SqliteAdapter,
+    TomlConnectionStore, TomlSettingsStore,
 };
 use sabiql_infra::config::project_root::{find_project_root, get_project_name};
 use sabiql_infra::export::DotExporter;
@@ -140,6 +140,7 @@ async fn main() -> Result<()> {
     let connection_store = TomlConnectionStore::new()?;
     let settings_store = TomlSettingsStore::new()?;
     let app_settings = settings_store.load().unwrap_or_default();
+    let clipboard = settings_store.load_clipboard()?;
     let connection_store = Arc::new(connection_store);
     let settings_store = Arc::new(settings_store);
 
@@ -167,7 +168,7 @@ async fn main() -> Result<()> {
             er_log_writer: Arc::new(FsErLogWriter),
         },
         UtilityDeps {
-            clipboard: Arc::new(ArboardClipboard),
+            clipboard,
             folder_opener: Arc::new(NativeFolderOpener),
         },
         Arc::clone(&settings_store) as _,

--- a/src/tests/clipboard.rs
+++ b/src/tests/clipboard.rs
@@ -1,0 +1,139 @@
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::os::fd::FromRawFd;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Barrier};
+use std::time::Instant;
+
+use sabiql_app::model::app_state::AppState;
+use sabiql_app::ports::outbound::renderer::Renderer;
+use sabiql_app::services::AppServices;
+use sabiql_infra::adapters::TomlSettingsStore;
+use sabiql_ui::adapters::TuiAdapter;
+use sabiql_ui::tui::TuiRunner;
+
+#[test]
+fn osc52_and_real_renderer_share_stdout_exclusion() {
+    if std::env::var_os("SABIQL_OSC52_PTY_CHILD").is_some() {
+        exercise_output();
+        return;
+    }
+    let mut master = -1;
+    let mut slave = -1;
+    let mut size = libc::winsize {
+        ws_row: 30,
+        ws_col: 120,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    // openpty initializes both descriptors on success; each is adopted exactly once below.
+    assert_eq!(
+        unsafe {
+            libc::openpty(
+                &raw mut master,
+                &raw mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &raw mut size,
+            )
+        },
+        0
+    );
+    let (mut master, slave) = unsafe { (File::from_raw_fd(master), File::from_raw_fd(slave)) };
+    let child = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "tests::clipboard::osc52_and_real_renderer_share_stdout_exclusion",
+            "--nocapture",
+        ])
+        .env("SABIQL_OSC52_PTY_CHILD", "1")
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stdin(Stdio::from(slave))
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut buffer = [0; 8192];
+        loop {
+            match master.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(length) => bytes.extend_from_slice(&buffer[..length]),
+                Err(error) if error.raw_os_error() == Some(libc::EIO) => break,
+                Err(error) => panic!("PTY read failed: {error}"),
+            }
+        }
+        bytes
+    });
+
+    let result = child.wait_with_output().unwrap();
+    let output = reader.join().unwrap();
+
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let sequence = b"\x1b]52;c;5pel5pys6Kqe8J+Zgg==\x07";
+    assert_eq!(
+        output
+            .windows(sequence.len())
+            .filter(|bytes| *bytes == sequence)
+            .count(),
+        100
+    );
+    let text = String::from_utf8(output).unwrap();
+    let frame = text
+        .split("FRAME_BEGIN")
+        .nth(1)
+        .unwrap()
+        .split("FRAME_END")
+        .next()
+        .unwrap();
+    assert!(!frame.contains("\x1b]52;"));
+    assert!(frame.contains("\x1b["));
+}
+
+fn exercise_output() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("connections.toml"),
+        "version = 3\nclipboard_backend = \"osc52\"\nconnections = []\n",
+    )
+    .unwrap();
+    let clipboard = TomlSettingsStore::with_config_dir(dir.path().to_path_buf())
+        .load_clipboard()
+        .unwrap();
+    let mut tui = TuiRunner::new().unwrap();
+    let services = AppServices::stub();
+    let mut state = AppState::new("osc52-pty".into());
+    let barrier = Arc::new(Barrier::new(2));
+    let stdout = std::io::stdout();
+    let mut output_lock = stdout.lock();
+    let worker_barrier = Arc::clone(&barrier);
+    let worker = std::thread::spawn(move || {
+        worker_barrier.wait();
+        for _ in 0..100 {
+            assert!(clipboard.copy_text("日本語🙂").is_ok());
+            std::thread::yield_now();
+        }
+    });
+    barrier.wait();
+    output_lock.write_all(b"FRAME_BEGIN").unwrap();
+    TuiAdapter::new(&mut tui)
+        .draw(&state, &services, Instant::now())
+        .unwrap();
+    output_lock.write_all(b"FRAME_END").unwrap();
+    output_lock.flush().unwrap();
+    drop(output_lock);
+    for index in 0..100 {
+        state
+            .messages
+            .set_success_at(format!("frame {index}"), Instant::now());
+        TuiAdapter::new(&mut tui)
+            .draw(&state, &services, Instant::now())
+            .unwrap();
+        std::thread::yield_now();
+    }
+    worker.join().unwrap();
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,7 @@
 mod adapter_mysql;
 mod adapter_postgres;
+#[cfg(unix)]
+mod clipboard;
 pub mod harness;
 
 use clap::Parser;

--- a/src/ui/adapters/tui_adapter.rs
+++ b/src/ui/adapters/tui_adapter.rs
@@ -34,6 +34,9 @@ impl Renderer for TuiAdapter<'_> {
         services: &AppServices,
         now: Instant,
     ) -> RenderResult<RenderOutput> {
+        // Keep background terminal clipboard output outside the entire frame.
+        let stdout = std::io::stdout();
+        let _output_lock = stdout.lock();
         let mut output = RenderOutput::default();
         self.tui.terminal().draw(|frame| {
             output = MainLayout::render(frame, state, None, services, now);


### PR DESCRIPTION
## Problem

The native clipboard operates on the host running sabiql, so copy actions cannot reach the local terminal's clipboard over SSH. Implements #1194 for the cloud-readiness integration branch.

## Approach

An explicit `clipboard_backend = "osc52"` setting sends the existing copy content through the terminal; omission retains native behavior. Output is serialized with rendering, and the UI distinguishes a flushed request from terminal clipboard acceptance. Requests exceeding 74,994 UTF-8 bytes are rejected without output; the complete encoded sequence is bounded at 100,000 bytes.

## Validation

Focused tests cover Base64/Unicode/control bytes, the exact size boundary, short writes and output errors, configuration compatibility/preservation, copy outcome dispatch, and existing yank paths. A local PTY exercises the actual renderer concurrently with OSC 52 output. Targeted Clippy, formatting, and repository lints pass; full workspace validation is delegated to CI.

Real SSH, tmux, foot, Cloud Shell, and clipboard acceptance remain untested. No cloud resources were accessed. Target and normal merge destination: `feat/cloud-readiness`; main merge is outside this PR's execution scope.
