### PR TITLE
refactor: centralize config file defaults

### DIFF
--- a/src/infra/adapters/settings_store.rs
+++ b/src/infra/adapters/settings_store.rs
@@ -76,15 +76,7 @@ impl SettingsStore for TomlSettingsStore {
     fn save(&self, settings: AppSettings) -> Result<(), SettingsStoreError> {
         let _guard = app_config_file::lock();
 
-        let mut config = self
-            .load_config_file_strict()?
-            .unwrap_or_else(|| ConnectionConfigFile {
-                version: CURRENT_VERSION,
-                theme: None,
-                keymap_preset: None,
-                er_browser: None,
-                connections: vec![],
-            });
+        let mut config = self.load_config_file_strict()?.unwrap_or_default();
         set_app_settings(&mut config, settings);
         let content = toml::to_string_pretty(&config)?;
         let content_with_header = render_config_file(&content);

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -74,15 +74,25 @@ pub(crate) struct ConnectionConfigEntry {
     pub path: Option<String>,
 }
 
-impl From<&[ConnectionProfile]> for ConnectionConfigFile {
-    fn from(profiles: &[ConnectionProfile]) -> Self {
+impl Default for ConnectionConfigFile {
+    fn default() -> Self {
         Self {
             version: CURRENT_VERSION,
             theme: None,
             keymap_preset: None,
             er_browser: None,
-            connections: profiles.iter().map(ConnectionConfigEntry::from).collect(),
+            connections: Vec::new(),
         }
+    }
+}
+
+impl From<&[ConnectionProfile]> for ConnectionConfigFile {
+    fn from(profiles: &[ConnectionProfile]) -> Self {
+        let mut config = Self::default();
+        config
+            .connections
+            .extend(profiles.iter().map(ConnectionConfigEntry::from));
+        config
     }
 }
 


### PR DESCRIPTION
## Problem
Empty configuration values are initialized in multiple save paths, so the baseline can drift.

## Background
The configuration schema has a non-zero version baseline that should not be reproduced at each call site.

## Approach
Define the empty configuration baseline once on `ConnectionConfigFile` and reuse it for both profile and settings persistence while preserving existing-file fields and version handling.