### PR TITLE
refactor: simplify adapter forwarding and deduplication

### DIFF
--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -110,19 +110,11 @@ impl TomlConnectionStore {
         let Some(reference) = entry.password_ref.as_deref() else {
             return Ok(entry.password.clone().unwrap_or_default());
         };
-        match self.get_secret(reference) {
+        match self.secret_store.get(reference) {
             Ok(password) => Ok(password),
             Err(SecretStoreError::NoEntry) => Ok(String::new()),
             Err(_) => Err(ConnectionStoreError::SecretStore),
         }
-    }
-
-    fn set_secret(&self, reference: &str, secret: &str) -> Result<(), SecretStoreError> {
-        self.secret_store.set(reference, secret)
-    }
-
-    fn get_secret(&self, reference: &str) -> Result<String, SecretStoreError> {
-        self.secret_store.get(reference)
     }
 
     fn delete_secret(&self, reference: &str) -> Result<(), ConnectionStoreError> {
@@ -202,7 +194,8 @@ impl ConnectionStore for TomlConnectionStore {
                 || Self::password_ref(profile),
                 |_| Self::replacement_password_ref(profile),
             );
-            self.set_secret(&reference, password)
+            self.secret_store
+                .set(&reference, password)
                 .map_err(|_| ConnectionStoreError::SecretStore)?;
             let entry = ConnectionConfigEntry::from_profile_with_password_ref(
                 profile,

--- a/src/infra/adapters/postgres/pg_service.rs
+++ b/src/infra/adapters/postgres/pg_service.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -151,16 +152,9 @@ fn parse(content: &str, path: &Path) -> Vec<ServiceEntry> {
     }
 
     // libpq uses the first matching section.
-    let mut seen = std::collections::HashMap::new();
-    for (i, entry) in entries.iter().enumerate() {
-        seen.entry(entry.service_name.clone()).or_insert(i);
-    }
-    let mut unique_indices: Vec<usize> = seen.into_values().collect();
-    unique_indices.sort_unstable();
-    unique_indices
-        .into_iter()
-        .map(|i| entries[i].clone())
-        .collect()
+    let mut seen = HashSet::new();
+    entries.retain(|entry| seen.insert(entry.service_name.clone()));
+    entries
 }
 
 #[cfg(test)]

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -208,29 +208,6 @@ fn select_result_segment<'a>(segments: &[&'a str]) -> Option<&'a str> {
 impl PostgresAdapter {
     const PGOPTIONS_READ_ONLY: &str = "-c default_transaction_read_only=on";
 
-    async fn run_psql(
-        &self,
-        dsn: &str,
-        extra_args: &[&str],
-        query: &str,
-        read_only: bool,
-    ) -> Result<String, DbOperationError> {
-        self.run_psql_args(dsn, extra_args, &["-c", query], read_only)
-            .await
-    }
-
-    async fn run_psql_args(
-        &self,
-        dsn: &str,
-        extra_args: &[&str],
-        query_args: &[&str],
-        read_only: bool,
-    ) -> Result<String, DbOperationError> {
-        let (mut cmd, passfile) = Self::build_psql_command(dsn, extra_args, query_args, read_only)?;
-
-        Self::collect_output(&mut cmd, passfile, self.timeout_secs).await
-    }
-
     fn build_psql_command(
         dsn: &str,
         extra_args: &[&str],
@@ -364,7 +341,10 @@ impl PostgresAdapter {
         dsn: &str,
         query: &str,
     ) -> Result<String, DbOperationError> {
-        self.run_psql(dsn, &["-t", "-A"], query, false).await
+        let (mut cmd, passfile) =
+            Self::build_psql_command(dsn, &["-t", "-A"], &["-c", query], false)?;
+
+        Self::collect_output(&mut cmd, passfile, self.timeout_secs).await
     }
 
     pub(in crate::adapters::postgres) async fn execute_query_result(

--- a/src/infra/adapters/settings_store.rs
+++ b/src/infra/adapters/settings_store.rs
@@ -53,24 +53,12 @@ impl TomlSettingsStore {
     }
 
     fn load_config_file_lenient(&self) -> Result<Option<ConnectionConfigFile>, SettingsStoreError> {
-        let path = config_file_path(&self.config_dir);
-        if !path.exists() {
-            return Ok(None);
+        match self.load_config_file_strict() {
+            Err(
+                SettingsStoreError::TomlDeserialize(_) | SettingsStoreError::VersionMismatch { .. },
+            ) => Ok(None),
+            result => result,
         }
-
-        let content = fs::read_to_string(&path)?;
-        let Ok(version_check) = toml::from_str::<ConfigVersionCheck>(&content) else {
-            return Ok(None);
-        };
-
-        if !is_supported_config_version(version_check.version) {
-            return Ok(None);
-        }
-
-        let Ok(config) = toml::from_str::<ConnectionConfigFile>(&content) else {
-            return Ok(None);
-        };
-        Ok(Some(config))
     }
 
     fn load_config_file_strict(&self) -> Result<Option<ConnectionConfigFile>, SettingsStoreError> {


### PR DESCRIPTION
## Problem
Several adapter paths used private one-caller forwarders and index bookkeeping that obscured direct control flow without changing behavior.

## Background
These paths are already covered by existing lifecycle and error-handling tests.

## Approach
Inline the PostgreSQL raw-output command path, delegate lenient settings loading to strict parsing with only legacy fallback errors ignored, retain service entries in first-seen order, and call the secret store directly. Preserve passfile lifetime, timeouts, error propagation, source precedence, and rollback behavior.