### PR TITLE
feat: add ephemeral PostgreSQL and MySQL URI connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,8 @@ dependencies = [
  "toml",
  "unicode-casefold",
  "unicode-width",
+ "url",
+ "urlencoding",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ You can also open an existing SQLite database directly:
 sabiql /path/to/app.db
 ```
 
+For a non-saved PostgreSQL or MySQL connection, pass a URI or the name of an
+environment variable containing one:
+
+```bash
+sabiql 'postgresql://user@localhost/app'
+sabiql --connection-env DATABASE_URL
+```
+
+Supported URI schemes are `postgres://`, `postgresql://`, and `mysql://`.
+Passing a URI with credentials can expose the secret in shell history and
+process arguments; `--connection-env` avoids putting the URI in the command
+line. The connection profile is not saved, but query history and CSV exports
+follow their normal persistence behavior.
+
 Use `Ctrl+R` before browsing data when you want to block writes. Press `?` for help, or open Settings with `,` to change the theme and keymap.
 
 For copying from SSH or a headless host, see [OSC 52 clipboard configuration](docs/clipboard.md).

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -25,6 +25,8 @@ tokio.workspace = true
 toml.workspace = true
 unicode-casefold.workspace = true
 unicode-width.workspace = true
+url.workspace = true
+urlencoding.workspace = true
 sabiql-domain.workspace = true
 uuid.workspace = true
 

--- a/src/app/cmd/cli_connection.rs
+++ b/src/app/cmd/cli_connection.rs
@@ -112,7 +112,7 @@ impl CliUriTarget {
 fn stable_cli_connection_id(dsn: &str) -> ConnectionId {
     let identity = redact_uri_passwords(dsn);
     let id = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, identity.as_bytes());
-    ConnectionId::from_string(format!("cli:{id}"))
+    ConnectionId::from_string(format!("cli-uri-{id}"))
 }
 
 fn redact_uri_passwords(uri: &str) -> String {
@@ -143,7 +143,9 @@ fn redact_uri_passwords(uri: &str) -> String {
             let segment_end = segment_start + segment.len();
             if let Some(equal_offset) = segment.find('=') {
                 let key = &segment[..equal_offset];
-                if key.eq_ignore_ascii_case("password") {
+                let is_password =
+                    urlencoding::decode(key).is_ok_and(|key| key.eq_ignore_ascii_case("password"));
+                if is_password {
                     ranges.push((segment_start + equal_offset + 1, segment_end));
                 }
             }
@@ -300,6 +302,7 @@ mod tests {
             panic!("expected URI targets");
         };
         assert_eq!(first.id, second.id);
+        assert!(!first.id.as_str().contains(':'));
     }
 
     #[test]

--- a/src/app/cmd/cli_connection.rs
+++ b/src/app/cmd/cli_connection.rs
@@ -143,8 +143,9 @@ fn redact_uri_passwords(uri: &str) -> String {
             let segment_end = segment_start + segment.len();
             if let Some(equal_offset) = segment.find('=') {
                 let key = &segment[..equal_offset];
-                let is_password =
-                    urlencoding::decode(key).is_ok_and(|key| key.eq_ignore_ascii_case("password"));
+                let is_password = urlencoding::decode(key).is_ok_and(|key| {
+                    key.eq_ignore_ascii_case("password") || key.eq_ignore_ascii_case("sslpassword")
+                });
                 if is_password {
                     ranges.push((segment_start + equal_offset + 1, segment_end));
                 }

--- a/src/app/cmd/cli_connection.rs
+++ b/src/app/cmd/cli_connection.rs
@@ -1,0 +1,268 @@
+use std::fmt;
+
+use url::Url;
+
+use crate::domain::{ConnectionId, DatabaseType};
+use crate::model::app_state::AppState;
+use crate::model::shared::input_mode::InputMode;
+use crate::policy::mask_password;
+use crate::ports::outbound::SqlitePathValidator;
+
+use super::cli_sqlite::{
+    CliSqliteActivateError, CliSqliteResolveError, CliSqliteTarget, activate_cli_sqlite_connection,
+    resolve_cli_sqlite_target,
+};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct CliUriTarget {
+    id: ConnectionId,
+    name: String,
+    database_type: DatabaseType,
+    database: Option<String>,
+    dsn: String,
+}
+
+impl fmt::Debug for CliUriTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CliUriTarget")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("database_type", &self.database_type)
+            .field("database", &self.database)
+            .field("dsn", &mask_password(&self.dsn))
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliConnectionTarget {
+    SQLite(CliSqliteTarget),
+    Uri(CliUriTarget),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CliConnectionResolveError {
+    #[error("{0}")]
+    SQLite(#[from] CliSqliteResolveError),
+    #[error(
+        "Unsupported connection target; use a SQLite path, sqlite:// DSN, PostgreSQL/MySQL URI, or --connection-env NAME"
+    )]
+    UnsupportedFormat,
+    #[error("Invalid {0} connection URI")]
+    InvalidUri(&'static str),
+    #[error("Connection environment variable {0} is not set or empty")]
+    EnvironmentVariableUnavailable(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CliConnectionActivateError {
+    #[error("{0}")]
+    SQLite(#[from] CliSqliteActivateError),
+}
+
+impl CliUriTarget {
+    fn parse(input: &str) -> Result<Self, CliConnectionResolveError> {
+        let dsn = input.trim();
+        let Some((scheme, remainder)) = dsn.split_once("://") else {
+            return Err(CliConnectionResolveError::UnsupportedFormat);
+        };
+        let (database_type, label) = match scheme {
+            "postgres" | "postgresql" => (DatabaseType::PostgreSQL, "PostgreSQL"),
+            "mysql" => (DatabaseType::MySQL, "MySQL"),
+            _ => return Err(CliConnectionResolveError::UnsupportedFormat),
+        };
+        if remainder.is_empty() || dsn.chars().any(|character| character == '\0') {
+            return Err(CliConnectionResolveError::InvalidUri(label));
+        }
+
+        let parsed = Url::parse(dsn).ok();
+        let database = (database_type == DatabaseType::MySQL)
+            .then(|| {
+                parsed.as_ref().and_then(|url| {
+                    url.path_segments()
+                        .and_then(|mut segments| segments.next())
+                        .filter(|segment| !segment.is_empty())
+                        .and_then(|segment| urlencoding::decode(segment).ok())
+                        .map(std::borrow::Cow::into_owned)
+                })
+            })
+            .flatten();
+        let host = parsed
+            .as_ref()
+            .and_then(Url::host_str)
+            .filter(|host| !host.is_empty());
+        let name = match (host, database.as_deref()) {
+            (Some(host), Some(database)) => format!("{host}/{database}"),
+            (Some(host), None) => host.to_string(),
+            (None, Some(database)) => database.to_string(),
+            (None, None) => label.to_string(),
+        };
+
+        Ok(Self {
+            id: ConnectionId::new(),
+            name,
+            database_type,
+            database,
+            dsn: dsn.to_string(),
+        })
+    }
+}
+
+pub fn resolve_cli_connection_target(
+    input: &str,
+    validator: &impl SqlitePathValidator,
+) -> Result<CliConnectionTarget, CliConnectionResolveError> {
+    let input = input.trim();
+    if let Some((scheme, _)) = input.split_once("://") {
+        return match scheme {
+            "postgres" | "postgresql" | "mysql" => {
+                Ok(CliConnectionTarget::Uri(CliUriTarget::parse(input)?))
+            }
+            "sqlite" => Ok(CliConnectionTarget::SQLite(resolve_cli_sqlite_target(
+                input, validator,
+            )?)),
+            _ => Err(CliConnectionResolveError::UnsupportedFormat),
+        };
+    }
+    if input.starts_with("service=") {
+        return Err(CliConnectionResolveError::UnsupportedFormat);
+    }
+    Ok(CliConnectionTarget::SQLite(resolve_cli_sqlite_target(
+        input, validator,
+    )?))
+}
+
+pub fn resolve_cli_connection_env(
+    name: &str,
+    validator: &impl SqlitePathValidator,
+) -> Result<CliConnectionTarget, CliConnectionResolveError> {
+    let value = std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| CliConnectionResolveError::EnvironmentVariableUnavailable(name.into()))?;
+    let target = resolve_cli_connection_target(&value, validator)?;
+    if matches!(&target, CliConnectionTarget::SQLite(_)) {
+        return Err(CliConnectionResolveError::UnsupportedFormat);
+    }
+    Ok(target)
+}
+
+pub fn activate_cli_connection(
+    state: &mut AppState,
+    target: &CliConnectionTarget,
+    validator: &impl SqlitePathValidator,
+) -> Result<(), CliConnectionActivateError> {
+    match target {
+        CliConnectionTarget::SQLite(target) => {
+            activate_cli_sqlite_connection(state, target, validator)?;
+        }
+        CliConnectionTarget::Uri(target) => {
+            state.session.activate_cli_ephemeral_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.modal.set_mode(InputMode::Normal);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::SqlitePathError;
+
+    struct AcceptingValidator;
+
+    impl SqlitePathValidator for AcceptingValidator {
+        fn validate_database_path(&self, _path: &str) -> Result<(), SqlitePathError> {
+            Ok(())
+        }
+
+        fn canonicalize_database_path(
+            &self,
+            path: &str,
+        ) -> Result<std::path::PathBuf, SqlitePathError> {
+            Ok(path.into())
+        }
+    }
+
+    #[test]
+    fn routes_sqlite_paths_to_existing_target() {
+        let target = resolve_cli_connection_target("data.db", &AcceptingValidator).unwrap();
+
+        assert!(matches!(target, CliConnectionTarget::SQLite(_)));
+    }
+
+    #[test]
+    fn accepts_postgres_uri_schemes() {
+        for scheme in ["postgres", "postgresql"] {
+            let target = resolve_cli_connection_target(
+                &format!("{scheme}://user:secret@localhost/app"),
+                &AcceptingValidator,
+            )
+            .unwrap();
+
+            let CliConnectionTarget::Uri(target) = target else {
+                panic!("expected URI target");
+            };
+            assert_eq!(target.database_type, DatabaseType::PostgreSQL);
+            assert_eq!(target.name, "localhost");
+            assert!(!format!("{target:?}").contains("secret"));
+        }
+    }
+
+    #[test]
+    fn extracts_mysql_database_without_exposing_credentials() {
+        let target = resolve_cli_connection_target(
+            "mysql://user:secret@localhost/app?ssl-mode=REQUIRED",
+            &AcceptingValidator,
+        )
+        .unwrap();
+
+        let CliConnectionTarget::Uri(target) = target else {
+            panic!("expected URI target");
+        };
+        assert_eq!(target.database_type, DatabaseType::MySQL);
+        assert_eq!(target.database.as_deref(), Some("app"));
+        assert_eq!(target.name, "localhost/app");
+        assert!(!format!("{target:?}").contains("secret"));
+    }
+
+    #[test]
+    fn rejects_unsupported_input_without_echoing_it() {
+        let result = resolve_cli_connection_target(
+            "redis://user:secret@example.com/db",
+            &AcceptingValidator,
+        );
+
+        assert!(matches!(
+            result,
+            Err(CliConnectionResolveError::UnsupportedFormat)
+        ));
+        assert!(!result.unwrap_err().to_string().contains("secret"));
+    }
+
+    #[test]
+    fn activates_mysql_uri_as_an_ephemeral_connection() {
+        let target =
+            resolve_cli_connection_target("mysql://user:secret@localhost/app", &AcceptingValidator)
+                .unwrap();
+        let mut state = AppState::new("test".to_string());
+
+        activate_cli_connection(&mut state, &target, &AcceptingValidator).unwrap();
+
+        assert_eq!(
+            state.session.active_database_type(),
+            Some(DatabaseType::MySQL)
+        );
+        assert_eq!(state.session.active_database(), Some("app"));
+        assert!(state.session.is_ephemeral_connection());
+        assert!(state.connections().is_empty());
+        assert_eq!(state.input_mode(), InputMode::Normal);
+    }
+}

--- a/src/app/cmd/cli_connection.rs
+++ b/src/app/cmd/cli_connection.rs
@@ -100,13 +100,62 @@ impl CliUriTarget {
         };
 
         Ok(Self {
-            id: ConnectionId::new(),
+            id: stable_cli_connection_id(dsn),
             name,
             database_type,
             database,
             dsn: dsn.to_string(),
         })
     }
+}
+
+fn stable_cli_connection_id(dsn: &str) -> ConnectionId {
+    let identity = redact_uri_passwords(dsn);
+    let id = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, identity.as_bytes());
+    ConnectionId::from_string(format!("cli:{id}"))
+}
+
+fn redact_uri_passwords(uri: &str) -> String {
+    let Some(scheme_end) = uri.find("://") else {
+        return uri.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = uri[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(uri.len(), |offset| authority_start + offset);
+    let mut ranges = Vec::new();
+    let authority = &uri[authority_start..authority_end];
+    if let Some(at_offset) = authority.rfind('@') {
+        let userinfo_end = authority_start + at_offset;
+        if let Some(colon_offset) = authority[..at_offset].find(':') {
+            ranges.push((authority_start + colon_offset + 1, userinfo_end));
+        }
+    }
+
+    if let Some(query_offset) = uri[authority_end..].find('?') {
+        let query_start = authority_end + query_offset + 1;
+        let query_end = uri[query_start..]
+            .find('#')
+            .map_or(uri.len(), |offset| query_start + offset);
+        let query = &uri[query_start..query_end];
+        let mut segment_start = query_start;
+        for segment in query.split('&') {
+            let segment_end = segment_start + segment.len();
+            if let Some(equal_offset) = segment.find('=') {
+                let key = &segment[..equal_offset];
+                if key.eq_ignore_ascii_case("password") {
+                    ranges.push((segment_start + equal_offset + 1, segment_end));
+                }
+            }
+            segment_start = segment_end.saturating_add(1);
+        }
+    }
+
+    let mut redacted = uri.to_string();
+    for (start, end) in ranges.into_iter().rev() {
+        redacted.replace_range(start..end, "");
+    }
+    redacted
 }
 
 pub fn resolve_cli_connection_target(
@@ -231,6 +280,26 @@ mod tests {
         assert_eq!(target.database.as_deref(), Some("app"));
         assert_eq!(target.name, "localhost/app");
         assert!(!format!("{target:?}").contains("secret"));
+    }
+
+    #[test]
+    fn reuses_uri_connection_id_without_password() {
+        let first = resolve_cli_connection_target(
+            "mysql://user:first-secret@localhost/app",
+            &AcceptingValidator,
+        )
+        .unwrap();
+        let second = resolve_cli_connection_target(
+            "mysql://user:second-secret@localhost/app",
+            &AcceptingValidator,
+        )
+        .unwrap();
+
+        let (CliConnectionTarget::Uri(first), CliConnectionTarget::Uri(second)) = (first, second)
+        else {
+            panic!("expected URI targets");
+        };
+        assert_eq!(first.id, second.id);
     }
 
     #[test]

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,13 +1,15 @@
+use std::fmt;
 use std::sync::Arc;
 
 use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
 use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{DatabaseMetadata, QueryValue, Table, TableSignatureSnapshot};
 use crate::model::browse::session::ConnectionSaveGuard;
+use crate::policy::mask_password;
 use crate::ports::outbound::{AccessMode, AppSettings};
 use crate::update::action::{Action, ConnectionTarget};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Effect {
     Render,
 
@@ -182,4 +184,336 @@ pub enum Effect {
     SwitchToService {
         service_index: usize,
     },
+}
+
+struct MaskedDsn<'a>(&'a str);
+
+impl fmt::Debug for MaskedDsn<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&mask_password(self.0))
+    }
+}
+
+impl fmt::Debug for Effect {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Render => formatter.write_str("Effect::Render"),
+            Self::SaveAndConnect {
+                id,
+                name,
+                run_id,
+                run_guard,
+                ..
+            } => formatter
+                .debug_struct("Effect::SaveAndConnect")
+                .field("id", id)
+                .field("name", name)
+                .field("config", &"<redacted>")
+                .field("run_id", run_id)
+                .field("run_guard", run_guard)
+                .finish(),
+            Self::ProbeMySqlConnection { target, run_id } => formatter
+                .debug_struct("Effect::ProbeMySqlConnection")
+                .field("target", target)
+                .field("run_id", run_id)
+                .finish(),
+            Self::LoadConnectionForEdit { id } => formatter
+                .debug_struct("Effect::LoadConnectionForEdit")
+                .field("id", id)
+                .finish(),
+            Self::LoadConnections => formatter.write_str("Effect::LoadConnections"),
+            Self::DeleteConnection { id } => formatter
+                .debug_struct("Effect::DeleteConnection")
+                .field("id", id)
+                .finish(),
+            Self::FetchMetadata { dsn, run_id } => formatter
+                .debug_struct("Effect::FetchMetadata")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .finish(),
+            Self::FetchTableDetail {
+                dsn,
+                schema,
+                table,
+                generation,
+                run_id,
+            } => formatter
+                .debug_struct("Effect::FetchTableDetail")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("schema", schema)
+                .field("table", table)
+                .field("generation", generation)
+                .field("run_id", run_id)
+                .finish(),
+            Self::PrefetchTableColumnsAndFks {
+                dsn,
+                run_id,
+                schema,
+                table,
+            } => formatter
+                .debug_struct("Effect::PrefetchTableColumnsAndFks")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("schema", schema)
+                .field("table", table)
+                .finish(),
+            Self::SchedulePrefetchQueueProcessing { run_id } => formatter
+                .debug_struct("Effect::SchedulePrefetchQueueProcessing")
+                .field("run_id", run_id)
+                .finish(),
+            Self::DelayedProcessPrefetchQueue { run_id, delay_secs } => formatter
+                .debug_struct("Effect::DelayedProcessPrefetchQueue")
+                .field("run_id", run_id)
+                .field("delay_secs", delay_secs)
+                .finish(),
+            Self::ExecutePreview {
+                dsn,
+                schema,
+                table,
+                generation,
+                run_id,
+                limit,
+                offset,
+                target_page,
+            } => formatter
+                .debug_struct("Effect::ExecutePreview")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("schema", schema)
+                .field("table", table)
+                .field("generation", generation)
+                .field("run_id", run_id)
+                .field("limit", limit)
+                .field("offset", offset)
+                .field("target_page", target_page)
+                .finish(),
+            Self::ExecuteAdhoc {
+                dsn,
+                run_id,
+                query,
+                access_mode,
+            } => formatter
+                .debug_struct("Effect::ExecuteAdhoc")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("query", query)
+                .field("access_mode", access_mode)
+                .finish(),
+            Self::ExecuteExplain {
+                dsn,
+                database_type,
+                database_generation,
+                run_id,
+                query,
+                source_query,
+                is_analyze,
+                access_mode,
+            } => formatter
+                .debug_struct("Effect::ExecuteExplain")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("database_type", database_type)
+                .field("database_generation", database_generation)
+                .field("run_id", run_id)
+                .field("query", query)
+                .field("source_query", source_query)
+                .field("is_analyze", is_analyze)
+                .field("access_mode", access_mode)
+                .finish(),
+            Self::ExecuteWrite {
+                dsn,
+                run_id,
+                query,
+                access_mode,
+            } => formatter
+                .debug_struct("Effect::ExecuteWrite")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("query", query)
+                .field("access_mode", access_mode)
+                .finish(),
+            Self::CancelConnectionTask => formatter.write_str("Effect::CancelConnectionTask"),
+            Self::CancelMetadataTasks => formatter.write_str("Effect::CancelMetadataTasks"),
+            Self::CancelSqliteDiagnostics => formatter.write_str("Effect::CancelSqliteDiagnostics"),
+            Self::CancelTrackedTasks => formatter.write_str("Effect::CancelTrackedTasks"),
+            Self::ExportCsv {
+                dsn,
+                run_id,
+                query,
+                file_name,
+            } => formatter
+                .debug_struct("Effect::ExportCsv")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("query", query)
+                .field("file_name", file_name)
+                .finish(),
+            Self::ExportCsvFromCache {
+                dsn,
+                run_id,
+                file_name,
+                columns,
+                values,
+                row_count,
+            } => formatter
+                .debug_struct("Effect::ExportCsvFromCache")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("file_name", file_name)
+                .field("columns", columns)
+                .field("values", values)
+                .field("row_count", row_count)
+                .finish(),
+            Self::CacheTableInCompletionEngine {
+                qualified_name,
+                table,
+            } => formatter
+                .debug_struct("Effect::CacheTableInCompletionEngine")
+                .field("qualified_name", qualified_name)
+                .field("table", table)
+                .finish(),
+            Self::EvictTablesFromCompletionCache { tables } => formatter
+                .debug_struct("Effect::EvictTablesFromCompletionCache")
+                .field("tables", tables)
+                .finish(),
+            Self::ClearCompletionEngineCache => {
+                formatter.write_str("Effect::ClearCompletionEngineCache")
+            }
+            Self::ResizeCompletionCache { capacity } => formatter
+                .debug_struct("Effect::ResizeCompletionCache")
+                .field("capacity", capacity)
+                .finish(),
+            Self::TriggerCompletion => formatter.write_str("Effect::TriggerCompletion"),
+            Self::GenerateErDiagramFromCache {
+                run_id,
+                total_tables,
+                project_name,
+                target_tables,
+            } => formatter
+                .debug_struct("Effect::GenerateErDiagramFromCache")
+                .field("run_id", run_id)
+                .field("total_tables", total_tables)
+                .field("project_name", project_name)
+                .field("target_tables", target_tables)
+                .finish(),
+            Self::WriteErFailureLog { failed_tables } => formatter
+                .debug_struct("Effect::WriteErFailureLog")
+                .field("failed_tables", failed_tables)
+                .finish(),
+            Self::ExtractFkNeighbors {
+                run_id,
+                seed_tables,
+            } => formatter
+                .debug_struct("Effect::ExtractFkNeighbors")
+                .field("run_id", run_id)
+                .field("seed_tables", seed_tables)
+                .finish(),
+            Self::SmartErRefresh { dsn, run_id } => formatter
+                .debug_struct("Effect::SmartErRefresh")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .finish(),
+            Self::SmartErRefreshCacheAndDiff {
+                dsn,
+                run_id,
+                new_metadata,
+                signature_snapshot,
+            } => formatter
+                .debug_struct("Effect::SmartErRefreshCacheAndDiff")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("new_metadata", new_metadata)
+                .field("signature_snapshot", signature_snapshot)
+                .finish(),
+            Self::CopyToClipboard {
+                content,
+                on_success,
+                on_failure,
+            } => formatter
+                .debug_struct("Effect::CopyToClipboard")
+                .field("content", &mask_password(content))
+                .field("on_success", on_success)
+                .field("on_failure", on_failure)
+                .finish(),
+            Self::OpenFolder {
+                path,
+                message_revision,
+                export_message,
+            } => formatter
+                .debug_struct("Effect::OpenFolder")
+                .field("path", path)
+                .field("message_revision", message_revision)
+                .field("export_message", export_message)
+                .finish(),
+            Self::LoadQueryHistory {
+                project_name,
+                scope,
+            } => formatter
+                .debug_struct("Effect::LoadQueryHistory")
+                .field("project_name", project_name)
+                .field("scope", scope)
+                .finish(),
+            Self::SaveSettings { settings } => formatter
+                .debug_struct("Effect::SaveSettings")
+                .field("settings", settings)
+                .finish(),
+            Self::FetchSqliteDiagnosticsCore { dsn, run_id } => formatter
+                .debug_struct("Effect::FetchSqliteDiagnosticsCore")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .finish(),
+            Self::FetchSqliteDiagnosticsQuickCheck { dsn, run_id } => formatter
+                .debug_struct("Effect::FetchSqliteDiagnosticsQuickCheck")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .finish(),
+            Self::DispatchActions(actions) => formatter
+                .debug_struct("Effect::DispatchActions")
+                .field("action_count", &actions.len())
+                .finish(),
+            Self::SwitchConnection { connection_index } => formatter
+                .debug_struct("Effect::SwitchConnection")
+                .field("connection_index", connection_index)
+                .finish(),
+            Self::SwitchToService { service_index } => formatter
+                .debug_struct("Effect::SwitchToService")
+                .field("service_index", service_index)
+                .finish(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::browse::session::BrowseSession;
+    use crate::model::connection::cache::ConnectionCache;
+
+    #[test]
+    fn debug_masks_uri_passwords_in_startup_effect_session_and_cache() {
+        let dsn = "postgresql://user@host/db?pass%77ord=secret";
+        let effect = Effect::FetchMetadata {
+            dsn: dsn.to_string(),
+            run_id: 1,
+        };
+        let mut session = BrowseSession::default();
+        session.activate_cli_ephemeral_connection_with_target(
+            &ConnectionId::from_string("cli-uri-test"),
+            "host",
+            DatabaseType::PostgreSQL,
+            dsn,
+            None,
+        );
+        let cache = ConnectionCache {
+            connection_dsn: Some(dsn.to_string()),
+            ..Default::default()
+        };
+
+        for debug in [
+            format!("{effect:?}"),
+            format!("{session:?}"),
+            format!("{cache:?}"),
+        ] {
+            assert!(!debug.contains("secret"));
+            assert!(debug.contains("pass%77ord=****"));
+        }
+    }
 }

--- a/src/app/cmd/mod.rs
+++ b/src/app/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub(in crate::cmd) mod browse;
+pub mod cli_connection;
 pub mod cli_sqlite;
 pub mod completion_engine;
 pub(in crate::cmd) mod connection;

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -141,7 +141,7 @@ impl fmt::Debug for PendingMySqlConnectionProbe {
 // where the aggregate API does not cover the exact semantics needed.
 // `set_connection_state` and `set_metadata_state` are test-only lifecycle
 // fixtures.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BrowseSession {
     // -- co-dependent: connection lifecycle --
     connection_state: ConnectionState,
@@ -171,6 +171,48 @@ pub struct BrowseSession {
     database_generation: u64,
     read_only: bool,
     is_reloading: bool,
+}
+
+impl fmt::Debug for BrowseSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let dsn = self.dsn.as_deref().map(mask_password);
+        formatter
+            .debug_struct("BrowseSession")
+            .field("connection_state", &self.connection_state)
+            .field("metadata_state", &self.metadata_state)
+            .field("selected_table_key", &self.selected_table_key)
+            .field("table_detail_state", &self.table_detail_state)
+            .field("selection_generation", &self.selection_generation)
+            .field("metadata", &self.metadata)
+            .field("metadata_run", &self.metadata_run)
+            .field(
+                "metadata_detail_generation",
+                &self.metadata_detail_generation,
+            )
+            .field("effective_user", &self.effective_user)
+            .field("table_detail_run", &self.table_detail_run)
+            .field("connection_save_run", &self.connection_save_run)
+            .field("connection_save_guard", &self.connection_save_guard)
+            .field("dsn", &dsn)
+            .field("active_connection", &self.active_connection)
+            .field(
+                "mysql_connection_probe_run",
+                &self.mysql_connection_probe_run,
+            )
+            .field(
+                "pending_mysql_connection_probe",
+                &self.pending_mysql_connection_probe,
+            )
+            .field(
+                "mysql_lower_case_table_names",
+                &self.mysql_lower_case_table_names,
+            )
+            .field("connection_generation", &self.connection_generation)
+            .field("database_generation", &self.database_generation)
+            .field("read_only", &self.read_only)
+            .field("is_reloading", &self.is_reloading)
+            .finish()
+    }
 }
 
 impl Default for BrowseSession {

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -466,12 +466,29 @@ impl BrowseSession {
     }
 
     pub fn activate_cli_ephemeral_connection(&mut self, id: &ConnectionId, name: &str, dsn: &str) {
+        self.activate_cli_ephemeral_connection_with_target(
+            id,
+            name,
+            DatabaseType::SQLite,
+            dsn,
+            None,
+        );
+    }
+
+    pub fn activate_cli_ephemeral_connection_with_target(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+        database: Option<&str>,
+    ) {
         self.active_connection = Some(ActiveConnection {
             id: id.clone(),
             name: name.to_string(),
-            database_type: DatabaseType::SQLite,
+            database_type,
             origin: ConnectionOrigin::CliEphemeral,
-            database: None,
+            database: database.map(str::to_string),
         });
         self.dsn = Some(dsn.to_string());
         self.mysql_lower_case_table_names = 0;

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -106,6 +106,7 @@ pub struct PendingMySqlConnectionProbe {
     pub name: String,
     pub dsn: String,
     pub database: Option<String>,
+    pub origin: ConnectionOrigin,
     pub run_id: u64,
     table_detail: Option<InterruptedTableDetail>,
 }
@@ -118,6 +119,7 @@ impl fmt::Debug for PendingMySqlConnectionProbe {
             .field("name", &self.name)
             .field("dsn", &mask_password(&self.dsn))
             .field("database", &self.database)
+            .field("origin", &self.origin)
             .field("run_id", &self.run_id)
             .field("table_detail", &self.table_detail)
             .finish()
@@ -355,6 +357,40 @@ impl BrowseSession {
         dsn: &str,
         database: Option<&str>,
     ) -> u64 {
+        self.begin_mysql_connection_probe_with_origin(
+            id,
+            name,
+            dsn,
+            database,
+            ConnectionOrigin::Profile,
+        )
+    }
+
+    #[must_use]
+    pub fn begin_cli_mysql_connection_probe(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        dsn: &str,
+        database: Option<&str>,
+    ) -> u64 {
+        self.begin_mysql_connection_probe_with_origin(
+            id,
+            name,
+            dsn,
+            database,
+            ConnectionOrigin::CliEphemeral,
+        )
+    }
+
+    fn begin_mysql_connection_probe_with_origin(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        dsn: &str,
+        database: Option<&str>,
+        origin: ConnectionOrigin,
+    ) -> u64 {
         let table_detail =
             self.dsn
                 .clone()
@@ -372,6 +408,7 @@ impl BrowseSession {
             name: name.to_string(),
             dsn: dsn.to_string(),
             database: database.map(str::to_string),
+            origin,
             run_id,
             table_detail,
         });
@@ -451,12 +488,31 @@ impl BrowseSession {
         dsn: &str,
         database: Option<&str>,
     ) {
+        self.activate_connection_with_target_and_origin(
+            id,
+            name,
+            database_type,
+            dsn,
+            database,
+            ConnectionOrigin::Profile,
+        );
+    }
+
+    pub fn activate_connection_with_target_and_origin(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+        database: Option<&str>,
+        origin: ConnectionOrigin,
+    ) {
         self.database_generation = self.database_generation.wrapping_add(1);
         self.active_connection = Some(ActiveConnection {
             id: id.clone(),
             name: name.to_string(),
             database_type,
-            origin: ConnectionOrigin::Profile,
+            origin,
             database: database.map(str::to_string),
         });
         self.dsn = Some(dsn.to_string());
@@ -483,17 +539,14 @@ impl BrowseSession {
         dsn: &str,
         database: Option<&str>,
     ) {
-        self.active_connection = Some(ActiveConnection {
-            id: id.clone(),
-            name: name.to_string(),
+        self.activate_connection_with_target_and_origin(
+            id,
+            name,
             database_type,
-            origin: ConnectionOrigin::CliEphemeral,
-            database: database.map(str::to_string),
-        });
-        self.dsn = Some(dsn.to_string());
-        self.mysql_lower_case_table_names = 0;
-        self.read_only = false;
-        self.clear_mysql_connection_probe();
+            dsn,
+            database,
+            ConnectionOrigin::CliEphemeral,
+        );
     }
 
     pub fn clear_connection(&mut self) {
@@ -670,6 +723,12 @@ impl BrowseSession {
     ) {
         self.restore_from_cache(cache, query);
         self.activate_connection_with_target(id, name, database_type, dsn, database);
+    }
+
+    pub fn set_active_connection_origin(&mut self, origin: ConnectionOrigin) {
+        if let Some(connection) = self.active_connection.as_mut() {
+            connection.origin = origin;
+        }
     }
 
     // Caller must also call `result_interaction.reset_view()` and restore UI state.

--- a/src/app/model/connection/cache.rs
+++ b/src/app/model/connection/cache.rs
@@ -1,10 +1,12 @@
+use std::fmt;
 use std::sync::Arc;
 
 use crate::domain::{DatabaseMetadata, QueryResult, Table};
 use crate::model::browse::query_execution::PaginationState;
 use crate::model::shared::inspector_tab::InspectorTab;
+use crate::policy::mask_password;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ConnectionCache {
     pub connection_dsn: Option<String>,
     pub metadata: Option<Arc<DatabaseMetadata>>,
@@ -15,6 +17,24 @@ pub struct ConnectionCache {
     pub pagination: PaginationState,
     pub explorer_selected: usize,
     pub inspector_tab: InspectorTab,
+}
+
+impl fmt::Debug for ConnectionCache {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let connection_dsn = self.connection_dsn.as_deref().map(mask_password);
+        formatter
+            .debug_struct("ConnectionCache")
+            .field("connection_dsn", &connection_dsn)
+            .field("metadata", &self.metadata)
+            .field("effective_user", &self.effective_user)
+            .field("table_detail", &self.table_detail)
+            .field("selected_table_key", &self.selected_table_key)
+            .field("query_result", &self.query_result)
+            .field("pagination", &self.pagination)
+            .field("explorer_selected", &self.explorer_selected)
+            .field("inspector_tab", &self.inspector_tab)
+            .finish()
+    }
 }
 
 impl ConnectionCache {

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -1,4 +1,7 @@
+use std::fmt;
+
 use crate::domain::{ConnectionId, QueryValue};
+use crate::policy::mask_password;
 use crate::update::action::ScrollDirection;
 
 #[derive(Debug, Clone)]
@@ -7,7 +10,7 @@ pub struct CsvExportCacheSnapshot {
     pub values: Vec<Vec<QueryValue>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ConfirmIntent {
     QuitNoConnection,
     DeleteConnection(ConnectionId),
@@ -29,6 +32,58 @@ pub enum ConfirmIntent {
         snapshot: CsvExportCacheSnapshot,
     },
     DisableReadOnly,
+}
+
+struct MaskedDsn<'a>(&'a str);
+
+impl fmt::Debug for MaskedDsn<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&mask_password(self.0))
+    }
+}
+
+impl fmt::Debug for ConfirmIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CsvExportRerunnable {
+                dsn,
+                run_id,
+                export_query,
+                file_name,
+            } => formatter
+                .debug_struct("ConfirmIntent::CsvExportRerunnable")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("export_query", export_query)
+                .field("file_name", file_name)
+                .finish(),
+            Self::CsvExportCached {
+                dsn,
+                run_id,
+                file_name,
+                row_count,
+                snapshot,
+            } => formatter
+                .debug_struct("ConfirmIntent::CsvExportCached")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("file_name", file_name)
+                .field("row_count", row_count)
+                .field("snapshot", snapshot)
+                .finish(),
+            Self::QuitNoConnection => formatter.write_str("ConfirmIntent::QuitNoConnection"),
+            Self::DeleteConnection(id) => formatter
+                .debug_tuple("ConfirmIntent::DeleteConnection")
+                .field(id)
+                .finish(),
+            Self::ExecuteWrite { sql, blocked } => formatter
+                .debug_struct("ConfirmIntent::ExecuteWrite")
+                .field("sql", sql)
+                .field("blocked", blocked)
+                .finish(),
+            Self::DisableReadOnly => formatter.write_str("ConfirmIntent::DisableReadOnly"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -111,5 +166,28 @@ impl Default for ConfirmDialogState {
             preview_viewport_height: None,
             preview_content_height: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_masks_uri_passwords_in_confirm_state() {
+        let intent = ConfirmIntent::CsvExportRerunnable {
+            dsn: "postgresql://user@host/db?pass%77ord=secret".to_string(),
+            run_id: 1,
+            export_query: "SELECT 1".to_string(),
+            file_name: "export.csv".to_string(),
+        };
+        let state = ConfirmDialogState {
+            intent: Some(intent),
+            ..Default::default()
+        };
+        let debug = format!("{state:?}");
+
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("pass%77ord=****"));
     }
 }

--- a/src/app/policy/password_masking.rs
+++ b/src/app/policy/password_masking.rs
@@ -97,19 +97,46 @@ fn has_assignment_boundary(text: &str, pos: usize) -> bool {
 fn password_assignment_prefix_len(text: &str, pos: usize) -> Option<usize> {
     const KEYS: &[&str] = &["password", "sslpassword"];
 
-    let key = KEYS.iter().find(|key| {
-        has_assignment_boundary(text, pos) && starts_with_ascii_ignore_case(text, pos, key)
-    })?;
-
     let bytes = text.as_bytes();
-    let mut i = pos + key.len();
-    while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
+    if let Some(key) = KEYS.iter().find(|key| {
+        has_assignment_boundary(text, pos) && starts_with_ascii_ignore_case(text, pos, key)
+    }) {
+        let mut i = pos + key.len();
+        while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
+            i += 1;
+        }
+        if bytes.get(i) != Some(&b'=') {
+            return None;
+        }
         i += 1;
+        while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
+            i += 1;
+        }
+
+        return Some(i - pos);
     }
-    if bytes.get(i) != Some(&b'=') {
+
+    if !has_assignment_boundary(text, pos) {
         return None;
     }
-    i += 1;
+    let mut key_end = pos;
+    while bytes
+        .get(key_end)
+        .is_some_and(|byte| !byte.is_ascii_whitespace() && *byte != b'=')
+    {
+        key_end += 1;
+    }
+    let encoded_key = text.get(pos..key_end)?;
+    let decoded_key = urlencoding::decode(encoded_key).ok()?;
+    if !decoded_key.eq_ignore_ascii_case("password")
+        && !decoded_key.eq_ignore_ascii_case("sslpassword")
+    {
+        return None;
+    }
+    if bytes.get(key_end) != Some(&b'=') {
+        return None;
+    }
+    let mut i = key_end + 1;
     while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
         i += 1;
     }
@@ -137,7 +164,7 @@ fn mask_after_prefix(text: &str, find_prefix: impl Fn(usize) -> Option<usize>) -
 }
 
 fn is_assignment_terminator(byte: u8) -> bool {
-    byte.is_ascii_whitespace() || matches!(byte, b';' | b'\'' | b'"' | b',')
+    byte.is_ascii_whitespace() || matches!(byte, b';' | b'\'' | b'"' | b',' | b'&' | b'#')
 }
 
 fn skip_masked_assignment_value(text: &str, value_start: usize, result: &mut String) -> usize {
@@ -209,6 +236,10 @@ mod tests {
     #[case(
         "mysql://user:p@ss%23word@host:3306/db?ssl-mode=REQUIRED",
         "mysql://user:****@host:3306/db?ssl-mode=REQUIRED"
+    )]
+    #[case(
+        "postgresql://user@host/db?pass%77ord=secret&sslmode=require",
+        "postgresql://user@host/db?pass%77ord=****&sslmode=require"
     )]
     fn masks_passwords_in_urls(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(mask_password(input), expected);

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -185,7 +185,7 @@ pub enum ModalKind {
     SqliteDiagnostics,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SmartErRefreshResult {
     pub dsn: String,
     pub run_id: u64,
@@ -196,7 +196,7 @@ pub struct SmartErRefreshResult {
     pub new_signatures: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SmartErRefreshFetched {
     pub dsn: String,
     pub run_id: u64,
@@ -204,7 +204,7 @@ pub struct SmartErRefreshFetched {
     pub signature_snapshot: Arc<TableSignatureSnapshot>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SmartErRefreshError {
     pub dsn: String,
     pub run_id: u64,
@@ -291,7 +291,7 @@ pub enum QueryFailureContext {
     Preview { generation: u64 },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Action {
     // App shell
     None,
@@ -653,6 +653,119 @@ pub enum Action {
     ErLogWriteFailed(String),
 }
 
+struct MaskedDsn<'a>(&'a str);
+
+impl fmt::Debug for MaskedDsn<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&mask_password(self.0))
+    }
+}
+
+impl fmt::Debug for SmartErRefreshResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SmartErRefreshResult")
+            .field("dsn", &MaskedDsn(&self.dsn))
+            .field("run_id", &self.run_id)
+            .field("new_metadata", &self.new_metadata)
+            .field("stale_tables", &self.stale_tables)
+            .field("removed_tables", &self.removed_tables)
+            .field("missing_in_cache", &self.missing_in_cache)
+            .field("new_signatures", &self.new_signatures)
+            .finish()
+    }
+}
+
+impl fmt::Debug for SmartErRefreshFetched {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SmartErRefreshFetched")
+            .field("dsn", &MaskedDsn(&self.dsn))
+            .field("run_id", &self.run_id)
+            .field("new_metadata", &self.new_metadata)
+            .field("signature_snapshot", &self.signature_snapshot)
+            .finish()
+    }
+}
+
+impl fmt::Debug for SmartErRefreshError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SmartErRefreshError")
+            .field("dsn", &MaskedDsn(&self.dsn))
+            .field("run_id", &self.run_id)
+            .field("error", &self.error)
+            .field("new_metadata", &self.new_metadata)
+            .finish()
+    }
+}
+
+impl fmt::Debug for Action {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TableDetailLoaded {
+                dsn,
+                run_id,
+                outcome,
+                generation,
+            } => formatter
+                .debug_struct("Action::TableDetailLoaded")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("outcome", outcome)
+                .field("generation", generation)
+                .finish(),
+            Self::TableDetailCached {
+                dsn,
+                run_id,
+                schema,
+                table,
+                detail,
+            } => formatter
+                .debug_struct("Action::TableDetailCached")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("schema", schema)
+                .field("table", table)
+                .field("detail", detail)
+                .finish(),
+            Self::TableDetailCacheFailed {
+                dsn,
+                run_id,
+                schema,
+                table,
+                error,
+            } => formatter
+                .debug_struct("Action::TableDetailCacheFailed")
+                .field("dsn", &MaskedDsn(dsn))
+                .field("run_id", run_id)
+                .field("schema", schema)
+                .field("table", table)
+                .field("error", error)
+                .finish(),
+            Self::CompletionUpdated {
+                candidates,
+                trigger_position,
+                visible,
+                dsn,
+                connection_generation,
+                database_generation,
+                metadata_generation,
+            } => formatter
+                .debug_struct("Action::CompletionUpdated")
+                .field("candidates", candidates)
+                .field("trigger_position", trigger_position)
+                .field("visible", visible)
+                .field("dsn", &dsn.as_deref().map(MaskedDsn))
+                .field("connection_generation", connection_generation)
+                .field("database_generation", database_generation)
+                .field("metadata_generation", metadata_generation)
+                .finish(),
+            _ => formatter.write_str("Action::<redacted>"),
+        }
+    }
+}
+
 impl Action {
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
@@ -993,6 +1106,35 @@ mod tests {
             Action::JsonExitEdit.feature_requirement_for_state(&normal_state),
             FeatureRequirement::JsonDocumentEdit
         );
+    }
+
+    #[test]
+    fn debug_masks_uri_passwords_in_actions() {
+        let dsn = "postgresql://user@host/db?pass%77ord=secret";
+        let actions = [
+            Action::TableDetailCached {
+                dsn: dsn.to_string(),
+                run_id: 1,
+                schema: "public".to_string(),
+                table: "users".to_string(),
+                detail: None,
+            },
+            Action::CompletionUpdated {
+                candidates: Vec::new(),
+                trigger_position: 0,
+                visible: false,
+                dsn: Some(dsn.to_string()),
+                connection_generation: 0,
+                database_generation: 0,
+                metadata_generation: 0,
+            },
+        ];
+
+        for action in actions {
+            let debug = format!("{action:?}");
+            assert!(!debug.contains("secret"));
+            assert!(debug.contains("pass%77ord=****"));
+        }
     }
 
     mod shared_scroll_helpers {

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
+use crate::model::connection::origin::ConnectionOrigin;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::ConnectionTarget;
 use crate::update::action::{Action, ScrollAmount, ScrollDirection, ScrollTarget};
@@ -91,12 +92,21 @@ pub(super) fn reduce_connection_error(
                     database_type: DatabaseType::MySQL,
                     database: pending.database,
                 };
-                let run_id = state.session.begin_mysql_connection_probe(
-                    &target.id,
-                    &target.name,
-                    &target.dsn,
-                    target.database.as_deref(),
-                );
+                let run_id = if pending.origin == ConnectionOrigin::CliEphemeral {
+                    state.session.begin_cli_mysql_connection_probe(
+                        &target.id,
+                        &target.name,
+                        &target.dsn,
+                        target.database.as_deref(),
+                    )
+                } else {
+                    state.session.begin_mysql_connection_probe(
+                        &target.id,
+                        &target.name,
+                        &target.dsn,
+                        target.database.as_deref(),
+                    )
+                };
                 state.connection_error.clear();
                 if state.session.dsn_matches(&target.dsn) {
                     state.session.mark_connecting();
@@ -136,12 +146,21 @@ pub(super) fn reduce_connection_error(
                         database_type: DatabaseType::MySQL,
                         database: state.session.active_database().map(str::to_string),
                     };
-                    let run_id = state.session.begin_mysql_connection_probe(
-                        &target.id,
-                        &target.name,
-                        &target.dsn,
-                        target.database.as_deref(),
-                    );
+                    let run_id = if state.session.is_ephemeral_connection() {
+                        state.session.begin_cli_mysql_connection_probe(
+                            &target.id,
+                            &target.name,
+                            &target.dsn,
+                            target.database.as_deref(),
+                        )
+                    } else {
+                        state.session.begin_mysql_connection_probe(
+                            &target.id,
+                            &target.name,
+                            &target.dsn,
+                            target.database.as_deref(),
+                        )
+                    };
                     state.session.mark_connecting();
                     state.modal.set_mode(InputMode::Normal);
                     return DispatchResult::handled_with(vec![Effect::ProbeMySqlConnection {
@@ -283,6 +302,47 @@ mod tests {
                 .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
         );
         assert!(state.session.connection_state().is_connecting());
+    }
+
+    #[test]
+    fn retry_cli_mysql_preserves_ephemeral_origin() {
+        let mut state = AppState::new("test".to_string());
+        let id = ConnectionId::from_string("cli:mysql");
+        let dsn = "mysql://user@localhost:3306/app?ssl-mode=PREFERRED";
+        state.session.activate_cli_ephemeral_connection_with_target(
+            &id,
+            "mysql",
+            DatabaseType::MySQL,
+            dsn,
+            Some("app"),
+        );
+        let _ = state
+            .session
+            .begin_cli_mysql_connection_probe(&id, "mysql", dsn, Some("app"));
+        state.connection_error.set_error(test_support::from_parts(
+            "Connection refused",
+            "Check the host, port, and server availability",
+            true,
+            "connection refused",
+        ));
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        let effects = reduce_connection_error(&mut state, &Action::RetryConnection, Instant::now())
+            .into_effects()
+            .unwrap();
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::ProbeMySqlConnection { .. }))
+        );
+        assert!(state.session.is_ephemeral_connection());
+        assert!(
+            state
+                .session
+                .pending_mysql_connection_probe()
+                .is_some_and(|pending| pending.origin == ConnectionOrigin::CliEphemeral)
+        );
     }
 
     #[test]

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::domain::DatabaseMetadata;
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
+use crate::model::connection::origin::ConnectionOrigin;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::update::action::{Action, ConnectionTarget};
 use crate::update::query_context::termination_effects;
@@ -30,17 +31,26 @@ fn reconcile_connection_state(state: &mut AppState, inspector_tab: InspectorTab)
 }
 
 pub(super) fn reset_for_new_connection(state: &mut AppState, target: &ConnectionTarget) {
+    reset_for_new_connection_with_origin(state, target, ConnectionOrigin::Profile);
+}
+
+pub(super) fn reset_for_new_connection_with_origin(
+    state: &mut AppState,
+    target: &ConnectionTarget,
+    origin: ConnectionOrigin,
+) {
     let inspector_tab = state.ui.inspector_tab();
     let sql_modal_tab = state.sql_modal.active_tab();
     reset_state_before_connection_reconciliation(state);
     state.ui.set_inspector_tab(inspector_tab);
     state.sql_modal.set_active_tab(sql_modal_tab);
-    state.session.activate_connection_with_target(
+    state.session.activate_connection_with_target_and_origin(
         &target.id,
         &target.name,
         target.database_type,
         &target.dsn,
         target.database.as_deref(),
+        origin,
     );
     reconcile_connection_state(state, inspector_tab);
 }
@@ -142,6 +152,15 @@ pub(super) fn restore_cache(
     cache: &ConnectionCache,
     target: &ConnectionTarget,
 ) {
+    restore_cache_with_origin(state, cache, target, ConnectionOrigin::Profile);
+}
+
+pub(super) fn restore_cache_with_origin(
+    state: &mut AppState,
+    cache: &ConnectionCache,
+    target: &ConnectionTarget,
+    origin: ConnectionOrigin,
+) {
     state.session.restore_from_cache_for_connection(
         cache,
         &mut state.query,
@@ -151,6 +170,7 @@ pub(super) fn restore_cache(
         &target.dsn,
         target.database.as_deref(),
     );
+    state.session.set_active_connection_origin(origin);
     reconcile_connection_state(state, cache.inspector_tab);
     state
         .ui

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -2,6 +2,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::connection::error::ConnectionErrorInfo;
+use crate::model::connection::origin::ConnectionOrigin;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
@@ -11,7 +12,8 @@ use crate::update::query_context::termination_effects;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
-    mysql_connection_completion_effects, reset_for_new_connection, restore_cache,
+    mysql_connection_completion_effects, reset_for_new_connection,
+    reset_for_new_connection_with_origin, restore_cache, restore_cache_with_origin,
     save_current_connection_cache,
 };
 
@@ -104,9 +106,13 @@ pub(in crate::update) fn reduce_connection_lifecycle(
             {
                 return DispatchResult::handled();
             }
+            let origin = state
+                .session
+                .pending_mysql_connection_probe()
+                .map_or(ConnectionOrigin::Profile, |pending| pending.origin);
             let cached = state.connection_caches.get(id).cloned();
             if let Some(cached) = cached.filter(|cache| cache.is_valid_mysql_snapshot(dsn)) {
-                restore_cache(state, &cached, target);
+                restore_cache_with_origin(state, &cached, target, origin);
                 state
                     .session
                     .set_mysql_lower_case_table_names(*lower_case_table_names);
@@ -118,7 +124,7 @@ pub(in crate::update) fn reduce_connection_lifecycle(
             }
 
             state.connection_caches.remove(id);
-            reset_for_new_connection(state, target);
+            reset_for_new_connection_with_origin(state, target, origin);
             state
                 .session
                 .set_mysql_lower_case_table_names(*lower_case_table_names);
@@ -194,12 +200,21 @@ pub(super) fn try_connect(state: &mut AppState) -> Vec<Effect> {
                     database_type: DatabaseType::MySQL,
                     database: state.session.active_database().map(str::to_string),
                 };
-                let run_id = state.session.begin_mysql_connection_probe(
-                    &target.id,
-                    &target.name,
-                    &target.dsn,
-                    target.database.as_deref(),
-                );
+                let run_id = if state.session.is_ephemeral_connection() {
+                    state.session.begin_cli_mysql_connection_probe(
+                        &target.id,
+                        &target.name,
+                        &target.dsn,
+                        target.database.as_deref(),
+                    )
+                } else {
+                    state.session.begin_mysql_connection_probe(
+                        &target.id,
+                        &target.name,
+                        &target.dsn,
+                        target.database.as_deref(),
+                    )
+                };
                 clear_query_confirmation(state);
                 state.query.reset_for_context_change();
                 state.session.mark_connecting();
@@ -1540,6 +1555,46 @@ mod tests {
                     .iter()
                     .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
             );
+        }
+
+        #[test]
+        fn cli_mysql_connection_stays_ephemeral_after_probe() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("cli:mysql");
+            let dsn = "mysql://user@localhost:3306/app";
+            state.session.activate_cli_ephemeral_connection_with_target(
+                &id,
+                "localhost/app",
+                DatabaseType::MySQL,
+                dsn,
+                Some("app"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::NotConnected);
+
+            let effects = reduce(&mut state, &Action::TryConnect).unwrap();
+            let (target, run_id) = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeMySqlConnection { target, run_id } => {
+                        Some((target.clone(), *run_id))
+                    }
+                    _ => None,
+                })
+                .expect("CLI MySQL connection should start a probe");
+
+            reduce(
+                &mut state,
+                &Action::MySqlConnectionProbeCompleted {
+                    target,
+                    run_id,
+                    lower_case_table_names: 0,
+                },
+            );
+
+            assert!(state.session.is_ephemeral_connection());
+            assert!(!state.session.can_reenter_connection_setup());
         }
 
         #[test]

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -59,7 +59,7 @@ fn find_conninfo_value(dsn: &str, key: &str) -> Option<String> {
 }
 
 // Keep credentials out of child argv for generated conninfo and PostgreSQL URIs.
-pub(super) fn take_explicit_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
+pub(super) fn take_explicit_password(dsn: &str) -> Result<Option<(String, String)>, &'static str> {
     if let Some((password, range)) = find_conninfo_part(dsn, "password") {
         if password.is_empty() {
             return Ok(None);
@@ -72,7 +72,7 @@ pub(super) fn take_explicit_password(dsn: &str) -> Result<Option<(String, String
     take_uri_password(dsn)
 }
 
-fn take_uri_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
+fn take_uri_password(dsn: &str) -> Result<Option<(String, String)>, &'static str> {
     if !(dsn.starts_with("postgres://") || dsn.starts_with("postgresql://")) {
         return Ok(None);
     }
@@ -95,7 +95,10 @@ fn take_uri_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
             let password_end = authority_start + at_offset;
             let encoded_password = &dsn[password_start..password_end];
             if !encoded_password.is_empty() {
-                password = Some(decode_uri_component(encoded_password)?);
+                password = Some(
+                    decode_uri_component(encoded_password)
+                        .map_err(|()| "Invalid PostgreSQL URI password encoding")?,
+                );
                 ranges.push((authority_start + colon_offset, password_end));
             }
         }
@@ -111,20 +114,26 @@ fn take_uri_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
         for segment in query.split('&') {
             let segment_end = segment_start + segment.len();
             if let Some(equal_offset) = segment.find('=') {
-                let key = &segment[..equal_offset];
-                let is_password =
-                    decode_uri_component(key).is_ok_and(|key| key.eq_ignore_ascii_case("password"));
-                if is_password {
-                    let value_start = segment_start + equal_offset + 1;
-                    let encoded_password = &dsn[value_start..segment_end];
-                    if !encoded_password.is_empty() {
-                        let decoded_password = decode_uri_component(encoded_password)?;
-                        if !decoded_password.is_empty() {
-                            // libpq applies later non-empty URI keywords last.
-                            password = Some(decoded_password);
-                        }
-                        ranges.push((value_start, segment_end));
+                let key = decode_uri_component(&segment[..equal_offset])
+                    .map_err(|()| "Invalid PostgreSQL URI parameter encoding")?;
+                let value_start = segment_start + equal_offset + 1;
+                let encoded_value = &dsn[value_start..segment_end];
+                if key.eq_ignore_ascii_case("sslpassword") {
+                    if !encoded_value.is_empty()
+                        && !decode_uri_component(encoded_value)
+                            .map_err(|()| "Invalid PostgreSQL URI password encoding")?
+                            .is_empty()
+                    {
+                        return Err("PostgreSQL URI sslpassword cannot be passed securely to psql");
                     }
+                } else if key.eq_ignore_ascii_case("password") && !encoded_value.is_empty() {
+                    let decoded_password = decode_uri_component(encoded_value)
+                        .map_err(|()| "Invalid PostgreSQL URI password encoding")?;
+                    if !decoded_password.is_empty() {
+                        // libpq applies later non-empty URI keywords last.
+                        password = Some(decoded_password);
+                    }
+                    ranges.push((value_start, segment_end));
                 }
             }
             segment_start = segment_end.saturating_add(1);

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -59,31 +59,108 @@ fn find_conninfo_value(dsn: &str, key: &str) -> Option<String> {
 }
 
 // Keep credentials out of child argv for generated conninfo and PostgreSQL URIs.
-pub(super) fn take_explicit_password(dsn: &str) -> Option<(String, String)> {
+pub(super) fn take_explicit_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
     if let Some((password, range)) = find_conninfo_part(dsn, "password") {
         if password.is_empty() {
-            return None;
+            return Ok(None);
         }
         let mut connection = dsn.to_string();
         // An explicit empty password suppresses service/environment defaults while allowing passfile.
         connection.replace_range(range, "password=''");
-        return Some((connection, password));
+        return Ok(Some((connection, password)));
     }
     take_uri_password(dsn)
 }
 
-fn take_uri_password(dsn: &str) -> Option<(String, String)> {
+fn take_uri_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
     if !(dsn.starts_with("postgres://") || dsn.starts_with("postgresql://")) {
-        return None;
+        return Ok(None);
     }
-    let mut url = url::Url::parse(dsn).ok()?;
-    let encoded_password = url.password()?.to_string();
-    if encoded_password.is_empty() {
-        return None;
+
+    let Some(scheme_end) = dsn.find("://") else {
+        return Ok(None);
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = dsn[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(dsn.len(), |offset| authority_start + offset);
+    let authority = &dsn[authority_start..authority_end];
+    let mut password = None;
+    let mut ranges = Vec::new();
+
+    if let Some(at_offset) = authority.rfind('@') {
+        let userinfo = &authority[..at_offset];
+        if let Some(colon_offset) = userinfo.find(':') {
+            let password_start = authority_start + colon_offset + 1;
+            let password_end = authority_start + at_offset;
+            let encoded_password = &dsn[password_start..password_end];
+            if !encoded_password.is_empty() {
+                password = Some(decode_uri_component(encoded_password)?);
+                ranges.push((authority_start + colon_offset, password_end));
+            }
+        }
     }
-    let password = urlencoding::decode(&encoded_password).ok()?.into_owned();
-    url.set_password(None).ok()?;
-    Some((url.to_string(), password))
+
+    if let Some(query_offset) = dsn[authority_end..].find('?') {
+        let query_start = authority_end + query_offset + 1;
+        let query_end = dsn[query_start..]
+            .find('#')
+            .map_or(dsn.len(), |offset| query_start + offset);
+        let query = &dsn[query_start..query_end];
+        let mut segment_start = query_start;
+        for segment in query.split('&') {
+            let segment_end = segment_start + segment.len();
+            if let Some(equal_offset) = segment.find('=') {
+                let key = &segment[..equal_offset];
+                if key.eq_ignore_ascii_case("password") {
+                    let value_start = segment_start + equal_offset + 1;
+                    let encoded_password = &dsn[value_start..segment_end];
+                    if !encoded_password.is_empty() {
+                        if password.is_none() {
+                            password = Some(decode_uri_component(encoded_password)?);
+                        } else {
+                            decode_uri_component(encoded_password)?;
+                        }
+                        ranges.push((value_start, segment_end));
+                    }
+                }
+            }
+            segment_start = segment_end.saturating_add(1);
+        }
+    }
+
+    let Some(password) = password else {
+        return Ok(None);
+    };
+    let mut connection = dsn.to_string();
+    for (start, end) in ranges.into_iter().rev() {
+        connection.replace_range(start..end, "");
+    }
+    Ok(Some((connection, password)))
+}
+
+fn decode_uri_component(value: &str) -> Result<String, ()> {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if bytes
+                .get(i + 1)
+                .is_none_or(|byte| !byte.is_ascii_hexdigit())
+                || bytes
+                    .get(i + 2)
+                    .is_none_or(|byte| !byte.is_ascii_hexdigit())
+            {
+                return Err(());
+            }
+            i += 3;
+        } else {
+            i += 1;
+        }
+    }
+    urlencoding::decode(value)
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|_| ())
 }
 
 fn find_conninfo_part(dsn: &str, key: &str) -> Option<(String, std::ops::Range<usize>)> {

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -112,14 +112,16 @@ fn take_uri_password(dsn: &str) -> Result<Option<(String, String)>, ()> {
             let segment_end = segment_start + segment.len();
             if let Some(equal_offset) = segment.find('=') {
                 let key = &segment[..equal_offset];
-                if key.eq_ignore_ascii_case("password") {
+                let is_password =
+                    decode_uri_component(key).is_ok_and(|key| key.eq_ignore_ascii_case("password"));
+                if is_password {
                     let value_start = segment_start + equal_offset + 1;
                     let encoded_password = &dsn[value_start..segment_end];
                     if !encoded_password.is_empty() {
-                        if password.is_none() {
-                            password = Some(decode_uri_component(encoded_password)?);
-                        } else {
-                            decode_uri_component(encoded_password)?;
+                        let decoded_password = decode_uri_component(encoded_password)?;
+                        if !decoded_password.is_empty() {
+                            // libpq applies later non-empty URI keywords last.
+                            password = Some(decoded_password);
                         }
                         ranges.push((value_start, segment_end));
                     }

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -58,16 +58,32 @@ fn find_conninfo_value(dsn: &str, key: &str) -> Option<String> {
     find_conninfo_part(dsn, key).map(|(value, _)| value)
 }
 
-// This scanner serves the quoted conninfo emitted by build_dsn, not arbitrary libpq input.
+// Keep credentials out of child argv for generated conninfo and PostgreSQL URIs.
 pub(super) fn take_explicit_password(dsn: &str) -> Option<(String, String)> {
-    let (password, range) = find_conninfo_part(dsn, "password")?;
-    if password.is_empty() {
+    if let Some((password, range)) = find_conninfo_part(dsn, "password") {
+        if password.is_empty() {
+            return None;
+        }
+        let mut connection = dsn.to_string();
+        // An explicit empty password suppresses service/environment defaults while allowing passfile.
+        connection.replace_range(range, "password=''");
+        return Some((connection, password));
+    }
+    take_uri_password(dsn)
+}
+
+fn take_uri_password(dsn: &str) -> Option<(String, String)> {
+    if !(dsn.starts_with("postgres://") || dsn.starts_with("postgresql://")) {
         return None;
     }
-    let mut connection = dsn.to_string();
-    // An explicit empty password suppresses service/environment defaults while allowing passfile.
-    connection.replace_range(range, "password=''");
-    Some((connection, password))
+    let mut url = url::Url::parse(dsn).ok()?;
+    let encoded_password = url.password()?.to_string();
+    if encoded_password.is_empty() {
+        return None;
+    }
+    let password = urlencoding::decode(&encoded_password).ok()?.into_owned();
+    url.set_password(None).ok()?;
+    Some((url.to_string(), password))
 }
 
 fn find_conninfo_part(dsn: &str, key: &str) -> Option<(String, std::ops::Range<usize>)> {

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -259,11 +259,8 @@ impl PostgresAdapter {
         dsn: &str,
     ) -> Result<Option<Passfile>, DbOperationError> {
         let passfile = if let Some((mut connection, password)) = take_explicit_password(dsn)
-            .map_err(|()| {
-                DbOperationError::ConnectionFailed(
-                    "Invalid PostgreSQL URI password encoding".into(),
-                )
-            })? {
+            .map_err(|message| DbOperationError::ConnectionFailed(message.into()))?
+        {
             let passfile = Passfile::create(&password)?;
             let path = passfile.path.to_str().ok_or_else(|| {
                 DbOperationError::ConnectionFailed(

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -265,9 +265,15 @@ impl PostgresAdapter {
                     "PostgreSQL password file path is not UTF-8".into(),
                 )
             })?;
-            connection.push_str(" passfile=");
-            connection.push_str(&quote_conninfo_value(path));
-            cmd.arg(connection).env_remove("PGPASSWORD");
+            if dsn.starts_with("postgres://") || dsn.starts_with("postgresql://") {
+                cmd.arg(connection)
+                    .env("PGPASSFILE", path)
+                    .env_remove("PGPASSWORD");
+            } else {
+                connection.push_str(" passfile=");
+                connection.push_str(&quote_conninfo_value(path));
+                cmd.arg(connection).env_remove("PGPASSWORD");
+            }
             Some(passfile)
         } else {
             cmd.arg(dsn);

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -258,7 +258,12 @@ impl PostgresAdapter {
         cmd: &mut Command,
         dsn: &str,
     ) -> Result<Option<Passfile>, DbOperationError> {
-        let passfile = if let Some((mut connection, password)) = take_explicit_password(dsn) {
+        let passfile = if let Some((mut connection, password)) = take_explicit_password(dsn)
+            .map_err(|()| {
+                DbOperationError::ConnectionFailed(
+                    "Invalid PostgreSQL URI password encoding".into(),
+                )
+            })? {
             let passfile = Passfile::create(&password)?;
             let path = passfile.path.to_str().ok_or_else(|| {
                 DbOperationError::ConnectionFailed(

--- a/src/infra/adapters/postgres/psql/password_tests.rs
+++ b/src/infra/adapters/postgres/psql/password_tests.rs
@@ -91,6 +91,7 @@ fn libpq_uri_password_is_absent_from_argv_when_url_parser_rejects_uri() {
     for dsn in [
         "postgresql://user:secret@/db?host=/var/run/postgresql",
         "postgresql://user:secret@host1,host2/db",
+        "postgresql://user@host/db?pass%77ord=secret",
     ] {
         let (cmd, passfile) =
             PostgresAdapter::build_psql_command(dsn, &[], &["-c", "SELECT 1"], false).unwrap();
@@ -104,6 +105,27 @@ fn libpq_uri_password_is_absent_from_argv_when_url_parser_rejects_uri() {
         assert!(args[0].contains("user@"));
         assert!(passfile.is_some());
     }
+}
+
+#[test]
+fn query_password_uses_last_non_empty_value() {
+    let dsn = "postgresql://user:first@host/db?password=second&pass%77ord=third";
+    let (cmd, passfile) =
+        PostgresAdapter::build_psql_command(dsn, &[], &["-c", "SELECT 1"], false).unwrap();
+    let args: Vec<_> = cmd
+        .as_std()
+        .get_args()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect();
+    let password_file = passfile.as_ref().unwrap().path.to_str().unwrap();
+    let password_file_contents = std::fs::read_to_string(password_file).unwrap();
+
+    assert!(
+        !args.iter().any(|arg| {
+            arg.contains("first") || arg.contains("second") || arg.contains("third")
+        })
+    );
+    assert!(password_file_contents.contains("third"));
 }
 
 #[test]

--- a/src/infra/adapters/postgres/psql/password_tests.rs
+++ b/src/infra/adapters/postgres/psql/password_tests.rs
@@ -52,6 +52,41 @@ fn password_text_inside_another_field_is_not_extracted() {
 }
 
 #[test]
+fn uri_password_is_absent_from_argv_and_uses_a_temporary_passfile() {
+    for scheme in ["postgres", "postgresql"] {
+        let dsn = format!("{scheme}://user:p%40ss%3Aword@localhost/db?sslmode=require");
+        let (cmd, passfile) =
+            PostgresAdapter::build_psql_command(&dsn, &[], &["-c", "SELECT 1"], false).unwrap();
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args[0],
+            format!("{scheme}://user@localhost/db?sslmode=require")
+        );
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg.contains("p%40ss") || arg.contains("word"))
+        );
+        let path = passfile.as_ref().unwrap().path.to_str().unwrap();
+        assert!(
+            cmd.as_std()
+                .get_envs()
+                .any(|(key, value)| key == "PGPASSFILE" && value == Some(path.as_ref()))
+        );
+        assert!(
+            cmd.as_std()
+                .get_envs()
+                .any(|(key, value)| key == "PGPASSWORD" && value.is_none())
+        );
+    }
+}
+
+#[test]
 fn no_explicit_password_preserves_service_passfile_and_environment() {
     for dsn in [
         "service=mydb",

--- a/src/infra/adapters/postgres/psql/password_tests.rs
+++ b/src/infra/adapters/postgres/psql/password_tests.rs
@@ -142,6 +142,23 @@ fn invalid_uri_password_encoding_fails_without_echoing_uri() {
 }
 
 #[test]
+fn uri_sslpassword_is_rejected_without_echoing_secret() {
+    for dsn in [
+        "postgresql://user@host/db?sslpassword=secret",
+        "postgresql://user@host/db?sslpass%77ord=secret",
+    ] {
+        let Err(error) = PostgresAdapter::build_psql_command(dsn, &[], &[], false) else {
+            panic!("URI sslpassword should be rejected before spawn")
+        };
+
+        assert!(
+            matches!(error, DbOperationError::ConnectionFailed(ref message) if message == "PostgreSQL URI sslpassword cannot be passed securely to psql")
+        );
+        assert!(!error.to_string().contains("secret"));
+    }
+}
+
+#[test]
 fn no_explicit_password_preserves_service_passfile_and_environment() {
     for dsn in [
         "service=mydb",

--- a/src/infra/adapters/postgres/psql/password_tests.rs
+++ b/src/infra/adapters/postgres/psql/password_tests.rs
@@ -87,6 +87,39 @@ fn uri_password_is_absent_from_argv_and_uses_a_temporary_passfile() {
 }
 
 #[test]
+fn libpq_uri_password_is_absent_from_argv_when_url_parser_rejects_uri() {
+    for dsn in [
+        "postgresql://user:secret@/db?host=/var/run/postgresql",
+        "postgresql://user:secret@host1,host2/db",
+    ] {
+        let (cmd, passfile) =
+            PostgresAdapter::build_psql_command(dsn, &[], &["-c", "SELECT 1"], false).unwrap();
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(!args.iter().any(|arg| arg.contains("secret")));
+        assert!(args[0].contains("user@"));
+        assert!(passfile.is_some());
+    }
+}
+
+#[test]
+fn invalid_uri_password_encoding_fails_without_echoing_uri() {
+    let dsn = "postgresql://user:%ZZ@localhost/db";
+    let Err(error) = PostgresAdapter::build_psql_command(dsn, &[], &[], false) else {
+        panic!("invalid URI password encoding should fail before spawn")
+    };
+
+    assert!(
+        matches!(error, DbOperationError::ConnectionFailed(ref message) if message == "Invalid PostgreSQL URI password encoding")
+    );
+    assert!(!error.to_string().contains("%ZZ"));
+}
+
+#[test]
 fn no_explicit_password_preserves_service_passfile_and_environment() {
     for dsn in [
         "service=mydb",

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -37,12 +37,15 @@ impl DbAdapterRegistry {
         if dsn.starts_with("mysql://") {
             return Ok(DatabaseType::MySQL);
         }
-        if dsn.starts_with("postgres://") || is_postgres_conninfo_dsn(dsn) {
+        if dsn.starts_with("postgres://")
+            || dsn.starts_with("postgresql://")
+            || is_postgres_conninfo_dsn(dsn)
+        {
             return Ok(DatabaseType::PostgreSQL);
         }
-        Err(DbOperationError::ConnectionFailed(format!(
-            "Unsupported database DSN scheme: {dsn}"
-        )))
+        Err(DbOperationError::ConnectionFailed(
+            "Unsupported database DSN scheme".to_string(),
+        ))
     }
 
     fn metadata_provider(&self, dsn: &str) -> Result<&dyn MetadataProvider, DbOperationError> {
@@ -279,10 +282,20 @@ mod tests {
     #[case::sqlite_url("sqlite:///tmp/app.db", Some(DatabaseType::SQLite))]
     #[case::mysql_url("mysql://localhost/db", Some(DatabaseType::MySQL))]
     #[case::postgres_url("postgres://localhost/db", Some(DatabaseType::PostgreSQL))]
+    #[case::postgresql_url("postgresql://localhost/db", Some(DatabaseType::PostgreSQL))]
     #[case::postgres_conninfo("host='localhost' dbname='db'", Some(DatabaseType::PostgreSQL))]
     #[case::unsupported_scheme("redis://localhost", None)]
     fn classifies_named_dsn_inputs(#[case] dsn: &str, #[case] expected: Option<DatabaseType>) {
         assert_eq!(DbAdapterRegistry::db_type_from_dsn(dsn).ok(), expected);
+    }
+
+    #[test]
+    fn unsupported_dsn_error_does_not_echo_credentials() {
+        let error = DbAdapterRegistry::db_type_from_dsn("redis://user:secret@example.com/database")
+            .unwrap_err();
+
+        assert!(!error.user_message().contains("secret"));
+        assert!(!format!("{error:?}").contains("secret"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ mod tests;
 #[path = "tests/render_snapshots/mod.rs"]
 mod render_snapshots;
 
-use sabiql_app::cmd::cli_sqlite::{activate_cli_sqlite_connection, resolve_cli_sqlite_target};
+use sabiql_app::cmd::cli_connection::{
+    activate_cli_connection, resolve_cli_connection_env, resolve_cli_connection_target,
+};
 use sabiql_app::cmd::completion_engine::CompletionEngine;
 use sabiql_app::cmd::effect::Effect;
 use sabiql_app::cmd::render_schedule::next_animation_deadline;
@@ -57,8 +59,13 @@ use sabiql_ui::tui::TuiRunner;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// SQLite database file path or sqlite:// DSN
+    /// SQLite path/DSN or PostgreSQL/MySQL URI (URI credentials may be visible in shell history and process arguments; use --connection-env NAME for an environment variable)
+    #[arg(conflicts_with = "connection_env", value_name = "TARGET")]
     database: Option<String>,
+
+    /// Read a PostgreSQL/MySQL URI from the named environment variable without saving a profile
+    #[arg(long, value_name = "NAME", conflicts_with = "database")]
+    connection_env: Option<String>,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -120,12 +127,14 @@ async fn main() -> Result<()> {
         }
     }
 
-    let cli_sqlite = match args.database {
-        Some(database) => Some(resolve_cli_sqlite_target(
+    let cli_connection = match (args.database, args.connection_env) {
+        (Some(database), None) => Some(resolve_cli_connection_target(
             &database,
             &FsSqlitePathValidator,
         )?),
-        None => None,
+        (None, Some(name)) => Some(resolve_cli_connection_env(&name, &FsSqlitePathValidator)?),
+        (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("clap rejects conflicting connection inputs"),
     };
 
     let project_root = find_project_root()?;
@@ -190,10 +199,10 @@ async fn main() -> Result<()> {
     match connection_store.load_all() {
         Ok(profiles) if profiles.is_empty() => {
             load_service_entries(&mut state, pg_service_entry_reader.as_ref());
-            if cli_sqlite.is_none() && state.service_entries().is_empty() {
+            if cli_connection.is_none() && state.service_entries().is_empty() {
                 state.connection_setup.set_first_run(true);
                 state.modal.set_mode(InputMode::ConnectionSetup);
-            } else if cli_sqlite.is_none() {
+            } else if cli_connection.is_none() {
                 state.modal.set_mode(InputMode::ConnectionSelector);
                 state.ui.set_connection_list_selection(Some(0));
             }
@@ -207,12 +216,14 @@ async fn main() -> Result<()> {
             state.set_connections(profiles);
             load_service_entries(&mut state, pg_service_entry_reader.as_ref());
 
-            if cli_sqlite.is_none() {
+            if cli_connection.is_none() {
                 state.modal.set_mode(InputMode::ConnectionSelector);
                 state.ui.set_connection_list_selection(Some(0));
             }
         }
-        Err(ConnectionStoreError::VersionMismatch { found, expected }) if cli_sqlite.is_none() => {
+        Err(ConnectionStoreError::VersionMismatch { found, expected })
+            if cli_connection.is_none() =>
+        {
             eprintln!(
                 "Error: Configuration file version mismatch (found v{}, expected v{}).\n\
                  Please delete {} and reconfigure.",
@@ -222,15 +233,15 @@ async fn main() -> Result<()> {
             );
             std::process::exit(1);
         }
-        Err(_) if cli_sqlite.is_none() => {
+        Err(_) if cli_connection.is_none() => {
             state.connection_setup.set_first_run(true);
             state.modal.set_mode(InputMode::ConnectionSetup);
         }
         Err(_) => {}
     }
 
-    if let Some(target) = cli_sqlite.as_ref() {
-        activate_cli_sqlite_connection(&mut state, target, &FsSqlitePathValidator)?;
+    if let Some(target) = cli_connection.as_ref() {
+        activate_cli_connection(&mut state, target, &FsSqlitePathValidator)?;
     }
 
     let mut tui = TuiRunner::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ use sabiql_infra::export::DotExporter;
 use sabiql_ui::adapters::TuiAdapter;
 use sabiql_ui::tui::TuiRunner;
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// SQLite path/DSN or PostgreSQL/MySQL URI (URI credentials may be visible in shell history and process arguments; use --connection-env NAME for an environment variable)


### PR DESCRIPTION
## Problem

Sabiql needs a one-off connection path for PostgreSQL and MySQL without creating a saved profile.

## Background

Cloud-hosted environments commonly provide a connection URI through an environment variable, while local one-off use benefits from direct CLI invocation.

## Approach

Explicit URI and environment-variable targets reuse the existing activation, probing, read-only, confirmation, stale-result, and cancellation lifecycle. Query history keeps its normal persistence behavior through a stable password-free connection identity, while URI credentials are excluded from debug output and PostgreSQL child-process arguments.

## Verification

- `cargo test -p sabiql-app --quiet` (3561 passed, 2 ignored)
- `cargo test -p sabiql-infra --quiet password` (21 passed, 1 ignored)
- `cargo test -p sabiql --quiet` (203 passed, 68 ignored)
- `cargo clippy -p sabiql-app -p sabiql-infra -p sabiql --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

The full `sabiql-infra` suite still has one unrelated SQLite export assertion failure reproduced on the base branch.
