### PR TITLE
refactor: combine metadata and effective user fetches

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -37,9 +37,6 @@ pub(in crate::cmd) async fn run(
             )
             .await;
         }
-        Effect::FetchEffectiveUser { dsn, run_id } => {
-            fetch_effective_user(action_tx, metadata_provider, metadata_tasks, dsn, run_id);
-        }
         Effect::FetchTableDetail {
             dsn,
             schema,
@@ -121,11 +118,14 @@ async fn fetch_metadata(
 
     MetadataTaskRegistry::spawn(metadata_tasks, async move {
         match provider.fetch_metadata(&dsn).await {
-            Ok(metadata) => {
-                let metadata = Arc::new(metadata);
-                tx.send(Action::MetadataLoaded { run_id, metadata })
-                    .await
-                    .ok();
+            Ok(result) => {
+                tx.send(Action::MetadataLoaded {
+                    run_id,
+                    metadata: Arc::new(result.metadata),
+                    effective_user: result.effective_user,
+                })
+                .await
+                .ok();
             }
             Err(e) => {
                 tx.send(Action::MetadataFailed { run_id, error: e })
@@ -133,27 +133,6 @@ async fn fetch_metadata(
                     .ok();
             }
         }
-    });
-}
-
-fn fetch_effective_user(
-    action_tx: &mpsc::Sender<Action>,
-    metadata_provider: &Arc<dyn MetadataProvider>,
-    metadata_tasks: &Arc<MetadataTaskRegistry>,
-    dsn: String,
-    run_id: u64,
-) {
-    let provider = Arc::clone(metadata_provider);
-    let tx = action_tx.clone();
-
-    MetadataTaskRegistry::spawn(metadata_tasks, async move {
-        let effective_user = provider.fetch_effective_user(&dsn).await.ok().flatten();
-        tx.send(Action::EffectiveUserLoaded {
-            run_id,
-            effective_user,
-        })
-        .await
-        .ok();
     });
 }
 
@@ -275,10 +254,10 @@ mod tests {
 
     use crate::domain::SqlitePathError;
     use crate::model::app_state::AppState;
-    use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
+    use crate::ports::outbound::{DbOperationError, MetadataFetchResult};
     use crate::update::action::Action;
 
     mod fetch_metadata {
@@ -342,10 +321,12 @@ mod tests {
             fs::write(&path, b"").unwrap();
             let dsn = format!("sqlite://{}", path.display());
             let mut mock_provider = MockMetadataProvider::new();
-            mock_provider
-                .expect_fetch_metadata()
-                .once()
-                .returning(|_| Ok(test_fixtures::sample_metadata()));
+            mock_provider.expect_fetch_metadata().once().returning(|_| {
+                Ok(MetadataFetchResult {
+                    metadata: test_fixtures::sample_metadata(),
+                    effective_user: None,
+                })
+            });
 
             let (tx, mut rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
@@ -379,10 +360,12 @@ mod tests {
         #[tokio::test]
         async fn fetches_metadata_and_returns_metadata_loaded() {
             let mut mock_provider = MockMetadataProvider::new();
-            mock_provider
-                .expect_fetch_metadata()
-                .once()
-                .returning(|_| Ok(test_fixtures::sample_metadata()));
+            mock_provider.expect_fetch_metadata().once().returning(|_| {
+                Ok(MetadataFetchResult {
+                    metadata: test_fixtures::sample_metadata(),
+                    effective_user: Some("app_user".to_string()),
+                })
+            });
 
             let (tx, mut rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
@@ -407,10 +390,14 @@ mod tests {
             .unwrap();
 
             let action = run.actions.into_iter().next().expect("action dispatched");
-            assert!(
-                matches!(action, Action::MetadataLoaded { run_id: 7, .. }),
-                "expected MetadataLoaded, got {action:?}"
-            );
+            assert!(matches!(
+                action,
+                Action::MetadataLoaded {
+                    run_id: 7,
+                    effective_user: Some(user),
+                    ..
+                } if user == "app_user"
+            ));
         }
 
         #[tokio::test]
@@ -420,7 +407,6 @@ mod tests {
                 .expect_fetch_metadata()
                 .once()
                 .returning(|_| Err(DbOperationError::ConnectionFailed("timeout".to_string())));
-            mock_provider.expect_fetch_effective_user().never();
 
             let (tx, mut rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
@@ -449,50 +435,6 @@ mod tests {
                 matches!(action, Action::MetadataFailed { run_id: 7, .. }),
                 "expected MetadataFailed, got {action:?}"
             );
-        }
-
-        #[tokio::test]
-        async fn effective_user_provider_error_is_reported_as_absent() {
-            let mut mock_provider = MockMetadataProvider::new();
-            mock_provider
-                .expect_fetch_effective_user()
-                .once()
-                .returning(|_| {
-                    Err(DbOperationError::QueryFailed(
-                        "permission denied".to_string(),
-                    ))
-                });
-
-            let (tx, mut rx) = mpsc::channel(8);
-            let runner = test_fixtures::make_runner(
-                Arc::new(mock_provider),
-                Arc::new(MockQueryExecutor::new()),
-                Arc::new(MockConnectionStore::new()),
-                tx,
-            );
-
-            let run = test_fixtures::run_one_effect(
-                &runner,
-                Effect::FetchEffectiveUser {
-                    dsn: "dsn://test".to_string(),
-                    run_id: 7,
-                },
-                AppState::new("test".to_string()),
-                RefCell::new(CompletionEngine::new()),
-                &mut rx,
-                Some(std::time::Duration::from_millis(500)),
-            )
-            .await
-            .unwrap();
-
-            let action = run.actions.into_iter().next().expect("action dispatched");
-            assert!(matches!(
-                action,
-                Action::EffectiveUserLoaded {
-                    run_id: 7,
-                    effective_user: None,
-                }
-            ));
         }
     }
 

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -148,6 +148,7 @@ pub(in crate::cmd) async fn run(
                                         run_id,
                                         mysql_lower_case_table_names: None,
                                         metadata: None,
+                                        effective_user: None,
                                     })
                                     .ok();
                                 }
@@ -191,6 +192,7 @@ pub(in crate::cmd) async fn run(
                                                 probe_result.lower_case_table_names,
                                             ),
                                             metadata: None,
+                                            effective_user: None,
                                         })
                                         .await
                                         .ok();
@@ -226,7 +228,7 @@ pub(in crate::cmd) async fn run(
             connection_task
                 .replace(async move {
                     match provider.fetch_metadata(&dsn).await {
-                        Ok(metadata) => {
+                        Ok(metadata_result) => {
                             let save_result = tokio::task::spawn_blocking(move || {
                                 claim_and_save(&run_guard, run_id, || store.save(&profile))
                             })
@@ -238,7 +240,8 @@ pub(in crate::cmd) async fn run(
                                         target,
                                         run_id,
                                         mysql_lower_case_table_names: None,
-                                        metadata: Some(Arc::new(metadata)),
+                                        metadata: Some(Arc::new(metadata_result.metadata)),
+                                        effective_user: metadata_result.effective_user,
                                     })
                                     .await
                                     .ok();
@@ -438,7 +441,8 @@ mod tests {
     use crate::ports::outbound::mysql_connection_probe::MockMySqlConnectionProbe;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
     use crate::ports::outbound::{
-        ConnectionStoreError, DbOperationError, DsnBuilder, MySqlConnectionProbeResult,
+        ConnectionStoreError, DbOperationError, DsnBuilder, MetadataFetchResult,
+        MySqlConnectionProbeResult,
     };
     use crate::services::AppServices;
     use crate::update::action::{
@@ -687,7 +691,10 @@ mod tests {
                 .once()
                 .returning(move |_| {
                     guard_for_provider.cancel();
-                    Ok(DatabaseMetadata::new("app".to_string()))
+                    Ok(MetadataFetchResult {
+                        metadata: DatabaseMetadata::new("app".to_string()),
+                        effective_user: None,
+                    })
                 });
 
             let mut store = MockConnectionStore::new();
@@ -733,7 +740,12 @@ mod tests {
                 .expect_fetch_metadata()
                 .with(eq(dsn.clone()))
                 .once()
-                .returning(|_| Ok(DatabaseMetadata::new("app".to_string())));
+                .returning(|_| {
+                    Ok(MetadataFetchResult {
+                        metadata: DatabaseMetadata::new("app".to_string()),
+                        effective_user: Some("app_user".to_string()),
+                    })
+                });
 
             let mut store = MockConnectionStore::new();
             store.expect_save().once().returning(|_| Ok(()));
@@ -781,7 +793,12 @@ mod tests {
                 .expect_fetch_metadata()
                 .with(eq(dsn.clone()))
                 .once()
-                .returning(|_| Ok(DatabaseMetadata::new("app".to_string())));
+                .returning(|_| {
+                    Ok(MetadataFetchResult {
+                        metadata: DatabaseMetadata::new("app".to_string()),
+                        effective_user: None,
+                    })
+                });
 
             let mut store = MockConnectionStore::new();
             store.expect_save().once().returning(|_| {

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -34,10 +34,6 @@ pub enum Effect {
         dsn: String,
         run_id: u64,
     },
-    FetchEffectiveUser {
-        dsn: String,
-        run_id: u64,
-    },
     // Updates state.table_detail on completion
     FetchTableDetail {
         dsn: String,

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -101,7 +101,7 @@ pub(in crate::cmd) fn smart_refresh_task(
 
     async move {
         let new_metadata = match metadata_provider.fetch_metadata(&dsn).await {
-            Ok(m) => m,
+            Ok(result) => result.metadata,
             Err(e) => {
                 tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
                     dsn,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -219,7 +219,6 @@ impl EffectRunner {
             }
 
             e @ (Effect::FetchMetadata { .. }
-            | Effect::FetchEffectiveUser { .. }
             | Effect::FetchTableDetail { .. }
             | Effect::PrefetchTableColumnsAndFks { .. }
             | Effect::SchedulePrefetchQueueProcessing { .. }
@@ -354,7 +353,9 @@ mod tests {
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
-    use crate::ports::outbound::{MySqlConnectionProbeResult, RenderOutput, RenderResult};
+    use crate::ports::outbound::{
+        MetadataFetchResult, MySqlConnectionProbeResult, RenderOutput, RenderResult,
+    };
     use crate::services::AppServices;
     use tokio::sync::mpsc;
 
@@ -899,7 +900,7 @@ mod tests {
             async fn fetch_metadata(
                 &self,
                 _dsn: &str,
-            ) -> Result<DatabaseMetadata, DbOperationError> {
+            ) -> Result<MetadataFetchResult, DbOperationError> {
                 unreachable!("test only starts table detail")
             }
 
@@ -1118,7 +1119,6 @@ mod tests {
 
         struct PendingMetadataProvider {
             metadata_started: Mutex<Option<oneshot::Sender<()>>>,
-            effective_user_started: Mutex<Option<oneshot::Sender<()>>>,
             dropped: Arc<AtomicUsize>,
         }
 
@@ -1127,28 +1127,13 @@ mod tests {
             async fn fetch_metadata(
                 &self,
                 _dsn: &str,
-            ) -> Result<DatabaseMetadata, DbOperationError> {
+            ) -> Result<MetadataFetchResult, DbOperationError> {
                 let _guard = DropSignal(Arc::clone(&self.dropped));
                 self.metadata_started
                     .lock()
                     .expect("metadata started signal lock poisoned")
                     .take()
                     .expect("metadata should start once")
-                    .send(())
-                    .ok();
-                pending().await
-            }
-
-            async fn fetch_effective_user(
-                &self,
-                _dsn: &str,
-            ) -> Result<Option<String>, DbOperationError> {
-                let _guard = DropSignal(Arc::clone(&self.dropped));
-                self.effective_user_started
-                    .lock()
-                    .expect("effective user started signal lock poisoned")
-                    .take()
-                    .expect("effective user should start once")
                     .send(())
                     .ok();
                 pending().await
@@ -1211,7 +1196,6 @@ mod tests {
             let dropped = Arc::new(AtomicUsize::new(0));
             let metadata_provider = PendingMetadataProvider {
                 metadata_started: Mutex::new(Some(metadata_started_tx)),
-                effective_user_started: Mutex::new(None),
                 dropped: Arc::clone(&dropped),
             };
             let probe = ProbeThatObservesDrop {
@@ -1275,13 +1259,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn quit_drops_effective_user_and_delayed_prefetch_tasks() {
-            let (effective_user_started_tx, effective_user_started_rx) = oneshot::channel();
-            let dropped = Arc::new(AtomicUsize::new(0));
+        async fn quit_drops_delayed_prefetch_task() {
             let provider = PendingMetadataProvider {
                 metadata_started: Mutex::new(None),
-                effective_user_started: Mutex::new(Some(effective_user_started_tx)),
-                dropped: Arc::clone(&dropped),
+                dropped: Arc::new(AtomicUsize::new(0)),
             };
             let (action_tx, mut action_rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(
@@ -1296,16 +1277,10 @@ mod tests {
 
             runner
                 .execute_effects(
-                    vec![
-                        Effect::FetchEffectiveUser {
-                            dsn: "postgres://localhost/current".to_string(),
-                            run_id: 1,
-                        },
-                        Effect::DelayedProcessPrefetchQueue {
-                            run_id: 1,
-                            delay_secs: 60,
-                        },
-                    ],
+                    vec![Effect::DelayedProcessPrefetchQueue {
+                        run_id: 1,
+                        delay_secs: 60,
+                    }],
                     &mut renderer,
                     &mut state,
                     &completion_engine,
@@ -1313,10 +1288,6 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            effective_user_started_rx
-                .await
-                .expect("effective user should start");
-
             let shutdown_effects = reduce(
                 &mut state,
                 Action::Quit,
@@ -1334,7 +1305,6 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(dropped.load(Ordering::SeqCst), 1);
             assert!(
                 timeout(Duration::from_millis(100), action_rx.recv())
                     .await
@@ -1399,7 +1369,7 @@ mod tests {
             async fn fetch_metadata(
                 &self,
                 dsn: &str,
-            ) -> Result<DatabaseMetadata, DbOperationError> {
+            ) -> Result<MetadataFetchResult, DbOperationError> {
                 let _drop_signal = DropSignal(Arc::clone(&self.dropped));
                 self.started
                     .send(dsn.to_string())
@@ -1824,7 +1794,7 @@ mod tests {
             async fn fetch_metadata(
                 &self,
                 dsn: &str,
-            ) -> Result<DatabaseMetadata, DbOperationError> {
+            ) -> Result<MetadataFetchResult, DbOperationError> {
                 let _guard = DropSignal(Arc::clone(&self.dropped));
                 self.started.send(dsn.to_string()).ok();
                 pending().await

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -155,7 +155,6 @@ pub struct BrowseSession {
     metadata_run: AsyncRun,
     metadata_detail_generation: Option<u64>,
     effective_user: Option<String>,
-    effective_user_run: AsyncRun,
     table_detail_run: AsyncRun,
     connection_save_run: AsyncRun,
     connection_save_guard: Arc<ConnectionSaveGuard>,
@@ -184,7 +183,6 @@ impl Default for BrowseSession {
             metadata_run: AsyncRun::default(),
             metadata_detail_generation: None,
             effective_user: None,
-            effective_user_run: AsyncRun::default(),
             table_detail_run: AsyncRun::default(),
             connection_save_run: AsyncRun::default(),
             connection_save_guard: Arc::new(ConnectionSaveGuard::default()),
@@ -320,7 +318,6 @@ impl BrowseSession {
         self.connection_state = ConnectionState::Connecting;
         self.metadata_state = MetadataState::Loading;
         self.effective_user = None;
-        self.effective_user_run.clear_active();
     }
 
     #[must_use]
@@ -387,7 +384,6 @@ impl BrowseSession {
 
     fn invalidate_inflight_state_for_mysql_probe(&mut self) {
         self.metadata_run.clear_active();
-        self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();
         self.is_reloading = false;
         match self.connection_state {
@@ -492,13 +488,20 @@ impl BrowseSession {
     }
 
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
+        self.mark_connected_with_user(metadata, None);
+    }
+
+    pub fn mark_connected_with_user(
+        &mut self,
+        metadata: Arc<DatabaseMetadata>,
+        effective_user: Option<String>,
+    ) {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.metadata = Some(metadata);
         self.metadata_run.clear_active();
         self.metadata_detail_generation = None;
-        self.effective_user = None;
-        self.effective_user_run.clear_active();
+        self.effective_user = effective_user;
     }
 
     pub fn mark_probe_connected(&mut self) {
@@ -508,7 +511,6 @@ impl BrowseSession {
         self.metadata_run.clear_active();
         self.metadata_detail_generation = None;
         self.effective_user = None;
-        self.effective_user_run.clear_active();
     }
 
     // On reload failure (already Connected), keeps Connected to preserve
@@ -519,7 +521,6 @@ impl BrowseSession {
         self.metadata_run.clear_active();
         if !self.connection_state.is_connected() {
             self.effective_user = None;
-            self.effective_user_run.clear_active();
             self.connection_state = ConnectionState::Failed;
         }
     }
@@ -540,7 +541,6 @@ impl BrowseSession {
         self.is_reloading = false;
         self.metadata_run.clear_active();
         self.effective_user = None;
-        self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();
         self.clear_mysql_connection_probe();
     }
@@ -594,20 +594,6 @@ impl BrowseSession {
             && self.metadata_generation() == metadata_generation
     }
 
-    #[must_use]
-    pub fn begin_effective_user_fetch(&mut self) -> u64 {
-        self.effective_user_run.begin()
-    }
-
-    pub fn is_current_effective_user_run(&self, run_id: u64) -> bool {
-        self.effective_user_run.is_current(run_id)
-    }
-
-    pub fn mark_effective_user_loaded(&mut self, effective_user: Option<String>) {
-        self.effective_user = effective_user;
-        self.effective_user_run.clear_active();
-    }
-
     // ── Cache operations ─────────────────────────────────────────────
 
     pub fn to_cache(
@@ -647,7 +633,6 @@ impl BrowseSession {
         self.metadata_detail_generation = None;
         self.is_reloading = false;
         self.metadata_run.clear_active();
-        self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();
         self.clear_mysql_connection_probe();
         match &cache.query_result {
@@ -682,7 +667,6 @@ impl BrowseSession {
         self.metadata_run.clear_active();
         self.metadata_detail_generation = None;
         self.effective_user = None;
-        self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();
         self.clear_connection();
         self.read_only = false;
@@ -1386,7 +1370,7 @@ mod tests {
                 DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
-            session.mark_effective_user_loaded(Some("old_user".to_string()));
+            session.mark_connected_with_user(make_metadata("test"), Some("old_user".to_string()));
 
             session.mark_connecting();
 
@@ -1447,9 +1431,8 @@ mod tests {
         #[test]
         fn mark_connection_failed_when_connected_keeps_connected() {
             let mut session = BrowseSession::default();
-            session.mark_connected(make_metadata("db"));
+            session.mark_connected_with_user(make_metadata("db"), Some("postgres".to_string()));
             let _ = session.begin_reload();
-            session.mark_effective_user_loaded(Some("postgres".to_string()));
 
             session.mark_connection_failed();
 
@@ -1460,15 +1443,11 @@ mod tests {
         }
 
         #[test]
-        fn effective_user_completion_updates_state() {
+        fn metadata_completion_updates_effective_user() {
             let mut session = BrowseSession::default();
-            let run_id = session.begin_effective_user_fetch();
-
-            assert!(session.is_current_effective_user_run(run_id));
-            session.mark_effective_user_loaded(Some("postgres".to_string()));
+            session.mark_connected_with_user(make_metadata("db"), Some("postgres".to_string()));
 
             assert_eq!(session.effective_user(), Some("postgres"));
-            assert!(!session.is_current_effective_user_run(run_id));
         }
 
         #[test]
@@ -1541,8 +1520,10 @@ mod tests {
         #[test]
         fn round_trip_preserves_state() {
             let mut session = BrowseSession::default();
-            session.mark_connected(make_metadata("round_trip_db"));
-            session.mark_effective_user_loaded(Some("postgres".to_string()));
+            session.mark_connected_with_user(
+                make_metadata("round_trip_db"),
+                Some("postgres".to_string()),
+            );
             let mut query = QueryExecution::default();
             let _ = session.select_table("public", "users", &mut query);
             let _ = session.set_table_detail(make_table_detail(), session.selection_generation());

--- a/src/app/ports/outbound/metadata.rs
+++ b/src/app/ports/outbound/metadata.rs
@@ -4,14 +4,16 @@ use crate::domain::{DatabaseMetadata, Table, TableSignatureSnapshot};
 
 use super::DbOperationError;
 
+#[derive(Debug, Clone)]
+pub struct MetadataFetchResult {
+    pub metadata: DatabaseMetadata,
+    pub effective_user: Option<String>,
+}
+
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait MetadataProvider: Send + Sync {
-    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError>;
-
-    async fn fetch_effective_user(&self, _dsn: &str) -> Result<Option<String>, DbOperationError> {
-        Ok(None)
-    }
+    async fn fetch_metadata(&self, dsn: &str) -> Result<MetadataFetchResult, DbOperationError>;
 
     async fn fetch_table_detail(
         &self,

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -38,7 +38,7 @@ pub use dsn_builder::DsnBuilder;
 pub use er_exporter::{ErDiagramExporter, ErExportError, ErExportResult};
 pub use er_log_writer::ErLogWriter;
 pub use folder_opener::FolderOpener;
-pub use metadata::MetadataProvider;
+pub use metadata::{MetadataFetchResult, MetadataProvider};
 pub use mysql_connection_probe::{MySqlConnectionProbe, MySqlConnectionProbeResult};
 pub use query_executor::QueryExecutor;
 pub use query_history::{QueryHistoryError, QueryHistoryStore};

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -375,6 +375,7 @@ pub enum Action {
         run_id: u64,
         mysql_lower_case_table_names: Option<u8>,
         metadata: Option<Arc<DatabaseMetadata>>,
+        effective_user: Option<String>,
     },
     ConnectionSaveFailed {
         error: ConnectionSaveError,
@@ -432,14 +433,11 @@ pub enum Action {
     MetadataLoaded {
         run_id: u64,
         metadata: Arc<DatabaseMetadata>,
+        effective_user: Option<String>,
     },
     MetadataFailed {
         run_id: u64,
         error: DbOperationError,
-    },
-    EffectiveUserLoaded {
-        run_id: u64,
-        effective_user: Option<String>,
     },
     TableDetailLoaded {
         dsn: String,

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -18,7 +18,11 @@ pub(super) fn reduce_loading(
     now: Instant,
 ) -> DispatchResult {
     match action {
-        Action::MetadataLoaded { run_id, metadata } => {
+        Action::MetadataLoaded {
+            run_id,
+            metadata,
+            effective_user,
+        } => {
             if !state.session.is_current_metadata_run(*run_id) {
                 return DispatchResult::handled();
             }
@@ -27,13 +31,11 @@ pub(super) fn reduce_loading(
             };
 
             let has_tables = !metadata.table_summaries.is_empty();
-            state.session.mark_connected(Arc::clone(metadata));
-            let effective_user_run_id = state.session.begin_effective_user_fetch();
+            state
+                .session
+                .mark_connected_with_user(Arc::clone(metadata), effective_user.clone());
 
-            let mut effects = vec![Effect::FetchEffectiveUser {
-                dsn: dsn.clone(),
-                run_id: effective_user_run_id,
-            }];
+            let mut effects = Vec::new();
 
             if state.query.pagination.table().is_empty() {
                 state
@@ -88,19 +90,6 @@ pub(super) fn reduce_loading(
             }
 
             DispatchResult::handled_with(effects)
-        }
-        Action::EffectiveUserLoaded {
-            run_id,
-            effective_user,
-        } => {
-            if !state.session.is_current_effective_user_run(*run_id) {
-                return DispatchResult::handled();
-            }
-
-            state
-                .session
-                .mark_effective_user_loaded(effective_user.clone());
-            DispatchResult::handled()
         }
         Action::MetadataFailed { run_id, error } => {
             if !state.session.is_current_metadata_run(*run_id) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -144,6 +144,7 @@ mod tests {
                 &Action::MetadataLoaded {
                     run_id: stale_run_id,
                     metadata: metadata_with_users(),
+                    effective_user: None,
                 },
                 Instant::now(),
             )
@@ -1262,7 +1263,11 @@ mod tests {
 
         fn metadata_loaded_action(state: &mut AppState, metadata: Arc<DatabaseMetadata>) -> Action {
             let run_id = state.session.begin_metadata_refresh();
-            Action::MetadataLoaded { run_id, metadata }
+            Action::MetadataLoaded {
+                run_id,
+                metadata,
+                effective_user: None,
+            }
         }
 
         #[test]
@@ -1299,6 +1304,7 @@ mod tests {
                 &Action::MetadataLoaded {
                     run_id: metadata_run_id,
                     metadata: make_metadata(vec![("public", "orders")]),
+                    effective_user: None,
                 },
                 Instant::now(),
             )

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -1788,7 +1788,11 @@ mod tests {
 
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
             let run_id = state.session.begin_metadata_refresh();
-            let action = Action::MetadataLoaded { run_id, metadata };
+            let action = Action::MetadataLoaded {
+                run_id,
+                metadata,
+                effective_user: None,
+            };
             let meta_effects = dispatch_metadata(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(state.ui.explorer_selected(), 1);
@@ -1821,7 +1825,11 @@ mod tests {
 
             let metadata = make_metadata(vec![("public", "orders")]);
             let run_id = state.session.begin_metadata_refresh();
-            let action = Action::MetadataLoaded { run_id, metadata };
+            let action = Action::MetadataLoaded {
+                run_id,
+                metadata,
+                effective_user: None,
+            };
             dispatch_metadata(&mut state, &action, Instant::now());
 
             assert!(state.query.pagination.table().is_empty());

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -50,9 +50,14 @@ pub(super) fn connection_save_fetch_effects(
     dsn: &str,
     run_id: u64,
     metadata: Option<Arc<DatabaseMetadata>>,
+    effective_user: Option<String>,
 ) -> Vec<Effect> {
     let metadata_effect = if let Some(metadata) = metadata {
-        Effect::DispatchActions(vec![Action::MetadataLoaded { run_id, metadata }])
+        Effect::DispatchActions(vec![Action::MetadataLoaded {
+            run_id,
+            metadata,
+            effective_user,
+        }])
     } else {
         Effect::FetchMetadata {
             dsn: dsn.to_string(),

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -69,14 +69,7 @@ pub(in crate::update) fn reduce_connection_lifecycle(
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, target);
-                let mut effects = vec![Effect::ClearCompletionEngineCache];
-                if state.session.effective_user().is_none() {
-                    let run_id = state.session.begin_effective_user_fetch();
-                    effects.push(Effect::FetchEffectiveUser {
-                        dsn: dsn.clone(),
-                        run_id,
-                    });
-                }
+                let effects = vec![Effect::ClearCompletionEngineCache];
                 DispatchResult::handled_with(termination_effects(&state.query, effects))
             } else {
                 // No cache: reset and fetch metadata
@@ -648,9 +641,10 @@ mod tests {
             state
                 .session
                 .mark_connected(Arc::new(DatabaseMetadata::new("current".to_string())));
+            let metadata = state.session.metadata().cloned().expect("metadata");
             state
                 .session
-                .mark_effective_user_loaded(Some("user@localhost".to_string()));
+                .mark_connected_with_user(Arc::new(metadata), Some("user@localhost".to_string()));
             state.ui.set_explorer_selected_raw(5);
             state.ui.set_inspector_tab(InspectorTab::Indexes);
             state
@@ -1092,11 +1086,6 @@ mod tests {
                     .iter()
                     .any(|effect| matches!(effect, Effect::CancelTrackedTasks))
             );
-            assert!(
-                !effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::FetchEffectiveUser { .. }))
-            );
             let metadata_run_id = effects
                 .iter()
                 .find_map(|effect| match effect {
@@ -1137,6 +1126,7 @@ mod tests {
                 Action::MetadataLoaded {
                     run_id: metadata_run_id,
                     metadata: refreshed_metadata,
+                    effective_user: None,
                 },
                 std::time::Instant::now(),
                 &AppServices::stub(),
@@ -1257,6 +1247,7 @@ mod tests {
                 Action::MetadataLoaded {
                     run_id: stale_run_id,
                     metadata: Arc::new(DatabaseMetadata::new("stale".to_string())),
+                    effective_user: None,
                 },
                 std::time::Instant::now(),
                 &AppServices::stub(),

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -250,6 +250,7 @@ pub(in crate::update) fn reduce_connection_setup(
             run_id,
             mysql_lower_case_table_names,
             metadata,
+            effective_user,
         } => {
             if !state.session.is_current_connection_save(*run_id) {
                 return DispatchResult::handled();
@@ -282,6 +283,7 @@ pub(in crate::update) fn reduce_connection_setup(
                 dsn,
                 run_id,
                 metadata.clone(),
+                effective_user.clone(),
             ))
         }
         Action::ConnectionSaveFailed { error: e, run_id } => {
@@ -887,6 +889,7 @@ mod tests {
                     run_id,
                     mysql_lower_case_table_names: None,
                     metadata: None,
+                    effective_user: None,
                 },
                 Instant::now(),
             );
@@ -926,6 +929,7 @@ mod tests {
                     run_id: save_run_id,
                     mysql_lower_case_table_names: None,
                     metadata: None,
+                    effective_user: None,
                 },
                 Instant::now(),
             );
@@ -1160,6 +1164,7 @@ mod tests {
                 run_id,
                 mysql_lower_case_table_names: None,
                 metadata: None,
+                effective_user: None,
             };
             reduce(&mut state, &action, Instant::now());
 
@@ -1206,6 +1211,7 @@ mod tests {
                 run_id,
                 mysql_lower_case_table_names: None,
                 metadata: None,
+                effective_user: None,
             };
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
@@ -1281,6 +1287,7 @@ mod tests {
                 run_id,
                 mysql_lower_case_table_names: None,
                 metadata: None,
+                effective_user: None,
             };
             reduce(&mut state, &action, Instant::now());
 
@@ -1303,6 +1310,7 @@ mod tests {
                 run_id,
                 mysql_lower_case_table_names: None,
                 metadata: None,
+                effective_user: None,
             };
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
@@ -1340,6 +1348,7 @@ mod tests {
                 run_id,
                 mysql_lower_case_table_names: None,
                 metadata: None,
+                effective_user: None,
             };
             reduce(&mut state, &action, Instant::now());
 
@@ -1363,6 +1372,7 @@ mod tests {
                 run_id,
                 mysql_lower_case_table_names: None,
                 metadata: None,
+                effective_user: None,
             };
 
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1158,6 +1158,7 @@ mod tests {
             Action::MetadataLoaded {
                 run_id,
                 metadata: Arc::new(metadata),
+                effective_user: None,
             }
         }
 
@@ -1182,30 +1183,16 @@ mod tests {
         }
 
         #[test]
-        fn metadata_loaded_starts_effective_user_fetch() {
-            let mut state = create_test_state();
-            let action =
-                metadata_loaded_action(&mut state, DatabaseMetadata::new("test".to_string()));
-
-            let effects = reduce(&mut state, action, Instant::now(), &AppServices::stub());
-
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::FetchEffectiveUser { .. }))
-            );
-        }
-
-        #[test]
-        fn effective_user_loaded_updates_session_state() {
+        fn metadata_loaded_updates_effective_user_without_extra_effect() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let run_id = state.session.begin_effective_user_fetch();
+            let run_id = state.session.begin_metadata_refresh();
 
-            reduce(
+            let effects = reduce(
                 &mut state,
-                Action::EffectiveUserLoaded {
+                Action::MetadataLoaded {
                     run_id,
+                    metadata: Arc::new(DatabaseMetadata::new("test".to_string())),
                     effective_user: Some("postgres".to_string()),
                 },
                 Instant::now(),
@@ -1213,85 +1200,11 @@ mod tests {
             );
 
             assert_eq!(state.session.effective_user(), Some("postgres"));
-        }
-
-        #[test]
-        fn stale_effective_user_loaded_does_not_replace_current_state() {
-            let mut state = create_test_state();
-            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
-            let old_run_id = state.session.begin_effective_user_fetch();
-            let _ = state.session.begin_effective_user_fetch();
-
-            reduce(
-                &mut state,
-                Action::EffectiveUserLoaded {
-                    run_id: old_run_id,
-                    effective_user: Some("old_user".to_string()),
-                },
-                Instant::now(),
-                &AppServices::stub(),
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
             );
-
-            assert!(state.session.effective_user().is_none());
-        }
-
-        #[test]
-        fn reload_failure_keeps_pending_effective_user_fetch_alive() {
-            let mut state = create_test_state();
-            let metadata_action =
-                metadata_loaded_action(&mut state, DatabaseMetadata::new("test".to_string()));
-            let metadata_effects = reduce(
-                &mut state,
-                metadata_action,
-                Instant::now(),
-                &AppServices::stub(),
-            );
-            let user_run_id = metadata_effects
-                .iter()
-                .find_map(|effect| match effect {
-                    Effect::FetchEffectiveUser { run_id, .. } => Some(*run_id),
-                    _ => None,
-                })
-                .expect("metadata load should start user fetch");
-
-            let reload_effects = reduce(
-                &mut state,
-                Action::ReloadMetadata,
-                Instant::now(),
-                &AppServices::stub(),
-            );
-            let reload_run_id = reload_effects
-                .iter()
-                .find_map(|effect| match effect {
-                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
-                    _ => None,
-                })
-                .expect("reload should start metadata fetch");
-
-            reduce(
-                &mut state,
-                Action::MetadataFailed {
-                    run_id: reload_run_id,
-                    error: DbOperationError::ConnectionFailed("reload failed".to_string()),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
-
-            assert!(state.session.connection_state().is_connected());
-            assert!(state.session.is_current_effective_user_run(user_run_id));
-
-            reduce(
-                &mut state,
-                Action::EffectiveUserLoaded {
-                    run_id: user_run_id,
-                    effective_user: Some("postgres".to_string()),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
-
-            assert_eq!(state.session.effective_user(), Some("postgres"));
         }
 
         #[test]
@@ -1719,6 +1632,7 @@ mod tests {
             let action = Action::MetadataLoaded {
                 run_id: 1,
                 metadata: Arc::new(metadata),
+                effective_user: None,
             };
             reduce(&mut state, action, now, &AppServices::stub());
 
@@ -2080,6 +1994,7 @@ mod tests {
                     run_id,
                     mysql_lower_case_table_names: None,
                     metadata: Some(Arc::new(DatabaseMetadata::new("validated".to_string()))),
+                    effective_user: None,
                 },
                 now,
                 &AppServices::stub(),
@@ -2455,6 +2370,7 @@ mod tests {
                 Action::MetadataLoaded {
                     run_id,
                     metadata: Arc::new(metadata),
+                    effective_user: None,
                 },
                 now,
                 &AppServices::stub(),
@@ -2611,6 +2527,7 @@ mod tests {
                     run_id,
                     mysql_lower_case_table_names: None,
                     metadata: Some(Arc::new(DatabaseMetadata::new("validated".to_string()))),
+                    effective_user: None,
                 },
                 now,
                 &AppServices::stub(),
@@ -2725,8 +2642,7 @@ mod tests {
                 effects.as_slice(),
                 [
                     Effect::CancelTrackedTasks,
-                    Effect::ClearCompletionEngineCache,
-                    Effect::FetchEffectiveUser { .. }
+                    Effect::ClearCompletionEngineCache
                 ]
             ));
             assert!(
@@ -2777,86 +2693,6 @@ mod tests {
                     .iter()
                     .any(|effect| matches!(effect, Effect::CancelSqliteDiagnostics))
             );
-        }
-
-        #[test]
-        fn switch_connection_reloads_missing_effective_user_after_round_trip() {
-            let mut state = create_test_state();
-            let conn_a = ConnectionId::new();
-            let conn_b = ConnectionId::new();
-            let dsn_a = "postgres://localhost/a".to_string();
-
-            state.session.activate_connection_with_dsn(
-                &conn_a,
-                "A",
-                DatabaseType::PostgreSQL,
-                &dsn_a,
-            );
-            state
-                .session
-                .mark_connected(Arc::new(DatabaseMetadata::new("a".to_string())));
-            let old_a_run_id = state.session.begin_effective_user_fetch();
-
-            reduce(
-                &mut state,
-                Action::SwitchConnection(ConnectionTarget {
-                    id: conn_b,
-                    dsn: "postgres://localhost/b".to_string(),
-                    name: "B".to_string(),
-                    database_type: DatabaseType::PostgreSQL,
-                    database: None,
-                }),
-                Instant::now(),
-                &AppServices::stub(),
-            );
-
-            let effects = reduce(
-                &mut state,
-                Action::SwitchConnection(ConnectionTarget {
-                    id: conn_a,
-                    dsn: dsn_a.clone(),
-                    name: "A".to_string(),
-                    database_type: DatabaseType::PostgreSQL,
-                    database: None,
-                }),
-                Instant::now(),
-                &AppServices::stub(),
-            );
-
-            let new_a_run_id = effects
-                .iter()
-                .find_map(|effect| match effect {
-                    Effect::FetchEffectiveUser { dsn, run_id }
-                        if dsn.as_str() == dsn_a.as_str() =>
-                    {
-                        Some(run_id.to_owned())
-                    }
-                    _ => None,
-                })
-                .expect("cached user miss should trigger a refetch");
-            assert_ne!(new_a_run_id, old_a_run_id);
-
-            reduce(
-                &mut state,
-                Action::EffectiveUserLoaded {
-                    run_id: old_a_run_id,
-                    effective_user: Some("old_a_user".to_string()),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
-            assert!(state.session.effective_user().is_none());
-
-            reduce(
-                &mut state,
-                Action::EffectiveUserLoaded {
-                    run_id: new_a_run_id,
-                    effective_user: Some("a_user".to_string()),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
-            assert_eq!(state.session.effective_user(), Some("a_user"));
         }
     }
 
@@ -2940,6 +2776,7 @@ mod tests {
             Action::MetadataLoaded {
                 run_id,
                 metadata: sample_metadata(),
+                effective_user: None,
             }
         }
 
@@ -3224,6 +3061,7 @@ mod tests {
                 Action::MetadataLoaded {
                     run_id,
                     metadata: Arc::new(metadata),
+                    effective_user: None,
                 },
                 now,
                 &AppServices::stub(),

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -128,6 +128,10 @@ impl MySqlMetadataSession {
         Ok(())
     }
 
+    pub(in crate::adapters::mysql) async fn cleanup(&mut self) {
+        cleanup_mysql_process(&mut self.process).await;
+    }
+
     pub(in crate::adapters::mysql) async fn finish_preview(
         &mut self,
     ) -> Result<(), DbOperationError> {
@@ -162,7 +166,7 @@ impl MySqlMetadataSession {
                 "mysql query exceeded the execution timeout".to_string(),
             )),
         };
-        cleanup_mysql_process(&mut self.process).await;
+        self.cleanup().await;
         result
     }
 }

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -15,7 +15,7 @@ use super::super::{
     option_file::MySqlOptionFile,
     sql::{
         COLUMN_METADATA_BASE_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS,
-        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
+        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, TABLES_RESULT_COLUMNS,
         UNIQUE_COLUMN_RESULT_COLUMNS, column_metadata_result_columns,
     },
 };
@@ -78,15 +78,6 @@ impl MySqlTableMetadata {
             create_options: self.create_options.clone(),
         }
     }
-}
-
-pub(super) async fn fetch_metadata_snapshot(
-    target: &MySqlDsn,
-    database: &str,
-) -> Result<Vec<MySqlTableMetadata>, DbOperationError> {
-    let (lower_case_table_names, result) =
-        execute_metadata_query(target, TABLES_QUERY, TABLES_RESULT_COLUMNS).await?;
-    metadata_snapshot_from_result(database, None, &result, lower_case_table_names)
 }
 
 fn mysql_table_not_found(schema: &str, table: &str) -> DbOperationError {
@@ -152,32 +143,83 @@ pub(super) fn parse_preview_columns_for_table(
     Ok(columns)
 }
 
-pub(super) async fn execute_metadata_query(
+pub(super) async fn execute_table_query_with_optional_effective_user(
     target: &MySqlDsn,
-    query: &str,
-    expected_columns: &[&str],
-) -> Result<(u8, MySqlResultSet), DbOperationError> {
-    let (capabilities, results) =
-        execute_metadata_queries_in_session(target, &[(query, expected_columns)]).await?;
-    let result = results.into_iter().next().ok_or_else(|| {
-        DbOperationError::MetadataParseFailed(
-            "MySQL metadata query returned no result set".to_string(),
-        )
-    })?;
-    Ok((capabilities.lower_case_table_names, result))
-}
-
-pub(super) async fn execute_metadata_queries_in_session(
-    target: &MySqlDsn,
-    queries: &[(&str, &[&str])],
-) -> Result<(MySqlServerCapabilities, Vec<MySqlResultSet>), DbOperationError> {
-    execute_metadata_queries_in_session_with_program(
+    table_query: &str,
+    table_columns: &[&str],
+    effective_user_query: &str,
+    effective_user_columns: &[&str],
+) -> Result<
+    (
+        MySqlServerCapabilities,
+        MySqlResultSet,
+        Option<MySqlResultSet>,
+    ),
+    DbOperationError,
+> {
+    execute_table_query_with_optional_effective_user_with_program(
         target,
-        queries,
+        table_query,
+        table_columns,
+        effective_user_query,
+        effective_user_columns,
         OsStr::new("mysql"),
         MYSQL_QUERY_TIMEOUT,
     )
     .await
+}
+
+pub(super) async fn execute_table_query_with_optional_effective_user_with_program(
+    target: &MySqlDsn,
+    table_query: &str,
+    table_columns: &[&str],
+    effective_user_query: &str,
+    effective_user_columns: &[&str],
+    program: &OsStr,
+    timeout: Duration,
+) -> Result<
+    (
+        MySqlServerCapabilities,
+        MySqlResultSet,
+        Option<MySqlResultSet>,
+    ),
+    DbOperationError,
+> {
+    let option_file = MySqlOptionFile::create(target)?;
+    let mut session = MySqlMetadataSession::spawn_with_metadata_program(program, option_file)?;
+    let deadline = tokio::time::Instant::now() + timeout;
+    let remaining_timeout = || deadline.saturating_duration_since(tokio::time::Instant::now());
+    let required_result = tokio::time::timeout(remaining_timeout(), async {
+        let capabilities = session.prepare_read_only_and_probe().await?;
+        let table_result = session
+            .execute_with_expected_columns(table_query, table_columns)
+            .await?;
+        Ok((capabilities, table_result))
+    })
+    .await;
+    let (capabilities, table_result) = session
+        .resolve_timed_result(required_result)
+        .await
+        .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
+    let effective_user_result = if let Ok(Ok(result)) = tokio::time::timeout(
+        remaining_timeout(),
+        session.execute_with_expected_columns(effective_user_query, effective_user_columns),
+    )
+    .await
+    {
+        Some(result)
+    } else {
+        session.cleanup().await;
+        None
+    };
+    if effective_user_result.is_some() {
+        let finish_result = tokio::time::timeout(remaining_timeout(), session.finish()).await;
+        session
+            .resolve_timed_result(finish_result)
+            .await
+            .map_err(|error| map_mysql_tls_failure(error, target.ssl_mode))?;
+    }
+    Ok((capabilities, table_result, effective_user_result))
 }
 
 pub(super) async fn execute_metadata_queries_in_session_with_program(
@@ -657,6 +699,11 @@ pub(super) fn metadata_shape_error(field: &str) -> DbOperationError {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     use crate::adapters::mysql::sql::COLUMN_METADATA_RESULT_COLUMNS;
 
     use super::super::test_support::result;
@@ -779,6 +826,90 @@ mod tests {
         );
         assert_eq!(tables[0].create_options.as_deref(), Some("partitioned"));
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn effective_user_failure_keeps_table_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let program = directory.path().join("mysql");
+        fs::write(&program, OPTIONAL_EFFECTIVE_USER_FAILURE_PROGRAM).unwrap();
+        fs::set_permissions(&program, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let target =
+            super::super::super::dsn::parse_and_validate_mysql_dsn("mysql://app@localhost/app")
+                .unwrap();
+        let result = execute_table_query_with_optional_effective_user_with_program(
+            &target,
+            "SELECT TABLES",
+            TABLES_RESULT_COLUMNS,
+            "SELECT CURRENT_USER()",
+            &["CURRENT_USER()"],
+            program.as_os_str(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.0.lower_case_table_names, 0);
+        assert_eq!(result.1.values.len(), 1);
+        assert!(result.2.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn effective_user_timeout_keeps_table_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let program = directory.path().join("mysql");
+        fs::write(&program, OPTIONAL_EFFECTIVE_USER_FAILURE_PROGRAM).unwrap();
+        fs::set_permissions(&program, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let target =
+            super::super::super::dsn::parse_and_validate_mysql_dsn("mysql://app@localhost/app")
+                .unwrap();
+        let result = execute_table_query_with_optional_effective_user_with_program(
+            &target,
+            "SELECT TABLES",
+            TABLES_RESULT_COLUMNS,
+            "SELECT CURRENT_USER() /* sabiql_hang */",
+            &["CURRENT_USER()"],
+            program.as_os_str(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.0.lower_case_table_names, 0);
+        assert_eq!(result.1.values.len(), 1);
+        assert!(result.2.is_none());
+    }
+
+    #[cfg(unix)]
+    const OPTIONAL_EFFECTIVE_USER_FAILURE_PROGRAM: &str = r#"#!/bin/sh
+eof=$(printf '\004')
+while IFS= read -r line; do
+  case "$line" in
+    *"$eof"*) exit 0 ;;
+    *"SET SESSION autocommit=1, completion_type=NO_CHAIN"*|*"SET SESSION TRANSACTION READ ONLY"*) ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_session_marker.*/\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      ;;
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_probe.*/\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_server_version">8.4.10</field><field name="__sabiql_lower_case_table_names">0</field></row></resultset>'
+      ;;
+    *"SELECT TABLES"*)
+      printf '%s\n' '<resultset><row><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">users</field><field name="TABLE_TYPE">BASE TABLE</field><field name="TABLE_ROWS">1</field><field name="TABLE_COMMENT"></field><field name="ENGINE">InnoDB</field><field name="ROW_FORMAT">Dynamic</field><field name="TABLE_COLLATION">utf8mb4_bin</field><field name="CREATE_OPTIONS"></field></row></resultset>'
+      ;;
+    *"SELECT CURRENT_USER()"*)
+      case "$line" in
+        *sabiql_hang*) read -r ignored ;;
+        *) printf '%s\n' 'ERROR 1142 (42000): access denied' >&2; exit 1 ;;
+      esac
+      ;;
+  esac
+done
+"#;
 
     #[test]
     fn metadata_rejects_database_with_different_case() {

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -1,12 +1,14 @@
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
+use crate::app::ports::outbound::{DbOperationError, MetadataFetchResult, MetadataProvider};
 use crate::domain::{DatabaseMetadata, Schema, Table, TableSignatureSnapshot};
 
 use super::adapter::MySqlAdapter;
 use super::cli::MySqlResultSet;
 use super::dsn::parse_and_validate_mysql_dsn;
-use super::sql::{EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS};
+use super::sql::{
+    EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
+};
 
 mod catalog;
 mod preview;
@@ -51,25 +53,34 @@ pub(super) use preview::{convert_preview_values_with_binary_charset, execute_pre
 
 #[async_trait]
 impl MetadataProvider for MySqlAdapter {
-    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<MetadataFetchResult, DbOperationError> {
         let target = parse_and_validate_mysql_dsn(dsn)?;
         let database = catalog::selected_database(&target)?;
-        let tables = catalog::fetch_metadata_snapshot(&target, database).await?;
+        let (capabilities, table_result, effective_user_result) =
+            catalog::execute_table_query_with_optional_effective_user(
+                &target,
+                TABLES_QUERY,
+                TABLES_RESULT_COLUMNS,
+                EFFECTIVE_USER_QUERY,
+                EFFECTIVE_USER_RESULT_COLUMNS,
+            )
+            .await?;
+        let tables = catalog::metadata_snapshot_from_result(
+            database,
+            None,
+            &table_result,
+            capabilities.lower_case_table_names,
+        )?;
+        let effective_user = effective_user_result
+            .as_ref()
+            .and_then(effective_user_from_result);
         let mut metadata = DatabaseMetadata::new(database.to_string());
         metadata.schemas = vec![Schema::new(database.to_string())];
         metadata.table_summaries = tables.into_iter().map(catalog::table_summary).collect();
-        Ok(metadata)
-    }
-
-    async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
-        let target = parse_and_validate_mysql_dsn(dsn)?;
-        let (_, result) = catalog::execute_metadata_query(
-            &target,
-            EFFECTIVE_USER_QUERY,
-            EFFECTIVE_USER_RESULT_COLUMNS,
-        )
-        .await?;
-        Ok(effective_user_from_result(&result))
+        Ok(MetadataFetchResult {
+            metadata,
+            effective_user,
+        })
     }
 
     async fn fetch_table_detail(

--- a/src/infra/adapters/postgres/metadata.rs
+++ b/src/infra/adapters/postgres/metadata.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
+use crate::app::ports::outbound::{DbOperationError, MetadataFetchResult, MetadataProvider};
 use crate::domain::{
-    Column, DatabaseMetadata, Table, TableKindInfo, TableSignatureSnapshot, TableStorageAttributes,
+    Column, DatabaseMetadata, Schema, Table, TableKindInfo, TableSignatureSnapshot,
+    TableStorageAttributes, TableSummary,
 };
 
 use super::PostgresAdapter;
@@ -24,29 +25,33 @@ fn postgres_table_not_found(schema: &str, table: &str) -> DbOperationError {
     DbOperationError::ObjectMissing(format!("PostgreSQL table not found: {schema}.{table}"))
 }
 
+struct ParsedMetadata {
+    schemas: Vec<Schema>,
+    tables: Vec<TableSummary>,
+    effective_user: Option<String>,
+}
+
 #[async_trait]
 impl MetadataProvider for PostgresAdapter {
-    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        let schemas_json = self.execute_raw_output(dsn, Self::schemas_query()).await?;
-        let tables_json = self.execute_raw_output(dsn, Self::tables_query()).await?;
-
-        let schemas = Self::parse_schemas(&schemas_json)?;
-        let tables = Self::parse_tables(&tables_json)?;
+    async fn fetch_metadata(&self, dsn: &str) -> Result<MetadataFetchResult, DbOperationError> {
+        let metadata_json = self
+            .execute_raw_output(dsn, &Self::metadata_query())
+            .await?;
+        let ParsedMetadata {
+            schemas,
+            tables,
+            effective_user,
+        } = parse_metadata(&metadata_json)?;
 
         let db_name = Self::extract_database_name(dsn);
         let mut metadata = DatabaseMetadata::new(db_name);
         metadata.schemas = schemas;
         metadata.table_summaries = tables;
 
-        Ok(metadata)
-    }
-
-    async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
-        let raw_user = self
-            .execute_raw_output(dsn, Self::effective_user_query())
-            .await?;
-        let user = raw_user.trim();
-        Ok((!user.is_empty()).then(|| user.to_string()))
+        Ok(MetadataFetchResult {
+            metadata,
+            effective_user,
+        })
     }
 
     async fn fetch_table_signatures(
@@ -128,6 +133,38 @@ impl MetadataProvider for PostgresAdapter {
     }
 }
 
+fn parse_metadata(json: &str) -> Result<ParsedMetadata, DbOperationError> {
+    let value: serde_json::Value = serde_json::from_str(json)?;
+    let object = value.as_object().ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(
+            "combined metadata response must be a JSON object".to_string(),
+        )
+    })?;
+    let schemas = object.get("schemas").ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(
+            "combined metadata response is missing schemas".to_string(),
+        )
+    })?;
+    let tables = object.get("tables").ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(
+            "combined metadata response is missing tables".to_string(),
+        )
+    })?;
+    let schemas = PostgresAdapter::parse_schemas(&serde_json::to_string(schemas)?)?;
+    let tables = PostgresAdapter::parse_tables(&serde_json::to_string(tables)?)?;
+    let effective_user = value
+        .get("effective_user")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|user| !user.is_empty())
+        .map(str::to_string);
+    Ok(ParsedMetadata {
+        schemas,
+        tables,
+        effective_user,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,6 +216,48 @@ mod tests {
             .map_err(|()| "failed to set PostgreSQL test password".to_string())?;
         url.set_path(&format!("/{database}"));
         Ok(url.to_string())
+    }
+
+    #[test]
+    fn combined_metadata_parses_tables_schemas_and_effective_user() {
+        let ParsedMetadata {
+            schemas,
+            tables,
+            effective_user,
+        } = parse_metadata(
+            r#"{
+                "schemas": [{"name": "public"}],
+                "tables": [{
+                    "schema": "public",
+                    "name": "users",
+                    "row_count_estimate": 4,
+                    "has_rls": true
+                }],
+                "effective_user": " app_user "
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(schemas[0].name, "public");
+        assert_eq!(tables[0].qualified_name(), "public.users");
+        assert!(tables[0].has_rls);
+        assert_eq!(effective_user.as_deref(), Some("app_user"));
+    }
+
+    #[test]
+    fn combined_metadata_rejects_non_object_response() {
+        assert!(matches!(
+            parse_metadata("[]"),
+            Err(DbOperationError::MetadataParseFailed(_))
+        ));
+    }
+
+    #[test]
+    fn combined_metadata_rejects_missing_required_field() {
+        assert!(matches!(
+            parse_metadata(r#"{"schemas": []}"#),
+            Err(DbOperationError::MetadataParseFailed(_))
+        ));
     }
 
     #[tokio::test]

--- a/src/infra/adapters/postgres/sql/query.rs
+++ b/src/infra/adapters/postgres/sql/query.rs
@@ -93,8 +93,12 @@ impl PostgresAdapter {
         "
     }
 
-    pub(in crate::adapters::postgres) fn effective_user_query() -> &'static str {
-        "SELECT current_user"
+    pub(in crate::adapters::postgres) fn metadata_query() -> String {
+        format!(
+            "SELECT json_build_object('schemas', ({schemas}), 'tables', ({tables}), 'effective_user', current_user)",
+            schemas = Self::schemas_query().trim(),
+            tables = Self::tables_query().trim(),
+        )
     }
 
     pub(in crate::adapters::postgres) fn columns_query(schema: &str, table: &str) -> String {
@@ -409,14 +413,6 @@ impl PostgresAdapter {
 mod tests {
     use crate::adapters::postgres::PostgresAdapter;
 
-    #[test]
-    fn effective_user_query_selects_current_user() {
-        assert_eq!(
-            PostgresAdapter::effective_user_query(),
-            "SELECT current_user"
-        );
-    }
-
     mod preview_query {
         use super::*;
 
@@ -650,6 +646,21 @@ mod tests {
                 sql.contains(ESCAPED),
                 "Hostile input must be quote_literal-escaped in: {sql}"
             );
+        }
+    }
+
+    mod combined_metadata_query {
+        use super::*;
+
+        #[test]
+        fn contains_catalog_queries_and_current_user_in_one_statement() {
+            let sql = PostgresAdapter::metadata_query();
+
+            assert!(sql.starts_with("SELECT json_build_object("));
+            assert!(sql.contains("'schemas'"));
+            assert!(sql.contains("'tables'"));
+            assert!(sql.contains("'effective_user', current_user"));
+            assert_eq!(sql.matches("SELECT json_agg").count(), 2);
         }
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -1,10 +1,9 @@
 use crate::app::ports::outbound::{
-    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor,
+    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataFetchResult, MetadataProvider,
+    QueryExecutor,
 };
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
-use crate::domain::{
-    DatabaseMetadata, QueryResult, Table, TableSignatureSnapshot, WriteExecutionResult,
-};
+use crate::domain::{QueryResult, Table, TableSignatureSnapshot, WriteExecutionResult};
 use async_trait::async_trait;
 use std::path::PathBuf;
 
@@ -99,12 +98,8 @@ impl DsnBuilder for DbAdapterRegistry {
 
 #[async_trait]
 impl MetadataProvider for DbAdapterRegistry {
-    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<MetadataFetchResult, DbOperationError> {
         self.metadata_provider(dsn)?.fetch_metadata(dsn).await
-    }
-
-    async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
-        self.metadata_provider(dsn)?.fetch_effective_user(dsn).await
     }
 
     async fn fetch_table_detail(
@@ -298,26 +293,29 @@ mod tests {
 
         let metadata = registry.fetch_metadata(&dsn).await.unwrap();
 
-        assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
+        assert_eq!(
+            metadata.metadata.table_summaries[0].qualified_name(),
+            "main.users"
+        );
     }
 
     #[tokio::test]
-    async fn sqlite_effective_user_dispatch_preserves_unknown_user() {
+    async fn sqlite_metadata_dispatch_preserves_unknown_user() {
         let (_dir, dsn) =
             test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
         let registry = DbAdapterRegistry::new();
 
-        let effective_user = registry.fetch_effective_user(&dsn).await.unwrap();
+        let effective_user = registry.fetch_metadata(&dsn).await.unwrap().effective_user;
 
         assert_eq!(effective_user, None);
     }
 
     #[tokio::test]
-    async fn mysql_effective_user_dispatch_does_not_expose_password_on_validation_failure() {
+    async fn mysql_metadata_dispatch_does_not_expose_password_on_validation_failure() {
         let registry = DbAdapterRegistry::new();
 
         let error = registry
-            .fetch_effective_user("mysql://app:header-secret%01@localhost/app")
+            .fetch_metadata("mysql://app:header-secret%01@localhost/app")
             .await
             .unwrap_err();
 

--- a/src/infra/adapters/sqlite/metadata/catalog_tests.rs
+++ b/src/infra/adapters/sqlite/metadata/catalog_tests.rs
@@ -69,15 +69,23 @@ mod metadata {
             let adapter = SqliteAdapter::new();
             let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
             let table_names: Vec<_> = metadata
+                .metadata
                 .table_summaries
                 .iter()
                 .map(|summary| summary.name.as_str())
                 .collect();
 
-            assert_eq!(metadata.schemas, vec![Schema::new("main")]);
+            assert_eq!(metadata.metadata.schemas, vec![Schema::new("main")]);
             assert_eq!(table_names, vec!["users"]);
-            assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
-            assert!(metadata.table_summaries[0].row_count_estimate.is_none());
+            assert_eq!(
+                metadata.metadata.table_summaries[0].qualified_name(),
+                "main.users"
+            );
+            assert!(
+                metadata.metadata.table_summaries[0]
+                    .row_count_estimate
+                    .is_none()
+            );
             return;
         }
 
@@ -102,15 +110,23 @@ mod metadata {
         #[cfg(not(unix))]
         {
             let table_names: Vec<_> = metadata
+                .metadata
                 .table_summaries
                 .iter()
                 .map(|summary| summary.name.as_str())
                 .collect();
 
-            assert_eq!(metadata.schemas, vec![Schema::new("main")]);
+            assert_eq!(metadata.metadata.schemas, vec![Schema::new("main")]);
             assert_eq!(table_names, vec!["users"]);
-            assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
-            assert!(metadata.table_summaries[0].row_count_estimate.is_none());
+            assert_eq!(
+                metadata.metadata.table_summaries[0].qualified_name(),
+                "main.users"
+            );
+            assert!(
+                metadata.metadata.table_summaries[0]
+                    .row_count_estimate
+                    .is_none()
+            );
             assert_eq!(process_counter.count(), 1);
         }
     }
@@ -176,8 +192,12 @@ mod metadata {
 
         let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
 
-        assert_eq!(metadata.table_summaries.len(), 1);
-        assert!(metadata.table_summaries[0].row_count_estimate.is_none());
+        assert_eq!(metadata.metadata.table_summaries.len(), 1);
+        assert!(
+            metadata.metadata.table_summaries[0]
+                .row_count_estimate
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -187,8 +207,8 @@ mod metadata {
 
         let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
 
-        assert_eq!(metadata.schemas, vec![Schema::new("main")]);
-        assert!(metadata.table_summaries.is_empty());
+        assert_eq!(metadata.metadata.schemas, vec![Schema::new("main")]);
+        assert!(metadata.metadata.table_summaries.is_empty());
     }
 
     #[tokio::test]
@@ -203,6 +223,7 @@ mod metadata {
 
         let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
         let table_names: Vec<_> = metadata
+            .metadata
             .table_summaries
             .iter()
             .map(|summary| summary.name.as_str())
@@ -233,6 +254,7 @@ mod metadata {
             let adapter = SqliteAdapter::new();
             let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
             let kind_info_by_name = metadata
+                .metadata
                 .table_summaries
                 .iter()
                 .map(|summary| (summary.name.clone(), summary.kind_info.clone()))
@@ -288,6 +310,7 @@ mod metadata {
 
         let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
         let table_names: Vec<_> = metadata
+            .metadata
             .table_summaries
             .iter()
             .map(|summary| summary.name.as_str())

--- a/src/infra/adapters/sqlite/metadata/mod.rs
+++ b/src/infra/adapters/sqlite/metadata/mod.rs
@@ -7,8 +7,8 @@ mod trigger;
 
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
-use crate::domain::{DatabaseMetadata, Table, TableSignatureSnapshot};
+use crate::app::ports::outbound::{DbOperationError, MetadataFetchResult, MetadataProvider};
+use crate::domain::{Table, TableSignatureSnapshot};
 
 use super::sqlite3::metadata::RawNamedTableMetadata;
 use super::{SqliteAdapter, schema::MAIN_SCHEMA};
@@ -22,10 +22,13 @@ fn sqlite_table_not_found(table: &str) -> DbOperationError {
 
 #[async_trait]
 impl MetadataProvider for SqliteAdapter {
-    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<MetadataFetchResult, DbOperationError> {
         let path = Self::path_from_dsn(dsn)?;
         let tables = self.fetch_catalog_rows(path).await?;
-        Ok(metadata_from_catalog(path, &tables))
+        Ok(MetadataFetchResult {
+            metadata: metadata_from_catalog(path, &tables),
+            effective_user: None,
+        })
     }
 
     async fn fetch_table_detail(

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -930,7 +930,7 @@ esac
                     test_support::display_row(&result, 0),
                     vec!["Grace".to_string()]
                 );
-                assert_eq!(metadata.table_summaries.len(), 1);
+                assert_eq!(metadata.metadata.table_summaries.len(), 1);
                 assert_eq!(
                     (
                         test_support::display_row(&preview, 0),

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -291,9 +291,10 @@ mod metadata_fetch {
             Box::pin(async move {
                 let registry = DbAdapterRegistry::new();
                 let effective_user = registry
-                    .fetch_effective_user(db.dsn())
+                    .fetch_metadata(db.dsn())
                     .await
                     .map_err(|error| format!("{error:?}"))?
+                    .effective_user
                     .ok_or_else(|| "MySQL effective user was empty".to_string())?;
                 let config = mysql_integration_config();
 
@@ -320,15 +321,20 @@ mod metadata_fetch {
                     .await
                     .map_err(|error| format!("{error:?}"))?;
                 if metadata
+                    .metadata
                     .schemas
                     .iter()
                     .map(|schema| schema.name.as_str())
                     .collect::<Vec<_>>()
                     != ["sabiql_test"]
                 {
-                    return Err(format!("unexpected MySQL schemas: {:?}", metadata.schemas));
+                    return Err(format!(
+                        "unexpected MySQL schemas: {:?}",
+                        metadata.metadata.schemas
+                    ));
                 }
                 let table = metadata
+                    .metadata
                     .table_summaries
                     .iter()
                     .find(|summary| summary.name == MYSQL_FIXTURE_TABLE)

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -30,13 +30,19 @@ mod metadata_fetch {
                     .await
                     .map_err(|err| err.to_string())?;
 
-                if !metadata.schemas.iter().any(|s| s.name == db.schema()) {
+                if !metadata
+                    .metadata
+                    .schemas
+                    .iter()
+                    .any(|s| s.name == db.schema())
+                {
                     return Err(format!(
                         "expected fixture schema '{}' in metadata",
                         db.schema()
                     ));
                 }
                 if !metadata
+                    .metadata
                     .table_summaries
                     .iter()
                     .any(|table| table.schema == db.schema() && table.name == db.table())

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -42,9 +42,10 @@ fn header_shows_effective_user_at_normal_width() {
         DatabaseType::PostgreSQL,
         "postgresql://localhost/test",
     );
+    let metadata = state.session.metadata().cloned().expect("metadata");
     state
         .session
-        .mark_effective_user_loaded(Some("app_user".to_string()));
+        .mark_connected_with_user(Arc::new(metadata), Some("app_user".to_string()));
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -61,9 +62,10 @@ fn mysql_header_shows_effective_user_without_dsn_password() {
         DatabaseType::MySQL,
         "mysql://app:header-secret@localhost/app",
     );
+    let metadata = state.session.metadata().cloned().expect("metadata");
     state
         .session
-        .mark_effective_user_loaded(Some("app@%".to_string()));
+        .mark_connected_with_user(Arc::new(metadata), Some("app@%".to_string()));
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -81,9 +83,10 @@ fn header_truncates_connection_name_at_narrow_width() {
         DatabaseType::PostgreSQL,
         "postgresql://localhost/test",
     );
+    let metadata = state.session.metadata().cloned().expect("metadata");
     state
         .session
-        .mark_effective_user_loaded(Some("app_user".to_string()));
+        .mark_connected_with_user(Arc::new(metadata), Some("app_user".to_string()));
     let mut terminal = create_test_terminal_sized(60, 20);
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -101,9 +104,10 @@ fn header_shows_read_only_badge_at_narrow_width() {
         "postgresql://localhost/test",
     );
     state.session.enable_read_only();
+    let metadata = state.session.metadata().cloned().expect("metadata");
     state
         .session
-        .mark_effective_user_loaded(Some("app_user".to_string()));
+        .mark_connected_with_user(Arc::new(metadata), Some("app_user".to_string()));
     let mut terminal = create_test_terminal_sized(80, 20);
 
     let output = render_to_string(&mut terminal, &mut state);


### PR DESCRIPTION
## Problem
PostgreSQL and MySQL fetched connection metadata and the effective user through separate paths, and cache restore could retry the user alone.

## Background
This duplicated session or process work and let the dedicated user-fetch lifecycle outlive metadata handling.

## Approach
Return metadata and the effective user together. PostgreSQL emits one combined JSON query, while MySQL runs the user query in its existing metadata session and treats only that optional query as non-fatal. SQLite returns no user and performs no extra operation; the dedicated action, effect, run, and cache-only retry paths are removed.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-547