### PR TITLE
docs: clarify remote ER diagram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ sabiql uses the CLI for the database you want to open:
 
 Graphviz is required only for PostgreSQL and MySQL ER diagrams. SQLite does not support ER diagrams.
 
+ER diagrams are generated and opened on the host running sabiql. Running sabiql itself on an SSH or other headless host is outside the guaranteed workflow for ER generation and viewer display; a local sabiql instance connecting to a database through an SSH tunnel remains supported.
+
 Windows support is experimental.
 
 See [MySQL support and limitations](docs/mysql.md) and [SQLite support and limitations](docs/sqlite.md) for supported versions and database-specific limitations.


### PR DESCRIPTION
## Problem
ER diagrams rely on the host running sabiql for generation and viewer display, but the supported scope did not distinguish that from local sabiql connections over SSH tunnels.

## Background
CF-12 clarifies the remote/headless boundary without changing runtime behavior or the existing SSH-tunnel use case.

## Approach
Document that running sabiql itself on an SSH or headless host is outside the guaranteed ER workflow, while local sabiql connecting through an SSH tunnel remains supported. SQLite's existing ER limitation and OSC 52 documentation are unchanged.