### PR TITLE
test: harden async cancellation timing coverage

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -1098,7 +1098,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         use tokio::sync::oneshot;
-        use tokio::time::{Duration, advance};
+        use tokio::time::{Duration, sleep, timeout};
 
         use super::*;
         use crate::domain::Table;
@@ -1286,15 +1286,12 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            tokio::task::yield_now().await;
-
-            advance(Duration::from_secs(59)).await;
+            sleep(Duration::from_secs(59)).await;
             assert!(action_rx.try_recv().is_err());
 
-            advance(Duration::from_secs(1)).await;
             assert!(matches!(
-                action_rx.recv().await,
-                Some(Action::ProcessPrefetchQueue { run_id: 1 })
+                timeout(Duration::from_secs(2), action_rx.recv()).await,
+                Ok(Some(Action::ProcessPrefetchQueue { run_id: 1 }))
             ));
         }
 
@@ -1328,9 +1325,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            tokio::task::yield_now().await;
-            tokio::task::yield_now().await;
-            advance(Duration::from_secs(59)).await;
+            sleep(Duration::from_secs(59)).await;
             assert!(action_rx.try_recv().is_err());
 
             let shutdown_effects = reduce(
@@ -1350,9 +1345,11 @@ mod tests {
                 .await
                 .unwrap();
 
-            advance(Duration::from_secs(2)).await;
-            tokio::task::yield_now().await;
-            assert!(action_rx.try_recv().is_err());
+            assert!(
+                timeout(Duration::from_secs(2), action_rx.recv())
+                    .await
+                    .is_err()
+            );
         }
     }
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -1098,7 +1098,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         use tokio::sync::oneshot;
-        use tokio::time::{Duration, timeout};
+        use tokio::time::{Duration, advance};
 
         use super::*;
         use crate::domain::Table;
@@ -1256,8 +1256,8 @@ mod tests {
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
         }
 
-        #[tokio::test]
-        async fn quit_drops_delayed_prefetch_task() {
+        #[tokio::test(start_paused = true)]
+        async fn delayed_prefetch_dispatches_after_deadline_without_cancellation() {
             let provider = PendingMetadataProvider {
                 metadata_started: Mutex::new(None),
                 dropped: Arc::new(AtomicUsize::new(0)),
@@ -1286,6 +1286,53 @@ mod tests {
                 )
                 .await
                 .unwrap();
+            tokio::task::yield_now().await;
+
+            advance(Duration::from_secs(59)).await;
+            assert!(action_rx.try_recv().is_err());
+
+            advance(Duration::from_secs(1)).await;
+            assert!(matches!(
+                action_rx.recv().await,
+                Some(Action::ProcessPrefetchQueue { run_id: 1 })
+            ));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn quit_drops_delayed_prefetch_task_after_timer_starts() {
+            let provider = PendingMetadataProvider {
+                metadata_started: Mutex::new(None),
+                dropped: Arc::new(AtomicUsize::new(0)),
+            };
+            let (action_tx, mut action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                action_tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .execute_effects(
+                    vec![Effect::DelayedProcessPrefetchQueue {
+                        run_id: 1,
+                        delay_secs: 60,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            tokio::task::yield_now().await;
+            tokio::task::yield_now().await;
+            advance(Duration::from_secs(59)).await;
+            assert!(action_rx.try_recv().is_err());
+
             let shutdown_effects = reduce(
                 &mut state,
                 Action::Quit,
@@ -1303,11 +1350,9 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert!(
-                timeout(Duration::from_millis(100), action_rx.recv())
-                    .await
-                    .is_err()
-            );
+            advance(Duration::from_secs(2)).await;
+            tokio::task::yield_now().await;
+            assert!(action_rx.try_recv().is_err());
         }
     }
 
@@ -1754,11 +1799,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
-            assert!(
-                timeout(Duration::from_millis(100), action_rx.recv())
-                    .await
-                    .is_err()
-            );
+            assert!(action_rx.try_recv().is_err());
         }
     }
 
@@ -1766,13 +1807,11 @@ mod tests {
         use std::future::pending;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        use tokio::sync::mpsc::UnboundedSender;
-        use tokio::time::{Duration, timeout};
-
         use super::*;
         use crate::domain::Table;
         use crate::ports::outbound::DbOperationError;
         use crate::update::reducer::reduce;
+        use tokio::sync::mpsc::UnboundedSender;
 
         struct DropSignal(Arc<AtomicUsize>);
 
@@ -1822,14 +1861,6 @@ mod tests {
             ) -> Result<TableSignatureSnapshot, DbOperationError> {
                 unreachable!("test only starts smart ER refresh")
             }
-        }
-
-        async fn wait_for_no_action(action_rx: &mut mpsc::Receiver<Action>) {
-            assert!(
-                timeout(Duration::from_millis(100), action_rx.recv())
-                    .await
-                    .is_err()
-            );
         }
 
         fn runner_with_pending_provider(
@@ -1892,7 +1923,7 @@ mod tests {
                 started_rx.recv().await.as_deref(),
                 Some("postgres://localhost/new")
             );
-            wait_for_no_action(&mut action_rx).await;
+            assert!(action_rx.try_recv().is_err());
         }
 
         #[tokio::test]
@@ -1937,7 +1968,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
-            wait_for_no_action(&mut action_rx).await;
+            assert!(action_rx.try_recv().is_err());
         }
 
         #[tokio::test]
@@ -1983,7 +2014,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
-            wait_for_no_action(&mut action_rx).await;
+            assert!(action_rx.try_recv().is_err());
         }
 
         #[tokio::test]
@@ -2033,7 +2064,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(dropped.load(Ordering::SeqCst), 1);
-            wait_for_no_action(&mut action_rx).await;
+            assert!(action_rx.try_recv().is_err());
         }
     }
 }


### PR DESCRIPTION
## Problem
Cancellation tests relied on real-time negative waits, and the delayed prefetch Quit case did not prove the timer path or a non-cancelled control case.

## Background
This left a regression that omitted prefetch task cancellation able to pass without exercising the delayed notification after its deadline.

## Approach
Use Tokio paused time with deadline-before/after observations and a non-cancelled control case. Replace only fixed waits backed by provider Drop and owner join with immediate queue checks; keep SQLite `spawn_blocking` coverage unchanged.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-549