### PR TITLE
feat(mysql): support server public key retrieval

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -10,6 +10,8 @@ MySQL connections can use TCP, a Unix socket file on Unix-like systems, or a Win
 
 Passphrase-protected TLS client keys are not supported. An unencrypted PEM private key can be used, but it weakens at-rest protection; store it with restrictive file permissions.
 
+For [Cloud SQL Auth Proxy](https://docs.cloud.google.com/sql/docs/mysql/connect-auth-proxy) TCP connections to MySQL 8.4 or later users authenticated with `caching_sha2_password`, set the MySQL connection form's **Get Server** option to `enabled`. sabiql then writes `get-server-public-key=true` to its protected temporary option file. The option is disabled by default and is never enabled based on a `localhost` or proxy-looking host. If **Server Key** also names a valid PEM key file, MySQL gives that file precedence over public-key retrieval, as described in the [MySQL connection option documentation](https://dev.mysql.com/doc/refman/8.4/en/connecting-using-uri-or-key-value-pairs.html). This documents the client option only; Cloud SQL, IAM, and Auth Proxy operation are not verified by sabiql.
+
 ## Version differences
 
 The Explorer, Inspector, and query-result panes select metadata and empty-result queries from the server version reported by `VERSION()`:

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -16,6 +16,8 @@ readonly mysql_user="${SABIQL_MYSQL_TEST_USER:-sabiql_test_runner}"
 readonly mysql_password="${SABIQL_MYSQL_TEST_PASSWORD:-p a#ss;=\"word}"
 readonly cache_miss_user="${SABIQL_MYSQL_TEST_CACHE_MISS_USER:-sabiql_cache_miss_runner}"
 readonly cache_miss_password="${SABIQL_MYSQL_TEST_CACHE_MISS_PASSWORD:-sabiql-cache-miss}"
+readonly cache_miss_retrieval_user="${SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_USER:-sabiql_cache_miss_retrieval_runner}"
+readonly cache_miss_retrieval_password="${SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_PASSWORD:-sabiql-cache-miss-retrieval}"
 readonly mysql_client_label_key='com.sabiql.mysql.integration'
 
 run_dir=''
@@ -235,7 +237,7 @@ create_server_public_key_material() {
     chmod 644 "$tls_dir/server-public-key.pem"
 }
 
-reset_cache_miss_account() {
+reset_cache_miss_accounts() {
     run_compose exec -T mysql mysql \
         --protocol=socket \
         --user=root \
@@ -243,7 +245,7 @@ reset_cache_miss_account() {
         --batch \
         --raw \
         --skip-column-names \
-        --execute="CREATE USER IF NOT EXISTS '$cache_miss_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_password'; ALTER USER '$cache_miss_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_password'; GRANT SELECT ON \`$mysql_database\`.* TO '$cache_miss_user'@'%';"
+        --execute="CREATE USER IF NOT EXISTS '$cache_miss_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_password'; ALTER USER '$cache_miss_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_password'; GRANT SELECT ON \`$mysql_database\`.* TO '$cache_miss_user'@'%'; CREATE USER IF NOT EXISTS '$cache_miss_retrieval_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_retrieval_password'; ALTER USER '$cache_miss_retrieval_user'@'%' IDENTIFIED WITH caching_sha2_password BY '$cache_miss_retrieval_password'; GRANT SELECT ON \`$mysql_database\`.* TO '$cache_miss_retrieval_user'@'%';"
 }
 
 install_cli_wrapper() {
@@ -292,6 +294,8 @@ run_tests() {
     export SABIQL_MYSQL_TEST_PASSWORD="$mysql_password"
     export SABIQL_MYSQL_TEST_CACHE_MISS_USER="$cache_miss_user"
     export SABIQL_MYSQL_TEST_CACHE_MISS_PASSWORD="$cache_miss_password"
+    export SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_USER="$cache_miss_retrieval_user"
+    export SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_PASSWORD="$cache_miss_retrieval_password"
     export SABIQL_MYSQL_TEST_TLS_DIR="$tls_dir"
     export SABIQL_MYSQL_TEST_SSL_CA="$tls_dir/ca.pem"
     export SABIQL_MYSQL_TEST_SSL_CERT="$tls_dir/client-cert.pem"
@@ -315,7 +319,7 @@ case "${1:-test}" in
         install_cli_wrapper
         create_option_file
         assert_versions
-        reset_cache_miss_account
+        reset_cache_miss_accounts
         run_tests
         ;;
     *)

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -16,7 +16,7 @@ readonly mysql_user="${SABIQL_MYSQL_TEST_USER:-sabiql_test_runner}"
 readonly mysql_password="${SABIQL_MYSQL_TEST_PASSWORD:-p a#ss;=\"word}"
 readonly cache_miss_user="${SABIQL_MYSQL_TEST_CACHE_MISS_USER:-sabiql_cache_miss_runner}"
 readonly cache_miss_password="${SABIQL_MYSQL_TEST_CACHE_MISS_PASSWORD:-sabiql-cache-miss}"
-readonly cache_miss_retrieval_user="${SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_USER:-sabiql_cache_miss_retrieval_runner}"
+readonly cache_miss_retrieval_user="${SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_USER:-sabiql_cache_miss_retrieval}"
 readonly cache_miss_retrieval_password="${SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_PASSWORD:-sabiql-cache-miss-retrieval}"
 readonly mysql_client_label_key='com.sabiql.mysql.integration'
 

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -549,7 +549,11 @@ fn connection_setup_current_rows(
 ) -> Vec<HelpRow> {
     let is_dropdown_field = matches!(
         focused_field,
-        ConnectionField::DatabaseType | ConnectionField::Transport | ConnectionField::SslMode
+        ConnectionField::DatabaseType
+            | ConnectionField::Transport
+            | ConnectionField::SslMode
+            | ConnectionField::CleartextAuth
+            | ConnectionField::GetServerPublicKey
     );
     let submit = if is_dropdown_field {
         &connection_setup::ENTER_DROPDOWN

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -28,6 +28,7 @@ pub enum ConnectionField {
     SslCert,
     SslKey,
     ServerPublicKeyPath,
+    GetServerPublicKey,
 }
 
 impl ConnectionField {
@@ -59,6 +60,7 @@ impl ConnectionField {
                 fields.extend([Self::Database, Self::User, Self::Password, Self::SslMode]);
                 fields.push(Self::CleartextAuth);
                 fields.push(Self::ServerPublicKeyPath);
+                fields.push(Self::GetServerPublicKey);
                 match mysql_ssl_mode {
                     MySqlSslMode::Disabled => {}
                     MySqlSslMode::Preferred | MySqlSslMode::Required => {
@@ -84,7 +86,11 @@ impl ConnectionField {
             | Self::ServerPublicKeyPath => Some(4096),
             Self::Host | Self::Database | Self::User | Self::Password => Some(255),
             Self::Port => Some(5),
-            Self::DatabaseType | Self::Transport | Self::SslMode | Self::CleartextAuth => None,
+            Self::DatabaseType
+            | Self::Transport
+            | Self::SslMode
+            | Self::CleartextAuth
+            | Self::GetServerPublicKey => None,
         }
     }
 
@@ -122,6 +128,7 @@ impl ConnectionField {
             Self::SslCert => "Cert Path:",
             Self::SslKey => "Key Path:",
             Self::ServerPublicKeyPath => "Server Key:",
+            Self::GetServerPublicKey => "Get Server:",
         }
     }
 }
@@ -161,6 +168,7 @@ pub struct ConnectionSetupState {
     pub(crate) mysql_ssl_mode: MySqlSslMode,
     pub(crate) mysql_transport: MySqlTransport,
     pub(crate) enable_cleartext_plugin: bool,
+    pub(crate) get_server_public_key: bool,
 
     pub(crate) focused_field: ConnectionField,
     pub(crate) database_type_dropdown: DropdownState,
@@ -193,6 +201,7 @@ impl Default for ConnectionSetupState {
             mysql_ssl_mode: MySqlSslMode::Preferred,
             mysql_transport: MySqlTransport::Tcp,
             enable_cleartext_plugin: false,
+            get_server_public_key: false,
             focused_field: ConnectionField::DatabaseType,
             database_type_dropdown: DropdownState::default(),
             transport_dropdown: DropdownState::default(),
@@ -223,6 +232,10 @@ impl ConnectionSetupState {
 
     pub fn cleartext_auth_plugin_enabled(&self) -> bool {
         self.enable_cleartext_plugin
+    }
+
+    pub fn get_server_public_key_enabled(&self) -> bool {
+        self.get_server_public_key
     }
 
     pub fn focused_field(&self) -> ConnectionField {
@@ -280,7 +293,8 @@ impl ConnectionSetupState {
             ConnectionField::DatabaseType
             | ConnectionField::Transport
             | ConnectionField::SslMode
-            | ConnectionField::CleartextAuth => None,
+            | ConnectionField::CleartextAuth
+            | ConnectionField::GetServerPublicKey => None,
             ConnectionField::Name => Some(&self.name),
             ConnectionField::SqlitePath => Some(&self.sqlite_path),
             ConnectionField::TransportPath => Some(&self.transport_path),
@@ -305,7 +319,8 @@ impl ConnectionSetupState {
             ConnectionField::DatabaseType
             | ConnectionField::Transport
             | ConnectionField::SslMode
-            | ConnectionField::CleartextAuth => None,
+            | ConnectionField::CleartextAuth
+            | ConnectionField::GetServerPublicKey => None,
             ConnectionField::Name => Some(&mut self.name),
             ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
             ConnectionField::TransportPath => Some(&mut self.transport_path),
@@ -422,7 +437,9 @@ impl ConnectionSetupState {
                         .unwrap_or(0);
                 }
             }
-            ConnectionField::SslMode | ConnectionField::CleartextAuth => {
+            ConnectionField::SslMode
+            | ConnectionField::CleartextAuth
+            | ConnectionField::GetServerPublicKey => {
                 self.ssl_dropdown.is_open = !self.ssl_dropdown.is_open;
                 self.database_type_dropdown.is_open = false;
                 self.transport_dropdown.is_open = false;
@@ -430,6 +447,8 @@ impl ConnectionSetupState {
                     self.ssl_dropdown.selected_index =
                         if self.focused_field == ConnectionField::CleartextAuth {
                             usize::from(self.enable_cleartext_plugin)
+                        } else if self.focused_field == ConnectionField::GetServerPublicKey {
+                            usize::from(self.get_server_public_key)
                         } else if self.database_type == DatabaseType::MySQL {
                             MySqlSslMode::all_variants()
                                 .iter()
@@ -459,7 +478,10 @@ impl ConnectionSetupState {
                 self.transport_dropdown.selected_index += 1;
             }
         } else if self.ssl_dropdown.is_open {
-            let max = if self.focused_field == ConnectionField::CleartextAuth {
+            let max = if matches!(
+                self.focused_field,
+                ConnectionField::CleartextAuth | ConnectionField::GetServerPublicKey
+            ) {
                 1
             } else if self.database_type == DatabaseType::MySQL {
                 MySqlSslMode::all_variants().len() - 1
@@ -502,6 +524,8 @@ impl ConnectionSetupState {
             if self.database_type == DatabaseType::MySQL {
                 if self.focused_field == ConnectionField::CleartextAuth {
                     self.enable_cleartext_plugin = self.ssl_dropdown.selected_index == 1;
+                } else if self.focused_field == ConnectionField::GetServerPublicKey {
+                    self.get_server_public_key = self.ssl_dropdown.selected_index == 1;
                 } else if let Some(mode) =
                     MySqlSslMode::all_variants().get(self.ssl_dropdown.selected_index)
                 {
@@ -623,6 +647,7 @@ impl ConnectionSetupState {
                         .flatten(),
                 )
                 .with_server_public_key_path(optional_path(&self.server_public_key_path))
+                .with_get_server_public_key(self.get_server_public_key)
                 .with_cleartext_auth_plugin(self.enable_cleartext_plugin),
             ),
         })
@@ -690,6 +715,7 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
                     TextInputState::new(&config.password, config.password.chars().count());
                 state.mysql_ssl_mode = config.ssl_mode;
                 state.enable_cleartext_plugin = config.enable_cleartext_plugin;
+                state.get_server_public_key = config.get_server_public_key;
                 if config.ssl_mode.uses_ca()
                     && let Some(path) = config.ssl_ca.as_deref()
                 {
@@ -773,6 +799,7 @@ mod tests {
                     ConnectionField::SslMode,
                     ConnectionField::CleartextAuth,
                     ConnectionField::ServerPublicKeyPath,
+                    ConnectionField::GetServerPublicKey,
                     ConnectionField::SslCert,
                     ConnectionField::SslKey,
                 ]
@@ -799,6 +826,7 @@ mod tests {
                     ConnectionField::SslMode,
                     ConnectionField::CleartextAuth,
                     ConnectionField::ServerPublicKeyPath,
+                    ConnectionField::GetServerPublicKey,
                 ]
             );
         }
@@ -816,6 +844,7 @@ mod tests {
             assert_eq!(ConnectionField::SslMode.max_chars(), None);
             assert_eq!(ConnectionField::CleartextAuth.max_chars(), None);
             assert_eq!(ConnectionField::ServerPublicKeyPath.max_chars(), Some(4096));
+            assert_eq!(ConnectionField::GetServerPublicKey.max_chars(), None);
         }
 
         #[rstest]
@@ -877,6 +906,22 @@ mod tests {
                 panic!("expected MySQL config");
             };
             assert!(config.enable_cleartext_plugin);
+        }
+
+        #[test]
+        fn server_public_key_retrieval_dropdown_updates_config() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            state.focused_field = ConnectionField::GetServerPublicKey;
+            state.toggle_focused_dropdown();
+            state.dropdown_next();
+            state.confirm_dropdown();
+
+            assert!(state.get_server_public_key_enabled());
+            let ConnectionConfig::MySQL(config) = state.to_connection_config().unwrap() else {
+                panic!("expected MySQL config");
+            };
+            assert!(config.get_server_public_key);
         }
     }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -82,7 +82,8 @@ pub(in crate::update) fn reduce_connection_setup(
                 ConnectionField::DatabaseType
                 | ConnectionField::Transport
                 | ConnectionField::SslMode
-                | ConnectionField::CleartextAuth => {}
+                | ConnectionField::CleartextAuth
+                | ConnectionField::GetServerPublicKey => {}
                 _ => {
                     let field = setup.focused_field();
                     if let Some(input) = setup.focused_input_mut()
@@ -351,7 +352,8 @@ fn insert_form_text(setup: &mut ConnectionSetupState, text: &str) {
         ConnectionField::DatabaseType
         | ConnectionField::Transport
         | ConnectionField::SslMode
-        | ConnectionField::CleartextAuth => {}
+        | ConnectionField::CleartextAuth
+        | ConnectionField::GetServerPublicKey => {}
         field => {
             if let Some(input) = setup.focused_input_mut() {
                 let remaining = remaining_input_capacity(field, input.char_count());

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -485,6 +485,7 @@ pub(in crate::update) fn validate_field(state: &mut ConnectionSetupState, field:
                 state.set_validation_error(field, "Requires TLS");
             }
         }
+        ConnectionField::GetServerPublicKey if state.database_type() == DatabaseType::MySQL => {}
         ConnectionField::SslMode if state.database_type() == DatabaseType::MySQL => {
             if state.mysql_transport() == MySqlTransport::NamedPipe
                 && !matches!(
@@ -513,6 +514,7 @@ pub(in crate::update) fn validate_field(state: &mut ConnectionSetupState, field:
         | ConnectionField::SslCert
         | ConnectionField::SslKey
         | ConnectionField::ServerPublicKeyPath
+        | ConnectionField::GetServerPublicKey
         | ConnectionField::CleartextAuth => {}
     }
 }

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -24,6 +24,7 @@ pub(super) fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) ->
                     | ConnectionField::Transport
                     | ConnectionField::SslMode
                     | ConnectionField::CleartextAuth
+                    | ConnectionField::GetServerPublicKey
             ))
     {
         return Action::ConnectionSetupSave;
@@ -53,6 +54,7 @@ pub(super) fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) ->
                     | ConnectionField::Transport
                     | ConnectionField::SslMode
                     | ConnectionField::CleartextAuth
+                    | ConnectionField::GetServerPublicKey
             ) =>
         {
             Action::ConnectionSetupToggleDropdown

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -198,6 +198,8 @@ pub struct MySqlConnectionConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_public_key_path: Option<String>,
     #[serde(default, skip_serializing_if = "is_false")]
+    pub get_server_public_key: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
     pub enable_cleartext_plugin: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transport_path: Option<String>,
@@ -224,6 +226,7 @@ impl MySqlConnectionConfig {
             ssl_cert: None,
             ssl_key: None,
             server_public_key_path: None,
+            get_server_public_key: false,
             enable_cleartext_plugin: false,
             transport_path: None,
         }
@@ -245,6 +248,12 @@ impl MySqlConnectionConfig {
     #[must_use]
     pub fn with_server_public_key_path(mut self, path: Option<String>) -> Self {
         self.server_public_key_path = path;
+        self
+    }
+
+    #[must_use]
+    pub fn with_get_server_public_key(mut self, enabled: bool) -> Self {
+        self.get_server_public_key = enabled;
         self
     }
 

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -22,6 +22,7 @@ pub(super) struct MySqlDsn {
     pub(super) ssl_cert: Option<String>,
     pub(super) ssl_key: Option<String>,
     pub(super) server_public_key_path: Option<String>,
+    pub(super) get_server_public_key: bool,
     pub(super) enable_cleartext_plugin: bool,
 }
 
@@ -41,6 +42,7 @@ impl fmt::Debug for MySqlDsn {
             .field("ssl_cert", &self.ssl_cert)
             .field("ssl_key", &self.ssl_key)
             .field("server_public_key_path", &self.server_public_key_path)
+            .field("get_server_public_key", &self.get_server_public_key)
             .field("enable_cleartext_plugin", &self.enable_cleartext_plugin)
             .finish()
     }
@@ -85,6 +87,10 @@ fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
     if let Some(path) = config.server_public_key_path.as_deref() {
         url.query_pairs_mut()
             .append_pair("server-public-key-path", path);
+    }
+    if config.get_server_public_key {
+        url.query_pairs_mut()
+            .append_pair("get-server-public-key", "true");
     }
     if config.enable_cleartext_plugin {
         url.query_pairs_mut()
@@ -149,6 +155,18 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
     let server_public_key_path = url
         .query_pairs()
         .find_map(|(key, value)| (key == "server-public-key-path").then(|| value.into_owned()));
+    let get_server_public_key = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "get-server-public-key").then(|| value.into_owned()))
+        .map(|value| match value.as_str() {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => Err(DbOperationError::ConnectionFailed(
+                "Invalid MySQL server public key retrieval setting".to_string(),
+            )),
+        })
+        .transpose()?
+        .unwrap_or(false);
     let enable_cleartext_plugin = url
         .query_pairs()
         .find_map(|(key, value)| (key == "enable-cleartext-plugin").then(|| value.into_owned()))
@@ -186,6 +204,7 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         ssl_cert,
         ssl_key,
         server_public_key_path,
+        get_server_public_key,
         enable_cleartext_plugin,
     })
 }
@@ -565,6 +584,40 @@ mod tests {
     }
 
     #[test]
+    fn builds_and_parses_mysql_dsn_with_server_public_key_retrieval() {
+        let config = MySqlConnectionConfig::new(
+            "127.0.0.1",
+            3306,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        )
+        .with_get_server_public_key(true);
+
+        let dsn = build_mysql_dsn(&config);
+        assert!(dsn.contains("get-server-public-key=true"));
+        let parsed = parse_mysql_dsn(&dsn).unwrap();
+
+        assert!(parsed.get_server_public_key);
+    }
+
+    #[test]
+    fn server_public_key_retrieval_defaults_to_disabled_and_rejects_invalid_values() {
+        let parsed = parse_mysql_dsn("mysql://user:password@localhost:3306/app").unwrap();
+        assert!(!parsed.get_server_public_key);
+
+        let error =
+            parse_mysql_dsn("mysql://user:password@localhost:3306/app?get-server-public-key=maybe")
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailed(details)
+                if details == "Invalid MySQL server public key retrieval setting"
+        ));
+    }
+
+    #[test]
     fn builds_and_parses_mysql_dsn_with_cleartext_auth_plugin() {
         let config = MySqlConnectionConfig::new(
             "db.example",
@@ -704,6 +757,7 @@ mod tests {
                 ssl_cert: None,
                 ssl_key: None,
                 server_public_key_path: None,
+                get_server_public_key: false,
                 enable_cleartext_plugin: false,
             };
             match field {

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -392,6 +392,9 @@ fn serialize_option_file(target: &MySqlDsn) -> String {
         push_option(&mut contents, "database", database);
     }
     push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
+    if target.get_server_public_key {
+        push_option(&mut contents, "get-server-public-key", "true");
+    }
     if target.enable_cleartext_plugin {
         push_option(&mut contents, "enable-cleartext-plugin", "true");
     }
@@ -510,6 +513,7 @@ mod tests {
             ssl_cert: None,
             ssl_key: None,
             server_public_key_path: None,
+            get_server_public_key: false,
             enable_cleartext_plugin: false,
         }
     }
@@ -586,6 +590,40 @@ mod tests {
         let option_file = MySqlOptionFile::create(&target).unwrap();
         let contents = fs::read_to_string(&option_file.path).unwrap();
 
+        assert!(contents.contains(&format!(
+            "server-public-key-path = {}\n",
+            quote_option_value(&key.display().to_string())
+        )));
+    }
+
+    #[test]
+    fn option_file_serializes_server_public_key_retrieval() {
+        let target = MySqlDsn {
+            get_server_public_key: true,
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        let contents = fs::read_to_string(&option_file.path).unwrap();
+
+        assert!(contents.contains("get-server-public-key = \"true\"\n"));
+    }
+
+    #[test]
+    fn option_file_keeps_a_valid_key_path_alongside_retrieval_option() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = directory.path().join("server-key.pem");
+        fs::write(&key, VALID_PUBLIC_KEY_PEM).unwrap();
+        let target = MySqlDsn {
+            server_public_key_path: Some(key.display().to_string()),
+            get_server_public_key: true,
+            ..target()
+        };
+
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        let contents = fs::read_to_string(&option_file.path).unwrap();
+
+        assert!(contents.contains("get-server-public-key = \"true\"\n"));
         assert!(contents.contains(&format!(
             "server-public-key-path = {}\n",
             quote_option_value(&key.display().to_string())

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -67,6 +67,8 @@ pub(crate) struct ConnectionConfigEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_server_public_key_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_get_server_public_key: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_enable_cleartext_plugin: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_transport: Option<MySqlTransport>,
@@ -118,6 +120,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_get_server_public_key: None,
             mysql_enable_cleartext_plugin: None,
             mysql_transport: None,
             mysql_transport_path: None,
@@ -154,6 +157,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry
                     .mysql_server_public_key_path
                     .clone_from(&config.server_public_key_path);
+                entry.mysql_get_server_public_key = config.get_server_public_key.then_some(true);
                 entry.mysql_enable_cleartext_plugin =
                     config.enable_cleartext_plugin.then_some(true);
                 entry
@@ -220,6 +224,9 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                             entry.mysql_ssl_key.clone(),
                         )
                         .with_server_public_key_path(entry.mysql_server_public_key_path.clone())
+                        .with_get_server_public_key(
+                            entry.mysql_get_server_public_key.unwrap_or(false),
+                        )
                         .with_transport(transport, entry.mysql_transport_path.clone())
                         .with_cleartext_auth_plugin(
                             entry.mysql_enable_cleartext_plugin.unwrap_or(false),
@@ -307,6 +314,7 @@ mod tests {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_get_server_public_key: None,
             mysql_enable_cleartext_plugin: None,
             mysql_transport: None,
             mysql_transport_path: None,
@@ -330,6 +338,7 @@ mod tests {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_get_server_public_key: None,
             mysql_enable_cleartext_plugin: None,
             mysql_transport: None,
             mysql_transport_path: None,
@@ -353,6 +362,7 @@ mod tests {
             mysql_ssl_cert: None,
             mysql_ssl_key: None,
             mysql_server_public_key_path: None,
+            mysql_get_server_public_key: None,
             mysql_enable_cleartext_plugin: None,
             mysql_transport: None,
             mysql_transport_path: None,
@@ -475,6 +485,7 @@ mod tests {
         assert_eq!(serialized.mysql_ssl_mode, Some(MySqlSslMode::Required));
         assert_eq!(serialized.port, Some(3306));
         assert_eq!(serialized.password.as_deref(), Some("p@ss#word"));
+        assert_eq!(serialized.mysql_get_server_public_key, None);
     }
 
     #[cfg(unix)]
@@ -541,6 +552,7 @@ mod tests {
     fn mysql_entry_round_trips_server_public_key_path() {
         let mut entry = mysql_entry(Some("app"));
         entry.mysql_server_public_key_path = Some(r"C:\keys\server-public.pem".to_string());
+        entry.mysql_get_server_public_key = Some(true);
 
         let profile = ConnectionProfile::try_from(&entry).unwrap();
         assert_eq!(
@@ -551,12 +563,14 @@ mod tests {
                 .as_deref(),
             Some(r"C:\keys\server-public.pem")
         );
+        assert!(profile.mysql_config().unwrap().get_server_public_key);
 
         let serialized = ConnectionConfigEntry::from(&profile);
         assert_eq!(
             serialized.mysql_server_public_key_path,
             entry.mysql_server_public_key_path
         );
+        assert_eq!(serialized.mysql_get_server_public_key, Some(true));
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -12,8 +12,8 @@ mod shared {
 mod connection {
 
     use crate::tests::harness::mysql::{
-        MYSQL_FIXTURE_TABLE, mysql_cache_miss_config, mysql_integration_config, mysql_tls_config,
-        with_mysql_test_db,
+        MYSQL_FIXTURE_TABLE, mysql_cache_miss_config, mysql_cache_miss_retrieval_config,
+        mysql_integration_config, mysql_tls_config, with_mysql_test_db,
     };
     use sabiql_app::model::connection::error::ConnectionErrorInfo;
     use sabiql_app::ports::outbound::{
@@ -134,22 +134,7 @@ mod connection {
             error => panic!("unexpected error kind: {error:?}"),
         }
 
-        let trusted_profile =
-            mysql_profile("mysql-caching-sha2-public-key", trusted_config.clone());
-        let dsn = adapter.build_dsn(&trusted_profile);
-
-        adapter.probe(&dsn).await.unwrap();
-        let result = adapter
-            .execute_adhoc(
-                &dsn,
-                &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
-                AccessMode::ReadWrite,
-            )
-            .await
-            .unwrap();
-        assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
-
-        let retrieval_config = trusted_config
+        let retrieval_config = mysql_cache_miss_retrieval_config()
             .with_server_public_key_path(None)
             .with_get_server_public_key(true);
         let retrieval_profile =
@@ -160,6 +145,21 @@ mod connection {
         let result = adapter
             .execute_adhoc(
                 &retrieval_dsn,
+                &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
+
+        let trusted_profile =
+            mysql_profile("mysql-caching-sha2-public-key", trusted_config.clone());
+        let dsn = adapter.build_dsn(&trusted_profile);
+
+        adapter.probe(&dsn).await.unwrap();
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
                 &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
                 AccessMode::ReadWrite,
             )

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -109,7 +109,7 @@ mod connection {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
-    async fn connects_to_oracle_mysql_84_without_tls_with_trusted_server_public_key() {
+    async fn connects_to_oracle_mysql_84_without_tls_with_trusted_or_retrieved_server_public_key() {
         let adapter = MySqlAdapter::new();
         let trusted_config = mysql_cache_miss_config();
         assert_eq!(trusted_config.ssl_mode, MySqlSslMode::Disabled);
@@ -134,13 +134,32 @@ mod connection {
             error => panic!("unexpected error kind: {error:?}"),
         }
 
-        let trusted_profile = mysql_profile("mysql-caching-sha2-public-key", trusted_config);
+        let trusted_profile =
+            mysql_profile("mysql-caching-sha2-public-key", trusted_config.clone());
         let dsn = adapter.build_dsn(&trusted_profile);
 
         adapter.probe(&dsn).await.unwrap();
         let result = adapter
             .execute_adhoc(
                 &dsn,
+                &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
+
+        let retrieval_config = trusted_config
+            .with_server_public_key_path(None)
+            .with_get_server_public_key(true);
+        let retrieval_profile =
+            mysql_profile("mysql-caching-sha2-public-key-retrieval", retrieval_config);
+        let retrieval_dsn = adapter.build_dsn(&retrieval_profile);
+
+        adapter.probe(&retrieval_dsn).await.unwrap();
+        let result = adapter
+            .execute_adhoc(
+                &retrieval_dsn,
                 &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
                 AccessMode::ReadWrite,
             )

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -152,8 +152,7 @@ mod connection {
             .unwrap();
         assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
 
-        let trusted_profile =
-            mysql_profile("mysql-caching-sha2-public-key", trusted_config.clone());
+        let trusted_profile = mysql_profile("mysql-caching-sha2-public-key", trusted_config);
         let dsn = adapter.build_dsn(&trusted_profile);
 
         adapter.probe(&dsn).await.unwrap();

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -118,6 +118,15 @@ pub fn mysql_cache_miss_config() -> MySqlConnectionConfig {
     config
 }
 
+pub fn mysql_cache_miss_retrieval_config() -> MySqlConnectionConfig {
+    let mut config = mysql_integration_config();
+    config.username = std::env::var("SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_USER")
+        .unwrap_or_else(|_| "sabiql_cache_miss_retrieval_runner".to_string());
+    config.password = std::env::var("SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_PASSWORD")
+        .unwrap_or_else(|_| "sabiql-cache-miss-retrieval".to_string());
+    config
+}
+
 fn mysql_tls_config_with_env(env: impl Fn(&str) -> Option<String>) -> MySqlConnectionConfig {
     mysql_config(MySqlSslMode::VerifyCa, &env).with_tls_paths(
         Some(env("SABIQL_MYSQL_TEST_SSL_CA").expect("TLS CA path")),

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -121,7 +121,7 @@ pub fn mysql_cache_miss_config() -> MySqlConnectionConfig {
 pub fn mysql_cache_miss_retrieval_config() -> MySqlConnectionConfig {
     let mut config = mysql_integration_config();
     config.username = std::env::var("SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_USER")
-        .unwrap_or_else(|_| "sabiql_cache_miss_retrieval_runner".to_string());
+        .unwrap_or_else(|_| "sabiql_cache_miss_retrieval".to_string());
     config.password = std::env::var("SABIQL_MYSQL_TEST_CACHE_MISS_RETRIEVAL_PASSWORD")
         .unwrap_or_else(|_| "sabiql-cache-miss-retrieval".to_string());
     config

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_cleartext_auth_notice.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 105
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
@@ -30,6 +31,7 @@ test_project ▸ - ▸ -                                                        
 │                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
 │                                       ││(select a │  Cleartext:  [ enabled                  ▼ ]                │                                                  │
 │                                       ││          │  Server Key: [                            ]                │                                                  │
+│                                       ││          │  Get Server: [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
@@ -38,7 +40,6 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 86
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -26,11 +26,12 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
 │                                       ││          │  Database:   [ app                        ]                │                                                  │
-│                                       │└──────────│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
-│                                       ││          │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
+│                                       ││          │  User:       [ mysql_user                 ]                │                                                  │
+│                                       │└──────────│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Server Key: [                            ]                │                                                  │
+│                                       ││          │  Get Server: [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_preview_does_not_mask_empty_password.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 132
 expression: output
 ---
 test_project ▸ - ▸ -                                                                                                                 not loaded | localhost:5432/test
@@ -30,6 +31,7 @@ test_project ▸ - ▸ -                                                        
 │                                       │┌ [3] Resul│  SSL Mode:   [ PREFERRED                ▼ ]                │──────────────────────────────────────────────────┐
 │                                       ││(select a │  Cleartext:  [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Server Key: [                            ]                │                                                  │
+│                                       ││          │  Get Server: [ disabled                 ▼ ]                │                                                  │
 │                                       ││          │  Cert Path:  [                            ]                │                                                  │
 │                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
@@ -38,7 +40,6 @@ test_project ▸ - ▸ -                                                        
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -24,7 +24,7 @@ const FIELD_HEIGHT: u16 = 1;
 const MODAL_VERTICAL_CHROME: u16 = 6;
 const MODAL_HORIZONTAL_CHROME: u16 = 6;
 const MIN_PREVIEW_LINES: usize = 2;
-const CLEARTEXT_AUTH_OPTIONS: &[&str] = &["disabled", "enabled"];
+const BOOLEAN_OPTIONS: &[&str] = &["disabled", "enabled"];
 
 fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> Line<'static> {
     Line::from(vec![
@@ -140,6 +140,15 @@ impl ConnectionSetup {
                     form_state.validation_error(ConnectionField::CleartextAuth),
                     theme,
                 ),
+                ConnectionField::GetServerPublicKey => Self::render_dropdown_field(
+                    frame,
+                    chunks[idx],
+                    field.label(),
+                    get_server_public_key_label(form_state),
+                    form_state.focused_field() == ConnectionField::GetServerPublicKey,
+                    form_state.validation_error(ConnectionField::GetServerPublicKey),
+                    theme,
+                ),
                 field => Self::render_text_field(
                     frame,
                     chunks[idx],
@@ -207,19 +216,22 @@ impl ConnectionSetup {
             && let Some(field_area) = Self::open_dropdown_field_area(
                 chunks.as_ref(),
                 &visible_fields,
-                if form_state.focused_field() == ConnectionField::CleartextAuth {
-                    ConnectionField::CleartextAuth
-                } else {
-                    ConnectionField::SslMode
+                match form_state.focused_field() {
+                    ConnectionField::CleartextAuth => ConnectionField::CleartextAuth,
+                    ConnectionField::GetServerPublicKey => ConnectionField::GetServerPublicKey,
+                    _ => ConnectionField::SslMode,
                 },
             )
         {
             if form_state.database_type() == DatabaseType::MySQL {
-                if form_state.focused_field() == ConnectionField::CleartextAuth {
+                if matches!(
+                    form_state.focused_field(),
+                    ConnectionField::CleartextAuth | ConnectionField::GetServerPublicKey
+                ) {
                     Self::render_dropdown_list(
                         frame,
                         field_area,
-                        CLEARTEXT_AUTH_OPTIONS.iter().copied(),
+                        BOOLEAN_OPTIONS.iter().copied(),
                         form_state.ssl_dropdown().selected_index(),
                         theme,
                     );
@@ -271,6 +283,7 @@ impl ConnectionSetup {
                 | ConnectionField::Transport
                 | ConnectionField::SslMode
                 | ConnectionField::CleartextAuth
+                | ConnectionField::GetServerPublicKey
         ) {
             vec![
                 connection_setup::ENTER_DROPDOWN.as_hint(),
@@ -520,6 +533,14 @@ fn ssl_mode_label(state: &ConnectionSetupState) -> String {
 
 fn cleartext_auth_label(state: &ConnectionSetupState) -> &'static str {
     if state.cleartext_auth_plugin_enabled() {
+        "enabled"
+    } else {
+        "disabled"
+    }
+}
+
+fn get_server_public_key_label(state: &ConnectionSetupState) -> &'static str {
+    if state.get_server_public_key_enabled() {
         "enabled"
     } else {
         "disabled"


### PR DESCRIPTION
## Summary

Add explicit MySQL `get-server-public-key` configuration through the connection form, TOML profiles, domain config, DSN, and protected temporary option files.

- Keep the option disabled by default without localhost or proxy-host inference.
- Preserve `server-public-key-path` precedence and existing TLS, cleartext-auth, and capability restrictions.
- Document the Cloud SQL Auth Proxy TCP setup and add an isolated Oracle MySQL 8.4 cold-cache integration case.