### PR TITLE
test: prune redundant app coverage

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -2921,57 +2921,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn cached_table_returns_columns() {
-            let mut e = engine();
-
-            let table = Table {
-                schema: "public".to_string(),
-                name: "users".to_string(),
-                columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_support::column::test_nullable_column("id", "int", 1)
-                    },
-                    test_support::column::test_nullable_column("name", "text", 2),
-                ],
-                primary_key: Some(vec!["id".to_string()]),
-                ..test_support::table::minimal("", "")
-            };
-
-            e.cache_table_detail("public.users".to_string(), table);
-
-            let sql_context = SqlContext {
-                tables: vec![TableReference {
-                    schema: Some("public".to_string()),
-                    table: "users".to_string(),
-                    alias: Some("u".to_string()),
-                }],
-                ctes: vec![],
-                target_table: None,
-            };
-
-            let mut metadata = DatabaseMetadata::new("test".to_string());
-            metadata.table_summaries = vec![TableSummary::new(
-                "public".to_string(),
-                "users".to_string(),
-                None,
-                false,
-            )];
-
-            let candidates = e.alias_column_candidates(
-                "u",
-                &sql_context,
-                Some(&metadata),
-                "",
-                DatabaseType::PostgreSQL,
-            );
-
-            assert_eq!(candidates.len(), 2);
-            assert!(candidates.iter().any(|c| c.text == "id"));
-            assert!(candidates.iter().any(|c| c.text == "name"));
-        }
-
-        #[test]
         fn non_cached_table_returns_empty() {
             let e = engine();
 
@@ -3425,20 +3374,6 @@ mod tests {
             assert_eq!(missing.len(), 10);
         }
 
-        #[test]
-        fn has_cached_table_returns_true_for_cached() {
-            let mut e = engine();
-            let table = Table {
-                schema: "public".to_string(),
-                name: "users".to_string(),
-                ..test_support::table::minimal("", "")
-            };
-            e.cache_table_detail("public.users".to_string(), table);
-
-            assert!(e.has_cached_table("public.users"));
-            assert!(!e.has_cached_table("public.orders"));
-        }
-
         fn make_table(schema: &str, name: &str) -> Table {
             Table {
                 schema: schema.to_string(),
@@ -3542,6 +3477,7 @@ mod tests {
                 e.get_candidates("SELECT u. FROM public.users u", 9, Some(&metadata), None);
 
             assert!(!candidates.is_empty());
+            assert_eq!(candidates.len(), 3);
             assert!(candidates.iter().any(|c| c.text == "id"));
             assert!(candidates.iter().any(|c| c.text == "name"));
             assert!(candidates.iter().any(|c| c.text == "email"));
@@ -3650,6 +3586,7 @@ mod tests {
                 first_keyword_idx < first_column_idx,
                 "Keywords should appear before columns"
             );
+            assert_eq!(candidates[0].kind, CompletionKind::Keyword);
         }
 
         #[test]
@@ -3687,22 +3624,6 @@ mod tests {
                 .count();
 
             assert_eq!(and_count, 1, "AND should appear only once (deduplicated)");
-        }
-
-        #[test]
-        fn empty_prefix_shows_keywords_first() {
-            let e = engine();
-            let table = create_users_table();
-
-            // Empty prefix: keywords should come first
-            let candidates = e.get_candidates("SELECT ", 7, None, Some(&table));
-
-            // First candidate should be a keyword (score 200)
-            assert_eq!(
-                candidates[0].kind,
-                CompletionKind::Keyword,
-                "With empty prefix, keywords should come first"
-            );
         }
 
         #[test]
@@ -3892,25 +3813,6 @@ mod tests {
             // SQL referencing evicted table should trigger re-fetch
             let missing = e.missing_tables("SELECT * FROM t1", Some(&metadata));
             assert_eq!(missing, vec!["public.t1".to_string()]);
-        }
-
-        #[test]
-        fn cached_table_not_in_missing_tables() {
-            let mut e = CompletionEngine::new_with_capacity(2);
-
-            let t1 = create_table("public", "t1", &["id"]);
-            e.cache_table_detail("public.t1".to_string(), t1);
-
-            let mut metadata = DatabaseMetadata::new("test".to_string());
-            metadata.table_summaries = vec![TableSummary::new(
-                "public".to_string(),
-                "t1".to_string(),
-                None,
-                false,
-            )];
-
-            let missing = e.missing_tables("SELECT * FROM t1", Some(&metadata));
-            assert!(missing.is_empty());
         }
 
         #[test]

--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -276,29 +276,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn idle_query_returns_false() {
-            let state = create_test_state();
-
-            assert!(!has_active_spinner(&state));
-        }
-
-        #[test]
-        fn running_query_returns_true() {
-            let mut state = create_test_state();
-            let _ = state.query.begin_running(Instant::now());
-
-            assert!(has_active_spinner(&state));
-        }
-
-        #[test]
-        fn er_waiting_returns_true() {
-            let mut state = create_test_state();
-            let _ = state.er_preparation.start_waiting_run();
-
-            assert!(has_active_spinner(&state));
-        }
-
-        #[test]
         fn er_rendering_returns_false() {
             let mut state = create_test_state();
             state.er_preparation.mark_rendering();
@@ -309,37 +286,6 @@ mod tests {
 
     mod has_blinking_cursor_tests {
         use super::*;
-
-        #[test]
-        fn normal_mode_returns_false() {
-            let state = create_test_state();
-
-            assert!(!has_blinking_cursor(&state));
-        }
-
-        #[test]
-        fn sql_modal_returns_true() {
-            let mut state = create_test_state();
-            state.modal.set_mode(InputMode::SqlModal);
-
-            assert!(has_blinking_cursor(&state));
-        }
-
-        #[test]
-        fn table_picker_returns_true() {
-            let mut state = create_test_state();
-            state.modal.set_mode(InputMode::TablePicker);
-
-            assert!(has_blinking_cursor(&state));
-        }
-
-        #[test]
-        fn command_line_returns_true() {
-            let mut state = create_test_state();
-            state.modal.set_mode(InputMode::CommandLine);
-
-            assert!(has_blinking_cursor(&state));
-        }
 
         #[test]
         fn connection_setup_returns_true() {

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -409,28 +409,6 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn calls_draw() {
-            let (tx, mut _rx) = mpsc::channel(8);
-            let runner = test_fixtures::make_runner(
-                Arc::new(MockMetadataProvider::new()),
-                Arc::new(MockQueryExecutor::new()),
-                Arc::new(MockConnectionStore::new()),
-                tx,
-            );
-
-            test_fixtures::run_one_effect(
-                &runner,
-                Effect::Render,
-                AppState::new("test".to_string()),
-                RefCell::new(CompletionEngine::new()),
-                &mut _rx,
-                None,
-            )
-            .await
-            .unwrap();
-        }
-
-        #[tokio::test]
         async fn clamps_stale_explorer_horizontal_offset_to_new_maximum() {
             let (tx, _rx) = mpsc::channel(8);
             let runner = test_fixtures::make_runner(

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -970,56 +970,16 @@ mod tests {
         use super::*;
 
         #[test]
-        fn result_rows_default_to_zero() {
-            let state = make_state();
-
-            let visible = state.result_visible_rows();
-
-            assert_eq!(visible, 0);
-        }
-
-        #[rstest]
-        #[case(10, 5)]
-        #[case(15, 10)]
-        #[case(20, 15)]
-        #[case(30, 25)]
-        fn result_rows_follow_pane_height(#[case] pane_height: u16, #[case] expected: usize) {
+        fn result_rows_delegate_to_ui_state() {
             let mut state = make_state();
-            state.ui.set_result_pane_height(pane_height);
 
-            let visible = state.result_visible_rows();
+            assert_eq!(state.result_visible_rows(), 0);
 
-            assert_eq!(visible, expected);
-        }
-
-        #[test]
-        fn result_rows_clamp_small_heights() {
-            let mut state = make_state();
-            state.ui.set_result_pane_height(2);
-
-            let visible = state.result_visible_rows();
-
-            assert_eq!(visible, 0);
-        }
-
-        #[test]
-        fn result_rows_stay_zero_at_minimum() {
-            let mut state = make_state();
-            state.ui.set_result_pane_height(1);
-
-            let visible = state.result_visible_rows();
-
-            assert_eq!(visible, 0);
-        }
-
-        #[test]
-        fn result_rows_scale_with_height() {
-            let mut state = make_state();
             state.ui.set_result_pane_height(50);
+            assert_eq!(state.result_visible_rows(), 45);
 
-            let visible = state.result_visible_rows();
-
-            assert_eq!(visible, 45);
+            state.ui.set_result_pane_height(0);
+            assert_eq!(state.result_visible_rows(), 0);
         }
 
         #[test]

--- a/src/app/model/connection/state.rs
+++ b/src/app/model/connection/state.rs
@@ -34,12 +34,6 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    #[test]
-    fn default_returns_not_connected() {
-        let state = ConnectionState::default();
-        assert!(state.is_not_connected());
-    }
-
     #[rstest]
     #[case(ConnectionState::NotConnected, true, false, false, false)]
     #[case(ConnectionState::Connecting, false, true, false, false)]

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -743,25 +743,6 @@ mod tests {
 
             assert_eq!(visible, 0);
         }
-
-        #[rstest]
-        #[case(30, 20)]
-        #[case(100, 25)]
-        #[case(50, 15)]
-        #[case(10, 30)]
-        fn scroll_can_reach_all_rows(#[case] total_rows: usize, #[case] pane_height: u16) {
-            let state = UiState {
-                result_pane_height: pane_height,
-                ..Default::default()
-            };
-            let visible = state.result_visible_rows();
-            let max_scroll = total_rows.saturating_sub(visible);
-
-            assert!(
-                max_scroll + visible >= total_rows,
-                "max_scroll={max_scroll}, visible={visible}, total={total_rows}"
-            );
-        }
     }
 
     mod focus_mode {
@@ -843,15 +824,6 @@ mod tests {
         }
     }
 
-    mod invariants {
-        use super::*;
-
-        #[test]
-        fn result_overhead_constants_are_consistent() {
-            assert_eq!(RESULT_PANE_OVERHEAD, RESULT_INNER_OVERHEAD + 2);
-        }
-    }
-
     mod help_scroll {
         use super::*;
 
@@ -899,6 +871,7 @@ mod tests {
             };
 
             assert_eq!(state.help_visible_rows(total_lines, content_width), 14);
+            assert_eq!(state.help_max_scroll(total_lines, content_width), 86);
         }
 
         #[test]

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -828,26 +828,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn help_max_scroll_plus_viewport_equals_content_line_count() {
-            let terminal_height: u16 = 24;
-            let total_lines = 100;
-            let content_width = 80;
-            let state = UiState {
-                terminal_height,
-                ..Default::default()
-            };
-            let viewport = state.help_visible_rows(total_lines, content_width);
-
-            let max = state.help_max_scroll(total_lines, content_width);
-
-            assert_eq!(
-                max + viewport,
-                total_lines,
-                "max_scroll({max}) + viewport({viewport}) != total_lines({total_lines})"
-            );
-        }
-
-        #[test]
         fn help_max_scroll_is_zero_when_terminal_very_tall() {
             let total_lines = 100;
             let content_width = 80;

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -53,11 +53,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn plain_select_is_rerunnable() {
-            assert!(is_sqlite_rerunnable_export_query("SELECT id FROM users"));
-        }
-
-        #[test]
         fn multi_select_is_not_rerunnable() {
             assert!(!is_sqlite_rerunnable_export_query("SELECT 1; SELECT 2"));
         }

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -1764,7 +1764,6 @@ mod tests {
     }
 
     mod fk_neighbors_discovered {
-        use super::prefetch::MAX_PREFETCH_RETRIES;
         use super::*;
 
         #[test]
@@ -1925,44 +1924,6 @@ mod tests {
                 Some("public.comments".to_string())
             );
             assert!(!state.table_prefetch.has_pending_prefetch());
-        }
-
-        #[test]
-        fn phase2_table_retry_limit_triggers_completion() {
-            // All Phase 2 tables fail → completion must still fire
-            let mut state = state_with_dsn("postgres://localhost/test");
-            let run_id = state.table_prefetch.begin_er_prefetch();
-            let _ = state.er_preparation.start_waiting_run();
-            state.er_preparation.mark_fk_expanded();
-            let neighbor = "public.posts".to_string();
-            state.table_prefetch.queue_table_prefetch(neighbor.clone());
-            state.table_prefetch.fail_table_prefetch(
-                neighbor,
-                FailedPrefetchEntry {
-                    failed_at: Instant::now(),
-                    error: "timeout".to_string(),
-                    retry_count: MAX_PREFETCH_RETRIES,
-                    retryable: true,
-                },
-            );
-
-            let effects = dispatch_metadata(
-                &mut state,
-                &Action::PrefetchTableDetail {
-                    run_id,
-                    schema: "public".to_string(),
-                    table: "posts".to_string(),
-                },
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
-            assert!(
-                effects
-                    .iter()
-                    .any(|e| matches!(e, Effect::WriteErFailureLog { .. }))
-            );
         }
     }
 }

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -221,21 +221,6 @@ mod tests {
             assert_eq!(state.result_interaction.selection().row(), None);
             assert!(state.result_interaction.staged_delete_rows().contains(&0));
         }
-
-        #[test]
-        fn escape_from_result_scroll_clears_all_staged_rows() {
-            let mut state = base_state(
-                Some(vec!["id"]),
-                vec![vec!["1", "alice"], vec!["2", "bob"]],
-                0,
-            );
-            state.result_interaction.stage_row(0);
-            state.result_interaction.stage_row(1);
-
-            reduce_selection(&mut state, &Action::ClearStagedDeletes, Instant::now());
-
-            assert!(state.result_interaction.staged_delete_rows().is_empty());
-        }
     }
 
     mod read_only_guard {

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -220,30 +220,12 @@ mod tests {
             use super::*;
 
             #[test]
-            fn ctrl_p_opens_table_picker() {
-                let state = browse_state();
-
-                let result = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
-
-                assert!(matches!(result, Action::OpenModal(ModalKind::TablePicker)));
-            }
-
-            #[test]
             fn plain_p_is_noop() {
                 let state = browse_state();
 
                 let result = handle_normal_mode(combo(Key::Char('p')), &state);
 
                 assert!(matches!(result, Action::None));
-            }
-
-            #[test]
-            fn comma_opens_settings() {
-                let state = browse_state();
-
-                let result = handle_normal_mode(combo(Key::Char(',')), &state);
-
-                assert!(matches!(result, Action::OpenModal(ModalKind::Settings)));
             }
 
             #[test]
@@ -373,18 +355,6 @@ mod tests {
                 let result = handle_normal_mode(combo(Key::Char(':')), &state);
 
                 assert!(matches!(result, Action::EnterCommandLine));
-            }
-
-            #[test]
-            fn f1_opens_command_palette() {
-                let state = browse_state();
-
-                let result = handle_normal_mode(combo(Key::F(1)), &state);
-
-                assert!(matches!(
-                    result,
-                    Action::OpenModal(ModalKind::CommandPalette)
-                ));
             }
 
             #[test]

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -1466,24 +1466,6 @@ mod tests {
         }
 
         #[rstest]
-        #[case(Key::Char('a'))]
-        #[case(Key::Enter)]
-        #[case(Key::Esc)]
-        #[case(Key::Tab)]
-        #[case(Key::Up)]
-        #[case(Key::Down)]
-        fn running_state_compare_tab_suppresses_all_keys(#[case] code: Key) {
-            let result = handle_sql_modal_keys(
-                combo(code),
-                false,
-                &SqlModalStatus::Running,
-                SqlModalTab::Compare,
-            );
-
-            assert_action(result, Expected::None);
-        }
-
-        #[rstest]
         #[case(success_status())]
         #[case(error_status())]
         fn plan_tab_read_only_keys_work_in_success_error(#[case] status: SqlModalStatus) {


### PR DESCRIPTION
## Problem

Several app tests duplicate coverage already provided by integration, deadline, state-constructor, or public-plan tests, while one render test observes only that execution succeeds.

## Background

The fixed-HEAD app test audit identified safe deletions and three assertion consolidations. The retained tests cover the same behavior through higher-value entrypoints and preserve cancellation, rendering, and mode-specific coverage.

## Approach

Remove only the audited redundant test cases and consolidate the alias candidate count, keyword-leading result, help scroll bound, and AppState delegation checks into surviving tests. Production behavior and public interfaces are unchanged.